### PR TITLE
Declare kml 2.2 gx extension support to serialize recorded tracks

### DIFF
--- a/kml/serdes.cpp
+++ b/kml/serdes.cpp
@@ -33,20 +33,20 @@ bool IsTrack(std::string const & s)
   return s == "Track" || s == "gx:Track";
 }
 
-std::string const kKmlHeader =
-  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-    "<kml xmlns=\"http://earth.google.com/kml/2.2\">\n"
+std::string_view constexpr kKmlHeader =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+    "<kml xmlns=\"http://www.opengis.net/kml/2.2\" xmlns:gx=\"http://www.google.com/kml/ext/2.2\">\n"
     "<Document>\n";
 
-std::string const kKmlFooter =
-  "</Document>\n"
+std::string_view constexpr kKmlFooter =
+    "</Document>\n"
     "</kml>\n";
 
-std::string const kExtendedDataHeader =
-  "<ExtendedData xmlns:mwm=\"https://omaps.app\">\n";
+std::string_view constexpr kExtendedDataHeader =
+    "<ExtendedData xmlns:mwm=\"https://omaps.app\">\n";
 
-std::string const kExtendedDataFooter =
-  "</ExtendedData>\n";
+std::string_view constexpr kExtendedDataFooter =
+    "</ExtendedData>\n";
 
 std::string const kCompilationFooter = "</" + kCompilation + ">\n";
 


### PR DESCRIPTION
To store tracks with timestamps and other data, we need to support `gx:Track` tag.

Details are here: https://developers.google.com/kml/documentation/kmlreference#kml-extension-namespace-and-the-gx-prefix