### PR TITLE
Fixed overlapping text when opening the category editing page

### DIFF
--- a/android/app/src/main/res/layout/fragment_bookmark_category_settings.xml
+++ b/android/app/src/main/res/layout/fragment_bookmark_category_settings.xml
@@ -31,6 +31,7 @@
       android:layout_height="wrap_content">
         <com.google.android.material.textfield.TextInputLayout
           android:id="@+id/edit_list_name_input"
+          app:hintAnimationEnabled="false"
           style="@style/MwmWidget.Editor.CustomTextInput"
           android:textColorHint="?android:textColorSecondary"
           app:endIconMode="custom"
@@ -45,6 +46,7 @@
         </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
     <com.google.android.material.textfield.TextInputLayout
+      app:hintAnimationEnabled="false"
       style="@style/MwmWidget.Editor.CustomTextInput"
       android:textColorHint="?android:textColorSecondary">
     <com.google.android.material.textfield.TextInputEditText


### PR DESCRIPTION
To fix this, I simply disabled the animation, which lags on low-end devices. I felt this was the best solution because such animation in the bottom sheet looks "messy", with noticeable jumps even on flagship phones.

https://github.com/user-attachments/assets/ebf865ec-b199-4dc7-9dcf-929c95f81494

