### PR TITLE
[strings] Cleanup Recent Track strings on Android

### DIFF
--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -248,12 +248,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">المسار الأخير</string>
 	<string name="pref_map_auto_zoom">تكبير تلقائي</string>
-	<string name="duration_disabled">لا يعمل</string>
-	<string name="duration_1_hour">1 ساعة</string>
-	<string name="duration_2_hours">2 ساعة</string>
-	<string name="duration_6_hours">6 ساعات</string>
-	<string name="duration_12_hours">12 ساعة</string>
-	<string name="duration_1_day">1 يوم</string>
 	<string name="placepage_distance">المسافة</string>
 	<string name="search_show_on_map">مشاهدة على الخريطة</string>
 	<!-- Menu button -->
@@ -578,7 +572,6 @@
 	<string name="editor_share_to_all_dialog_message_1">تأكد من أنك لم تقم بإدخال أية بيانات شخصية.</string>
 	<string name="editor_share_to_all_dialog_message_2">سيتحقق محررو خرائط الشارع المفتوحة من التغييرات ويتواصلون معك إذا كان لديهم أي أسئلة.</string>
 	<string name="navigation_stop_button">توقف</string>
-	<string name="recent_track_background_dialog_message">يستخدم Organic Maps موقعك الجغرافي في الخلفية لتسجيل مسار سفرك الأخير.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">تسجيل المسار</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -247,12 +247,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Son marşrut</string>
 	<string name="pref_map_auto_zoom">Avtomatik böyütmə</string>
-	<string name="duration_disabled">Bağlı</string>
-	<string name="duration_1_hour">1 saat</string>
-	<string name="duration_2_hours">2 saat</string>
-	<string name="duration_6_hours">6 saat</string>
-	<string name="duration_12_hours">12 saat</string>
-	<string name="duration_1_day">1 gün</string>
 	<string name="placepage_distance">Məsafə</string>
 	<string name="search_show_on_map">Xəritədə baxın</string>
 	<!-- Text in menu -->
@@ -565,7 +559,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Heç bir şəxsi məlumat daxil etmədiyinizə əmin olun.</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap redaktorları dəyişikliklərinizi yoxlayacaq və hər hansı sualınız olarsa, sizinlə əlaqə saxlayacaq.</string>
 	<string name="navigation_stop_button">Dayan</string>
-	<string name="recent_track_background_dialog_message">Organic Maps son səyahət etdiyiniz marşrutu qeyd etmək üçün arxa fonda geolokasiyadan istifadə edir.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Marşrutu qeyd etmək</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -246,12 +246,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Нядаўні маршрут</string>
 	<string name="pref_map_auto_zoom">Аўтаматычны маштаб</string>
-	<string name="duration_disabled">Выключана</string>
-	<string name="duration_1_hour">1 гадзіна</string>
-	<string name="duration_2_hours">2 гадзіны</string>
-	<string name="duration_6_hours">6 гадзін</string>
-	<string name="duration_12_hours">12 гадзін</string>
-	<string name="duration_1_day">1 дзень</string>
 	<string name="placepage_distance">Адлегласць</string>
 	<string name="search_show_on_map">Паглядзець на мапе</string>
 	<!-- Text in menu -->
@@ -559,7 +553,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Упэўніцеся, што вы не ўвялі ніякіх асабістых даных.</string>
 	<string name="editor_share_to_all_dialog_message_2">Рэдактары OpenStreetMap правераць змены і звяжуцца з вамі, калі ў іх узнікнуць пытанні.</string>
 	<string name="navigation_stop_button">Cпыніць</string>
-	<string name="recent_track_background_dialog_message">Organic Maps выкарыстоўвае вашу геалакацыю ў фонавым рэжыме, каб запісваць ваш нядаўна пройдзены маршрут.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Запіс маршруту</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -235,12 +235,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Скорошна пътека</string>
 	<string name="pref_map_auto_zoom">Автоматично мащабиране</string>
-	<string name="duration_disabled">Изключено</string>
-	<string name="duration_1_hour">1 час</string>
-	<string name="duration_2_hours">2 часа</string>
-	<string name="duration_6_hours">6 часа</string>
-	<string name="duration_12_hours">12 часа</string>
-	<string name="duration_1_day">1 ден</string>
 	<string name="search_show_on_map">Преглед на картата</string>
 	<!-- Text in menu -->
 	<string name="website">Уебсайт</string>
@@ -520,7 +514,6 @@
 	<!-- Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Уверете се, че не сте въвели никакви лични данни.</string>
 	<string name="editor_share_to_all_dialog_message_2">Редакторите на OpenStreetMap ще проверят промените и ще се свържат с вас, ако имат въпроси.</string>
-	<string name="recent_track_background_dialog_message">Organic Maps използва геопозицията ви във фонов режим за записване на последния ви маршрут.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Записване на пътя</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -245,12 +245,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Traces recents</string>
 	<string name="pref_map_auto_zoom">Zoom automàtic</string>
-	<string name="duration_disabled">Desactivada</string>
-	<string name="duration_1_hour">1 hora</string>
-	<string name="duration_2_hours">2 hores</string>
-	<string name="duration_6_hours">6 hores</string>
-	<string name="duration_12_hours">12 hores</string>
-	<string name="duration_1_day">1 dia</string>
 	<string name="placepage_distance">Distància</string>
 	<string name="search_show_on_map">Veure al mapa</string>
 	<!-- Menu button -->
@@ -564,7 +558,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Assegureu-vos que no heu introduït cap dada personal.</string>
 	<string name="editor_share_to_all_dialog_message_2">Revisarem els canvis. Si tenim cap pregunta contactem amb vós via correu electrònic.</string>
 	<string name="navigation_stop_button">Atura\'t</string>
-	<string name="recent_track_background_dialog_message">Organic Maps usa la vostra ubicaicó en segon pla per a enregistrar la ruta que heu fet recentment.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Enregistrament de la pista</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -232,12 +232,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Historie polohy</string>
 	<string name="pref_map_auto_zoom">Automatické zvětšení</string>
