### PR TITLE
The "More" button no longer appears when the category description is short

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
@@ -524,30 +524,37 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
 
   private void setMoreButtonVisibility(TextView text, TextView moreBtn)
   {
-    text.post(() ->
-    {
-      final int lineCount = text.getLineCount();
-      if (lineCount > MAX_VISIBLE_LINES)
-      {
-        text.setMaxLines(MAX_VISIBLE_LINES);
-        moreBtn.setVisibility(View.VISIBLE);
-      }
-      else
-        moreBtn.setVisibility(View.GONE);
-    });
+    text.post(() -> setShortModeDescription(text, moreBtn));
   }
 
-  private void onMoreButtonClicked(TextView text, TextView moreBtn)
+  private void onMoreButtonClicked(TextView textView, TextView moreBtn)
   {
-    if (text.getMaxLines() == MAX_VISIBLE_LINES)
+    if (isShortModeDescription(textView))
     {
-      text.setMaxLines(Integer.MAX_VALUE);
-      moreBtn.setVisibility(View.GONE);
+      setExpandedModeDescription(textView, moreBtn);
     }
     else
     {
-      text.setMaxLines(MAX_VISIBLE_LINES);
-      moreBtn.setVisibility(View.VISIBLE);
+      setShortModeDescription(textView, moreBtn);
     }
+  }
+
+  private boolean isShortModeDescription(TextView text)
+  {
+    return text.getMaxLines() == MAX_VISIBLE_LINES;
+  }
+
+  private void setExpandedModeDescription(TextView textView, TextView moreBtn)
+  {
+    textView.setMaxLines(Integer.MAX_VALUE);
+    moreBtn.setVisibility(View.GONE);
+  }
+
+  private void setShortModeDescription(TextView textView, TextView moreBtn)
+  {
+    textView.setMaxLines(MAX_VISIBLE_LINES);
+
+    boolean isDescriptionTooLong = textView.getLineCount() > MAX_VISIBLE_LINES;
+    moreBtn.setVisibility(isDescriptionTooLong ? View.VISIBLE : View.GONE);
   }
 }


### PR DESCRIPTION
Now, whenever the UI state changes, the number of lines in the description is checked, and the visibility of the "More" button is determined based on that.

Fixes https://github.com/organicmaps/organicmaps/issues/5502