### PR TITLE
Apply new category description immediately after editing

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/Holders.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/Holders.java
@@ -455,20 +455,17 @@ public class Holders
               @NonNull BookmarkListAdapter.SectionsDataSource sectionsDataSource)
     {
       mTitle.setText(sectionsDataSource.getCategory().getName());
-      bindDescriptionIfEmpty(sectionsDataSource.getCategory());
+      bindDescription(sectionsDataSource.getCategory());
     }
 
-    private void bindDescriptionIfEmpty(@NonNull BookmarkCategory category)
+    private void bindDescription(@NonNull BookmarkCategory category)
     {
-      if (TextUtils.isEmpty(mDescText.getText()))
-      {
-        String desc = TextUtils.isEmpty(category.getAnnotation())
-                      ? category.getDescription()
-                      : category.getAnnotation();
+      String desc = TextUtils.isEmpty(category.getAnnotation())
+                    ? category.getDescription()
+                    : category.getAnnotation();
 
-        Spanned spannedDesc = Utils.fromHtml(desc);
-        mDescText.setText(spannedDesc);
-      }
+      Spanned spannedDesc = Utils.fromHtml(desc);
+      mDescText.setText(spannedDesc);
     }
   }
 }


### PR DESCRIPTION
The problem was due to excessive optimization when calculating the value for description, even though the entire page display logic relies on a complete, unconditional redraw.

Fixes https://github.com/organicmaps/organicmaps/issues/4826