-	<string name="duration_disabled">Vypnuto</string>
-	<string name="duration_1_hour">1 hodina</string>
-	<string name="duration_2_hours">2 hodiny</string>
-	<string name="duration_6_hours">6 hodin</string>
-	<string name="duration_12_hours">12 hodin</string>
-	<string name="duration_1_day">1 den</string>
 	<string name="placepage_distance">Vzdálenost</string>
 	<string name="search_show_on_map">Zobrazit na mapě</string>
 	<!-- Text in menu -->
@@ -537,7 +531,6 @@
 	<!-- Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Ujistěte se, že jste nezadali žádná osobní data.</string>
 	<string name="editor_share_to_all_dialog_message_2">Redaktoři OpenStreetMap zkontrolují změny a budou vás kontaktovat, pokud budou mít nějaké dotazy.</string>
-	<string name="recent_track_background_dialog_message">Organic Maps používají geopozici na pozadí, aby se zaznamenala vaše nedávno ujetá trasa.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Záznam trasy</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -228,12 +228,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Seneste sti</string>
 	<string name="pref_map_auto_zoom">Auto zoom</string>
-	<string name="duration_disabled">Fra</string>
-	<string name="duration_1_hour">1 time</string>
-	<string name="duration_2_hours">2 timer</string>
-	<string name="duration_6_hours">6 timer</string>
-	<string name="duration_12_hours">12 timer</string>
-	<string name="duration_1_day">1 dag</string>
 	<string name="placepage_distance">Afstand</string>
 	<string name="search_show_on_map">Vis på kortet</string>
 	<!-- Text in menu -->
@@ -533,7 +527,6 @@
 	<!-- Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Sørg for at du ikke indtastede personlige oplysninger.</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap-redaktører vil tjekke ændringerne og kontakte dig, hvis de har spørgsmål.</string>
-	<string name="recent_track_background_dialog_message">Organic Maps anvender din geoposition i baggrunden til at gemme din seneste rejserute.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Registrering af sporet</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -245,12 +245,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Letzter Track</string>
 	<string name="pref_map_auto_zoom">Auto-Zoom</string>
-	<string name="duration_disabled">Aus</string>
-	<string name="duration_1_hour">1 Stunde</string>
-	<string name="duration_2_hours">2 Stunden</string>
-	<string name="duration_6_hours">6 Stunden</string>
-	<string name="duration_12_hours">12 Stunden</string>
-	<string name="duration_1_day">1 Tag</string>
 	<string name="placepage_distance">Entfernung</string>
 	<string name="search_show_on_map">Auf der Karte ansehen</string>
 	<!-- Text in menu -->
@@ -563,7 +557,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Stellen Sie sicher, dass Sie keine persönlichen oder privaten Daten eingegeben haben.</string>
 	<string name="editor_share_to_all_dialog_message_2">Freiwillige von OpenStreetMap werden die Änderungen prüfen und sich bei Fragen mit Ihnen in Verbindung setzen.</string>
 	<string name="navigation_stop_button">Beenden</string>
-	<string name="recent_track_background_dialog_message">Organic Maps verwendet Ihre Geoposition im Hintergrund, um Ihre kürzlich gefahrene Route aufzunehmen.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Aufnahme der Strecke</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -246,12 +246,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Πρόσφατη διαδρομή</string>
 	<string name="pref_map_auto_zoom">Αυτόματη μεγέθυνση</string>
-	<string name="duration_disabled">Απενεργ.</string>
-	<string name="duration_1_hour">1 ώρα</string>
-	<string name="duration_2_hours">2 ώρες</string>
-	<string name="duration_6_hours">6 ώρες</string>
-	<string name="duration_12_hours">12 ώρες</string>
-	<string name="duration_1_day">1 ημέρα</string>
 	<string name="placepage_distance">Απόσταση</string>
 	<string name="search_show_on_map">Προβολή στο χάρτη</string>
 	<!-- Menu button -->
@@ -561,7 +555,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Βεβαιωθείτε ότι δεν έχετε εισάγει προσωπικά δεδομένα.</string>
 	<string name="editor_share_to_all_dialog_message_2">Οι συντάκτες του OpenStreetMap θα ελέγξουν τις αλλαγές και θα επικοινωνήσουν μαζί σας εάν έχουν απορίες.</string>
 	<string name="navigation_stop_button">τέλος</string>
-	<string name="recent_track_background_dialog_message">Το Organic Maps χρησιμοποιεί την τοποθεσία σας στο παρασκήνιο για την καταγραφή των πρόσφατων διαδρομών σας.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Καταγραφή της διαδρομής</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -245,12 +245,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Trayecto reciente</string>
 	<string name="pref_map_auto_zoom">Zoom automático</string>
-	<string name="duration_disabled">Desactivada</string>
-	<string name="duration_1_hour">1 hora</string>
-	<string name="duration_2_hours">2 horas</string>
-	<string name="duration_6_hours">6 horas</string>
-	<string name="duration_12_hours">12 horas</string>
-	<string name="duration_1_day">1 día</string>
 	<string name="placepage_distance">Distancia</string>
 	<string name="search_show_on_map">Ver en el mapa</string>
 	<!-- Menu button -->
@@ -565,7 +559,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Asegúrate de que no has introducido ningún dato personal.</string>
 	<string name="editor_share_to_all_dialog_message_2">Los editores de OpenStreetMap comprobarán los cambios y se pondrán en contacto con usted si tienen alguna pregunta.</string>
 	<string name="navigation_stop_button">Detener</string>
-	<string name="recent_track_background_dialog_message">Organic Maps usa su geolocalización en segundo plano para registrar su ruta recorrida recientemente.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Registro de la pista</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -239,12 +239,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Hiljutine rada</string>
 	<string name="pref_map_auto_zoom">Automaatne zoom</string>
-	<string name="duration_disabled">Väljas</string>
-	<string name="duration_1_hour">1 tund</string>
-	<string name="duration_2_hours">2 tundi</string>
-	<string name="duration_6_hours">6 tundi</string>
-	<string name="duration_12_hours">12 tundi</string>
-	<string name="duration_1_day">1 päev</string>
 	<string name="placepage_distance">Kaugus</string>
 	<string name="search_show_on_map">Vaata kaardil</string>
 	<!-- Text in menu -->
