### PR TITLE
Add `self_service` and `outdoor_seating` to iOS editor

### DIFF
--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -32804,7 +32804,7 @@
 
   [self_service]
     comment = To indicate if the place proposed self service...
-    tags = android
+    tags = android,ios
     en = Self-service
     af = Selfdiens
     ar = الخدمة الذاتية

--- a/indexer/feature_utils.cpp
+++ b/indexer/feature_utils.cpp
@@ -521,6 +521,7 @@ constexpr char const * kWired = "wired";
 constexpr char const * kTerminal = "terminal";
 constexpr char const * kYes = "yes";
 constexpr char const * kNo = "no";
+constexpr char const * kOnly = "only";
 
 string DebugPrint(Internet internet)
 {
@@ -557,6 +558,8 @@ YesNoUnknown YesNoUnknownFromString(std::string_view str)
 {
   if (str.empty())
     return Unknown;
+  if (str.find(kOnly) != string::npos)
+    return Yes;
   if (str.find(kYes) != string::npos)
     return Yes;
   if (str.find(kNo) != string::npos)

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "فتح في تطبيق آخر";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "الخدمة الذاتية";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "مقاعد خارجية";
 

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Başqa Tətbiqdə Açın";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Özünəxidmət";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Çöldə oturma";
 

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Адкрыць у іншай прыладзе";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Самаабслугоўванне";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Месцы на адкрытым паветры";
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Отваряне в друго приложение";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Самообслужване";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Места за сядане на открито";
 

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Obre en una altra aplicació";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Autoservei";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Seients a l'aire lliure";
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Otevřít v jiné aplikaci";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Samoobsluha";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Venkovní posezení";
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Åbn i en anden app";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Selvbetjening";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Udendørs siddepladser";
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "In einer anderen App öffnen";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Selbstbedienung";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Sitzplätze im Freien";
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Άνοιγμα σε άλλη εφαρμογή";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Αυτοεξυπηρέτηση";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Εξωτερικά καθίσματα";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Open In Another App";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Self-service";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Outdoor seating";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Open In Another App";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Self-service";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Outdoor seating";
 

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Abrir en otra aplicación";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Autoservicio";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Asientos al aire libre";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Abrir en otra aplicación";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Autoservicio";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Asientos al aire libre";
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Avatud teises rakenduses";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Iseteenindus";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Istekohad õues";
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Ireki beste aplikazio batean";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Autozerbitzu";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Kanpoko eserlekuak";
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "در یک برنامه دیگر باز کنید";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "سلف سرویس";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "نشستن در فضای باز";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Avaa toisessa sovelluksessa";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Itsepalvelu";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Ulkona istuminen";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Ouvrir dans une autre application";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Libre-service";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Places en terrasse";
 

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "פתח באפליקציה אחרת";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "שירות עצמי";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "ישיבה בחוץ";
 

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "किसी अन्य ऐप में खोलें";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "स्वयं सेवा    hu = Önkiszolgáló";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "घर के बाहर बैठने";
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Megnyitás egy másik alkalmazásban";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Self-service";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Kültéri ülőhelyek";
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Buka di Aplikasi Lain";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Layanan mandiri";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Tempat duduk di luar ruangan";
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Apri in un'altra applicazione";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Self service";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Posti a sedere all'aperto";
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "別のアプリで開く";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "セルフサービス";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "屋外席";
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "다른 앱에서 열기";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "셀프 서비스";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "야외 좌석";
 

--- a/iphone/Maps/LocalizedStrings/lv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/lv.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Atvērt citā lietotnē";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Pašapkalpošanās";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Sēdvietas ārā";
 

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "दुसऱ्या ॲपमध्ये उघडा";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "स्व: सेवा    nb = Selvbetjening";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "बाहेरची आसनव्यवस्था    nb = Uteservering";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Åpne i en annen app";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Self-service";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Outdoor seating";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Openen in een andere app";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Zelfbediening";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Zitplaatsen buiten";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Otwórz w innej aplikacji";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Samoobsługa";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Siedzenia na zewnątrz";
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Abrir em outro aplicativo";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Autoatendimento";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Assentos ao ar livre";
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Abrir noutra aplicação";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Autosserviço";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Assentos ao ar livre";
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Deschidere în altă aplicație";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Autoservire";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Scaune în aer liber";
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Открыть в другом приложении";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Самообслуживание";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Сидения на открытом воздухе";
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Otvoriť v inej aplikácii";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Samoobslužné služby";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Vonkajšie sedenie";
 

--- a/iphone/Maps/LocalizedStrings/sr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sr.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Отвори у другој апликацији";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Самопослуживање";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Башта";
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Öppna i en annan app";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Självbetjäning";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Sittplatser utomhus";
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Fungua Katika Programu Nyingine";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Kujihudumia";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Viti vya nje";
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "เปิดในแอปอื่น";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "บริการตนเอง";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "ที่นั่งกลางแจ้ง";
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Başka Bir Uygulamada Aç";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Self servis";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Açık oturma alanı";
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Відкрити в іншій програмі";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Самообслуговування";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Сидіння на відкритому повітрі";
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Mở trong ứng dụng khác";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "Tự phục vụ";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "Chỗ ngồi ngoài trời";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "在另一个应用程序中打开";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "自助服务";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "室外座位";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 /* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "在另一個應用程式中打開";
 
+/* To indicate if the place proposed self service... */
+"self_service" = "自助服務";
+
 /* To indicate if restaurant or other place has outdoor seating */
 "outdoor_seating" = "戶外座位";
 

--- a/iphone/Maps/UI/Editor/MWMEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/MWMEditorViewController.mm
@@ -69,6 +69,7 @@ std::map<MWMEditorCellID, Class> const kCellType2Class {
     {MetadataID::FMD_INTERNET, [MWMEditorSwitchTableViewCell class]},
     {MetadataID::FMD_DRIVE_THROUGH, [MWMEditorSegmentedTableViewCell class]},
     {MetadataID::FMD_SELF_SERVICE, [MWMEditorSegmentedTableViewCell class]},
+    {MetadataID::FMD_OUTDOOR_SEATING, [MWMEditorSegmentedTableViewCell class]},
     {MWMEditorCellTypeNote, [MWMNoteCell class]},
     {MWMEditorCellTypeReportButton, [MWMButtonCell class]}
 };
@@ -668,6 +669,15 @@ void registerCellsForTableView(std::vector<MWMEditorCellID> const & cells, UITab
                          value:feature::YesNoUnknownFromString(m_mapObject.GetMetadata(feature::Metadata::FMD_SELF_SERVICE))];
     break;
   }
+  case MetadataID::FMD_OUTDOOR_SEATING:
+  {
+    MWMEditorSegmentedTableViewCell * tCell = static_cast<MWMEditorSegmentedTableViewCell *>(cell);
+    [tCell configWithDelegate:self
+                         icon:[UIImage imageNamed:@"ic_placepage_outdoor_seating"]
+                         text:L(@"outdoor_seating")
+                         value:feature::YesNoUnknownFromString(m_mapObject.GetMetadata(feature::Metadata::FMD_OUTDOOR_SEATING))];
+    break;
+  } 
   case MetadataID::FMD_CONTACT_FACEBOOK:
   {
     [self configTextViewCell:cell
@@ -1004,6 +1014,22 @@ void registerCellsForTableView(std::vector<MWMEditorCellID> const & cells, UITab
           break;
       }
       break;
+
+    case MetadataID::FMD_OUTDOOR_SEATING:
+      switch (changeSegmented)
+      {
+        case Yes:
+          m_mapObject.SetMetadata(feature::Metadata::FMD_OUTDOOR_SEATING, "yes");
+          break;
+        case No:
+          m_mapObject.SetMetadata(feature::Metadata::FMD_OUTDOOR_SEATING, "no");
+          break;
+        case Unknown:
+          m_mapObject.SetMetadata(feature::Metadata::FMD_OUTDOOR_SEATING, "");
+          break;
+      }
+      break;
+
   default: NSAssert(false, @"Invalid field for changeSegmented"); break;
   }
 }

--- a/iphone/Maps/UI/Editor/MWMEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/MWMEditorViewController.mm
@@ -68,6 +68,7 @@ std::map<MWMEditorCellID, Class> const kCellType2Class {
     {MetadataID::FMD_CUISINE, [MWMEditorSelectTableViewCell class]},
     {MetadataID::FMD_INTERNET, [MWMEditorSwitchTableViewCell class]},
     {MetadataID::FMD_DRIVE_THROUGH, [MWMEditorSegmentedTableViewCell class]},
+    {MetadataID::FMD_SELF_SERVICE, [MWMEditorSegmentedTableViewCell class]},
     {MWMEditorCellTypeNote, [MWMNoteCell class]},
     {MWMEditorCellTypeReportButton, [MWMButtonCell class]}
 };
@@ -658,6 +659,15 @@ void registerCellsForTableView(std::vector<MWMEditorCellID> const & cells, UITab
                          value:feature::YesNoUnknownFromString(m_mapObject.GetMetadata(feature::Metadata::FMD_DRIVE_THROUGH))];
     break;
   }
