### PR TITLE
[kml] Implement support for KML tracks with timestamps

### DIFF
--- a/data/gpx_test_data/track_with_timestamps.gpx
+++ b/data/gpx_test_data/track_with_timestamps.gpx
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1">
+  <trk>
+    <name>new</name>
+    <type>Cycling</type>
+    <trkseg>
+      <trkpt lat="54.23955053156179" lon="24.114990234375004">
+        <ele>130.5</ele>
+        <time>2010-10-30T10:11:14Z</time>
+      </trkpt>
+      <trkpt lat="54.32933804825253" lon="25.136718750000004">
+        <ele>0.0</ele>
+        <time>2010-10-30T10:11:16Z</time>
+      </trkpt>
+      <trkpt lat="54.05293900056246" lon="25.72998046875">
+        <ele>0.0</ele>
+        <time>2010-10-30T10:11:18Z</time>
+      </trkpt>
+    </trkseg>
+    <trkseg>
+      <trkpt lat="55.23955053156179" lon="25.114990234375004">
+        <ele>131.5</ele>
+        <time>2010-10-30T10:11:14Z</time>
+      </trkpt>
+      <trkpt lat="54.32933804825253" lon="25.136718750000004">
+        <ele>0.0</ele>
+        <time>2010-10-30T10:11:16Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/gpx_test_data/track_with_timestamps_broken.gpx
+++ b/data/gpx_test_data/track_with_timestamps_broken.gpx
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.0">
+  <trk>
+    <name>new</name>
+    <type>Cycling</type>
+    <trkseg>
+      <trkpt lat="54.23955053156179" lon="24.114990234375004">
+        <ele>130.5</ele>
+        <time>2010-10-30T10:11:14Z</time>
+      </trkpt>
+      <trkpt lat="54.32933804825253" lon="25.136718750000004">
+        <ele>0.0</ele>
+        <time>2010-10-30T10:11:16Z</time>
+      </trkpt>
+      <trkpt lat="54.05293900056246" lon="25.72998046875">
+        <ele>0.0</ele>
+      </trkpt>
+    </trkseg>
+    <trkseg>
+      <trkpt lat="55.23955053156179" lon="25.114990234375004">
+        <ele>131.5</ele>
+        <time>2010-10-30T10:11:14Z</time>
+      </trkpt>
+      <trkpt lat="54.32933804825253" lon="25.136718750000004">
+        <ele>0.0</ele>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/gpx_test_data/track_without_timestamps.gpx
+++ b/data/gpx_test_data/track_without_timestamps.gpx
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1">
+  <trk>
+    <name>new</name>
+    <type>Cycling</type>
+    <trkseg>
+      <trkpt lat="54.23955053156179" lon="24.114990234375004">
+        <ele>130.5</ele>
+      </trkpt>
+      <trkpt lat="54.32933804825253" lon="25.136718750000004">
+        <ele>0.0</ele>
+      </trkpt>
+      <trkpt lat="54.05293900056246" lon="25.72998046875">
+        <ele>0.0</ele>
+      </trkpt>
+    </trkseg>
+    <trkseg>
+      <trkpt lat="55.23955053156179" lon="25.114990234375004">
+        <ele>131.5</ele>
+      </trkpt>
+      <trkpt lat="54.32933804825253" lon="25.136718750000004">
+        <ele>0.0</ele>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/kml_test_data/generated.kml
+++ b/data/kml_test_data/generated.kml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://earth.google.com/kml/2.2">
+<Document>
+  <Style id="placemark-red">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-red.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-blue">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-blue.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-purple">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-purple.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-yellow">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-yellow.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-pink">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-pink.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-brown">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-brown.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-green">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-green.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-orange">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-orange.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-deeppurple">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-deeppurple.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-lightblue">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-lightblue.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-cyan">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-cyan.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-teal">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-teal.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-lime">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-lime.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-deeporange">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-deeporange.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-gray">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-gray.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-bluegray">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-bluegray.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <name>Test category</name>
+  <description>Test description</description>
+  <visibility>1</visibility>
+  <ExtendedData xmlns:mwm="https://omaps.app">
+    <mwm:serverId>AAAA-BBBB-CCCC-DDDD</mwm:serverId>
+    <mwm:name>
+      <mwm:lang code="ru">Тестовая категория</mwm:lang>
+      <mwm:lang code="default">Test category</mwm:lang>
+    </mwm:name>
+    <mwm:annotation>
+      <mwm:lang code="en">Test annotation</mwm:lang>
+      <mwm:lang code="default">Test annotation</mwm:lang>
+    </mwm:annotation>
+    <mwm:description>
+      <mwm:lang code="ru">Тестовое описание</mwm:lang>
+      <mwm:lang code="default">Test description</mwm:lang>
+    </mwm:description>
+    <mwm:imageUrl>https://localhost/123.png</mwm:imageUrl>
+    <mwm:author id="12345">Organic Maps</mwm:author>
+    <mwm:lastModified>1970-01-01T00:16:40Z</mwm:lastModified>
+    <mwm:rating>8.9</mwm:rating>
+    <mwm:reviewsNumber>567</mwm:reviewsNumber>
+    <mwm:accessRules>Public</mwm:accessRules>
+    <mwm:tags>
+      <mwm:value>mountains</mwm:value>
+      <mwm:value>ski</mwm:value>
+      <mwm:value>snowboard</mwm:value>
+    </mwm:tags>
+    <mwm:toponyms>
+      <mwm:value>12345</mwm:value>
+      <mwm:value>54321</mwm:value>
+    </mwm:toponyms>
+    <mwm:languageCodes>
+      <mwm:value>en</mwm:value>
+      <mwm:value>ja</mwm:value>
+      <mwm:value>ru</mwm:value>
+    </mwm:languageCodes>
+    <mwm:properties>
+      <mwm:value key="property1">value1</mwm:value>
+      <mwm:value key="property2">value2</mwm:value>
+    </mwm:properties>
+    <mwm:compilation id="1" type="Collection">
+      <mwm:name>
+        <mwm:lang code="ru">Тестовая коллекция</mwm:lang>
+        <mwm:lang code="default">Test collection</mwm:lang>
+      </mwm:name>
+      <mwm:annotation>
+        <mwm:lang code="en">Test collection annotation</mwm:lang>
+        <mwm:lang code="default">Test collection annotation</mwm:lang>
+      </mwm:annotation>
+      <mwm:description>
+        <mwm:lang code="ru">Тестовое описание коллекции</mwm:lang>
+        <mwm:lang code="default">Test collection description</mwm:lang>
+      </mwm:description>
+      <mwm:visibility>1</mwm:visibility>
+      <mwm:imageUrl>https://localhost/1234.png</mwm:imageUrl>
+      <mwm:author id="54321">Organic Maps</mwm:author>
+      <mwm:lastModified>1970-01-01T00:16:39Z</mwm:lastModified>
+      <mwm:rating>5.9</mwm:rating>
+      <mwm:reviewsNumber>333</mwm:reviewsNumber>
+      <mwm:accessRules>Public</mwm:accessRules>
+      <mwm:tags>
+        <mwm:value>mountains</mwm:value>
+        <mwm:value>ski</mwm:value>
+      </mwm:tags>
+      <mwm:toponyms>
+        <mwm:value>8</mwm:value>
+        <mwm:value>9</mwm:value>
+      </mwm:toponyms>
+      <mwm:languageCodes>
+        <mwm:value>en</mwm:value>
+        <mwm:value>ja</mwm:value>
+        <mwm:value>ru</mwm:value>
+      </mwm:languageCodes>
+      <mwm:properties>
+        <mwm:value key="property1">value1</mwm:value>
+        <mwm:value key="property2">value2</mwm:value>
+      </mwm:properties>
+    </mwm:compilation>
+    <mwm:compilation id="4" type="Category">
+      <mwm:name>
+        <mwm:lang code="ru">Тестовая категория</mwm:lang>
+        <mwm:lang code="default">Test category</mwm:lang>
+      </mwm:name>
+      <mwm:annotation>
+        <mwm:lang code="en">Test category annotation</mwm:lang>
+        <mwm:lang code="default">Test category annotation</mwm:lang>
+      </mwm:annotation>
+      <mwm:description>
+        <mwm:lang code="ru">Тестовое описание категории</mwm:lang>
+        <mwm:lang code="default">Test category description</mwm:lang>
+      </mwm:description>
+      <mwm:visibility>0</mwm:visibility>
+      <mwm:imageUrl>https://localhost/134.png</mwm:imageUrl>
+      <mwm:author id="11111">Organic Maps</mwm:author>
+      <mwm:lastModified>1970-01-01T00:05:23Z</mwm:lastModified>
+      <mwm:rating>3.3</mwm:rating>
+      <mwm:reviewsNumber>222</mwm:reviewsNumber>
+      <mwm:accessRules>Public</mwm:accessRules>
+      <mwm:tags>
+        <mwm:value>mountains</mwm:value>
+        <mwm:value>bike</mwm:value>
+      </mwm:tags>
+      <mwm:toponyms>
+        <mwm:value>10</mwm:value>
+        <mwm:value>11</mwm:value>
+      </mwm:toponyms>
+      <mwm:languageCodes>
+        <mwm:value>en</mwm:value>
+        <mwm:value>ja</mwm:value>
+        <mwm:value>ru</mwm:value>
+      </mwm:languageCodes>
+      <mwm:properties>
+        <mwm:value key="property1">value1</mwm:value>
+        <mwm:value key="property2">value2</mwm:value>
+      </mwm:properties>
+    </mwm:compilation>
+  </ExtendedData>
+  <Placemark>
+    <name>Мое любимое место</name>
+    <description>Test bookmark description</description>
+    <TimeStamp><when>1970-01-01T00:13:20Z</when></TimeStamp>
+    <styleUrl>#placemark-blue</styleUrl>
+    <Point><coordinates>45.9242,49.326859</coordinates></Point>
+    <ExtendedData xmlns:mwm="https://omaps.app">
+      <mwm:name>
+        <mwm:lang code="ru">Тестовая метка</mwm:lang>
+        <mwm:lang code="default">Test bookmark</mwm:lang>
+      </mwm:name>
+      <mwm:description>
+        <mwm:lang code="ru">Тестовое описание метки</mwm:lang>
+        <mwm:lang code="default">Test bookmark description</mwm:lang>
+      </mwm:description>
+      <mwm:featureTypes>
+        <mwm:value>historic-castle</mwm:value>
+        <mwm:value>historic-memorial</mwm:value>
+      </mwm:featureTypes>
+      <mwm:customName>
+        <mwm:lang code="en">My favorite place</mwm:lang>
+        <mwm:lang code="default">Мое любимое место</mwm:lang>
+      </mwm:customName>
+      <mwm:scale>15</mwm:scale>
+      <mwm:boundTracks>
+        <mwm:value>0</mwm:value>
+      </mwm:boundTracks>
+      <mwm:visibility>0</mwm:visibility>
+      <mwm:nearestToponym>12345</mwm:nearestToponym>
+      <mwm:minZoom>10</mwm:minZoom>
+      <mwm:properties>
+        <mwm:value key="bm_property1">value1</mwm:value>
+        <mwm:value key="bm_property2">value2</mwm:value>
+        <mwm:value key="score">5</mwm:value>
+      </mwm:properties>
+      <mwm:compilations>1,2,3,4,5</mwm:compilations>
+    </ExtendedData>
+  </Placemark>
+  <Placemark>
+    <name>Test track</name>
+    <description>Test track description</description>
+    <Style><LineStyle>
+      <color>FF0000FF</color>
+      <width>6</width>
+    </LineStyle></Style>
+    <TimeStamp><when>1970-01-01T00:15:00Z</when></TimeStamp>
+    <LineString><coordinates>45.9242,49.326859,1 45.2244,48.941288,2 45.1964,49.401948,3</coordinates></LineString>
+    <ExtendedData xmlns:mwm="https://omaps.app">
+      <mwm:name>
+        <mwm:lang code="ru">Тестовый трек</mwm:lang>
+        <mwm:lang code="default">Test track</mwm:lang>
+      </mwm:name>
+      <mwm:description>
+        <mwm:lang code="ru">Тестовое описание трека</mwm:lang>
+        <mwm:lang code="default">Test track description</mwm:lang>
+      </mwm:description>
+      <mwm:localId>0</mwm:localId>
+      <mwm:additionalStyle>
+        <mwm:additionalLineStyle>
+          <color>FF00FF00</color>
+          <width>7</width>
+        </mwm:additionalLineStyle>
+      </mwm:additionalStyle>
+      <mwm:visibility>0</mwm:visibility>
+      <mwm:nearestToponyms>
+        <mwm:value>12345</mwm:value>
+        <mwm:value>54321</mwm:value>
+        <mwm:value>98765</mwm:value>
+      </mwm:nearestToponyms>
+      <mwm:properties>
+        <mwm:value key="tr_property1">value1</mwm:value>
+        <mwm:value key="tr_property2">value2</mwm:value>
+      </mwm:properties>
+    </ExtendedData>
+  </Placemark>
+</Document>
+</kml>