@@ -557,7 +551,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Palun kontrolli, et Sa ei sisestanud isiklikke andmeid.</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap muutjad kontrollivad muudatused üle ja võtavad küsimuste korral Sinuga ühendust.</string>
 	<string name="navigation_stop_button">Lõpeta</string>
-	<string name="recent_track_background_dialog_message">Organic Maps kasutab Sinu geograafilist asukohta taustal Sinu hiljuti läbitud teekonna salvestamiseks.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Rada registreerimine</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -245,12 +245,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Azken arrastoa</string>
 	<string name="pref_map_auto_zoom">Zoom automatikoa</string>
-	<string name="duration_disabled">Desaktibatuta</string>
-	<string name="duration_1_hour">ordu 1</string>
-	<string name="duration_2_hours">2 ordu</string>
-	<string name="duration_6_hours">6 ordu</string>
-	<string name="duration_12_hours">12 ordu</string>
-	<string name="duration_1_day">egun 1</string>
 	<string name="placepage_distance">Distantzia</string>
 	<string name="search_show_on_map">Ikusi mapan</string>
 	<!-- Menu button -->
@@ -563,7 +557,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Ziurtatu ez duzula datu pertsonalik sartu.</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap editoreek aldaketak egiaztatuko dituzte eta zurekin harremanetan jarriko dira zalantzaren bat izanez gero.</string>
 	<string name="navigation_stop_button">Gelditu</string>
-	<string name="recent_track_background_dialog_message">Organic Maps-ek zure geokokapena erabiltzen du atzeko planoan egindako azken ibilbidea erregistratzeko.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Ibilbidea grabatzea</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -221,12 +221,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">مسیر اخیر</string>
 	<string name="pref_map_auto_zoom">بزرگنمایی خودکار</string>
-	<string name="duration_disabled">خاموش</string>
-	<string name="duration_1_hour">1 ساعت</string>
-	<string name="duration_2_hours">2 ساعت</string>
-	<string name="duration_6_hours">6 ساعت</string>
-	<string name="duration_12_hours">12 ساعت</string>
-	<string name="duration_1_day">1 روز</string>
 	<string name="placepage_distance">مسافت</string>
 	<string name="search_show_on_map">مشاهده بر روی نقشه</string>
 	<!-- Text in menu -->
@@ -529,7 +523,6 @@
 	<string name="editor_share_to_all_dialog_message_1">مطمئن شوید که هیچ اطلاعات شخصی وارد نکرده باشد.</string>
 	<string name="editor_share_to_all_dialog_message_2">ویرایشگران OpenStreetMap ﺗﻐﯿﯿﺮﺍﺕ ﺭﺍ ﺑﺮﺭﺳﯽ ﮐﺮﺩﻩ ﻭ ﺩﺭ ﺻﻮﺭﺕ ﺩﺍﺷﺘﻦ ﻫﺮﮔﻮﻧﻪ ﺳﻮﺍﻝ ﺑﺎ ﺷﻤﺎ ﺗﻤﺎﺱ ﺧﻮﺍﻫﻨﺪ ﮔﺮﻓﺖ.</string>
 	<string name="navigation_stop_button">توقف</string>
-	<string name="recent_track_background_dialog_message">Organic Maps  از اطلاعات موقعیت مکانی شما در پس ضمینه برای ذخیره مسیر‌هایی که اخیرا سفر کرده اید استفاده می کند.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">ضبط مسیر</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -247,12 +247,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Viimeisin reitti</string>
 	<string name="pref_map_auto_zoom">Automaattinen zoomaus</string>
-	<string name="duration_disabled">Pois päältä</string>
-	<string name="duration_1_hour">1 tunti</string>
-	<string name="duration_2_hours">2 tuntia</string>
-	<string name="duration_6_hours">6 tuntia</string>
-	<string name="duration_12_hours">12 tuntia</string>
-	<string name="duration_1_day">1 päivä</string>
 	<string name="placepage_distance">Etäisyys</string>
 	<string name="search_show_on_map">Näytä kartalla</string>
 	<!-- Menu button -->
@@ -567,7 +561,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Varmista, ettet syöttänyt henkilökohtaisia tietojasi.</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap-editorit tarkistavat muutokset ja ottavat sinuun yhteyttä, jos heillä on kysyttävää.</string>
 	<string name="navigation_stop_button">Lopeta</string>
-	<string name="recent_track_background_dialog_message">Organic Maps käyttää sijaintipalveluita taustalla viimeisimmän reittisi tallentamiseksi.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Reitin kirjaaminen</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -248,12 +248,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Parcours récent</string>
 	<string name="pref_map_auto_zoom">Zoom automatique</string>
-	<string name="duration_disabled">Désactivé</string>
-	<string name="duration_1_hour">1 heure</string>
-	<string name="duration_2_hours">2 heures</string>
-	<string name="duration_6_hours">6 heures</string>
-	<string name="duration_12_hours">12 heures</string>
-	<string name="duration_1_day">1 jour</string>
 	<string name="placepage_distance">Distance</string>
 	<string name="search_show_on_map">Voir sur la carte</string>
 	<!-- Menu button -->
@@ -569,7 +563,6 @@
 	<!-- Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Assurez-vous de n’avoir pas saisi de données personnelles.</string>
 	<string name="editor_share_to_all_dialog_message_2">Les contributeurs d\'OpenStreetMap vérifieront vos modifications et vous contacteront s\'ils ont des questions.</string>
-	<string name="recent_track_background_dialog_message">Organic Maps utilise votre géolocalisation en arrière-plan pour enregistrer vos itinéraires récents.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Enregistreur de traces</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -246,12 +246,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">हालिया ट्रैक</string>
 	<string name="pref_map_auto_zoom">ऑटो ज़ूम</string>
