### PR TITLE
[editor] prevent overwriting existing features using EditingLifecycle

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/editor/Editor.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/Editor.cpp
@@ -369,6 +369,12 @@ Java_app_organicmaps_editor_Editor_nativeStartEdit(JNIEnv *, jclass)
 }
 
 JNIEXPORT void JNICALL
+Java_app_organicmaps_editor_Editor_nativeSetEditingLifecycle(JNIEnv *, jclass, int lifecycle)
+{
+  g_editableMapObject.SetEditingLifecycle((osm::EditingLifecycle) lifecycle);
+}
+
+JNIEXPORT void JNICALL
 Java_app_organicmaps_editor_Editor_nativeCreateMapObject(JNIEnv * env, jclass,
                                                              jstring featureType)
 {

--- a/android/app/src/main/java/app/organicmaps/editor/Editor.java
+++ b/android/app/src/main/java/app/organicmaps/editor/Editor.java
@@ -145,6 +145,8 @@ public final class Editor
    * could refresh.
    */
   public static native void nativeStartEdit();
+
+  public static native void nativeSetEditingLifecycle(int lifecycle);
   /**
    * @return true if feature was saved. False if some error occurred (eg. no space)
    */

--- a/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
@@ -44,6 +44,13 @@ public class EditorHostFragment extends BaseMwmToolbarFragment implements View.O
   @Nullable
   private View mSave;
 
+  enum EditingLifecycle
+  {
+    CREATED,      //newly created and not synced with OSM
+    MODIFIED,     //modified and not synced with OSM
+    IN_SYNC       //synced with OSM (including never edited)
+  }
+
   enum Mode
   {
     MAP_OBJECT,
@@ -339,6 +346,9 @@ public class EditorHostFragment extends BaseMwmToolbarFragment implements View.O
 
   private void saveMapObjectEdits()
   {
+    int lifecycle = mIsNewObject ? EditingLifecycle.CREATED.ordinal() : EditingLifecycle.MODIFIED.ordinal();
+    Editor.nativeSetEditingLifecycle(lifecycle);
+
     if (Editor.nativeSaveEditedFeature())
       processEditedFeatures();
     else

--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -646,9 +646,18 @@ void Editor::UploadChanges(string const & oauthToken, ChangesetTags tags,
               }
               else
               {
-                LOG(LDEBUG, ("Create case: uploading patched feature", osmFeature));
-                changeset.AddChangesetTag("info:features_merged", "yes");
-                changeset.Modify(osmFeature);
+                if (fti.m_object.GetEditingLifecycle() == EditingLifecycle::CREATED) {
+                  //New OSM feature for edits with lifecycle CREADED
+                  LOG(LDEBUG, ("Create case: uploading new feature", feature));
+                  changeset.AddChangesetTag("info:feature_created", "yes");
+                  changeset.Create(feature);
+                }
+                else {
+                  //Update existing OSM feature
+                  LOG(LDEBUG, ("Create case: uploading patched feature", osmFeature));
+                  changeset.AddChangesetTag("info:features_merged", "yes");
+                  changeset.Modify(osmFeature);
+                }
               }
             }
             catch (ChangesetWrapper::OsmObjectWasDeletedException const &)
@@ -754,6 +763,8 @@ void Editor::UploadChanges(string const & oauthToken, ChangesetTags tags,
                                 // Call Save every time we modify each feature's information.
                                 SaveUploadedInformation(id, uploadInfo);
                               });
+
+        fti.m_object.SetEditingLifecycle(EditingLifecycle::IN_SYNC);
       }
     }
 

--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -167,6 +167,18 @@ void EditableMapObject::SetTestId(uint64_t id)
   m_metadata.Set(feature::Metadata::FMD_TEST_ID, std::to_string(id));
 }
 
+void EditableMapObject::SetEditingLifecycle(EditingLifecycle lifecycle) {
+  //switching from CREATED to MODIFIED with out syncing first is not allowed
+  if (editingLifecycle == EditingLifecycle::CREATED && lifecycle == EditingLifecycle::MODIFIED) {
+    return;
+  }
+  editingLifecycle = (EditingLifecycle) lifecycle;
+}
+
+EditingLifecycle EditableMapObject::GetEditingLifecycle() {
+  return editingLifecycle;
+}
+
 void EditableMapObject::SetEditableProperties(osm::EditableProperties const & props)
 {
   m_editableProperties = props;

--- a/indexer/editable_map_object.hpp
+++ b/indexer/editable_map_object.hpp
@@ -64,6 +64,15 @@ struct LocalizedStreet
   bool operator==(LocalizedStreet const & st) const { return m_defaultName == st.m_defaultName; }
 };
 
+enum class EditingLifecycle
+{
+  CREATED,      //newly created and not synced with OSM
+  MODIFIED,     //modified and not synced with OSM
+  IN_SYNC       //synced with OSM (including never edited)
+};
+
+static EditingLifecycle editingLifecycle = EditingLifecycle::IN_SYNC;
+
 class EditableMapObject : public MapObject
 {
 public:
@@ -86,6 +95,9 @@ public:
 
   // Used only in testing framework.
   void SetTestId(uint64_t id);
+
+  static void SetEditingLifecycle(EditingLifecycle lifecycle) ;
+  static EditingLifecycle GetEditingLifecycle() ;
 
   void SetEditableProperties(osm::EditableProperties const & props);
   //  void SetFeatureID(FeatureID const & fid);


### PR DESCRIPTION
This is a follow up of #7853 to fix #2298

This approach propagates the information whether a feature is modified or newly created down to editor core. This way we can distinguish between case 1 and case 2 or 3 from https://github.com/organicmaps/organicmaps/issues/2298#issuecomment-2308788517. For case 1 the feature is merged with the existing OSM feature. Case 2 and 3 always result in a new node. This way the behaviour originally intended in #7853 is achieved.

#### Details
- This only works on Android for now, iOS will keep the previous behaviour as the EditingLifecycle always stays IN_SYNC
- Functionality was tested with the OSM dev API (https://master.apis.dev.openstreetmap.org/changeset/380248, https://master.apis.dev.openstreetmap.org/changeset/380249)
- A new variable is necessary, FeatureStatus can not be used, as this variable keeps the value CREATED after a new feature was synced with OSM