### PR TITLE
The absence of a category description no longer results in a blank description page

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
@@ -95,12 +95,10 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
     {
       mBookmarksSectionIndex = SectionPosition.INVALID_POSITION;
       mTracksSectionIndex = SectionPosition.INVALID_POSITION;
-      mDescriptionSectionIndex = SectionPosition.INVALID_POSITION;
 
       mSectionsCount = 0;
-      // Hide the category description
-      if (hasDescription())
-       mDescriptionSectionIndex = mSectionsCount++;
+      // We must always show the description, even if it's blank.
+      mDescriptionSectionIndex = mSectionsCount++;
       if (getCategory().getTracksCount() > 0)
         mTracksSectionIndex = mSectionsCount++;
       if (getCategory().getBookmarksCount() > 0)

--- a/android/app/src/main/java/app/organicmaps/bookmarks/Holders.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/Holders.java
@@ -466,6 +466,8 @@ public class Holders
 
       Spanned spannedDesc = Utils.fromHtml(desc);
       mDescText.setText(spannedDesc);
+
+      UiUtils.showIf(!TextUtils.isEmpty(spannedDesc), mDescText);
     }
   }
 }


### PR DESCRIPTION
My fix ensures that the category's metadata (including the title) is always displayed, regardless of the presence of a description. Additionally, if the description is empty, the view is not shown at all to avoid taking up space.

https://github.com/user-attachments/assets/8a5a9292-3dcc-4ff0-9154-1ae3ca0b0d2a