--- a/data/kml_test_data/generated_mixed_tracks.kml
+++ b/data/kml_test_data/generated_mixed_tracks.kml
@@ -1,0 +1,326 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+<Document>
+  <Style id="placemark-red">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-red.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-blue">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-blue.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-purple">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-purple.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-yellow">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-yellow.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-pink">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-pink.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-brown">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-brown.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-green">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-green.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-orange">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-orange.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-deeppurple">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-deeppurple.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-lightblue">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-lightblue.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-cyan">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-cyan.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-teal">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-teal.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-lime">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-lime.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-deeporange">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-deeporange.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-gray">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-gray.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-bluegray">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-bluegray.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <name>Test category</name>
+  <description>Test description</description>
+  <visibility>1</visibility>
+  <ExtendedData xmlns:mwm="https://omaps.app">
+    <mwm:serverId>AAAA-BBBB-CCCC-DDDD</mwm:serverId>
+    <mwm:name>
+      <mwm:lang code="ru">Тестовая категория</mwm:lang>
+      <mwm:lang code="default">Test category</mwm:lang>
+    </mwm:name>
+    <mwm:annotation>
+      <mwm:lang code="en">Test annotation</mwm:lang>
+      <mwm:lang code="default">Test annotation</mwm:lang>
+    </mwm:annotation>
+    <mwm:description>
+      <mwm:lang code="ru">Тестовое описание</mwm:lang>
+      <mwm:lang code="default">Test description</mwm:lang>
+    </mwm:description>
+    <mwm:imageUrl>https://localhost/123.png</mwm:imageUrl>
+    <mwm:author id="12345">Organic Maps</mwm:author>
+    <mwm:lastModified>1970-01-01T00:16:40Z</mwm:lastModified>
+    <mwm:rating>8.9</mwm:rating>
+    <mwm:reviewsNumber>567</mwm:reviewsNumber>
+    <mwm:accessRules>Public</mwm:accessRules>
+    <mwm:tags>
+      <mwm:value>mountains</mwm:value>
+      <mwm:value>ski</mwm:value>
+      <mwm:value>snowboard</mwm:value>
+    </mwm:tags>
+    <mwm:toponyms>
+      <mwm:value>12345</mwm:value>
+      <mwm:value>54321</mwm:value>
+    </mwm:toponyms>
+    <mwm:languageCodes>
+      <mwm:value>en</mwm:value>
+      <mwm:value>ja</mwm:value>
+      <mwm:value>ru</mwm:value>
+    </mwm:languageCodes>
+    <mwm:properties>
+      <mwm:value key="property1">value1</mwm:value>
+      <mwm:value key="property2">value2</mwm:value>
+    </mwm:properties>
+    <mwm:compilation id="1" type="Collection">
+      <mwm:name>
+        <mwm:lang code="ru">Тестовая коллекция</mwm:lang>
+        <mwm:lang code="default">Test collection</mwm:lang>
+      </mwm:name>
+      <mwm:annotation>
+        <mwm:lang code="en">Test collection annotation</mwm:lang>
+        <mwm:lang code="default">Test collection annotation</mwm:lang>
+      </mwm:annotation>
+      <mwm:description>
+        <mwm:lang code="ru">Тестовое описание коллекции</mwm:lang>
+        <mwm:lang code="default">Test collection description</mwm:lang>
+      </mwm:description>
+      <mwm:visibility>1</mwm:visibility>
+      <mwm:imageUrl>https://localhost/1234.png</mwm:imageUrl>
+      <mwm:author id="54321">Organic Maps</mwm:author>
+      <mwm:lastModified>1970-01-01T00:16:39Z</mwm:lastModified>
+      <mwm:rating>5.9</mwm:rating>
+      <mwm:reviewsNumber>333</mwm:reviewsNumber>
+      <mwm:accessRules>Public</mwm:accessRules>
+      <mwm:tags>
+        <mwm:value>mountains</mwm:value>
+        <mwm:value>ski</mwm:value>
+      </mwm:tags>
+      <mwm:toponyms>
+        <mwm:value>8</mwm:value>
+        <mwm:value>9</mwm:value>
+      </mwm:toponyms>
+      <mwm:languageCodes>
+        <mwm:value>en</mwm:value>
+        <mwm:value>ja</mwm:value>
+        <mwm:value>ru</mwm:value>
+      </mwm:languageCodes>
+      <mwm:properties>
+        <mwm:value key="property1">value1</mwm:value>
+        <mwm:value key="property2">value2</mwm:value>
+      </mwm:properties>
+    </mwm:compilation>
+    <mwm:compilation id="4" type="Category">
+      <mwm:name>
+        <mwm:lang code="ru">Тестовая категория</mwm:lang>
+        <mwm:lang code="default">Test category</mwm:lang>
+      </mwm:name>
+      <mwm:annotation>
+        <mwm:lang code="en">Test category annotation</mwm:lang>
+        <mwm:lang code="default">Test category annotation</mwm:lang>
+      </mwm:annotation>
+      <mwm:description>
+        <mwm:lang code="ru">Тестовое описание категории</mwm:lang>
+        <mwm:lang code="default">Test category description</mwm:lang>
+      </mwm:description>
+      <mwm:visibility>0</mwm:visibility>
+      <mwm:imageUrl>https://localhost/134.png</mwm:imageUrl>
+      <mwm:author id="11111">Organic Maps</mwm:author>
+      <mwm:lastModified>1970-01-01T00:05:23Z</mwm:lastModified>
+      <mwm:rating>3.3</mwm:rating>
+      <mwm:reviewsNumber>222</mwm:reviewsNumber>
+      <mwm:accessRules>Public</mwm:accessRules>
+      <mwm:tags>
+        <mwm:value>mountains</mwm:value>
+        <mwm:value>bike</mwm:value>
+      </mwm:tags>
+      <mwm:toponyms>
+        <mwm:value>10</mwm:value>
+        <mwm:value>11</mwm:value>
+      </mwm:toponyms>
+      <mwm:languageCodes>
+        <mwm:value>en</mwm:value>
+        <mwm:value>ja</mwm:value>
+        <mwm:value>ru</mwm:value>
+      </mwm:languageCodes>
+      <mwm:properties>
+        <mwm:value key="property1">value1</mwm:value>
+        <mwm:value key="property2">value2</mwm:value>
+      </mwm:properties>
+    </mwm:compilation>
+  </ExtendedData>
+  <Placemark>
+    <name>Мое любимое место</name>
+    <description>Test bookmark description</description>
+    <TimeStamp><when>1970-01-01T00:13:20Z</when></TimeStamp>
+    <styleUrl>#placemark-blue</styleUrl>
+    <Point><coordinates>45.9242,49.326859</coordinates></Point>
+    <ExtendedData xmlns:mwm="https://omaps.app">
+      <mwm:name>
+        <mwm:lang code="ru">Тестовая метка</mwm:lang>
+        <mwm:lang code="default">Test bookmark</mwm:lang>
+      </mwm:name>
+      <mwm:description>
+        <mwm:lang code="ru">Тестовое описание метки</mwm:lang>
+        <mwm:lang code="default">Test bookmark description</mwm:lang>
+      </mwm:description>
+      <mwm:featureTypes>
+        <mwm:value>historic-castle</mwm:value>
+        <mwm:value>historic-memorial</mwm:value>
+      </mwm:featureTypes>
+      <mwm:customName>
+        <mwm:lang code="en">My favorite place</mwm:lang>
+        <mwm:lang code="default">Мое любимое место</mwm:lang>
+      </mwm:customName>
+      <mwm:scale>15</mwm:scale>
+      <mwm:boundTracks>
+        <mwm:value>0</mwm:value>
+      </mwm:boundTracks>
+      <mwm:visibility>0</mwm:visibility>
+      <mwm:nearestToponym>12345</mwm:nearestToponym>
+      <mwm:minZoom>10</mwm:minZoom>
+      <mwm:properties>
+        <mwm:value key="bm_property1">value1</mwm:value>
+        <mwm:value key="bm_property2">value2</mwm:value>
+        <mwm:value key="score">5</mwm:value>
+      </mwm:properties>
+      <mwm:compilations>1,2,3,4,5</mwm:compilations>
+    </ExtendedData>
+  </Placemark>
+  <Placemark>
+    <name>Test track</name>
+    <description>Test track description</description>
+    <Style><LineStyle>
+      <color>FF0000FF</color>
+      <width>6</width>
+    </LineStyle></Style>
+    <TimeStamp><when>1970-01-01T00:15:00Z</when></TimeStamp>
+    <LineString><coordinates>45.9242,49.326859,1 45.2244,48.941288,2 45.1964,49.401948,3</coordinates></LineString>
+    <gx:MultiTrack>
+      <gx:Track>
+        <when>1970-01-01T00:00:00Z</when>
+        <when>1970-01-01T00:00:01Z</when>
+        <when>1970-01-01T00:00:02Z</when>
+        <gx:coord>45.9242 49.326859 1</gx:coord>
+        <gx:coord>45.2244 48.941288 2</gx:coord>
+        <gx:coord>45.1964 49.401948 3</gx:coord>
+      </gx:Track>
+      <gx:Track>
+        <when>1970-01-01T00:00:00Z</when>
+        <when>1970-01-01T00:00:01Z</when>
+        <gx:coord>45.9242 49.326859 1</gx:coord>
+        <gx:coord>45.2244 48.941288 2</gx:coord>
+      </gx:Track>
+    </gx:MultiTrack>
+    <ExtendedData xmlns:mwm="https://omaps.app">
+      <mwm:name>
+        <mwm:lang code="ru">Тестовый трек</mwm:lang>
+        <mwm:lang code="default">Test track</mwm:lang>
+      </mwm:name>
+      <mwm:description>
+        <mwm:lang code="ru">Тестовое описание трека</mwm:lang>
+        <mwm:lang code="default">Test track description</mwm:lang>
+      </mwm:description>
+      <mwm:localId>0</mwm:localId>
+      <mwm:additionalStyle>
+        <mwm:additionalLineStyle>
+          <color>FF00FF00</color>
+          <width>7</width>
+        </mwm:additionalLineStyle>
+      </mwm:additionalStyle>
+      <mwm:visibility>0</mwm:visibility>
+      <mwm:nearestToponyms>
+        <mwm:value>12345</mwm:value>
+        <mwm:value>54321</mwm:value>
+        <mwm:value>98765</mwm:value>
+      </mwm:nearestToponyms>
+      <mwm:properties>
+        <mwm:value key="tr_property1">value1</mwm:value>
+        <mwm:value key="tr_property2">value2</mwm:value>
+      </mwm:properties>
+    </ExtendedData>
+  </Placemark>
+</Document>
+</kml>

