### PR TITLE
Improved calculations for speed limit violations on the road

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
@@ -222,7 +222,7 @@ public class NavMenu
     else
       mSpeedValue.setText(speedAndUnits.first);
 
-    if (info.speedLimitMps > 0.0 && last.getSpeed() > info.speedLimitMps)
+    if (info.speedLimitMps > 0.0 && (int) last.getSpeed() > (int) info.speedLimitMps)
     {
       if (info.isSpeedCamLimitExceeded())
         mSpeedValue.setTextColor(ContextCompat.getColor(mActivity, R.color.white_primary));


### PR DESCRIPTION
This PR resolves the issue mentioned in the comment: https://github.com/organicmaps/organicmaps/issues/8934#issuecomment-2295239837

![image](https://github.com/user-attachments/assets/a770c091-0faa-4dac-9802-99ab2fc47851)

The error was in the condition:
last.getSpeed() > info.speedLimitMps

Here, a float was compared with a double, leading to incorrect calculations when determining the text color. For example:

(22.375252f > 22.37525199999) = false (expected true) 
(22.375252f > 22.375252) = false (this is correct) 
(22.375252f > 22.37521) = true (this is correct)

![Screenshot from 2024-08-28 15-16-52](https://github.com/user-attachments/assets/749d6ad9-f94a-48f7-b808-ee9beeb5592b)


My fix involves converting the numbers to int before comparing them, which eliminates these comparison anomalies.