-	<string name="duration_disabled">बंद</string>
-	<string name="duration_1_hour">1 घंटा</string>
-	<string name="duration_2_hours">2 घंटे</string>
-	<string name="duration_6_hours">6 घंटे</string>
-	<string name="duration_12_hours">12 घंटे</string>
-	<string name="duration_1_day">1 दिन</string>
 	<string name="placepage_distance">दूरी</string>
 	<string name="search_show_on_map">मानचित्र पर देखें</string>
 	<!-- Menu button -->
@@ -406,7 +400,6 @@
 	<string name="editor_remove_place_button">मिटाना</string>
 	<string name="editor_place_doesnt_exist">जगह मौजूद नहीं है</string>
 	<string name="placepage_add_place_button">OpenStreetMap में स्थान जोड़ें</string>
-	<string name="recent_track_background_dialog_message">Organic Maps आपके हाल ही में यात्रा किए गए मार्ग को रिकॉर्ड करने के लिए पृष्ठभूमि में आपके स्थान का उपयोग करता है।</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">ट्रैक रिकॉर्ड करना</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -242,12 +242,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Legutolsó útvonal</string>
 	<string name="pref_map_auto_zoom">Automatikus nagyítás</string>
-	<string name="duration_disabled">Kikapcsolva</string>
-	<string name="duration_1_hour">1 óra</string>
-	<string name="duration_2_hours">2 óra</string>
-	<string name="duration_6_hours">6 óra</string>
-	<string name="duration_12_hours">12 óra</string>
-	<string name="duration_1_day">1 nap</string>
 	<string name="placepage_distance">Távolság</string>
 	<string name="search_show_on_map">Megtekintés a térképen</string>
 	<!-- Text in menu -->
@@ -545,7 +539,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Győződj meg arról, hogy nem adsz meg semmilyen személyes információt.</string>
 	<string name="editor_share_to_all_dialog_message_2">Az OpenStreetMap szerkesztői ellenőrzik a változásokat, és felveszik Önnel a kapcsolatot, ha kérdéseik vannak.</string>
 	<string name="navigation_stop_button">Megállítás</string>
-	<string name="recent_track_background_dialog_message">A Organic Maps a geopozíciód használatával a háttérben rögzíti a legutóbb megtett utad.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">A nyomvonal rögzítése</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -230,12 +230,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Jalur terkini</string>
 	<string name="pref_map_auto_zoom">Perbesar otomatis</string>
-	<string name="duration_disabled">Nonaktif</string>
-	<string name="duration_1_hour">1 jam</string>
-	<string name="duration_2_hours">2 jam</string>
-	<string name="duration_6_hours">6 jam</string>
-	<string name="duration_12_hours">12 jam</string>
-	<string name="duration_1_day">1 hari</string>
 	<string name="placepage_distance">Jarak</string>
 	<string name="search_show_on_map">Tampilkan pada peta</string>
 	<!-- Text in menu -->
@@ -534,7 +528,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Pastikan Anda tidak memasukkan data pribadi apa pun.</string>
 	<string name="editor_share_to_all_dialog_message_2">Editor OpenStreetMap akan memeriksa perubahan dan menghubungi Anda jika ada pertanyaan.</string>
 	<string name="navigation_stop_button">Berhenti</string>
-	<string name="recent_track_background_dialog_message">Organic Maps menggunakan geoposisi di latar belakang untuk merekam rute yang baru Anda lalui.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Merekam jejak</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -233,12 +233,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Percorso recente</string>
 	<string name="pref_map_auto_zoom">Zoom automatico</string>
-	<string name="duration_disabled">Spento</string>
-	<string name="duration_1_hour">1 ora</string>
-	<string name="duration_2_hours">2 ore</string>
-	<string name="duration_6_hours">6 ore</string>
-	<string name="duration_12_hours">12 ore</string>
-	<string name="duration_1_day">1 giorno</string>
 	<string name="placepage_distance">Distanza</string>
 	<string name="search_show_on_map">Visualizza sulla mappa</string>
 	<!-- Text in menu -->
@@ -548,7 +542,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Assicurati di non aver inserito alcun dato personale.</string>
 	<string name="editor_share_to_all_dialog_message_2">Gli editori di OpenStreetMap controlleranno le modifiche e si metteranno in contatto con te in caso di domande.</string>
 	<string name="navigation_stop_button">Ferma</string>
-	<string name="recent_track_background_dialog_message">Organic Maps usa la tua posizione geografica per registrare il tuo percorso effettuato più di recente.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Registrazione della traccia</string>
 	<!-- For the first routing -->
@@ -1240,9 +1233,9 @@
 	<string name="type.highway.motorway_link.tunnel">Tunnel</string>
 	<string name="type.highway.path">Sentiero</string>
 	<!-- Hiking trail tagged as sac_scale=demanding_mountain_hiking (3 of 6) or trail_visibility=bad. -->
-	<string name="type.highway.path.difficult">Sentiero</string>
+	<string name="type.highway.path.difficult">Sentiero difficile o poco tracciato</string>
 	<!-- Hiking trail tagged as sac_scale=alpine_hiking (4+ of 6) or trail_visibility=horrible or more extreme. -->
-	<string name="type.highway.path.expert">Sentiero</string>
+	<string name="type.highway.path.expert">Sentiero estremamente difficile o molto poco tracciato</string>
 	<string name="type.highway.path.bicycle">Sentiero</string>
 	<string name="type.highway.footway.bicycle">Sentiero</string>
 	<!-- These translations are used for all type.highway.*.bridge. -->

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -243,12 +243,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">מסלול אחרון</string>
 	<string name="pref_map_auto_zoom">זום אוטומטי</string>
-	<string name="duration_disabled">כבוי</string>
-	<string name="duration_1_hour">1 שעה</string>
-	<string name="duration_2_hours">2 שעות</string>
-	<string name="duration_6_hours">6 שעות</string>
-	<string name="duration_12_hours">12 שעות</string>
-	<string name="duration_1_day">1 יום</string>
 	<string name="placepage_distance">מרחק</string>
 	<string name="search_show_on_map">הראה במפה</string>
 	<!-- Menu button -->
