### PR TITLE
Get rid of GpsTrackInfo

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/LocationState.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/LocationState.cpp
@@ -85,7 +85,7 @@ Java_app_organicmaps_location_LocationState_nativeLocationUpdated(JNIEnv * env, 
     info.m_bearing = bearing;
 
   if (speed > 0.0)
-    info.m_speedMpS = speed;
+    info.m_speed = speed;
 
   g_framework->OnLocationUpdated(info);
   GpsTracker::Instance().OnLocationUpdated(info);

--- a/drape_frontend/my_position_controller.cpp
+++ b/drape_frontend/my_position_controller.cpp
@@ -407,11 +407,11 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
   m_errorRadius = rect.SizeX() * 0.5;
   m_horizontalAccuracy = info.m_horizontalAccuracy;
 
-  if (info.m_speedMpS > 0.0)
+  if (info.m_speed > 0.0)
   {
     double const mercatorPerMeter = m_errorRadius / info.m_horizontalAccuracy;
-    m_autoScale2d = mercatorPerMeter * CalculateZoomBySpeed(info.m_speedMpS, false /* isPerspectiveAllowed */);
-    m_autoScale3d = mercatorPerMeter * CalculateZoomBySpeed(info.m_speedMpS, true /* isPerspectiveAllowed */);
+    m_autoScale2d = mercatorPerMeter * CalculateZoomBySpeed(info.m_speed, false /* isPerspectiveAllowed */);
+    m_autoScale3d = mercatorPerMeter * CalculateZoomBySpeed(info.m_speed, true /* isPerspectiveAllowed */);
   }
   else
   {
@@ -423,7 +423,7 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
   // 2. Direction must be glued to the route during routing (route-corrected angle is set only in
   // OnLocationUpdate(): in OnCompassUpdate() the angle always has the original value.
   // 3. Device is moving faster then pedestrian.
-  bool const isMovingFast = info.HasSpeed() && info.m_speedMpS > kMinSpeedThresholdMps;
+  bool const isMovingFast = info.HasSpeed() && info.m_speed > kMinSpeedThresholdMps;
   bool const glueArrowInRouting = isNavigable && m_isArrowGluedInRouting;
 
   if ((!m_isCompassAvailable || glueArrowInRouting || isMovingFast) && info.HasBearing())

--- a/iphone/Maps/Core/Location/location_util.h
+++ b/iphone/Maps/Core/Location/location_util.h
@@ -24,7 +24,7 @@ static location::GpsInfo gpsInfoFromLocation(CLLocation * l, location::TLocation
     info.m_bearing = l.course;
 
   if (l.speed >= 0.0)
-    info.m_speedMpS = l.speed;
+    info.m_speed = l.speed;
   return info;
 }
 

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -1149,7 +1149,7 @@ void BookmarkManager::SaveTrackRecording(std::string trackName)
   CHECK(!tracker.IsEmpty(), ("Track recording should be not be empty"));
 
   kml::MultiGeometry::LineT line;
-  tracker.ForEachTrackPoint([&line](location::GpsTrackInfo const & pt, size_t id)->bool
+  tracker.ForEachTrackPoint([&line](location::GpsInfo const & pt, size_t id)->bool
   {
     line.emplace_back(mercator::FromLatLon(pt.m_latitude, pt.m_longitude));
     return true;

--- a/map/extrapolation/extrapolator.cpp
+++ b/map/extrapolation/extrapolator.cpp
@@ -76,7 +76,7 @@ location::GpsInfo LinearExtrapolation(location::GpsInfo const & gpsInfo1,
   // look nice when the road changes its direction.
 
   if (gpsInfo1.HasSpeed() && gpsInfo2.HasSpeed())
-    result.m_speedMpS = e.Extrapolate(gpsInfo1.m_speedMpS, gpsInfo2.m_speedMpS);
+    result.m_speed = e.Extrapolate(gpsInfo1.m_speed, gpsInfo2.m_speed);
 
   return result;
 }

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1693,7 +1693,7 @@ bool Framework::IsTrackRecordingEnabled() const
   return GpsTracker::Instance().IsEnabled();
 }
 
-void Framework::OnUpdateGpsTrackPointsCallback(vector<pair<size_t, location::GpsTrackInfo>> && toAdd,
+void Framework::OnUpdateGpsTrackPointsCallback(vector<pair<size_t, location::GpsInfo>> && toAdd,
                                                pair<size_t, size_t> const & toRemove)
 {
   ASSERT(m_drapeEngine.get() != nullptr, ());

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -462,7 +462,7 @@ private:
   storage::CountryId m_lastReportedCountry;
   TCurrentCountryChanged m_currentCountryChanged;
 
-  void OnUpdateGpsTrackPointsCallback(std::vector<std::pair<size_t, location::GpsTrackInfo>> && toAdd,
+  void OnUpdateGpsTrackPointsCallback(std::vector<std::pair<size_t, location::GpsInfo>> && toAdd,
                                       std::pair<size_t, size_t> const & toRemove);
 
   CachingRankTableLoader m_popularityLoader;

--- a/map/gps_track.cpp
+++ b/map/gps_track.cpp
@@ -195,7 +195,7 @@ void GpsTrack::InitCollection(hours duration)
       originPoints.emplace_back(originPoint);
       if (originPoints.size() == originPoints.capacity())
       {
-        vector<location::GpsTrackInfo> points;
+        vector<location::GpsInfo> points;
         m_filter->Process(originPoints, points);
 
         pair<size_t, size_t> evictedIds;
@@ -208,7 +208,7 @@ void GpsTrack::InitCollection(hours duration)
 
     if (!originPoints.empty())
     {
-      vector<location::GpsTrackInfo> points;
+      vector<location::GpsInfo> points;
       m_filter->Process(originPoints, points);
 
       pair<size_t, size_t> evictedIds;
@@ -249,7 +249,7 @@ void GpsTrack::ProcessPoints()
   if (!m_collection)
     return;
 
-  vector<location::GpsTrackInfo> points;
+  vector<location::GpsInfo> points;
   m_filter->Process(originPoints, points);
 
   pair<size_t, size_t> addedIds;
@@ -285,7 +285,7 @@ void GpsTrack::UpdateStorage(bool needClear, vector<location::GpsInfo> const & p
   }
 }
 
-void GpsTrack::UpdateCollection(hours duration, bool needClear, vector<location::GpsTrackInfo> const & points,
+void GpsTrack::UpdateCollection(hours duration, bool needClear, vector<location::GpsInfo> const & points,
                                 pair<size_t, size_t> & addedIds, pair<size_t, size_t> & evictedIds)
 {
   // Apply Clear, SetDuration and Add points
@@ -323,9 +323,9 @@ void GpsTrack::NotifyCallback(pair<size_t, size_t> const & addedIds, pair<size_t
   {
     m_needSendSnapshop = false;
 
-    vector<pair<size_t, location::GpsTrackInfo>> toAdd;
+    vector<pair<size_t, location::GpsInfo>> toAdd;
     toAdd.reserve(m_collection->GetSize());
-    m_collection->ForEach([&toAdd](location::GpsTrackInfo const & point, size_t id)->bool
+    m_collection->ForEach([&toAdd](location::GpsInfo const & point, size_t id)->bool
     {
       toAdd.emplace_back(id, point);
       return true;
@@ -338,13 +338,13 @@ void GpsTrack::NotifyCallback(pair<size_t, size_t> const & addedIds, pair<size_t
   }
   else
   {
-    vector<pair<size_t, location::GpsTrackInfo>> toAdd;
+    vector<pair<size_t, location::GpsInfo>> toAdd;
     if (addedIds.first != kInvalidId)
     {
       size_t const addedCount = addedIds.second - addedIds.first + 1;
       ASSERT_GREATER_OR_EQUAL(m_collection->GetSize(), addedCount, ());
       toAdd.reserve(addedCount);
-      m_collection->ForEach([&toAdd](location::GpsTrackInfo const & point, size_t id)->bool
+      m_collection->ForEach([&toAdd](location::GpsInfo const & point, size_t id)->bool
       {
         toAdd.emplace_back(id, point);
         return true;

--- a/map/gps_track.hpp
+++ b/map/gps_track.hpp
@@ -53,7 +53,7 @@ public:
   /// @param toRemove - range of point indices to remove, or pair(kInvalidId,kInvalidId) if nothing to remove
   /// @note Calling of a GpsTrack.SetCallback function from the callback causes deadlock.
   using TGpsTrackDiffCallback =
-      std::function<void(std::vector<std::pair<size_t, location::GpsTrackInfo>> && toAdd,
+      std::function<void(std::vector<std::pair<size_t, location::GpsInfo>> && toAdd,
                          std::pair<size_t, size_t> const & toRemove)>;
 
   /// Sets callback on change of gps track.
@@ -79,7 +79,7 @@ private:
   void InitCollection(std::chrono::hours duration);
   void UpdateStorage(bool needClear, std::vector<location::GpsInfo> const & points);
   void UpdateCollection(std::chrono::hours duration, bool needClear,
-                        std::vector<location::GpsTrackInfo> const & points,
+                        std::vector<location::GpsInfo> const & points,
                         std::pair<size_t, size_t> & addedIds,
                         std::pair<size_t, size_t> & evictedIds);
   void NotifyCallback(std::pair<size_t, size_t> const & addedIds,

--- a/map/gps_track_collection.hpp
+++ b/map/gps_track_collection.hpp
@@ -13,7 +13,7 @@ class GpsTrackCollection final
 public:
   static size_t const kInvalidId; // = numeric_limits<size_t>::max();
 
-  using TItem = location::GpsTrackInfo;
+  using TItem = location::GpsInfo;
 
   /// Constructor
   /// @param maxSize - max number of items in collection

--- a/map/gps_track_filter.cpp
+++ b/map/gps_track_filter.cpp
@@ -40,7 +40,7 @@ double GetDistance(location::GpsInfo const & from, location::GpsInfo const & to)
 } // namespace
 
 void GpsTrackNullFilter::Process(std::vector<location::GpsInfo> const & inPoints,
-                                 std::vector<location::GpsTrackInfo> & outPoints)
+                                 std::vector<location::GpsInfo> & outPoints)
 {
   outPoints.insert(outPoints.end(), inPoints.begin(), inPoints.end());
 }
@@ -59,7 +59,7 @@ GpsTrackFilter::GpsTrackFilter()
 }
 
 void GpsTrackFilter::Process(std::vector<location::GpsInfo> const & inPoints,
-                             std::vector<location::GpsTrackInfo> & outPoints)
+                             std::vector<location::GpsInfo> & outPoints)
 {
   outPoints.reserve(inPoints.size());
 

--- a/map/gps_track_filter.cpp
+++ b/map/gps_track_filter.cpp
@@ -145,7 +145,7 @@ bool GpsTrackFilter::IsGoodPoint(location::GpsInfo const & info) const
   double const speedFromLast = distanceFromLast / timeFromLast;
 
   // Filter by acceleration: skip point if it jumps too far in short time
-  double const accelerationFromLast = (speedFromLast - lastInfo.m_speedMpS) / timeFromLast;
+  double const accelerationFromLast = (speedFromLast - lastInfo.m_speed) / timeFromLast;
   if (accelerationFromLast > kMaxAcceptableAcceleration)
     return false;
 

--- a/map/gps_track_filter.hpp
+++ b/map/gps_track_filter.hpp
@@ -13,7 +13,7 @@ public:
   virtual ~IGpsTrackFilter() = default;
 
   virtual void Process(std::vector<location::GpsInfo> const & inPoints,
-                       std::vector<location::GpsTrackInfo> & outPoints) = 0;
+                       std::vector<location::GpsInfo> & outPoints) = 0;
 };
 
 class GpsTrackNullFilter : public IGpsTrackFilter
@@ -21,7 +21,7 @@ class GpsTrackNullFilter : public IGpsTrackFilter
 public:
   // IGpsTrackFilter overrides
   void Process(std::vector<location::GpsInfo> const & inPoints,
-               std::vector<location::GpsTrackInfo> & outPoints) override;
+               std::vector<location::GpsInfo> & outPoints) override;
 };
 
 class GpsTrackFilter : public IGpsTrackFilter
@@ -34,7 +34,7 @@ public:
 
   // IGpsTrackFilter overrides
   void Process(std::vector<location::GpsInfo> const & inPoints,
-               std::vector<location::GpsTrackInfo> & outPoints) override;
+               std::vector<location::GpsInfo> & outPoints) override;
 
 private:
   bool IsGoodPoint(location::GpsInfo const & info) const;

--- a/map/gps_track_storage.cpp
+++ b/map/gps_track_storage.cpp
@@ -47,12 +47,12 @@ T MemRead(void const * ptr)
 }
 
 void Pack(char * p, location::GpsInfo const & info)
-{  
+{
   MemWrite<double>(p + 0 * sizeof(double), info.m_timestamp);
   MemWrite<double>(p + 1 * sizeof(double), info.m_latitude);
   MemWrite<double>(p + 2 * sizeof(double), info.m_longitude);
   MemWrite<double>(p + 3 * sizeof(double), info.m_altitude);
-  MemWrite<double>(p + 4 * sizeof(double), info.m_speedMpS);
+  MemWrite<double>(p + 4 * sizeof(double), info.m_speed);
   MemWrite<double>(p + 5 * sizeof(double), info.m_bearing);
   MemWrite<double>(p + 6 * sizeof(double), info.m_horizontalAccuracy);
   MemWrite<double>(p + 7 * sizeof(double), info.m_verticalAccuracy);
@@ -67,7 +67,7 @@ void Unpack(char const * p, location::GpsInfo & info)
   info.m_latitude = MemRead<double>(p + 1 * sizeof(double));
   info.m_longitude = MemRead<double>(p + 2 * sizeof(double));
   info.m_altitude = MemRead<double>(p + 3 * sizeof(double));
-  info.m_speedMpS = MemRead<double>(p + 4 * sizeof(double));
+  info.m_speed = MemRead<double>(p + 4 * sizeof(double));
   info.m_bearing = MemRead<double>(p + 5 * sizeof(double));
   info.m_horizontalAccuracy = MemRead<double>(p + 6 * sizeof(double));
   info.m_verticalAccuracy = MemRead<double>(p + 7 * sizeof(double));
@@ -124,7 +124,7 @@ GpsTrackStorage::GpsTrackStorage(string const & filePath, size_t maxItemCount)
     m_itemCount = 0;
   };
 
-  
+
   // Open existing file
   m_stream.open(m_filePath, ios::in | ios::out | ios::binary);
 
@@ -155,7 +155,7 @@ GpsTrackStorage::GpsTrackStorage(string const & filePath, size_t maxItemCount)
       m_stream.seekp(offset, ios::beg);
       if (!m_stream.good())
         MYTHROW(OpenException, ("Seek to the offset error:", offset, m_filePath));
-      
+
       LOG(LINFO, ("Restored", m_itemCount, "points from gps track storage"));
     }
     else
@@ -250,7 +250,7 @@ void GpsTrackStorage::ForEach(std::function<bool(TItem const & item)> const & fn
       MYTHROW(ReadException, ("File:", m_filePath));
 
     for (size_t j = 0; j < n; ++j)
-    {      
+    {
       TItem item;
       Unpack(&buff[0] + j * kPointSize, item);
       if (!fn(item))

--- a/map/gps_tracker.hpp
+++ b/map/gps_tracker.hpp
@@ -22,7 +22,7 @@ public:
   void SetDuration(std::chrono::hours duration);
 
   using TGpsTrackDiffCallback =
-      std::function<void(std::vector<std::pair<size_t, location::GpsTrackInfo>> && toAdd,
+      std::function<void(std::vector<std::pair<size_t, location::GpsInfo>> && toAdd,
                          std::pair<size_t, size_t> const & toRemove)>;
 
   void Connect(TGpsTrackDiffCallback const & fn);
@@ -30,7 +30,7 @@ public:
 
   void OnLocationUpdated(location::GpsInfo const & info);
 
-  using GpsTrackCallback = std::function<bool(location::GpsTrackInfo const &, size_t)>;
+  using GpsTrackCallback = std::function<bool(location::GpsInfo const &, size_t)>;
   void ForEachTrackPoint(GpsTrackCallback const & callback) const;
 
 private:

--- a/map/map_tests/extrapolator_tests.cpp
+++ b/map/map_tests/extrapolator_tests.cpp
@@ -22,7 +22,7 @@ void TestGpsInfo(GpsInfo const & tested, GpsInfo const & expected)
   TEST(base::AlmostEqualAbs(tested.m_altitude, expected.m_altitude, kEpsilon), ());
   TEST(base::AlmostEqualAbs(tested.m_verticalAccuracy, expected.m_verticalAccuracy, kEpsilon), ());
   TEST(base::AlmostEqualAbs(tested.m_bearing, expected.m_bearing, kEpsilon), ());
-  TEST(base::AlmostEqualAbs(tested.m_speedMpS, expected.m_speedMpS, kEpsilon), ());
+  TEST(base::AlmostEqualAbs(tested.m_speed, expected.m_speed, kEpsilon), ());
 }
 
 GpsInfo GetGpsInfo(double timestampS, double lat, double lon, double altitude, double speed)
@@ -41,9 +41,9 @@ GpsInfo GetGpsInfo(double timestampS, double lat, double lon, double altitude, d
 UNIT_TEST(LinearExtrapolation)
 {
   GpsInfo const loc1 = GetGpsInfo(0.0 /* timestampS */, 1.0 /* m_latitude */, 1.0 /* m_longitude */,
-                                  1.0 /* m_altitude */, 10.0 /* m_speedMpS */);
+                                  1.0 /* m_altitude */, 10.0 /* m_speed */);
   GpsInfo const loc2 = GetGpsInfo(1.0 /* timestampS */, 1.01 /* m_latitude */, 1.01 /* m_longitude */,
-                                  2.0 /* m_altitude */, 12.0 /* m_speedMpS */);
+                                  2.0 /* m_altitude */, 12.0 /* m_speed */);
 
   // 0 ms after |point2|.
   TestGpsInfo(LinearExtrapolation(loc1, loc2, 0 /* timeAfterPoint2Ms */), loc2);
@@ -51,21 +51,21 @@ UNIT_TEST(LinearExtrapolation)
   // 100 ms after |point2|.
   {
     GpsInfo const expected = GetGpsInfo(1.1 /* timestampS */, 1.011 /* m_latitude */,
-                                        1.011 /* m_longitude */, 2.1 /* m_altitude */, 12.2 /* m_speedMpS */);
+                                        1.011 /* m_longitude */, 2.1 /* m_altitude */, 12.2 /* m_speed */);
     TestGpsInfo(LinearExtrapolation(loc1, loc2, 100 /* timeAfterPoint2Ms */), expected);
   }
 
   // 200 ms after |point2|.
   {
     GpsInfo const expected = GetGpsInfo(1.2 /* timestampS */, 1.012 /* m_latitude */,
-                                        1.012 /* m_longitude */, 2.2 /* m_altitude */, 12.4 /* m_speedMpS */);
+                                        1.012 /* m_longitude */, 2.2 /* m_altitude */, 12.4 /* m_speed */);
     TestGpsInfo(LinearExtrapolation(loc1, loc2, 200 /* timeAfterPoint2Ms */), expected);
   }
 
   // 1000 ms after |point2|.
   {
     GpsInfo const expected = GetGpsInfo(2.0 /* timestampS */, 1.02 /* m_latitude */,
-                                        1.02 /* m_longitude */, 3.0 /* m_altitude */, 14.0 /* m_speedMpS */);
+                                        1.02 /* m_longitude */, 3.0 /* m_altitude */, 14.0 /* m_speed */);
     TestGpsInfo(LinearExtrapolation(loc1, loc2, 1000 /* timeAfterPoint2Ms */), expected);
   }
 }

--- a/map/map_tests/gps_track_collection_test.cpp
+++ b/map/map_tests/gps_track_collection_test.cpp
@@ -11,21 +11,19 @@
 #include <map>
 #include <utility>
 
-using namespace std;
+namespace gps_track_collection_test
+{
 using namespace std::chrono;
 
-namespace
+location::GpsInfo MakeGpsTrackInfo(double timestamp, ms::LatLon const & ll, double speed)
 {
-location::GpsTrackInfo MakeGpsTrackInfo(double timestamp, ms::LatLon const & ll, double speed)
-{
-  location::GpsTrackInfo info;
+  location::GpsInfo info;
   info.m_timestamp = timestamp;
   info.m_speed = speed;
   info.m_latitude = ll.m_lat;
   info.m_longitude = ll.m_lon;
   return info;
 }
-} // namespace
 
 UNIT_TEST(GpsTrackCollection_Simple)
 {
@@ -35,14 +33,14 @@ UNIT_TEST(GpsTrackCollection_Simple)
 
   GpsTrackCollection collection(100, hours(24));
 
-  map<size_t, location::GpsTrackInfo> data;
+  std::map<size_t, location::GpsInfo> data;
 
   TEST_EQUAL(100, collection.GetMaxSize(), ());
 
   for (size_t i = 0; i < 50; ++i)
   {
     auto info = MakeGpsTrackInfo(timestamp + i, ms::LatLon(-90 + i, -180 + i), i);
-    pair<size_t, size_t> evictedIds;
+    std::pair<size_t, size_t> evictedIds;
     size_t addedId = collection.Add(info, evictedIds);
     TEST_EQUAL(addedId, i, ());
     TEST_EQUAL(evictedIds.first, GpsTrackCollection::kInvalidId, ());
@@ -52,10 +50,10 @@ UNIT_TEST(GpsTrackCollection_Simple)
 
   TEST_EQUAL(50, collection.GetSize(), ());
 
-  collection.ForEach([&data](location::GpsTrackInfo const & info, size_t id)->bool
+  collection.ForEach([&data](location::GpsInfo const & info, size_t id)->bool
   {
     TEST(data.end() != data.find(id), ());
-    location::GpsTrackInfo const & originInfo = data[id];
+    location::GpsInfo const & originInfo = data[id];
     TEST_EQUAL(info.m_latitude, originInfo.m_latitude, ());
     TEST_EQUAL(info.m_longitude, originInfo.m_longitude, ());
     TEST_EQUAL(info.m_speed, originInfo.m_speed, ());
@@ -81,7 +79,7 @@ UNIT_TEST(GpsTrackCollection_EvictedByTimestamp)
 
   GpsTrackCollection collection(100, hours(24));
 
-  pair<size_t, size_t> evictedIds;
+  std::pair<size_t, size_t> evictedIds;
   size_t addedId = collection.Add(MakeGpsTrackInfo(timestamp, ms::LatLon(-90, -180), 1), evictedIds);
   TEST_EQUAL(addedId, 0, ());
   TEST_EQUAL(evictedIds.first, GpsTrackCollection::kInvalidId, ());
@@ -102,7 +100,7 @@ UNIT_TEST(GpsTrackCollection_EvictedByTimestamp)
 
   TEST_EQUAL(1, collection.GetSize(), ());
 
-  collection.ForEach([&](location::GpsTrackInfo const & info, size_t id)->bool
+  collection.ForEach([&](location::GpsInfo const & info, size_t id)->bool
   {
     TEST_EQUAL(id, 2, ());
     TEST_EQUAL(info.m_latitude, lastInfo.m_latitude, ());
@@ -127,14 +125,14 @@ UNIT_TEST(GpsTrackCollection_EvictedByCount)
 
   GpsTrackCollection collection(100, hours(24));
 
-  map<size_t, location::GpsTrackInfo> data;
+  std::map<size_t, location::GpsInfo> data;
 
   TEST_EQUAL(100, collection.GetMaxSize(), ());
 
   for (size_t i = 0; i < 100; ++i)
   {
     auto info = MakeGpsTrackInfo(timestamp + i, ms::LatLon(-90 + i, -180 + i), i);
-    pair<size_t, size_t> evictedIds;
+    std::pair<size_t, size_t> evictedIds;
     size_t addedId = collection.Add(info, evictedIds);
     TEST_EQUAL(addedId, i, ());
     TEST_EQUAL(evictedIds.first, GpsTrackCollection::kInvalidId, ());
@@ -145,7 +143,7 @@ UNIT_TEST(GpsTrackCollection_EvictedByCount)
   TEST_EQUAL(100, collection.GetSize(), ());
 
   auto info = MakeGpsTrackInfo(timestamp + 100, ms::LatLon(45, 60), 110);
-  pair<size_t, size_t> evictedIds;
+  std::pair<size_t, size_t> evictedIds;
   size_t addedId = collection.Add(info, evictedIds);
   TEST_EQUAL(addedId, 100, ());
   TEST_EQUAL(evictedIds.first, 0, ());
@@ -156,10 +154,10 @@ UNIT_TEST(GpsTrackCollection_EvictedByCount)
 
   data.erase(0);
 
-  collection.ForEach([&data](location::GpsTrackInfo const & info, size_t id)->bool
+  collection.ForEach([&data](location::GpsInfo const & info, size_t id)->bool
   {
     TEST(data.end() != data.find(id), ());
-    location::GpsTrackInfo const & originInfo = data[id];
+    location::GpsInfo const & originInfo = data[id];
     TEST_EQUAL(info.m_latitude, originInfo.m_latitude, ());
     TEST_EQUAL(info.m_longitude, originInfo.m_longitude, ());
     TEST_EQUAL(info.m_speed, originInfo.m_speed, ());
@@ -190,7 +188,7 @@ UNIT_TEST(GpsTrackCollection_EvictedByTimestamp2)
   for (size_t i = 0; i < 500; ++i)
   {
     auto info = MakeGpsTrackInfo(timestamp + i, ms::LatLon(-90 + i, -180 + i), i);
-    pair<size_t, size_t> evictedIds;
+    std::pair<size_t, size_t> evictedIds;
     size_t addedId = collection.Add(info, evictedIds);
     TEST_EQUAL(addedId, i, ());
     TEST_EQUAL(evictedIds.first, GpsTrackCollection::kInvalidId, ());
@@ -204,7 +202,7 @@ UNIT_TEST(GpsTrackCollection_EvictedByTimestamp2)
   for (size_t i = 0; i < 500; ++i)
   {
     auto info = MakeGpsTrackInfo(timestamp_12h + i, ms::LatLon(-90 + i, -180 + i), i);
-    pair<size_t, size_t> evictedIds;
+    std::pair<size_t, size_t> evictedIds;
     size_t addedId = collection.Add(info, evictedIds);
     TEST_EQUAL(addedId, 500 + i, ());
     TEST_EQUAL(evictedIds.first, GpsTrackCollection::kInvalidId, ());
@@ -216,7 +214,7 @@ UNIT_TEST(GpsTrackCollection_EvictedByTimestamp2)
   TEST_EQUAL(1000, collection.GetSize(), ());
 
   auto info = MakeGpsTrackInfo(timestamp_35h, ms::LatLon(45, 60), 110);
-  pair<size_t, size_t> evictedIds;
+  std::pair<size_t, size_t> evictedIds;
   size_t addedId = collection.Add(info, evictedIds);
   TEST_EQUAL(addedId, 1000, ());
   TEST_EQUAL(evictedIds.first, 0, ());
@@ -228,3 +226,4 @@ UNIT_TEST(GpsTrackCollection_EvictedByTimestamp2)
 
   TEST_EQUAL(0, collection.GetSize(), ());
 }
+}  // namespace gps_track_collection_test

--- a/map/map_tests/gps_track_storage_test.cpp
+++ b/map/map_tests/gps_track_storage_test.cpp
@@ -61,7 +61,7 @@ UNIT_TEST(GpsTrackStorage_WriteReadWithoutTrunc)
     stg.Append(points);
 
     size_t i = 0;
-    stg.ForEach([&](location::GpsTrackInfo const & point)->bool
+    stg.ForEach([&](location::GpsInfo const & point)->bool
     {
       TEST_EQUAL(point.m_latitude, points[i].m_latitude, ());
       TEST_EQUAL(point.m_longitude, points[i].m_longitude, ());
@@ -78,7 +78,7 @@ UNIT_TEST(GpsTrackStorage_WriteReadWithoutTrunc)
     GpsTrackStorage stg(filePath, fileMaxItemCount);
 
     size_t i = 0;
-    stg.ForEach([&](location::GpsTrackInfo const & point)->bool
+    stg.ForEach([&](location::GpsInfo const & point)->bool
     {
       TEST_EQUAL(point.m_latitude, points[i].m_latitude, ());
       TEST_EQUAL(point.m_longitude, points[i].m_longitude, ());
@@ -98,7 +98,7 @@ UNIT_TEST(GpsTrackStorage_WriteReadWithoutTrunc)
     GpsTrackStorage stg(filePath, fileMaxItemCount);
 
     size_t i = 0;
-    stg.ForEach([&](location::GpsTrackInfo const & point)->bool{ ++i; return true; });
+    stg.ForEach([&](location::GpsInfo const & point)->bool{ ++i; return true; });
     TEST_EQUAL(i, 0, ());
   }
 }

--- a/map/map_tests/gps_track_storage_test.cpp
+++ b/map/map_tests/gps_track_storage_test.cpp
@@ -25,7 +25,7 @@ location::GpsInfo Make(double timestamp, ms::LatLon const & ll, double speed)
 {
   location::GpsInfo info;
   info.m_timestamp = timestamp;
-  info.m_speedMpS = speed;
+  info.m_speed = speed;
   info.m_latitude = ll.m_lat;
   info.m_longitude = ll.m_lon;
   info.m_source = location::EAndroidNative;
@@ -66,7 +66,7 @@ UNIT_TEST(GpsTrackStorage_WriteReadWithoutTrunc)
       TEST_EQUAL(point.m_latitude, points[i].m_latitude, ());
       TEST_EQUAL(point.m_longitude, points[i].m_longitude, ());
       TEST_EQUAL(point.m_timestamp, points[i].m_timestamp, ());
-      TEST_EQUAL(point.m_speed, points[i].m_speedMpS, ());
+      TEST_EQUAL(point.m_speed, points[i].m_speed, ());
       ++i;
       return true;
     });
@@ -83,7 +83,7 @@ UNIT_TEST(GpsTrackStorage_WriteReadWithoutTrunc)
       TEST_EQUAL(point.m_latitude, points[i].m_latitude, ());
       TEST_EQUAL(point.m_longitude, points[i].m_longitude, ());
       TEST_EQUAL(point.m_timestamp, points[i].m_timestamp, ());
-      TEST_EQUAL(point.m_speed, points[i].m_speedMpS, ());
+      TEST_EQUAL(point.m_speed, points[i].m_speed, ());
       ++i;
       return true;
     });
@@ -159,14 +159,14 @@ UNIT_TEST(GpsTrackStorage_WriteReadWithTrunc)
         TEST_EQUAL(point.m_latitude, points2[fileMaxItemCount/2 + i].m_latitude, ());
         TEST_EQUAL(point.m_longitude, points2[fileMaxItemCount/2 + i].m_longitude, ());
         TEST_EQUAL(point.m_timestamp, points2[fileMaxItemCount/2 + i].m_timestamp, ());
-        TEST_EQUAL(point.m_speedMpS, points2[fileMaxItemCount/2 + i].m_speedMpS, ());
+        TEST_EQUAL(point.m_speed, points2[fileMaxItemCount/2 + i].m_speed, ());
       }
       else
       {
         TEST_EQUAL(point.m_latitude, points3[i - fileMaxItemCount/2].m_latitude, ());
         TEST_EQUAL(point.m_longitude, points3[i - fileMaxItemCount/2].m_longitude, ());
         TEST_EQUAL(point.m_timestamp, points3[i - fileMaxItemCount/2].m_timestamp, ());
-        TEST_EQUAL(point.m_speedMpS, points3[i - fileMaxItemCount/2].m_speedMpS, ());
+        TEST_EQUAL(point.m_speed, points3[i - fileMaxItemCount/2].m_speed, ());
       }
       ++i;
       return true;

--- a/map/map_tests/gps_track_test.cpp
+++ b/map/map_tests/gps_track_test.cpp
@@ -26,7 +26,7 @@ inline location::GpsInfo Make(double timestamp, ms::LatLon const & ll, double sp
 {
   location::GpsInfo info;
   info.m_timestamp = timestamp;
-  info.m_speedMpS = speed;
+  info.m_speed = speed;
   info.m_latitude = ll.m_lat;
   info.m_longitude = ll.m_lon;
   info.m_horizontalAccuracy = 15;
@@ -120,7 +120,7 @@ UNIT_TEST(GpsTrack_Simple)
     {
       TEST_EQUAL(i, callback.m_toAdd[i].first, ());
       TEST_EQUAL(points[i].m_timestamp, callback.m_toAdd[i].second.m_timestamp, ());
-      TEST_EQUAL(points[i].m_speedMpS, callback.m_toAdd[i].second.m_speed, ());
+      TEST_EQUAL(points[i].m_speed, callback.m_toAdd[i].second.m_speed, ());
       TEST_EQUAL(points[i].m_latitude, callback.m_toAdd[i].second.m_latitude, ());
       TEST_EQUAL(points[i].m_longitude, callback.m_toAdd[i].second.m_longitude, ());
     }
@@ -144,7 +144,7 @@ UNIT_TEST(GpsTrack_Simple)
     {
       TEST_EQUAL(i, callback.m_toAdd[i].first, ());
       TEST_EQUAL(points[i].m_timestamp, callback.m_toAdd[i].second.m_timestamp, ());
-      TEST_EQUAL(points[i].m_speedMpS, callback.m_toAdd[i].second.m_speed, ());
+      TEST_EQUAL(points[i].m_speed, callback.m_toAdd[i].second.m_speed, ());
       TEST_EQUAL(points[i].m_latitude, callback.m_toAdd[i].second.m_latitude, ());
       TEST_EQUAL(points[i].m_longitude, callback.m_toAdd[i].second.m_longitude, ());
     }
@@ -178,7 +178,7 @@ UNIT_TEST(GpsTrack_EvictedByAdd)
   TEST_EQUAL(1, callback.m_toAdd.size(), ());
   TEST_EQUAL(0, callback.m_toAdd[0].first, ());
   TEST_EQUAL(pt1.m_timestamp, callback.m_toAdd[0].second.m_timestamp, ());
-  TEST_EQUAL(pt1.m_speedMpS, callback.m_toAdd[0].second.m_speed, ());
+  TEST_EQUAL(pt1.m_speed, callback.m_toAdd[0].second.m_speed, ());
   TEST_EQUAL(pt1.m_latitude, callback.m_toAdd[0].second.m_latitude, ());
   TEST_EQUAL(pt1.m_longitude, callback.m_toAdd[0].second.m_longitude, ());
   // and nothing was evicted
@@ -195,7 +195,7 @@ UNIT_TEST(GpsTrack_EvictedByAdd)
   TEST_EQUAL(1, callback.m_toAdd.size(), ());
   TEST_EQUAL(1, callback.m_toAdd[0].first, ());
   TEST_EQUAL(pt2.m_timestamp, callback.m_toAdd[0].second.m_timestamp, ());
-  TEST_EQUAL(pt2.m_speedMpS, callback.m_toAdd[0].second.m_speed, ());
+  TEST_EQUAL(pt2.m_speed, callback.m_toAdd[0].second.m_speed, ());
   TEST_EQUAL(pt2.m_latitude, callback.m_toAdd[0].second.m_latitude, ());
   TEST_EQUAL(pt2.m_longitude, callback.m_toAdd[0].second.m_longitude, ());
   // and pt1 was evicted as old

--- a/map/map_tests/gps_track_test.cpp
+++ b/map/map_tests/gps_track_test.cpp
@@ -47,7 +47,7 @@ public:
     , m_gotCallback(false)
   {
   }
-  void OnUpdate(vector<pair<size_t, location::GpsTrackInfo>> && toAdd,
+  void OnUpdate(vector<pair<size_t, location::GpsInfo>> && toAdd,
                 pair<size_t, size_t> const & toRemove)
   {
     m_toAdd = std::move(toAdd);
@@ -71,7 +71,7 @@ public:
     return m_cv.wait_for(ul, t, [this]()->bool{ return m_gotCallback; });
   }
 
-  vector<pair<size_t, location::GpsTrackInfo>> m_toAdd;
+  vector<pair<size_t, location::GpsInfo>> m_toAdd;
   pair<size_t, size_t> m_toRemove;
 
 private:

--- a/platform/apple_location_service.mm
+++ b/platform/apple_location_service.mm
@@ -82,7 +82,7 @@ public:
   //info.m_verticalAccuracy = location.verticalAccuracy;
   //info.m_altitude = location.altitude;
   //info.m_course = location.course;
-  //info.m_speedMpS = location.speed;
+  //info.m_speed = location.speed;
 }
 
 - (void)locationManager:(CLLocationManager *)manager

--- a/platform/location.hpp
+++ b/platform/location.hpp
@@ -54,11 +54,11 @@ namespace location
     double m_altitude = 0.0;              //!< metres
     double m_verticalAccuracy = -1.0;     //!< metres
     double m_bearing = -1.0;              //!< positive degrees from the true North
-    double m_speedMpS = -1.0;             //!< metres per second
+    double m_speed = -1.0;                //!< metres per second
 
     bool IsValid() const { return m_source != EUndefined; }
     bool HasBearing() const { return m_bearing >= 0.0; }
-    bool HasSpeed() const { return m_speedMpS >= 0.0; }
+    bool HasSpeed() const { return m_speed >= 0.0; }
     bool HasVerticalAccuracy() const { return m_verticalAccuracy >= 0.0; }
   };
 
@@ -78,7 +78,7 @@ namespace location
       : m_timestamp(info.m_timestamp)
       , m_latitude(info.m_latitude)
       , m_longitude(info.m_longitude)
-      , m_speed(info.m_speedMpS)
+      , m_speed(info.m_speed)
     {}
     GpsTrackInfo & operator=(GpsInfo const & info)
     {

--- a/platform/location.hpp
+++ b/platform/location.hpp
@@ -62,30 +62,6 @@ namespace location
     bool HasVerticalAccuracy() const { return m_verticalAccuracy >= 0.0; }
   };
 
-  /// GpsTrackInfo struct describes a point for GPS tracking
-  /// It is similar to the GpsInfo but contains only needed fields.
-  struct GpsTrackInfo
-  {
-    double m_timestamp; //!< seconds from 1st Jan 1970
-    double m_latitude;  //!< degrees
-    double m_longitude; //!< degrees
-    double m_speed;     //!< meters per second
-
-    GpsTrackInfo() = default;
-    GpsTrackInfo(GpsTrackInfo const &) = default;
-    GpsTrackInfo & operator=(GpsTrackInfo const &) = default;
-    GpsTrackInfo(GpsInfo const & info)
-      : m_timestamp(info.m_timestamp)
-      , m_latitude(info.m_latitude)
-      , m_longitude(info.m_longitude)
-      , m_speed(info.m_speed)
-    {}
-    GpsTrackInfo & operator=(GpsInfo const & info)
-    {
-      return operator=(GpsTrackInfo(info));
-    }
-  };
-
   class CompassInfo
   {
   public:

--- a/platform/qt_location_service.cpp
+++ b/platform/qt_location_service.cpp
@@ -28,7 +28,7 @@ static location::GpsInfo gpsInfoFromQGeoPositionInfo(QGeoPositionInfo const & i,
     info.m_bearing = static_cast<double>(i.attribute(QGeoPositionInfo::Direction));
 
   if (i.hasAttribute(QGeoPositionInfo::GroundSpeed))
-    info.m_speedMpS = static_cast<double>(i.attribute(QGeoPositionInfo::GroundSpeed));
+    info.m_speed = static_cast<double>(i.attribute(QGeoPositionInfo::GroundSpeed));
 
   return info;
 }

--- a/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
+++ b/routing/routing_integration_tests/speed_camera_notifications_tests.cpp
@@ -39,7 +39,7 @@ location::GpsInfo MoveTo(ms::LatLon const & coords, double speed = -1)
   info.m_verticalAccuracy = kGpsAccuracy;
   info.m_latitude = coords.m_lat;
   info.m_longitude = coords.m_lon;
-  info.m_speedMpS = speed;
+  info.m_speed = speed;
   return info;
 }
 

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -272,7 +272,7 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
   if (!m_route->IsValid())
     return m_state;
 
-  m_turnNotificationsMgr.SetSpeedMetersPerSecond(info.m_speedMpS);
+  m_turnNotificationsMgr.SetSpeedMetersPerSecond(info.m_speed);
 
   auto const formerIter = m_route->GetCurrentIteratorTurn();
   if (m_route->MoveIterator(info))
@@ -318,7 +318,7 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
     if (base::AlmostEqualAbs(dist, m_lastDistance, kRunawayDistanceSensitivityMeters))
       return m_state;
 
-    if (!info.HasSpeed() || info.m_speedMpS < m_routingSettings.m_minSpeedForRouteRebuildMpS)
+    if (!info.HasSpeed() || info.m_speed < m_routingSettings.m_minSpeedForRouteRebuildMpS)
       m_moveAwayCounter += 1;
     else
       m_moveAwayCounter += 2;

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -335,7 +335,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingA
   GetPlatform().RunTask(Platform::Thread::Gui, [&checkTimedSignal, &info, this]() {
     info.m_longitude = 0.;
     info.m_latitude = 1.;
-    info.m_speedMpS = measurement_utils::KmphToMps(60);
+    info.m_speed = measurement_utils::KmphToMps(60);
     SessionState code = SessionState::NoValidRoute;
     for (size_t i = 0; i < 10; ++i)
     {
@@ -385,7 +385,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingMovingT
     GetPlatform().RunTask(Platform::Thread::Gui, [&checkTimedSignalAway, &info, this]() {
       info.m_longitude = 0.0;
       info.m_latitude = 0.0;
-      info.m_speedMpS = measurement_utils::KmphToMps(60);
+      info.m_speed = measurement_utils::KmphToMps(60);
       SessionState code = SessionState::NoValidRoute;
       {
         for (size_t i = 0; i < 8; ++i)
@@ -465,7 +465,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRouteFlagPersist
     TEST(m_session->IsFollowing(), ());
     info.m_longitude = 0.;
     info.m_latitude = 1.;
-    info.m_speedMpS = measurement_utils::KmphToMps(60);
+    info.m_speed = measurement_utils::KmphToMps(60);
     SessionState code = SessionState::NoValidRoute;
     for (size_t i = 0; i < 10; ++i)
     {

--- a/routing/speed_camera_manager.cpp
+++ b/routing/speed_camera_manager.cpp
@@ -57,7 +57,7 @@ void SpeedCameraManager::OnLocationPositionChanged(location::GpsInfo const & inf
     }
     else if (!m_closestCamera.NoSpeed())
     {
-      m_speedLimitExceeded = IsSpeedHigh(distFromCurrentPosAndClosestCam, info.m_speedMpS, m_closestCamera);
+      m_speedLimitExceeded = IsSpeedHigh(distFromCurrentPosAndClosestCam, info.m_speed, m_closestCamera);
     }
   }
 
@@ -68,7 +68,7 @@ void SpeedCameraManager::OnLocationPositionChanged(location::GpsInfo const & inf
     // invalidate |closestSpeedCam|.
     auto const closestSpeedCam = m_cachedSpeedCameras.front();
 
-    if (NeedToUpdateClosestCamera(passedDistanceMeters, info.m_speedMpS, closestSpeedCam))
+    if (NeedToUpdateClosestCamera(passedDistanceMeters, info.m_speed, closestSpeedCam))
     {
       m_closestCamera = closestSpeedCam;
       ResetNotifications();
@@ -78,10 +78,10 @@ void SpeedCameraManager::OnLocationPositionChanged(location::GpsInfo const & inf
   }
 
   if (m_closestCamera.IsValid() &&
-      SetNotificationFlags(passedDistanceMeters, info.m_speedMpS, m_closestCamera))
+      SetNotificationFlags(passedDistanceMeters, info.m_speed, m_closestCamera))
   {
     // If some notifications available now.
-    SendNotificationStat(passedDistanceMeters, info.m_speedMpS, m_closestCamera);
+    SendNotificationStat(passedDistanceMeters, info.m_speed, m_closestCamera);
   }
 }
 


### PR DESCRIPTION
This struct was introduced to save a bit of memory compared to GpsInfo. Now, when we are recording and saving tracks, there is no need in the incomplete struct, or in duplicating the same fields that are already present in GpsInfo.

Related to https://github.com/organicmaps/organicmaps/pull/9107

CC @rtsisyk 