### PR TITLE
Fix the use of infinity

### DIFF
--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -1278,7 +1278,7 @@ std::pair<FeatureID, kml::MarkId> FrontendRenderer::GetVisiblePOI(m2::RectD cons
   if (selectResult.empty())
     return {FeatureID(), kml::kInvalidMarkId};
 
-  double minSquaredDist = std::numeric_limits<double>::infinity();
+  double minSquaredDist = std::numeric_limits<double>::max();
   ref_ptr<dp::OverlayHandle> closestOverlayHandle;
   for (ref_ptr<dp::OverlayHandle> const & handle : selectResult)
   {

--- a/geometry/bounding_box.hpp
+++ b/geometry/bounding_box.hpp
@@ -49,11 +49,11 @@ public:
   DECLARE_DEBUG_PRINT(BoundingBox)
 
 private:
-  static_assert(std::numeric_limits<double>::has_infinity, "");
-  static double constexpr kPositiveInfinity = std::numeric_limits<double>::infinity();
-  static double constexpr kNegativeInfinity = -kPositiveInfinity;
+  // Infinity can not be used with -ffast-math
+  static double constexpr kLargestDouble = std::numeric_limits<double>::max();
+  static double constexpr kLowestDouble = std::numeric_limits<double>::lowest();
 
-  m2::PointD m_min = m2::PointD(kPositiveInfinity, kPositiveInfinity);
-  m2::PointD m_max = m2::PointD(kNegativeInfinity, kNegativeInfinity);
+  m2::PointD m_min = m2::PointD(kLargestDouble, kLargestDouble);
+  m2::PointD m_max = m2::PointD(kLowestDouble, kLowestDouble);
 };
 }  // namespace m2


### PR DESCRIPTION
`-ffast-math` does not support infinity values, and recent gcc properly warns about it:

```
 /home/runner/work/organicmaps/organicmaps/geometry/bounding_box.hpp:53:47: warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   53 |   static double constexpr kPositiveInfinity = std::numeric_limits<double>::infinity();
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```