@@ -557,7 +551,6 @@
 	<string name="editor_share_to_all_dialog_message_1">יש לוודא שלא הזנת מידע אישי או פרטי.</string>
 	<string name="editor_share_to_all_dialog_message_2">עורכי OpenStreetMap יבדקו את השינויים ויצרו איתך קשר אם יש להם שאלות כלשהן.</string>
 	<string name="navigation_stop_button">עצור</string>
-	<string name="recent_track_background_dialog_message">האפליקצייה Organic Maps משתמשת במיקום שלך ברקע כדי להקליט את המסלול האחרון שלך.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">הקלטת המסלול</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -245,12 +245,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">最近のトラック</string>
 	<string name="pref_map_auto_zoom">自動ズーム</string>
-	<string name="duration_disabled">オフ</string>
-	<string name="duration_1_hour">1時間</string>
-	<string name="duration_2_hours">2時間</string>
-	<string name="duration_6_hours">6時間</string>
-	<string name="duration_12_hours">12時間</string>
-	<string name="duration_1_day">1日</string>
 	<string name="placepage_distance">距離</string>
 	<string name="search_show_on_map">地図に表示</string>
 	<!-- Menu button -->
@@ -567,7 +561,6 @@
 	<string name="editor_share_to_all_dialog_message_1">個人情報を入力していないことを確認してください。</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap の編集者が変更を確認し、質問があれば連絡します。</string>
 	<string name="navigation_stop_button">停止</string>
-	<string name="recent_track_background_dialog_message">Organic Mapsは、あなたの位置情報をバックグラウンドで使用して最近の走行ルートを記録します。</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">トラックの記録</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -228,12 +228,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">최근 추적</string>
 	<string name="pref_map_auto_zoom">자동 줌</string>
-	<string name="duration_disabled">선택 안 함</string>
-	<string name="duration_1_hour">1시간</string>
-	<string name="duration_2_hours">2시간</string>
-	<string name="duration_6_hours">6시간</string>
-	<string name="duration_12_hours">12시간</string>
-	<string name="duration_1_day">1일</string>
 	<string name="placepage_distance">거리</string>
 	<string name="search_show_on_map">지도 보기</string>
 	<!-- Text in menu -->
@@ -532,7 +526,6 @@
 	<string name="editor_share_to_all_dialog_message_1">개인 정보를 입력하지 않았는지 확인하십시오.</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap 편집자가 변경 사항을 확인하고 질문이 있는 경우 귀하에게 연락할 것입니다.</string>
 	<string name="navigation_stop_button">중지</string>
-	<string name="recent_track_background_dialog_message">Organic Maps는 최근 여행한 경로를 녹음하기 위해 배경 화면에서 지역 위치 서비스를 사용합니다.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">트랙 기록하기</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -219,12 +219,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">अलीकडील ट्रॅक</string>
 	<string name="pref_map_auto_zoom">स्वयं झूम</string>
-	<string name="duration_disabled">बंद</string>
-	<string name="duration_1_hour">१ तास</string>
-	<string name="duration_2_hours">२ तास</string>
-	<string name="duration_6_hours">६ तास</string>
-	<string name="duration_12_hours">१२ तास</string>
-	<string name="duration_1_day">१ दिवस</string>
 	<string name="placepage_distance">अंतर</string>
 	<string name="search_show_on_map">नकाशावर पहा</string>
 	<!-- Text in menu -->
@@ -529,7 +523,6 @@
 	<!-- Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">आपण कोणतीही वैयक्तिक माहिती प्रविष्ट केला नाही याची खात्री करा.</string>
 	<string name="navigation_stop_button">थांबा</string>
-	<string name="recent_track_background_dialog_message">तुम्ही अलीकडे प्रवास केलेला मार्ग रेकॉर्ड करण्यासाठी Organic Maps पार्श्वभूमीत तुमचे स्थान वापरते.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">ट्रॅक रेकॉर्ड करत आहे</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -247,12 +247,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Siste rute</string>
 	<string name="pref_map_auto_zoom">Automatisk zooming</string>
-	<string name="duration_disabled">Av</string>
-	<string name="duration_1_hour">1 time</string>
-	<string name="duration_2_hours">2 timer</string>
-	<string name="duration_6_hours">6 timer</string>
-	<string name="duration_12_hours">12 timer</string>
-	<string name="duration_1_day">1 dag</string>
 	<string name="placepage_distance">Avstand</string>
 	<string name="search_show_on_map">Vis på kartet</string>
 	<!-- Menu button -->
@@ -565,7 +559,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Sørg for at du ikke har skrevet noe personlig informasjon.</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap-redaktører vil sjekke endringene og ta kontakt med deg hvis de har spørsmål.</string>
 	<string name="navigation_stop_button">Stopp</string>
-	<string name="recent_track_background_dialog_message">Organic Maps bruker geografiske funksjoner i bakgrunnen for å registrere din nylig reiste rute.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Registrere sporet</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -245,12 +245,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Recente track</string>
 	<string name="pref_map_auto_zoom">Automatisch zoomen</string>
-	<string name="duration_disabled">Uit</string>
-	<string name="duration_1_hour">1 uur</string>
-	<string name="duration_2_hours">2 uur</string>
-	<string name="duration_6_hours">6 uur</string>
-	<string name="duration_12_hours">12 uur</string>
-	<string name="duration_1_day">1 dag</string>
 	<string name="placepage_distance">Afstand</string>
 	<string name="search_show_on_map">Bekijk op de kaart</string>
 	<!-- Text in menu -->
@@ -561,7 +555,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Controleer dat je geen persoonlijke gegevens hebt ingevoerd.</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap-editors zullen de wijzigingen controleren en contact met u opnemen als ze vragen hebben.</string>
 	<string name="navigation_stop_button">Stop</string>
-	<string name="recent_track_background_dialog_message">Organic Maps gebruikt uw geografische positie op de achtergrond om uw onlangs afgelegde route vast te leggen.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Het spoor opnemen</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -245,12 +245,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Ostatnia trasa</string>
 	<string name="pref_map_auto_zoom">Automatyczne powiększanie</string>
