### PR TITLE
[Android] Speedometer warning static threshold

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/util/StringUtils.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/util/StringUtils.cpp
@@ -82,4 +82,10 @@ Java_app_organicmaps_util_StringUtils_nativeGetLocalizedSpeedUnits(JNIEnv * env,
 {
   return jni::ToJavaString(env, platform::GetLocalizedSpeedUnits());
 }
+
+JNIEXPORT jdouble JNICALL
+Java_app_organicmaps_util_StringUtils_nativeLocalizedSpeedToMps(JNIEnv * env, jclass, jdouble speed)
+{
+    return measurement_utils::UnitsToMps(speed, measurement_utils::GetMeasurementUnits());
+}
 } // extern "C"

--- a/android/app/src/main/java/app/organicmaps/util/StringUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/StringUtils.java
@@ -31,6 +31,7 @@ public class StringUtils
 
   public static native Pair<String, String> nativeFormatSpeedAndUnits(double metersPerSecond);
   public static native Distance nativeFormatDistance(double meters);
+  public static native double nativeLocalizedSpeedToMps(double speed);
   @NonNull
   public static native Pair<String, String> nativeGetLocalizedDistanceUnits();
   @NonNull

--- a/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
@@ -28,6 +28,11 @@ import java.util.concurrent.TimeUnit;
 
 public class NavMenu
 {
+  // If the current speed exceeds the allowed speed by 0.5 we do not show any warnings.
+  // If the speed exceeds by more than 1 we inform the user about speed violation.
+  // This constant should be treated as kmph or mph depending on locale.
+  public static final double SPEED_LIMIT_THRESHOLD = 1.0;
+
   private final BottomSheetBehavior<View> mNavBottomSheetBehavior;
   private final View mBottomSheetBackground;
   private final View mHeaderFrame;
@@ -222,7 +227,8 @@ public class NavMenu
     else
       mSpeedValue.setText(speedAndUnits.first);
 
-    if (info.speedLimitMps > 0.0 && last.getSpeed() > info.speedLimitMps)
+    final double speedLimitThresholdMps = StringUtils.nativeLocalizedSpeedToMps(SPEED_LIMIT_THRESHOLD);
+    if (info.speedLimitMps > 0.0 && last.getSpeed() > info.speedLimitMps + speedLimitThresholdMps)
     {
       if (info.isSpeedCamLimitExceeded())
         mSpeedValue.setTextColor(ContextCompat.getColor(mActivity, R.color.white_primary));

--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -184,6 +184,16 @@ double MpsToUnits(double metersPerSecond, Units units)
   UNREACHABLE();
 }
 
+double UnitsToMps(double speed, Units units)
+{
+  switch (units)
+  {
+    case Units::Imperial: return MphToMps(speed); break;
+    case Units::Metric: return KmphToMps(speed); break;
+  }
+  UNREACHABLE();
+}
+
 std::string FormatSpeedNumeric(double metersPerSecond, Units units)
 {
   double const unitsPerHour = MpsToUnits(metersPerSecond, units);

--- a/platform/measurement_utils.hpp
+++ b/platform/measurement_utils.hpp
@@ -29,9 +29,11 @@ inline double FeetToMiles(double ft) { return ft * 0.00018939; }
 inline double InchesToMeters(double in) { return in / 39.370; }
 inline double NauticalMilesToMeters(double nmi) { return nmi * 1852; }
 inline double constexpr KmphToMps(double kmph) { return kmph * 1000 / 3600; }
+inline double constexpr MphToMps(double mph) { return MiphToKmph(mph) * 1000 / 3600; }
 
 double ToSpeedKmPH(double speed, Units units);
 double MpsToUnits(double mps, Units units);
+double UnitsToMps(double speed, Units units);
 
 /// @return Speed value string (without suffix) in km/h for Metric and in mph for Imperial.
 std::string FormatSpeedNumeric(double metersPerSecond, Units units);


### PR DESCRIPTION
Introduced static `SPEED_LIMIT_THRESHOLD` for speedometer warning. If `current_speed > speed_limit + SPEED_LIMIT_THRESHOLD` then speedometer becomes red.

Depending on user locale `SPEED_LIMIT_THRESHOLD` value should be treated either as kilometers-per-hour or as miles-per-hour.

We can change threshold from static value to configurable parameter.

Expected result:

| Current speed | Speed on UI  | Limit | Limit + Threshold | Status  |
| ------------- | ------------ | ----- | ----------------- | ------- |
| `59.4` kph    | `59`         | `60`  | `61`              | Ok      |
| `60.1` kph    | `60`         | `60`  | `61`              | Ok      |
| `60.9` kph    | `60`         | `60`  | `61`              | Ok      |
| `61.2` kph    | `61`         | `60`  | `61`              | Warning |
| `65.5` kph    | `65`         | `60`  | `61`              | Warning |