--- a/data/kml_test_data/track_with_timestamps_mismatch.kml
+++ b/data/kml_test_data/track_with_timestamps_mismatch.kml
@@ -1,0 +1,19 @@
+  <?xml version="1.0" encoding="utf-8"?>
+  <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+      <Placemark id="PM005">
+        <gx:Track>
+          <when>2010-05-28T02:02:44Z</when>
+          <when>2010-05-28T02:02:53Z</when>
+          <when>2010-05-28T02:02:54Z</when>
+          <when>2010-05-28T02:02:55Z</when>
+          <when>2010-05-28T02:02:56Z</when>
+          <gx:coord>-122.207881 37.371915 156.000000</gx:coord>
+          <gx:coord>-122.205712 37.373288 152.000000</gx:coord>
+          <gx:coord>-122.204678 37.373939 147.000000</gx:coord>
+          <gx:coord>-122.203572 37.374630 142.199997</gx:coord>
+          <gx:coord>-122.203451 37.374706 141.800003</gx:coord>
+          <gx:coord>-122.203329 37.374780 141.199997</gx:coord>
+          <gx:coord>-122.203207 37.374857 140.199997</gx:coord>
+        </gx:Track>
+      </Placemark>
+    </kml>

--- a/data/kml_test_data/track_with_timestams_different_orders.kml
+++ b/data/kml_test_data/track_with_timestams_different_orders.kml
@@ -1,0 +1,343 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+<Document>
+  <Style id="placemark-red">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-red.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-blue">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-blue.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-purple">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-purple.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-yellow">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-yellow.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-pink">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-pink.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-brown">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-brown.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-green">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-green.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-orange">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-orange.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-deeppurple">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-deeppurple.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-lightblue">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-lightblue.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-cyan">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-cyan.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-teal">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-teal.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-lime">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-lime.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-deeporange">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-deeporange.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-gray">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-gray.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <Style id="placemark-bluegray">
+    <IconStyle>
+      <Icon>
+        <href>https://omaps.app/placemarks/placemark-bluegray.png</href>
+      </Icon>
+    </IconStyle>
+  </Style>
+  <name>Test category</name>
+  <description>Test description</description>
+  <visibility>1</visibility>
+  <ExtendedData xmlns:mwm="https://omaps.app">
+    <mwm:serverId>AAAA-BBBB-CCCC-DDDD</mwm:serverId>
+    <mwm:name>
+      <mwm:lang code="ru">Тестовая категория</mwm:lang>
+      <mwm:lang code="default">Test category</mwm:lang>
+    </mwm:name>
+    <mwm:annotation>
+      <mwm:lang code="en">Test annotation</mwm:lang>
+      <mwm:lang code="default">Test annotation</mwm:lang>
+    </mwm:annotation>
+    <mwm:description>
+      <mwm:lang code="ru">Тестовое описание</mwm:lang>
+      <mwm:lang code="default">Test description</mwm:lang>
+    </mwm:description>
+    <mwm:imageUrl>https://localhost/123.png</mwm:imageUrl>
+    <mwm:author id="12345">Organic Maps</mwm:author>
+    <mwm:lastModified>1970-01-01T00:16:40Z</mwm:lastModified>
+    <mwm:rating>8.9</mwm:rating>
+    <mwm:reviewsNumber>567</mwm:reviewsNumber>
+    <mwm:accessRules>Public</mwm:accessRules>
+    <mwm:tags>
+      <mwm:value>mountains</mwm:value>
+      <mwm:value>ski</mwm:value>
+      <mwm:value>snowboard</mwm:value>
+    </mwm:tags>
+    <mwm:toponyms>
+      <mwm:value>12345</mwm:value>
+      <mwm:value>54321</mwm:value>
+    </mwm:toponyms>
+    <mwm:languageCodes>
+      <mwm:value>en</mwm:value>
+      <mwm:value>ja</mwm:value>
+      <mwm:value>ru</mwm:value>
+    </mwm:languageCodes>
+    <mwm:properties>
+      <mwm:value key="property1">value1</mwm:value>
+      <mwm:value key="property2">value2</mwm:value>
+    </mwm:properties>
+    <mwm:compilation id="1" type="Collection">
+      <mwm:name>
+        <mwm:lang code="ru">Тестовая коллекция</mwm:lang>
+        <mwm:lang code="default">Test collection</mwm:lang>
+      </mwm:name>
+      <mwm:annotation>
+        <mwm:lang code="en">Test collection annotation</mwm:lang>
+        <mwm:lang code="default">Test collection annotation</mwm:lang>
+      </mwm:annotation>
+      <mwm:description>
+        <mwm:lang code="ru">Тестовое описание коллекции</mwm:lang>
+        <mwm:lang code="default">Test collection description</mwm:lang>
+      </mwm:description>
+      <mwm:visibility>1</mwm:visibility>
+      <mwm:imageUrl>https://localhost/1234.png</mwm:imageUrl>
+      <mwm:author id="54321">Organic Maps</mwm:author>
+      <mwm:lastModified>1970-01-01T00:16:39Z</mwm:lastModified>
+      <mwm:rating>5.9</mwm:rating>
+      <mwm:reviewsNumber>333</mwm:reviewsNumber>
+      <mwm:accessRules>Public</mwm:accessRules>
+      <mwm:tags>
+        <mwm:value>mountains</mwm:value>
+        <mwm:value>ski</mwm:value>
+      </mwm:tags>
+      <mwm:toponyms>
+        <mwm:value>8</mwm:value>
+        <mwm:value>9</mwm:value>
+      </mwm:toponyms>
+      <mwm:languageCodes>
+        <mwm:value>en</mwm:value>
+        <mwm:value>ja</mwm:value>
+        <mwm:value>ru</mwm:value>
+      </mwm:languageCodes>
+      <mwm:properties>
+        <mwm:value key="property1">value1</mwm:value>
+        <mwm:value key="property2">value2</mwm:value>
+      </mwm:properties>
+    </mwm:compilation>
+    <mwm:compilation id="4" type="Category">
+      <mwm:name>
+        <mwm:lang code="ru">Тестовая категория</mwm:lang>
+        <mwm:lang code="default">Test category</mwm:lang>
+      </mwm:name>
+      <mwm:annotation>
+        <mwm:lang code="en">Test category annotation</mwm:lang>
+        <mwm:lang code="default">Test category annotation</mwm:lang>
+      </mwm:annotation>
+      <mwm:description>
+        <mwm:lang code="ru">Тестовое описание категории</mwm:lang>
+        <mwm:lang code="default">Test category description</mwm:lang>
+      </mwm:description>
+      <mwm:visibility>0</mwm:visibility>
+      <mwm:imageUrl>https://localhost/134.png</mwm:imageUrl>
+      <mwm:author id="11111">Organic Maps</mwm:author>
+      <mwm:lastModified>1970-01-01T00:05:23Z</mwm:lastModified>
+      <mwm:rating>3.3</mwm:rating>
+      <mwm:reviewsNumber>222</mwm:reviewsNumber>
+      <mwm:accessRules>Public</mwm:accessRules>
+      <mwm:tags>
+        <mwm:value>mountains</mwm:value>
+        <mwm:value>bike</mwm:value>
+      </mwm:tags>
+      <mwm:toponyms>
+        <mwm:value>10</mwm:value>
+        <mwm:value>11</mwm:value>
+      </mwm:toponyms>
+      <mwm:languageCodes>
+        <mwm:value>en</mwm:value>
+        <mwm:value>ja</mwm:value>
+        <mwm:value>ru</mwm:value>
+      </mwm:languageCodes>
+      <mwm:properties>
+        <mwm:value key="property1">value1</mwm:value>
+        <mwm:value key="property2">value2</mwm:value>
+      </mwm:properties>
+    </mwm:compilation>
+  </ExtendedData>
+  <Placemark>
+    <name>Мое любимое место</name>
+    <description>Test bookmark description</description>
+    <TimeStamp><when>1970-01-01T00:13:20Z</when></TimeStamp>
+    <styleUrl>#placemark-blue</styleUrl>
+    <Point><coordinates>45.9242,49.326859</coordinates></Point>
+    <ExtendedData xmlns:mwm="https://omaps.app">
+      <mwm:name>
+        <mwm:lang code="ru">Тестовая метка</mwm:lang>
+        <mwm:lang code="default">Test bookmark</mwm:lang>
+      </mwm:name>
+      <mwm:description>
+        <mwm:lang code="ru">Тестовое описание метки</mwm:lang>
+        <mwm:lang code="default">Test bookmark description</mwm:lang>
+      </mwm:description>
+      <mwm:featureTypes>
+        <mwm:value>historic-castle</mwm:value>
+        <mwm:value>historic-memorial</mwm:value>
+      </mwm:featureTypes>
+      <mwm:customName>
+        <mwm:lang code="en">My favorite place</mwm:lang>
+        <mwm:lang code="default">Мое любимое место</mwm:lang>
+      </mwm:customName>
+      <mwm:scale>15</mwm:scale>
+      <mwm:boundTracks>
+        <mwm:value>0</mwm:value>
+      </mwm:boundTracks>
+      <mwm:visibility>0</mwm:visibility>
+      <mwm:nearestToponym>12345</mwm:nearestToponym>
+      <mwm:minZoom>10</mwm:minZoom>
+      <mwm:properties>
+        <mwm:value key="bm_property1">value1</mwm:value>
+        <mwm:value key="bm_property2">value2</mwm:value>
+        <mwm:value key="score">5</mwm:value>
+      </mwm:properties>
+      <mwm:compilations>1,2,3,4,5</mwm:compilations>
+    </ExtendedData>
+  </Placemark>
+  <Placemark>
+    <name>Test track</name>
+    <description>Test track description</description>
+    <Style><LineStyle>
+      <color>FF0000FF</color>
+      <width>6</width>
+    </LineStyle></Style>
+    <TimeStamp><when>1970-01-01T00:15:00Z</when></TimeStamp>
+    <gx:MultiTrack>
+      <gx:Track>
+        <when>1970-01-01T00:00:00Z</when>
+        <when>1970-01-01T00:00:01Z</when>
+        <when>1970-01-01T00:00:02Z</when>
+        <gx:coord>45.9242 49.326859 1</gx:coord>
+        <gx:coord>45.2244 48.941288 2</gx:coord>
+        <gx:coord>45.1964 49.401948 3</gx:coord>
+      </gx:Track>
+      <gx:Track>
+        <when>1970-01-01T00:00:00Z</when>
+        <gx:coord>45.9242 49.326859 1</gx:coord>
+        <when>1970-01-01T00:00:01Z</when>
+        <gx:coord>45.2244 48.941288 2</gx:coord>
+        <when>1970-01-01T00:00:02Z</when>
+        <gx:coord>45.1964 49.401948 3</gx:coord>
+      </gx:Track>
+      <gx:Track>
+        <gx:coord>45.9242 49.326859 1</gx:coord>
+        <gx:coord>45.2244 48.941288 2</gx:coord>
+        <gx:coord>45.1964 49.401948 3</gx:coord>
+        <when>1970-01-01T00:00:00Z</when>
+        <when>1970-01-01T00:00:01Z</when>
+        <when>1970-01-01T00:00:02Z</when>
+      </gx:Track>
+      <gx:Track>
+        <gx:coord>45.9242 49.326859 1</gx:coord>
+        <when>1970-01-01T00:00:00Z</when>
+        <gx:coord>45.2244 48.941288 2</gx:coord>
+        <when>1970-01-01T00:00:01Z</when>
+        <gx:coord>45.1964 49.401948 3</gx:coord>
+        <when>1970-01-01T00:00:02Z</when>
+      </gx:Track>
+    </gx:MultiTrack>
+    <ExtendedData xmlns:mwm="https://omaps.app">
+      <mwm:name>
+        <mwm:lang code="ru">Тестовый трек</mwm:lang>
+        <mwm:lang code="default">Test track</mwm:lang>
+      </mwm:name>
+      <mwm:description>
+        <mwm:lang code="ru">Тестовое описание трека</mwm:lang>
+        <mwm:lang code="default">Test track description</mwm:lang>
+      </mwm:description>
+      <mwm:localId>0</mwm:localId>
+      <mwm:additionalStyle>
+        <mwm:additionalLineStyle>
+          <color>FF00FF00</color>
+          <width>7</width>
+        </mwm:additionalLineStyle>
+      </mwm:additionalStyle>
+      <mwm:visibility>0</mwm:visibility>
+      <mwm:nearestToponyms>
+        <mwm:value>12345</mwm:value>
+        <mwm:value>54321</mwm:value>
+        <mwm:value>98765</mwm:value>
+      </mwm:nearestToponyms>
+      <mwm:properties>
+        <mwm:value key="tr_property1">value1</mwm:value>
+        <mwm:value key="tr_property2">value2</mwm:value>
+      </mwm:properties>
+    </ExtendedData>
+  </Placemark>
+</Document>
+</kml>