-	<string name="duration_disabled">Wyłączona</string>
-	<string name="duration_1_hour">1 godzina</string>
-	<string name="duration_2_hours">2 godziny</string>
-	<string name="duration_6_hours">6 godzin</string>
-	<string name="duration_12_hours">12 godzin</string>
-	<string name="duration_1_day">1 dzień</string>
 	<string name="placepage_distance">Dystans</string>
 	<string name="search_show_on_map">Wyświetl na mapie</string>
 	<!-- Menu button -->
@@ -564,7 +558,6 @@
 	<!-- Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Upewnij się, że nie podałeś osobistych danych.</string>
 	<string name="editor_share_to_all_dialog_message_2">Redaktorzy OpenStreetMap sprawdzą zmiany i skontaktują się z Tobą, jeśli będą mieli jakiekolwiek pytania.</string>
-	<string name="recent_track_background_dialog_message">Organic Maps używa w tle geolokalizacji w celu rejestrowania niedawno przebytej trasy.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Rejestrowanie trasy</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -233,12 +233,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Percurso recente</string>
 	<string name="pref_map_auto_zoom">Zoom automático</string>
-	<string name="duration_disabled">Desligado</string>
-	<string name="duration_1_hour">1 hora</string>
-	<string name="duration_2_hours">2 horas</string>
-	<string name="duration_6_hours">6 horas</string>
-	<string name="duration_12_hours">12 horas</string>
-	<string name="duration_1_day">1 dia</string>
 	<string name="placepage_distance">Distância</string>
 	<string name="search_show_on_map">Ver no mapa</string>
 	<!-- Text in menu -->
@@ -514,7 +508,6 @@
 	<!-- Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Certifique-se de não ter incluído nenhum dado pessoal.</string>
 	<string name="editor_share_to_all_dialog_message_2">Os editores do OpenStreetMap verificarão as mudanças e entrarão em contato com você se tiverem alguma dúvida.</string>
-	<string name="recent_track_background_dialog_message">O Organic Maps usa sua localização geográfica em segundo plano para registrar sua rota recente.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Registro da pista</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -233,12 +233,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Percurso recente</string>
 	<string name="pref_map_auto_zoom">Ampliação automática</string>
-	<string name="duration_disabled">Desligado</string>
-	<string name="duration_1_hour">1 hora</string>
-	<string name="duration_2_hours">2 horas</string>
-	<string name="duration_6_hours">6 horas</string>
-	<string name="duration_12_hours">12 horas</string>
-	<string name="duration_1_day">1 dia</string>
 	<string name="placepage_distance">Distância</string>
 	<string name="search_show_on_map">Ver no mapa</string>
 	<!-- Text in menu -->
@@ -539,7 +533,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Certifique-se que não incluiu nenhuns dados pessoais.</string>
 	<string name="editor_share_to_all_dialog_message_2">Os editores do OpenStreetMap verificarão as alterações e entrarão em contacto consigo se tiverem alguma dúvida.</string>
 	<string name="navigation_stop_button">Parar</string>
-	<string name="recent_track_background_dialog_message">O Organic Maps usa a sua localização geográfica em segundo plano para gravar a sua rota recente.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Registar a pista</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -233,12 +233,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Traseu recent</string>
 	<string name="pref_map_auto_zoom">Zoom automat</string>
-	<string name="duration_disabled">Oprit</string>
-	<string name="duration_1_hour">1 oră</string>
-	<string name="duration_2_hours">2 ore</string>
-	<string name="duration_6_hours">6 ore</string>
-	<string name="duration_12_hours">12 ore</string>
-	<string name="duration_1_day">1 zi</string>
 	<string name="placepage_distance">Distanță</string>
 	<string name="search_show_on_map">Vezi pe hartă</string>
 	<!-- Text in menu -->
@@ -549,7 +543,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Asigură-te că nu ai introdus niciun fel de date personale.</string>
 	<string name="editor_share_to_all_dialog_message_2">Editorii OpenStreetMap vor verifica modificările și vor lua legătura cu dvs. dacă au întrebări.</string>
 	<string name="navigation_stop_button">Oprește</string>
-	<string name="recent_track_background_dialog_message">Organic Maps folosește poziția ta geografică pentru a înregistra cel mai recent traseu urmat.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Înregistrarea traseului</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -248,12 +248,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Недавний путь</string>
 	<string name="pref_map_auto_zoom">Автозум</string>
-	<string name="duration_disabled">Выключено</string>
-	<string name="duration_1_hour">1 час</string>
-	<string name="duration_2_hours">2 часа</string>
-	<string name="duration_6_hours">6 часов</string>
-	<string name="duration_12_hours">12 часов</string>
-	<string name="duration_1_day">1 сутки</string>
 	<string name="placepage_distance">Расстояние</string>
 	<string name="search_show_on_map">Посмотреть на карте</string>
 	<!-- Menu button -->
@@ -570,7 +564,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Убедитесь, что вы не ввели личные данные.</string>
 	<string name="editor_share_to_all_dialog_message_2">Редакторы OpenStreetMap проверят изменения и свяжутся с вами, если у них возникнут вопросы.</string>
 	<string name="navigation_stop_button">Cтоп</string>
-	<string name="recent_track_background_dialog_message">Organic Maps использует вашу геопозицию в фоновом режиме для записи недавно пройденного пути.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Запись трека</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -245,12 +245,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Posledná trasa</string>
 	<string name="pref_map_auto_zoom">Automatický zoom</string>
-	<string name="duration_disabled">Vypnúť</string>
-	<string name="duration_1_hour">1 hodina</string>
-	<string name="duration_2_hours">2 hodiny</string>
-	<string name="duration_6_hours">6 hodín</string>
-	<string name="duration_12_hours">12 hodín</string>
-	<string name="duration_1_day">1 deň</string>
 	<string name="placepage_distance">Vzdialenosť</string>
 	<string name="search_show_on_map">Zobraziť na mape</string>
 	<!-- Text in menu -->
@@ -562,7 +556,6 @@
 	<!-- Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Nezadávajte žiadne osobné udaje.</string>
 	<string name="editor_share_to_all_dialog_message_2">Redaktori OpenStreetMap skontrolujú zmeny a budú vás kontaktovať, ak budú mať nejaké otázky.</string>