+  case MetadataID::FMD_SELF_SERVICE:
+  {
+    MWMEditorSegmentedTableViewCell * tCell = static_cast<MWMEditorSegmentedTableViewCell *>(cell);
+    [tCell configWithDelegate:self
+                         icon:[UIImage imageNamed:@"ic_placepage_self_service"]
+                         text:L(@"self_service")
+                         value:feature::YesNoUnknownFromString(m_mapObject.GetMetadata(feature::Metadata::FMD_SELF_SERVICE))];
+    break;
+  }
   case MetadataID::FMD_CONTACT_FACEBOOK:
   {
     [self configTextViewCell:cell
@@ -976,6 +986,21 @@ void registerCellsForTableView(std::vector<MWMEditorCellID> const & cells, UITab
           break;
         case Unknown:
           m_mapObject.SetMetadata(feature::Metadata::FMD_DRIVE_THROUGH, "");
+          break;
+      }
+      break;
+
+    case MetadataID::FMD_SELF_SERVICE:
+      switch (changeSegmented)
+      {
+        case Yes:
+          m_mapObject.SetMetadata(feature::Metadata::FMD_SELF_SERVICE, "yes");
+          break;
+        case No:
+          m_mapObject.SetMetadata(feature::Metadata::FMD_SELF_SERVICE, "no");
+          break;
+        case Unknown:
+          m_mapObject.SetMetadata(feature::Metadata::FMD_SELF_SERVICE, "");
           break;
       }
       break;


### PR DESCRIPTION
This PR adds `self_service` and `outdoor_seating` tag editing to iOS editor. It uses the same tri-state selector as `drive_through` editing (https://github.com/organicmaps/organicmaps/pull/7835#issuecomment-2053664755).

* Fixes https://github.com/organicmaps/organicmaps/issues/8924

---

<img src="https://github.com/user-attachments/assets/9451e370-2f5e-4ebd-aa15-810d97c5a015" width="320"/>