--- a/kml/kml_tests/serdes_tests.cpp
+++ b/kml/kml_tests/serdes_tests.cpp
@@ -5,6 +5,8 @@
 #include "kml/serdes.hpp"
 #include "kml/serdes_binary.hpp"
 
+#include "map/bookmark_helpers.hpp"
+
 #include "indexer/classificator_loader.hpp"
 
 #include "platform/platform.hpp"
@@ -101,7 +103,7 @@ kml::FileData GenerateKmlFileData()
                         {7.0, {kml::PredefinedColor::None, 0x00ff00ff}}};
   trackData.m_timestamp = kml::TimestampClock::from_time_t(900);
 
-  trackData.m_geometry.AssignPoints({
+  trackData.m_geometry.AddLine({
     {{45.9242, 56.8679}, 1}, {{45.2244, 56.2786}, 2}, {{45.1964, 56.9832}, 3}
   });
 
@@ -159,317 +161,43 @@ kml::FileData GenerateKmlFileData()
   return result;
 }
 
-char const * kGeneratedKml =
-R"(<?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://earth.google.com/kml/2.2">
-<Document>
-  <Style id="placemark-red">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-red.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-blue">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-blue.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-purple">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-purple.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-yellow">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-yellow.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-pink">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-pink.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-brown">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-brown.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-green">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-green.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-orange">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-orange.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-deeppurple">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-deeppurple.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-lightblue">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-lightblue.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-cyan">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-cyan.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-teal">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-teal.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-lime">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-lime.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-deeporange">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-deeporange.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-gray">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-gray.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <Style id="placemark-bluegray">
-    <IconStyle>
-      <Icon>
-        <href>https://omaps.app/placemarks/placemark-bluegray.png</href>
-      </Icon>
-    </IconStyle>
-  </Style>
-  <name>Test category</name>
-  <description>Test description</description>
-  <visibility>1</visibility>
-  <ExtendedData xmlns:mwm="https://omaps.app">
-    <mwm:serverId>AAAA-BBBB-CCCC-DDDD</mwm:serverId>
-    <mwm:name>
-      <mwm:lang code="ru">Тестовая категория</mwm:lang>
-      <mwm:lang code="default">Test category</mwm:lang>
-    </mwm:name>
-    <mwm:annotation>
-      <mwm:lang code="en">Test annotation</mwm:lang>
-      <mwm:lang code="default">Test annotation</mwm:lang>
-    </mwm:annotation>
-    <mwm:description>
-      <mwm:lang code="ru">Тестовое описание</mwm:lang>
-      <mwm:lang code="default">Test description</mwm:lang>
-    </mwm:description>
-    <mwm:imageUrl>https://localhost/123.png</mwm:imageUrl>
-    <mwm:author id="12345">Organic Maps</mwm:author>
-    <mwm:lastModified>1970-01-01T00:16:40Z</mwm:lastModified>
-    <mwm:rating>8.9</mwm:rating>
-    <mwm:reviewsNumber>567</mwm:reviewsNumber>
-    <mwm:accessRules>Public</mwm:accessRules>
-    <mwm:tags>
-      <mwm:value>mountains</mwm:value>
-      <mwm:value>ski</mwm:value>
-      <mwm:value>snowboard</mwm:value>
-    </mwm:tags>
-    <mwm:toponyms>
-      <mwm:value>12345</mwm:value>
-      <mwm:value>54321</mwm:value>
-    </mwm:toponyms>
-    <mwm:languageCodes>
-      <mwm:value>en</mwm:value>
-      <mwm:value>ja</mwm:value>
-      <mwm:value>ru</mwm:value>
-    </mwm:languageCodes>
-    <mwm:properties>
-      <mwm:value key="property1">value1</mwm:value>
-      <mwm:value key="property2">value2</mwm:value>
-    </mwm:properties>
-    <mwm:compilation id="1" type="Collection">
-      <mwm:name>
-        <mwm:lang code="ru">Тестовая коллекция</mwm:lang>
-        <mwm:lang code="default">Test collection</mwm:lang>
-      </mwm:name>
-      <mwm:annotation>
-        <mwm:lang code="en">Test collection annotation</mwm:lang>
-        <mwm:lang code="default">Test collection annotation</mwm:lang>
-      </mwm:annotation>
-      <mwm:description>
-        <mwm:lang code="ru">Тестовое описание коллекции</mwm:lang>
-        <mwm:lang code="default">Test collection description</mwm:lang>
-      </mwm:description>
-      <mwm:visibility>1</mwm:visibility>
-      <mwm:imageUrl>https://localhost/1234.png</mwm:imageUrl>
-      <mwm:author id="54321">Organic Maps</mwm:author>
-      <mwm:lastModified>1970-01-01T00:16:39Z</mwm:lastModified>
-      <mwm:rating>5.9</mwm:rating>
-      <mwm:reviewsNumber>333</mwm:reviewsNumber>
-      <mwm:accessRules>Public</mwm:accessRules>
-      <mwm:tags>
-        <mwm:value>mountains</mwm:value>
-        <mwm:value>ski</mwm:value>
-      </mwm:tags>
-      <mwm:toponyms>
-        <mwm:value>8</mwm:value>
-        <mwm:value>9</mwm:value>
-      </mwm:toponyms>
-      <mwm:languageCodes>
-        <mwm:value>en</mwm:value>
-        <mwm:value>ja</mwm:value>
-        <mwm:value>ru</mwm:value>
-      </mwm:languageCodes>
-      <mwm:properties>
-        <mwm:value key="property1">value1</mwm:value>
-        <mwm:value key="property2">value2</mwm:value>
-      </mwm:properties>
-    </mwm:compilation>
-    <mwm:compilation id="4" type="Category">
-      <mwm:name>
-        <mwm:lang code="ru">Тестовая категория</mwm:lang>
-        <mwm:lang code="default">Test category</mwm:lang>
-      </mwm:name>
-      <mwm:annotation>
-        <mwm:lang code="en">Test category annotation</mwm:lang>
-        <mwm:lang code="default">Test category annotation</mwm:lang>
-      </mwm:annotation>
-      <mwm:description>
-        <mwm:lang code="ru">Тестовое описание категории</mwm:lang>
-        <mwm:lang code="default">Test category description</mwm:lang>
-      </mwm:description>
-      <mwm:visibility>0</mwm:visibility>
-      <mwm:imageUrl>https://localhost/134.png</mwm:imageUrl>
-      <mwm:author id="11111">Organic Maps</mwm:author>
-      <mwm:lastModified>1970-01-01T00:05:23Z</mwm:lastModified>
-      <mwm:rating>3.3</mwm:rating>
-      <mwm:reviewsNumber>222</mwm:reviewsNumber>
-      <mwm:accessRules>Public</mwm:accessRules>
-      <mwm:tags>
-        <mwm:value>mountains</mwm:value>
-        <mwm:value>bike</mwm:value>
-      </mwm:tags>
-      <mwm:toponyms>
-        <mwm:value>10</mwm:value>
-        <mwm:value>11</mwm:value>
-      </mwm:toponyms>
-      <mwm:languageCodes>
-        <mwm:value>en</mwm:value>
-        <mwm:value>ja</mwm:value>
-        <mwm:value>ru</mwm:value>
-      </mwm:languageCodes>
-      <mwm:properties>
-        <mwm:value key="property1">value1</mwm:value>
-        <mwm:value key="property2">value2</mwm:value>
-      </mwm:properties>
-    </mwm:compilation>
-  </ExtendedData>
-  <Placemark>
-    <name>Мое любимое место</name>
-    <description>Test bookmark description</description>
-    <TimeStamp><when>1970-01-01T00:13:20Z</when></TimeStamp>
-    <styleUrl>#placemark-blue</styleUrl>
-    <Point><coordinates>45.9242,49.326859</coordinates></Point>
-    <ExtendedData xmlns:mwm="https://omaps.app">
-      <mwm:name>
-        <mwm:lang code="ru">Тестовая метка</mwm:lang>
-        <mwm:lang code="default">Test bookmark</mwm:lang>
-      </mwm:name>
-      <mwm:description>
-        <mwm:lang code="ru">Тестовое описание метки</mwm:lang>
-        <mwm:lang code="default">Test bookmark description</mwm:lang>
-      </mwm:description>
-      <mwm:featureTypes>
-        <mwm:value>historic-castle</mwm:value>
-        <mwm:value>historic-memorial</mwm:value>
-      </mwm:featureTypes>
-      <mwm:customName>
-        <mwm:lang code="en">My favorite place</mwm:lang>
-        <mwm:lang code="default">Мое любимое место</mwm:lang>
-      </mwm:customName>
-      <mwm:scale>15</mwm:scale>
-      <mwm:boundTracks>
-        <mwm:value>0</mwm:value>
-      </mwm:boundTracks>
-      <mwm:visibility>0</mwm:visibility>
-      <mwm:nearestToponym>12345</mwm:nearestToponym>
-      <mwm:minZoom>10</mwm:minZoom>
-      <mwm:properties>
-        <mwm:value key="bm_property1">value1</mwm:value>
-        <mwm:value key="bm_property2">value2</mwm:value>
-        <mwm:value key="score">5</mwm:value>
-      </mwm:properties>
-      <mwm:compilations>1,2,3,4,5</mwm:compilations>
-    </ExtendedData>
-  </Placemark>
-  <Placemark>
-    <name>Test track</name>
-    <description>Test track description</description>
-    <Style><LineStyle>
-      <color>FF0000FF</color>
-      <width>6</width>
-    </LineStyle></Style>
-    <TimeStamp><when>1970-01-01T00:15:00Z</when></TimeStamp>
-    <LineString><coordinates>45.9242,49.326859,1 45.2244,48.941288,2 45.1964,49.401948,3</coordinates></LineString>
-    <ExtendedData xmlns:mwm="https://omaps.app">
-      <mwm:name>
-        <mwm:lang code="ru">Тестовый трек</mwm:lang>
-        <mwm:lang code="default">Test track</mwm:lang>
-      </mwm:name>
-      <mwm:description>
-        <mwm:lang code="ru">Тестовое описание трека</mwm:lang>
-        <mwm:lang code="default">Test track description</mwm:lang>
-      </mwm:description>
-      <mwm:localId>0</mwm:localId>
-      <mwm:additionalStyle>
-        <mwm:additionalLineStyle>
-          <color>FF00FF00</color>
-          <width>7</width>
-        </mwm:additionalLineStyle>
-      </mwm:additionalStyle>
-      <mwm:visibility>0</mwm:visibility>
-      <mwm:nearestToponyms>
-        <mwm:value>12345</mwm:value>
-        <mwm:value>54321</mwm:value>
-        <mwm:value>98765</mwm:value>
-      </mwm:nearestToponyms>
-      <mwm:properties>
-        <mwm:value key="tr_property1">value1</mwm:value>
-        <mwm:value key="tr_property2">value2</mwm:value>
-      </mwm:properties>
-    </ExtendedData>
-  </Placemark>
-</Document>
-</kml>)";
+kml::FileData GenerateKmlFileDataForTrackWithoutTimestamps()
+{
+  auto data = GenerateKmlFileData();
+  auto & trackData = data.m_tracksData[0];
+  trackData.m_geometry.Clear();
+  trackData.m_geometry.AddLine({
+    {{45.9242, 56.8679}, 1}, {{45.2244, 56.2786}, 2}, {{45.1964, 56.9832}, 3}
+  });
+  trackData.m_geometry.AddTimestamps({});
+  return data;
+}
+
+kml::FileData GenerateKmlFileDataForTrackWithTimestamps()
+{
+  auto data = GenerateKmlFileData();
+  auto & trackData = data.m_tracksData[0];
+  trackData.m_geometry.Clear();
+  
+  // track 1 (without timestamps)
+  trackData.m_geometry.AddLine({
+    {{45.9242, 56.8679}, 1}, {{45.2244, 56.2786}, 2}, {{45.1964, 56.9832}, 3}
+  });
+  trackData.m_geometry.AddTimestamps({});
+  
+  // track 2
+  trackData.m_geometry.AddLine({
+    {{45.9242, 56.8679}, 1}, {{45.2244, 56.2786}, 2}, {{45.1964, 56.9832}, 3}
+  });
+  trackData.m_geometry.AddTimestamps({0.0, 1.0, 2.0});
+
+  // track 3
+  trackData.m_geometry.AddLine({
+    {{45.9242, 56.8679}, 1}, {{45.2244, 56.2786}, 2}
+  });
+  trackData.m_geometry.AddTimestamps({0.0, 1.0});
+  return data;
+}
 }  // namespace
 
 // 1. Check text and binary deserialization from the prepared sources in memory.