-	<string name="recent_track_background_dialog_message">Organic Maps používa vašu geopozíciu na pozadí pre zaznamenávanie vami nedávno precestovanej trasy.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Zaznamenávanie trasy</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -226,12 +226,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Senaste resväg</string>
 	<string name="pref_map_auto_zoom">Automatisk zoom</string>
-	<string name="duration_disabled">Av</string>
-	<string name="duration_1_hour">1 timme</string>
-	<string name="duration_2_hours">2 timmar</string>
-	<string name="duration_6_hours">6 timmar</string>
-	<string name="duration_12_hours">12 timmar</string>
-	<string name="duration_1_day">1 dag</string>
 	<string name="placepage_distance">Avstånd</string>
 	<string name="search_show_on_map">Visa på kartan</string>
 	<!-- Text in menu -->
@@ -530,7 +524,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Se till att du inte angett någon personinformation</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap-redigerare kommer att kontrollera ändringarna och kontakta dig om de har några frågor.</string>
 	<string name="navigation_stop_button">Stopp</string>
-	<string name="recent_track_background_dialog_message">Organic Maps använder din geografiska position i bakgrunden för att spela in din senaste resta rutt.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Registrering av spåret</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -230,12 +230,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">เส้นทางล่าสุด</string>
 	<string name="pref_map_auto_zoom">ซูมอัตโนมัติ</string>
-	<string name="duration_disabled">ปิด</string>
-	<string name="duration_1_hour">1 ชั่วโมง</string>
-	<string name="duration_2_hours">2 ชั่วโมง</string>
-	<string name="duration_6_hours">6 ชั่วโมง</string>
-	<string name="duration_12_hours">12 ชั่วโมง</string>
-	<string name="duration_1_day">1 วัน</string>
 	<string name="placepage_distance">ระยะห่าง</string>
 	<string name="search_show_on_map">ดูบนแผนที่</string>
 	<!-- Text in menu -->
@@ -534,7 +528,6 @@
 	<string name="editor_share_to_all_dialog_message_1">ตรวจสอบว่าคุณไม่ได้กรอกข้อมูลส่วนตัวใด ๆ</string>
 	<string name="editor_share_to_all_dialog_message_2">ผู้แก้ไข OpenStreetMap จะตรวจสอบการเปลี่ยนแปลงและติดต่อคุณหากมีคำถามใดๆ</string>
 	<string name="navigation_stop_button">หยุด</string>
-	<string name="recent_track_background_dialog_message">Organic Maps ใช้ตำแหน่งทางภูมิศาสตร์ของคุณในพื้นหลังเพื่อบันทึกเส้นทางที่คุณเดินทางเมื่อเร็ว ๆ นี้</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">การบันทึกเส้นทาง</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -247,12 +247,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">En sonki rotayı kaydet</string>
 	<string name="pref_map_auto_zoom">Otomatik yakınlaştırma</string>
-	<string name="duration_disabled">Kapalı</string>
-	<string name="duration_1_hour">1 saat</string>
-	<string name="duration_2_hours">2 saat</string>
-	<string name="duration_6_hours">6 saat</string>
-	<string name="duration_12_hours">12 saat</string>
-	<string name="duration_1_day">1 gün</string>
 	<string name="placepage_distance">Mesafe</string>
 	<string name="search_show_on_map">Haritada görüntüle</string>
 	<!-- Text in menu -->
@@ -567,7 +561,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Herhangi bir kişisel bilgi girmediğinizden emin olun.</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap editörleri değişikliklerinizi kontrol edecek ve bir soruları olursa sizinle iletişime geçecekler.</string>
 	<string name="navigation_stop_button">Dur</string>
-	<string name="recent_track_background_dialog_message">Organic Maps, en son seyahat ettiğiniz rotayı kaydetmek için arka planda coğrafi konumunuzu kullanır.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Yolun kaydedilmesi</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -248,12 +248,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Недавній маршрут</string>
 	<string name="pref_map_auto_zoom">Автозум</string>
-	<string name="duration_disabled">Вимкнуто</string>
-	<string name="duration_1_hour">1 година</string>
-	<string name="duration_2_hours">2 години</string>
-	<string name="duration_6_hours">6 годин</string>
-	<string name="duration_12_hours">12 годин</string>
-	<string name="duration_1_day">1 день</string>
 	<string name="placepage_distance">Відстань</string>
 	<string name="search_show_on_map">Подивитись на мапі</string>
 	<!-- Menu button -->
@@ -567,7 +561,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Переконайтеся, що ви не ввели особисті дані.</string>
 	<string name="editor_share_to_all_dialog_message_2">Редактори OpenStreetMap перевірять зміни та зв’яжуться з вами, якщо у них виникнуть запитання.</string>
 	<string name="navigation_stop_button">Cтоп</string>
-	<string name="recent_track_background_dialog_message">Organic Maps використовує вашу геопозицію у фоновому режимі для запису нещодавно пройденого шляху.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Запис маршруту</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -228,12 +228,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Tìm kiếm gần đây</string>
 	<string name="pref_map_auto_zoom">Ống dòm tự động</string>
-	<string name="duration_disabled">Tắt</string>
-	<string name="duration_1_hour">1 giờ</string>
-	<string name="duration_2_hours">2 giờ</string>
-	<string name="duration_6_hours">6 giờ</string>
-	<string name="duration_12_hours">12 giờ</string>
-	<string name="duration_1_day">1 ngày</string>
 	<string name="placepage_distance">Khoảng cách</string>
 	<string name="search_show_on_map">Xem trên bản đồ</string>
 	<!-- Text in menu -->
@@ -532,7 +526,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Chắc chắn rằng bạn không nhập bất kỳ thông tin cá nhân nào.</string>
 	<string name="editor_share_to_all_dialog_message_2">Các biên tập viên của OpenStreetMap sẽ kiểm tra các thay đổi và liên hệ với bạn nếu họ có bất kỳ câu hỏi nào.</string>
 	<string name="navigation_stop_button">Dừng</string>
