### PR TITLE
Android: Exclude parent logs/ directory from exported zip archive

### DIFF
--- a/android/app/src/main/java/app/organicmaps/util/log/ZipLogsTask.java
+++ b/android/app/src/main/java/app/organicmaps/util/log/ZipLogsTask.java
@@ -51,7 +51,7 @@ class ZipLogsTask implements Runnable
         FileOutputStream dest = new FileOutputStream(toLocation, false);
         ZipOutputStream out = new ZipOutputStream(new BufferedOutputStream(dest)))
     {
-      zipSubFolder(out, sourceFile, sourceFile.getParent().length());
+      zipSubFolder(out, sourceFile, sourceFile.getPath().length());
     }
     catch (Exception e)
     {


### PR DESCRIPTION
Problem: Currently, the exported file has the following structure:
* logs.zip/logs/app.log
* logs.zip/logs/logcat.log

The logs/ folder is unnecessary. This issue is tracked here: https://github.com/organicmaps/organicmaps/issues/6219

Solution: Now, the zip archive will contain only the files and folders inside the /logs/ directory, but not the directory itself.