@@ -478,16 +206,12 @@ UNIT_TEST(Kml_Deserialization_Text_Bin_Memory)
   UNUSED_VALUE(FormatBytesFromBuffer({}));
 
   kml::FileData dataFromText;
-  try
+  TEST_NO_THROW(
   {
     kml::DeserializerKml des(dataFromText);
     MemReader reader(kTextKml, strlen(kTextKml));
     des.Deserialize(reader);
-  }
-  catch (kml::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
 // TODO: uncomment to output bytes to the log.
 //  std::vector<uint8_t> buffer;
@@ -499,16 +223,12 @@ UNIT_TEST(Kml_Deserialization_Text_Bin_Memory)
 //  LOG(LINFO, (FormatBytesFromBuffer(buffer)));
 
   kml::FileData dataFromBin;
-  try
+  TEST_NO_THROW(
   {
     MemReader reader(kBinKml.data(), kBinKml.size());
     kml::binary::DeserializerKml des(dataFromBin);
     des.Deserialize(reader);
-  }
-  catch (kml::binary::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
   TEST_EQUAL(dataFromText, dataFromBin, ());
 }
@@ -574,35 +294,27 @@ UNIT_TEST(Kml_Deserialization_Text_File)
 {
   std::string const kmlFile = base::JoinPath(GetPlatform().TmpDir(), "tmp.kml");
   SCOPE_GUARD(fileGuard, std::bind(&FileWriter::DeleteFileX, kmlFile));
-  try
+  TEST_NO_THROW(
   {
     FileWriter file(kmlFile);
     file.Write(kTextKml, strlen(kTextKml));
-  }
-  catch (FileWriter::Exception const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
   kml::FileData dataFromFile;
-  try
+  TEST_NO_THROW(
   {
     kml::DeserializerKml des(dataFromFile);
     FileReader reader(kmlFile);
     des.Deserialize(reader);
-  }
-  catch (FileReader::Exception const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
   kml::FileData dataFromText;
+  TEST_NO_THROW(
   {
     kml::DeserializerKml des(dataFromText);
     MemReader reader(kTextKml, strlen(kTextKml));
     des.Deserialize(reader);
-  }
-
+  }, ());
   TEST_EQUAL(dataFromFile, dataFromText, ());
 }
 
@@ -611,34 +323,27 @@ UNIT_TEST(Kml_Deserialization_Bin_File)
 {
   std::string const kmbFile = base::JoinPath(GetPlatform().TmpDir(), "tmp.kmb");
   SCOPE_GUARD(fileGuard, std::bind(&FileWriter::DeleteFileX, kmbFile));
-  try
+  TEST_NO_THROW(
   {
     FileWriter file(kmbFile);
     file.Write(kBinKml.data(), kBinKml.size());
-  }
-  catch (FileWriter::Exception & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
   kml::FileData dataFromFile;
-  try
+  TEST_NO_THROW(
   {
     kml::binary::DeserializerKml des(dataFromFile);
     FileReader reader(kmbFile);
     des.Deserialize(reader);
-  }
-  catch (FileReader::Exception const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
   kml::FileData dataFromBin;
+  TEST_NO_THROW(
   {
     kml::binary::DeserializerKml des(dataFromBin);
     MemReader reader(kBinKml.data(), kBinKml.size());
     des.Deserialize(reader);
-  }
+  }, ());
 
   TEST_EQUAL(dataFromFile, dataFromBin, ());
 }
@@ -651,28 +356,20 @@ UNIT_TEST(Kml_Serialization_Bin_File)
 
   std::string const kmbFile = base::JoinPath(GetPlatform().TmpDir(), "tmp.kmb");
   SCOPE_GUARD(fileGuard, std::bind(&FileWriter::DeleteFileX, kmbFile));
-  try
+  TEST_NO_THROW(
   {
     kml::binary::SerializerKml ser(data);
     FileWriter writer(kmbFile);
     ser.Serialize(writer);
-  }
-  catch (FileWriter::Exception const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
   kml::FileData dataFromFile;
-  try
+  TEST_NO_THROW(
   {
     kml::binary::DeserializerKml des(dataFromFile);
     FileReader reader(kmbFile);
     des.Deserialize(reader);
-  }
-  catch (FileReader::Exception const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
   TEST_EQUAL(data, dataFromFile, ());
 }
@@ -681,28 +378,20 @@ UNIT_TEST(Kml_Serialization_Bin_File)
 // The text in the file can be not equal to the original generated data, because
 // text representation does not support all features, e.g. we do not store ids for
 // bookmarks and tracks.
-UNIT_TEST(Kml_Serialization_Text_File)
+UNIT_TEST(Kml_Serialization_Text_File_Track_Without_Timestamps)
 {
   classificator::Load();
 
-  auto data = GenerateKmlFileData();
+  auto data = GenerateKmlFileDataForTrackWithoutTimestamps();
 
   std::string const kmlFile = base::JoinPath(GetPlatform().TmpDir(), "tmp.kml");
   SCOPE_GUARD(fileGuard, std::bind(&FileWriter::DeleteFileX, kmlFile));
-  try
+  TEST_NO_THROW(
   {
     kml::SerializerKml ser(data);
     FileWriter sink(kmlFile);
     ser.Serialize(sink);
-  }
-  catch (kml::SerializerKml::SerializeException const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
-  catch (FileWriter::Exception const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
 // TODO: uncomment to output KML to the log.
 //  std::string buffer;
@@ -713,84 +402,111 @@ UNIT_TEST(Kml_Serialization_Text_File)
 //  }
 //  LOG(LINFO, (buffer));
 
-  kml::FileData dataFromFile;
-  try
+  kml::FileData dataFromGeneratedFile;
+  TEST_NO_THROW(
   {
-    kml::DeserializerKml des(dataFromFile);
+    kml::DeserializerKml des(dataFromGeneratedFile);
     FileReader reader(kmlFile);
     des.Deserialize(reader);
-  }
-  catch (FileReader::Exception const & exc)
+  }, ());
+  TEST_EQUAL(dataFromGeneratedFile, data, ());
+
+  kml::FileData dataFromFile;
+  TEST_NO_THROW(
   {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+    kml::DeserializerKml des(dataFromFile);
+    FileReader reader(GetPlatform().TestsDataPathForFile("kml_test_data/generated.kml"));
+    des.Deserialize(reader);
+  }, ());
   TEST_EQUAL(dataFromFile, data, ());
 
-  kml::FileData dataFromMemory;
+  std::string dataFromFileBuffer;
   {
-    kml::DeserializerKml des(dataFromMemory);
-    MemReader reader(kGeneratedKml, strlen(kGeneratedKml));
-    des.Deserialize(reader);
+    MemWriter<decltype(dataFromFileBuffer)> sink(dataFromFileBuffer);
+    kml::SerializerKml ser(dataFromFile);
+    ser.Serialize(sink);
   }
-  TEST_EQUAL(dataFromMemory, data, ());
+  std::string dataFromGeneratedFileBuffer;
+  {
+    MemWriter<decltype(dataFromGeneratedFileBuffer)> sink(dataFromGeneratedFileBuffer);
+    kml::SerializerKml ser(dataFromGeneratedFile);
+    ser.Serialize(sink);
+  }
+  TEST_EQUAL(dataFromFileBuffer, dataFromGeneratedFileBuffer, ());
+}
+
+UNIT_TEST(Kml_Serialization_Text_File_Tracks_With_Timestamps)
+{
+  classificator::Load();
+
+  auto data = GenerateKmlFileDataForTrackWithTimestamps();
+
+  std::string const kmlFile = base::JoinPath(GetPlatform().TmpDir(), "tmp.kml");
+  SCOPE_GUARD(fileGuard, std::bind(&FileWriter::DeleteFileX, kmlFile));
+  TEST_NO_THROW(
+  {
+    kml::SerializerKml ser(data);
+    FileWriter sink(kmlFile);
+    ser.Serialize(sink);
+  }, ());
+
+  kml::FileData dataFromGeneratedFile;
+  TEST_NO_THROW(
+  {
+    kml::DeserializerKml des(dataFromGeneratedFile);
+    FileReader reader(kmlFile);
+    des.Deserialize(reader);
+  }, ());
+  TEST_EQUAL(dataFromGeneratedFile, data, ());
+
+  kml::FileData dataFromFile;
+  TEST_NO_THROW(
+  {
+    kml::DeserializerKml des(dataFromFile);
+    FileReader reader(GetPlatform().TestsDataPathForFile("kml_test_data/generated_mixed_tracks.kml"));
+    des.Deserialize(reader);
+  }, ());
+  TEST_EQUAL(dataFromFile, data, ());
 }
 
 // 8. Check binary deserialization of v.3 format.
 UNIT_TEST(Kml_Deserialization_From_Bin_V3_And_V4)
 {
   kml::FileData dataFromBinV3;
-  try
+  TEST_NO_THROW(
   {
     MemReader reader(kBinKmlV3.data(), kBinKmlV3.size());
     kml::binary::DeserializerKml des(dataFromBinV3);
     des.Deserialize(reader);
-  }
-  catch (kml::binary::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
   kml::FileData dataFromBinV4;
-  try
+  TEST_NO_THROW(
   {
     MemReader reader(kBinKmlV4.data(), kBinKmlV4.size());
     kml::binary::DeserializerKml des(dataFromBinV4);
     des.Deserialize(reader);
-  }
-  catch (kml::binary::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
-
+  }, ());
   TEST_EQUAL(dataFromBinV3, dataFromBinV4, ());
 }
 
 UNIT_TEST(Kml_Deserialization_From_Bin_V6_And_V7)
 {
   kml::FileData dataFromBinV6;
-  try
+  TEST_NO_THROW(
   {
     MemReader reader(kBinKmlV6.data(), kBinKmlV6.size());
     kml::binary::DeserializerKml des(dataFromBinV6);
     des.Deserialize(reader);
-  }
-  catch (kml::binary::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
   kml::FileData dataFromBinV7;
-  try
+  TEST_NO_THROW(
   {
     MemReader reader(kBinKmlV7.data(), kBinKmlV7.size());
     kml::binary::DeserializerKml des(dataFromBinV7);
     des.Deserialize(reader);
-  }
-  catch (kml::binary::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
-
+  }, ());
   TEST_EQUAL(dataFromBinV6, dataFromBinV7, ());
 }
 
@@ -798,57 +514,40 @@ UNIT_TEST(Kml_Deserialization_From_Bin_V6_And_V7)
 UNIT_TEST(Kml_Deserialization_From_Bin_V7_And_V8)
 {
   kml::FileData dataFromBinV7;
-  try
+  TEST_NO_THROW(
   {
     MemReader reader(kBinKmlV7.data(), kBinKmlV7.size());
     kml::binary::DeserializerKml des(dataFromBinV7);
     des.Deserialize(reader);
-  }
-  catch (kml::binary::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
   kml::FileData dataFromBinV8;
-  try
+  TEST_NO_THROW(
   {
     MemReader reader(kBinKmlV8.data(), kBinKmlV8.size());
     kml::binary::DeserializerKml des(dataFromBinV8);
     des.Deserialize(reader);
-  }
-  catch (kml::binary::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
-
+  }, ());
   TEST_EQUAL(dataFromBinV7, dataFromBinV8, ());
 }
 
 UNIT_TEST(Kml_Deserialization_From_Bin_V8_And_V8MM)
 {
   kml::FileData dataFromBinV8;
-  try
+  TEST_NO_THROW(
   {
     MemReader reader(kBinKmlV8.data(), kBinKmlV8.size());
     kml::binary::DeserializerKml des(dataFromBinV8);
     des.Deserialize(reader);
-  }
-  catch (kml::binary::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
   kml::FileData dataFromBinV8MM;
-  try
+  TEST_NO_THROW(
   {
     MemReader reader(kBinKmlV8MM.data(), kBinKmlV8MM.size());
     kml::binary::DeserializerKml des(dataFromBinV8MM);
     des.Deserialize(reader);
-  }
-  catch (kml::binary::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Exception raised", exc.what()));
-  }
+  }, ());
 
 // Can't compare dataFromBinV8.m_categoryData and dataFromBinV8MM.m_categoryData directly
 // because new format has less properties and different m_id. Compare some properties here:
@@ -869,28 +568,20 @@ UNIT_TEST(Kml_Deserialization_From_Bin_V8_And_V8MM)
 UNIT_TEST(Kml_Deserialization_From_KMB_V8_And_V9MM)
 {
   kml::FileData dataFromBinV8;
-  try
+  TEST_NO_THROW(
   {
     MemReader reader(kBinKmlV8.data(), kBinKmlV8.size());
     kml::binary::DeserializerKml des(dataFromBinV8);
     des.Deserialize(reader);
-  }
-  catch (kml::binary::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Failed to deserialize data from KMB V8 and V9MM", exc.what()));
-  }
+  }, ());
 
   kml::FileData dataFromBinV9MM;
-  try
+  TEST_NO_THROW(
   {
     MemReader reader(kBinKmlV9MM.data(), kBinKmlV9MM.size());
     kml::binary::DeserializerKml des(dataFromBinV9MM);
     des.Deserialize(reader);
-  }
-  catch (kml::binary::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Failed to deserialize data from KMB V9MM", exc.what()));
-  }
+  }, ());
 
   // Can't compare dataFromBinV8.m_categoryData and dataFromBinV9MM.m_categoryData directly
   // because new format has less properties and different m_id. Compare some properties here:
@@ -914,16 +605,12 @@ UNIT_TEST(Kml_Deserialization_From_KMB_V8_And_V9MM)
 UNIT_TEST(Kml_Deserialization_From_KMB_V9MM_With_MultiGeometry)
 {
   kml::FileData dataFromBinV9MM;
-  try
+  TEST_NO_THROW(
   {
     MemReader reader(kBinKmlMultiGeometryV9MM.data(), kBinKmlMultiGeometryV9MM.size());
     kml::binary::DeserializerKml des(dataFromBinV9MM);
     des.Deserialize(reader);
-  }
-  catch (kml::binary::DeserializerKml::DeserializeException const & exc)
-  {
-    TEST(false, ("Failed to deserialize data from KMB V9MM", exc.what()));
-  }
+  }, ());
 
   TEST_EQUAL(dataFromBinV9MM.m_tracksData.size(), 1, ());
 
@@ -1003,22 +690,26 @@ UNIT_TEST(Kml_Ver_2_3)
   )";
 
   kml::FileData fData;
-  try
+  TEST_NO_THROW(
   {
     MemReader const reader(data);
     kml::DeserializerKml des(fData);
     des.Deserialize(reader);
-  }
-  catch (kml::DeserializerKml::DeserializeException const & ex)
-  {
-    TEST(false, ("Exception raised", ex.Msg()));
-  }
+  }, ());
 
   TEST_EQUAL(fData.m_tracksData.size(), 1, ());
-  auto const & lines = fData.m_tracksData[0].m_geometry.m_lines;
+  auto const & geom = fData.m_tracksData[0].m_geometry;
+  auto const & lines = geom.m_lines;
+  auto const & timestamps = geom.m_timestamps;
   TEST_EQUAL(lines.size(), 2, ());
   TEST_EQUAL(lines[0].size(), 7, ());
   TEST_EQUAL(lines[1].size(), 6, ());
+  TEST(geom.HasTimestamps(), ());
+  TEST(geom.HasTimestampsFor(0), ());
+  TEST(geom.HasTimestampsFor(1), ());
+  TEST_EQUAL(timestamps.size(), 2, ());
+  TEST_EQUAL(timestamps[0].size(), 7, ());
+  TEST_EQUAL(timestamps[1].size(), 6, ());
 }
 
 UNIT_TEST(Kml_Placemark_contains_both_Bookmark_and_Track_data)
@@ -1049,19 +740,18 @@ UNIT_TEST(Kml_Placemark_contains_both_Bookmark_and_Track_data)
   )";
 
   kml::FileData fData;
-  try
+  TEST_NO_THROW(
   {
     MemReader const reader(input);
     kml::DeserializerKml des(fData);
     des.Deserialize(reader);
-  }
-  catch (kml::DeserializerKml::DeserializeException const & ex)
-  {
-    TEST(false, ("Exception raised", ex.Msg()));
-  }
+  }, ());
 
   TEST_EQUAL(fData.m_bookmarksData.size(), 2, ());
   TEST_EQUAL(fData.m_tracksData.size(), 2, ());
+
+  TEST(!fData.m_tracksData[0].m_geometry.HasTimestamps(), ());
+  TEST(!fData.m_tracksData[1].m_geometry.HasTimestamps(), ());
 }
 
 // See https://github.com/organicmaps/organicmaps/issues/5800
@@ -1089,18 +779,47 @@ UNIT_TEST(Fix_Invisible_Color_Bug_In_Gpx_Tracks)
   )";
 
   kml::FileData fData;
-  try
+  TEST_NO_THROW(
   {
     kml::DeserializerKml(fData).Deserialize(MemReader(input));
-  }
-  catch (kml::DeserializerKml::DeserializeException const & ex)
-  {
-    TEST(false, ("Exception raised", ex.Msg()));
-  }
+  }, ());
 
   TEST_EQUAL(fData.m_tracksData.size(), 2, ());
   TEST_EQUAL(fData.m_tracksData[0].m_layers.size(), 1, ());
   auto const & layer = fData.m_tracksData[0].m_layers[0];
   TEST_EQUAL(layer.m_color.m_rgba, kml::kDefaultTrackColor, ("Wrong transparency should be fixed"));
   TEST_EQUAL(layer.m_lineWidth, 3, ());
+}
+
+UNIT_TEST(Kml_Tracks_With_Different_Points_And_Timestamps_Order)
+{
+  kml::FileData dataFromFile;
+  TEST_NO_THROW(
+  {
+    kml::DeserializerKml des(dataFromFile);
+    FileReader reader(GetPlatform().TestsDataPathForFile("kml_test_data/track_with_timestams_different_orders.kml"));
+    des.Deserialize(reader);
+  }, ());
+  TEST_EQUAL(dataFromFile.m_tracksData.size(), 1, ());
+  auto const & geom = dataFromFile.m_tracksData[0].m_geometry;
+  TEST_EQUAL(geom.m_lines.size(), 4, ());
+  TEST_EQUAL(geom.m_timestamps.size(), 4, ());
+  TEST_EQUAL(geom.m_lines[0], geom.m_lines[1], ());
+  TEST_EQUAL(geom.m_lines[0], geom.m_lines[2], ());
+  TEST_EQUAL(geom.m_lines[0], geom.m_lines[3], ());
+  TEST_EQUAL(geom.m_timestamps[0], geom.m_timestamps[1], ());
+  TEST_EQUAL(geom.m_timestamps[0], geom.m_timestamps[2], ());
+  TEST_EQUAL(geom.m_timestamps[0], geom.m_timestamps[3], ());
+}
+
+UNIT_TEST(Kml_Track_Points_And_Timestamps_Sizes_Mismatch)
+{
+  kml::FileData dataFromFile;
+  TEST_ANY_THROW(
+  {
+    kml::DeserializerKml des(dataFromFile);
+    FileReader reader(GetPlatform().TestsDataPathForFile("kml_test_data/track_with_timestamps_mismatch.kml"));
+    des.Deserialize(reader);
+  }, ());
+  TEST_EQUAL(dataFromFile.m_tracksData.size(), 0, ());
 }

--- a/kml/kml_tests/serdes_tests.cpp
+++ b/kml/kml_tests/serdes_tests.cpp
@@ -101,7 +101,7 @@ kml::FileData GenerateKmlFileData()
                         {7.0, {kml::PredefinedColor::None, 0x00ff00ff}}};
   trackData.m_timestamp = kml::TimestampClock::from_time_t(900);
 
-  trackData.m_geometry.Assign({
+  trackData.m_geometry.AssignPoints({
     {{45.9242, 56.8679}, 1}, {{45.2244, 56.2786}, 2}, {{45.1964, 56.9832}, 3}
   });
 

--- a/kml/serdes.cpp
+++ b/kml/serdes.cpp
@@ -438,7 +438,7 @@ void SaveBookmarkData(Writer & writer, BookmarkData const & bookmarkData)
 
   auto const style = GetStyleForPredefinedColor(bookmarkData.m_color.m_predefinedColor);
   writer << kIndent4 << "<styleUrl>#" << style << "</styleUrl>\n"
-         << kIndent4 << "<Point><coordinates>" << PointToString(bookmarkData.m_point)
+         << kIndent4 << "<Point><coordinates>" << PointToLineString(bookmarkData.m_point)
          << "</coordinates></Point>\n";
 
   SaveBookmarkExtendedData(writer, bookmarkData);
@@ -455,41 +455,101 @@ void SaveTrackLayer(Writer & writer, TrackLayer const & layer,
   writer << indent << "<width>" << strings::to_string(layer.m_lineWidth) << "</width>\n";
 }
 
-void SaveTrackGeometry(Writer & writer, MultiGeometry const & geom)
+void SaveLineStrings(Writer & writer, MultiGeometry const & geom)
 {
-  size_t const sz = geom.m_lines.size();
-  if (sz == 0)
-  {
-    ASSERT(false, ());
-    return;
-  }
-
   auto linesIndent = kIndent4;
-  if (sz > 1)
+  auto const lineStringsSize = geom.GetNumberOfLinesWithouTimestamps();
+  
+  if (lineStringsSize > 1)
   {
     linesIndent = kIndent8;
     writer << kIndent4 << "<MultiGeometry>\n";
   }
 
-  for (auto const & e : geom.m_lines)
+  for (size_t lineIndex = 0; lineIndex < geom.m_lines.size(); ++lineIndex)
   {
-    if (e.empty())
+    auto const & line = geom.m_lines[lineIndex];
+    if (line.empty())
     {
-      ASSERT(false, ());
+      LOG(LERROR, ("Unexpected empty Track"));
       continue;
     }
 
+    // Skip the tracks with the timestamps when writing the <LineString> points.
+    if (geom.HasTimestampsFor(lineIndex))
+      continue;
+
     writer << linesIndent << "<LineString><coordinates>";
 
-    writer << PointToString(e[0]);
-    for (size_t i = 1; i < e.size(); ++i)
-      writer << " " << PointToString(e[i]);
+    writer << PointToLineString(line[0]);
+    for (size_t pointIndex = 1; pointIndex < line.size(); ++pointIndex)
+      writer << " " << PointToLineString(line[pointIndex]);
 
     writer << "</coordinates></LineString>\n";
   }
 
-  if (sz > 1)
+  if (lineStringsSize > 1)
     writer << kIndent4 << "</MultiGeometry>\n";
+}
+
+void SaveGxTracks(Writer & writer, MultiGeometry const & geom)
+{
+  auto linesIndent = kIndent4;
+  auto const gxTracksSize = geom.GetNumberOfLinesWithTimestamps();
+  
+  if (gxTracksSize > 1)
+  {
+    linesIndent = kIndent8;
+    writer << kIndent4 << "<gx:MultiTrack>\n";
+    /// @TODO(KK): add the <altitudeMode>absolute</altitudeMode> if needed
+  }
+
+  for (size_t lineIndex = 0; lineIndex < geom.m_lines.size(); ++lineIndex)
+  {
+    auto const & line = geom.m_lines[lineIndex];
+    if (line.empty())
+    {
+      LOG(LERROR, ("Unexpected empty Track"));
+      continue;
+    }
+
+    // Skip the tracks without the timestamps when writing the <gx:Track> points.
+    if (!geom.HasTimestampsFor(lineIndex))
+      continue;
+
+    writer << linesIndent << "<gx:Track>\n";
+    /// @TODO(KK): add the <altitudeMode>absolute</altitudeMode> if needed
+
+    auto const & timestampsForLine = geom.m_timestamps[lineIndex];
+    if (line.size() != timestampsForLine.size())
+      CHECK_EQUAL(line.size(), timestampsForLine.size(), ());
+
+    for (size_t pointIndex = 0; pointIndex < line.size(); ++pointIndex)
+      writer << linesIndent << kIndent4 << "<when>" << base::SecondsSinceEpochToString(timestampsForLine[pointIndex]) << "</when>\n";
+
+    for (const auto & point : line)
+      writer << linesIndent << kIndent4 << "<gx:coord>" << PointToGxString(point) << "</gx:coord>\n";
+
+    writer << linesIndent << "</gx:Track>\n";
+  }
+
+  if (gxTracksSize > 1)
+    writer << kIndent4 << "</gx:MultiTrack>\n";
+}
+
+void SaveTrackGeometry(Writer & writer, MultiGeometry const & geom)
+{
+  size_t const sz = geom.m_lines.size();
+  if (sz == 0)
+  {
+    LOG(LERROR, ("Unexpected empty MultiGeometry"));
+    return;
+  }
+
+  CHECK_EQUAL(geom.m_lines.size(), geom.m_timestamps.size(), ("Number of coordinates and timestamps should match"));
+
+  SaveLineStrings(writer, geom);
+  SaveGxTracks(writer, geom);
 }
 
 void SaveTrackExtendedData(Writer & writer, TrackData const & trackData)
@@ -547,7 +607,6 @@ void SaveTrackData(Writer & writer, TrackData const & trackData)
   }
 
   SaveTrackGeometry(writer, trackData.m_geometry);
-
   SaveTrackExtendedData(writer, trackData);
 
   writer << kIndent2 << "</Placemark>\n";
@@ -689,7 +748,10 @@ void KmlParser::ParseLineString(std::string const & s)
   ParseAndAddPoints(line, s, " \n\r\t", ",");
 
   if (line.size() > 1)
+  {
     m_geometry.m_lines.push_back(std::move(line));
+    m_geometry.m_timestamps.emplace_back();
+  }
 }
 
 bool KmlParser::MakeValid()
@@ -700,7 +762,7 @@ bool KmlParser::MakeValid()
     {
       // Set default name.
       if (m_name.empty() && m_featureTypes.empty())
-        m_name[kDefaultLang] = PointToString(m_org);
+        m_name[kDefaultLang] = PointToLineString(m_org);
 
       // Set default pin.
       if (m_predefinedColor == PredefinedColor::None)
@@ -769,6 +831,7 @@ bool KmlParser::Push(std::string movedTag)
   {
     m_geometryType = GEOMETRY_TYPE_LINE;
     m_geometry.m_lines.emplace_back();
+    m_geometry.m_timestamps.emplace_back();
   }
   return true;
 }
@@ -973,7 +1036,12 @@ void KmlParser::CharData(std::string & value)
     {
       if (!IsTrack(prevTag))
         return false;
-
+      if (currTag == "when")
+      {
+        auto & timestamps = m_geometry.m_timestamps;
+        ASSERT(!timestamps.empty(), ());
+        timestamps.back().emplace_back(base::StringToTimestamp(value));
+      }
       if (currTag == "coord" || currTag == "gx:coord")
       {
         auto & lines = m_geometry.m_lines;

--- a/kml/serdes.cpp
+++ b/kml/serdes.cpp
@@ -673,13 +673,9 @@ void KmlParser::ParseAndAddPoints(MultiGeometry::LineT & line, std::string_view 
   {
     geometry::PointWithAltitude point;
     if (ParsePointWithAltitude(v, coordSeparator, point))
-    {
-      // We don't expect vertical surfaces, so do not compare heights here.
-      // Will get a lot of duplicating points otherwise after import some user KMLs.
-      // https://github.com/organicmaps/organicmaps/issues/3895
-      if (line.empty() || !AlmostEqualAbs(line.back().GetPoint(), point.GetPoint(), kMwmPointAccuracy))
-        line.emplace_back(point);
-    }
+      line.emplace_back(point);
+    else
+      LOG(LWARNING, ("Can not parse KML coordinates from", v));
   });
 }
 

--- a/kml/serdes_common.cpp
+++ b/kml/serdes_common.cpp
@@ -6,7 +6,7 @@
 namespace kml
 {
 
-std::string PointToString(m2::PointD const & org)
+std::string PointToString(m2::PointD const & org, char const separator)
 {
   double const lon = mercator::XToLon(org.x);
   double const lat = mercator::YToLat(org.y);
@@ -14,15 +14,24 @@ std::string PointToString(m2::PointD const & org)
   std::ostringstream ss;
   ss.precision(8);
 
-  ss << lon << "," << lat;
+  ss << lon << separator << lat;
   return ss.str();
 }
 
-std::string PointToString(geometry::PointWithAltitude const & pt)
+std::string PointToLineString(geometry::PointWithAltitude const & pt)
 {
+  char constexpr kSeparator = ',';
   if (pt.GetAltitude() != geometry::kInvalidAltitude)
-    return PointToString(pt.GetPoint()) + "," + strings::to_string(pt.GetAltitude());
-  return PointToString(pt.GetPoint());
+    return PointToString(pt.GetPoint(), kSeparator) + kSeparator + strings::to_string(pt.GetAltitude());
+  return PointToString(pt.GetPoint(), kSeparator);
+}
+
+std::string PointToGxString(geometry::PointWithAltitude const & pt)
+{
+  char constexpr kSeparator = ' ';
+  if (pt.GetAltitude() != geometry::kInvalidAltitude)
+    return PointToString(pt.GetPoint(), kSeparator) + kSeparator + strings::to_string(pt.GetAltitude());
+  return PointToString(pt.GetPoint(), kSeparator);
 }
 
 void SaveStringWithCDATA(Writer & writer, std::string s)

--- a/kml/serdes_common.hpp
+++ b/kml/serdes_common.hpp
@@ -20,9 +20,10 @@ uint32_t ToRGBA(Channel red, Channel green, Channel blue, Channel alpha)
          static_cast<uint8_t>(blue) << 8 | static_cast<uint8_t>(alpha);
 }
 
-std::string PointToString(m2::PointD const & org);
+std::string PointToString(m2::PointD const & org, char const separator);
 
-std::string PointToString(geometry::PointWithAltitude const & pt);
+std::string PointToLineString(geometry::PointWithAltitude const & pt);
+std::string PointToGxString(geometry::PointWithAltitude const & pt);
 
 void SaveStringWithCDATA(Writer & writer, std::string s);
 

--- a/kml/serdes_gpx.cpp
+++ b/kml/serdes_gpx.cpp
@@ -74,7 +74,7 @@ bool GpxParser::MakeValid()
     {
       // Set default name.
       if (m_name.empty())
-        m_name = kml::PointToString(m_org);
+        m_name = kml::PointToLineString(m_org);
 
       // Set default pin.
       if (m_predefinedColor == PredefinedColor::None)

--- a/kml/serdes_gpx.hpp
+++ b/kml/serdes_gpx.hpp
@@ -96,12 +96,15 @@ private:
   double m_lat;
   double m_lon;
   geometry::Altitude m_altitude;
+  time_t m_timestamp;
 
   MultiGeometry::LineT m_line;
+  MultiGeometry::TimeT m_timestamps;
   std::string m_customName;
   void ParseName(std::string const & value, std::string const & prevTag);
   void ParseDescription(std::string const & value, std::string const & prevTag);
   void ParseAltitude(std::string const & value);
+  void ParseTimestamp(std::string const & value);
   std::string BuildDescription() const;
 };
 }  // namespace gpx

--- a/kml/types.cpp
+++ b/kml/types.cpp
@@ -30,6 +30,52 @@ void SetBookmarksMinZoom(FileData & fileData, double countPerTile, int maxZoom)
   minZoomQuadtree.SetMinZoom(countPerTile, maxZoom, setMinZoom);
 }
 
+bool MultiGeometry::IsValid() const
+{
+  ASSERT_EQUAL(m_lines.size(), m_timestamps.size(), ());
+  return !m_lines.empty();
+}
+
+void MultiGeometry::Clear() 
+{
+  m_lines.clear();
+  m_timestamps.clear();
+}
+
+bool MultiGeometry::HasTimestamps() const
+{
+  if (m_timestamps.empty())
+    return false;
+  for (auto const & timestamp : m_timestamps)
+  {
+    if (!timestamp.empty())
+      return true;
+  }
+  return false;
+}
+
+bool MultiGeometry::HasTimestampsFor(size_t lineIndex) const
+{
+  ASSERT(!m_timestamps.empty(), ());
+  ASSERT_EQUAL(m_lines.size(), m_timestamps.size(), ());
+  return !m_timestamps[lineIndex].empty();
+}
+
+size_t MultiGeometry::GetNumberOfLinesWithouTimestamps() const
+{
+  return m_lines.size() - GetNumberOfLinesWithTimestamps();
+}
+
+size_t MultiGeometry::GetNumberOfLinesWithTimestamps() const
+{
+  ASSERT_EQUAL(m_lines.size(), m_timestamps.size(), ());
+  size_t size = 0;
+  for (auto const & timestamp : m_timestamps)
+    if (!timestamp.empty())
+      ++size;
+  return size;
+}
+
 void MultiGeometry::FromPoints(std::vector<m2::PointD> const & points)
 {
   LineT line;
@@ -38,6 +84,18 @@ void MultiGeometry::FromPoints(std::vector<m2::PointD> const & points)
 
   ASSERT(line.size() > 1, ());
   m_lines.push_back(std::move(line));
+}
+
+void MultiGeometry::AddLine(std::initializer_list<geometry::PointWithAltitude> lst)
+{
+  m_lines.emplace_back();
+  m_lines.back().assign(lst);
+}
+
+void MultiGeometry::AddTimestamps(std::initializer_list<double> lst)
+{
+  m_timestamps.emplace_back();
+  m_timestamps.back().assign(lst);
 }
 
 MultiGeometry mergeGeometry(std::vector<MultiGeometry> && aGeometries)

--- a/kml/types.hpp
+++ b/kml/types.hpp
@@ -344,27 +344,39 @@ struct TrackLayer
 struct MultiGeometry
 {
   using LineT = std::vector<geometry::PointWithAltitude>;
-  std::vector<LineT> m_lines;
+  using TimeT = std::vector<double>;
 
-  void Clear() { m_lines.clear(); }
-  bool IsValid() const { return !m_lines.empty(); }
+  std::vector<LineT> m_lines;
+  std::vector<TimeT> m_timestamps;
+
+  void Clear();
+  bool IsValid() const;
 
   bool operator==(MultiGeometry const & rhs) const
   {
-    return IsEqual(m_lines, rhs.m_lines);
+    return IsEqual(m_lines, rhs.m_lines) && m_timestamps == rhs.m_timestamps;
   }
 
   friend std::string DebugPrint(MultiGeometry const & geom)
   {
-    return ::DebugPrint(geom.m_lines);
+    auto str = ::DebugPrint(geom.m_lines);
+    if (geom.HasTimestamps())
+      str.append(" ").append(::DebugPrint(geom.m_timestamps));
+    return str;
   }
 
   void FromPoints(std::vector<m2::PointD> const & points);
-  void Assign(std::initializer_list<geometry::PointWithAltitude> lst)
-  {
-    m_lines.emplace_back();
-    m_lines.back().assign(lst);
-  }
+
+  /// This method should be used for tests only.
+  void AddLine(std::initializer_list<geometry::PointWithAltitude> lst);
+  /// This method should be used for tests only.
+  void AddTimestamps(std::initializer_list<double> lst);
+
+  bool HasTimestamps() const;
+  bool HasTimestampsFor(size_t lineIndex) const;
+  
+  size_t GetNumberOfLinesWithouTimestamps() const;
+  size_t GetNumberOfLinesWithTimestamps() const;
 };
 
 struct TrackData

--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -813,7 +813,7 @@ UNIT_TEST(Bookmarks_Sorting)
       kml::TrackData trackData;
       trackData.m_id = id;
       trackData.m_name = kml::LocalizableString{{kml::kDefaultLangCode, name}};
-      trackData.m_geometry.Assign({{{0.0, 0.0}, 1}, {{1.0, 0.0}, 2}});
+      trackData.m_geometry.AddLine({{{0.0, 0.0}, 1}, {{1.0, 0.0}, 2}});
       if (hours != kUnknownTime)
         trackData.m_timestamp = currentTime - hours;
       auto const * track = es.CreateTrack(std::move(trackData));

--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -814,6 +814,7 @@ UNIT_TEST(Bookmarks_Sorting)
       trackData.m_id = id;
       trackData.m_name = kml::LocalizableString{{kml::kDefaultLangCode, name}};
       trackData.m_geometry.AddLine({{{0.0, 0.0}, 1}, {{1.0, 0.0}, 2}});
+      trackData.m_geometry.AddTimestamps({});
       if (hours != kUnknownTime)
         trackData.m_timestamp = currentTime - hours;
       auto const * track = es.CreateTrack(std::move(trackData));


### PR DESCRIPTION
This PR:
1. Adds timestamps to the `MultiGeometry`
2. Implement the KML deserealization for the tracks with the timestamps that uses [`gx:Track`/`gx:MultiTrack` format ](https://developers.google.com/kml/documentation/kmlreference#gx:track)
3. Implement the KML serealization for the tracks with the timestamps to the `gx:Track` format:  
- The tracks **without** timestamps will be saved using the `<LineString>` tag (and grouped with the `<MultilineGeometry>` if there are several tracks).
- The tracks **with** the timestamps will be saved using the `gx:Track` (and grouped with the `<gx:MultiTrack>` if there are several tracks)

@cyber-toad can you please review the changes?