-	<string name="recent_track_background_dialog_message">Organic Maps sử dụng định vị của bạn trong ứng dụng chạy nền để ghi lại tuyến đường đã đi gần đây của bạn.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Ghi lại hành trình</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -248,12 +248,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">最近的軌跡</string>
 	<string name="pref_map_auto_zoom">自動縮放</string>
-	<string name="duration_disabled">關閉</string>
-	<string name="duration_1_hour">1 小時</string>
-	<string name="duration_2_hours">2 小時</string>
-	<string name="duration_6_hours">6 小時</string>
-	<string name="duration_12_hours">12 小時</string>
-	<string name="duration_1_day">1 天</string>
 	<string name="placepage_distance">距離</string>
 	<string name="search_show_on_map">在地圖上查看</string>
 	<!-- Menu button -->
@@ -576,7 +570,6 @@
 	<string name="editor_share_to_all_dialog_message_1">確保您沒有輸入任何個人資料。</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap 編輯人員將檢查更改並在有任何問題時與您聯繫。</string>
 	<string name="navigation_stop_button">停止</string>
-	<string name="recent_track_background_dialog_message">Organic Maps 在後臺使用您的位置記錄您最近去過的路線。</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">記錄軌跡</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -248,12 +248,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">最近的轨迹</string>
 	<string name="pref_map_auto_zoom">自动缩放</string>
-	<string name="duration_disabled">关闭</string>
-	<string name="duration_1_hour">1 小时</string>
-	<string name="duration_2_hours">2 小时</string>
-	<string name="duration_6_hours">6 小时</string>
-	<string name="duration_12_hours">12 小时</string>
-	<string name="duration_1_day">1 天</string>
 	<string name="placepage_distance">距离</string>
 	<string name="search_show_on_map">在地图上查看</string>
 	<!-- Menu button -->
@@ -576,7 +570,6 @@
 	<string name="editor_share_to_all_dialog_message_1">确保您没有输入任何个人数据。</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap 编辑人员将检查更改并在有任何问题时与您联系。</string>
 	<string name="navigation_stop_button">停止</string>
-	<string name="recent_track_background_dialog_message">Organic Maps 在后台使用您的位置记录您最近去过的路线。</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">记录轨迹</string>
 	<!-- For the first routing -->

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -248,12 +248,6 @@
 	<!-- The name of the feature in the main menu, settings, and messages. -->
 	<string name="recent_track">Recent Track</string>
 	<string name="pref_map_auto_zoom">Auto zoom</string>
-	<string name="duration_disabled">Off</string>
-	<string name="duration_1_hour">1 hour</string>
-	<string name="duration_2_hours">2 hours</string>
-	<string name="duration_6_hours">6 hours</string>
-	<string name="duration_12_hours">12 hours</string>
-	<string name="duration_1_day">1 day</string>
 	<string name="placepage_distance">Distance</string>
 	<string name="search_show_on_map">View on map</string>
 	<!-- Menu button -->
@@ -592,7 +586,6 @@
 	<string name="editor_share_to_all_dialog_message_1">Make sure you did not enter any private or personal data.</string>
 	<string name="editor_share_to_all_dialog_message_2">OpenStreetMap editors will check the changes and contact you if they have any questions.</string>
 	<string name="navigation_stop_button">Stop</string>
-	<string name="recent_track_background_dialog_message">Organic Maps uses your location in the background to record your recently travelled route.</string>
 	<!-- Shown as toast when starting the recent track recording -->
 	<string name="track_recording">Recording the track</string>
 	<!-- For the first routing -->

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -6276,7 +6276,7 @@
     zh-Hant = 自動縮放
 
   [duration_disabled]
-    tags = android,ios
+    tags = ios
     en = Off
     af = Af
     ar = لا يعمل
@@ -6320,7 +6320,7 @@
     zh-Hant = 關閉
 
   [duration_1_hour]
-    tags = android,ios
+    tags = ios
     en = 1 hour
     af = 1 uur
     ar = 1 ساعة
@@ -6364,7 +6364,7 @@
     zh-Hant = 1 小時
 
   [duration_2_hours]
-    tags = android,ios
+    tags = ios
     en = 2 hours
     af = 2 uur
     ar = 2 ساعة
@@ -6408,7 +6408,7 @@
     zh-Hant = 2 小時
 
   [duration_6_hours]
-    tags = android,ios
+    tags = ios
     en = 6 hours
     af = 6 uur
     ar = 6 ساعات
@@ -6452,7 +6452,7 @@
     zh-Hant = 6 小時
 
   [duration_12_hours]
-    tags = android,ios
+    tags = ios
     en = 12 hours
     af = 12 uur
     ar = 12 ساعة
@@ -6496,7 +6496,7 @@
     zh-Hant = 12 小時
 
   [duration_1_day]
-    tags = android,ios
+    tags = ios
     en = 1 day
     af = 1 dag
     ar = 1 يوم
@@ -19287,7 +19287,7 @@
     zh-Hant = 查看
 
   [recent_track_background_dialog_message]
-    tags = android,ios
+    tags = ios
     en = Organic Maps uses your location in the background to record your recently travelled route.
     af = Organic Maps gebruik u ligging in die agtergrond om u onlangs berese roete op te neem.
     ar = يستخدم Organic Maps موقعك الجغرافي في الخلفية لتسجيل مسار سفرك الأخير.

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -2197,10 +2197,10 @@
 "type.highway.path" = "Sentiero";
 
 /* Hiking trail tagged as sac_scale=demanding_mountain_hiking (3 of 6) or trail_visibility=bad. */
-"type.highway.path.difficult" = "Sentiero";
+"type.highway.path.difficult" = "Sentiero difficile o poco tracciato";
 
 /* Hiking trail tagged as sac_scale=alpine_hiking (4+ of 6) or trail_visibility=horrible or more extreme. */
-"type.highway.path.expert" = "Sentiero";
+"type.highway.path.expert" = "Sentiero estremamente difficile o molto poco tracciato";
 
 "type.highway.path.bicycle" = "Sentiero";
 


### PR DESCRIPTION
@kavikhalique @rtsisyk These strings are not used on Android, correct? The current recent track duration is always capped now at 24H, right?