### PR TITLE
Support navigation with the keyboard arrows

### DIFF
--- a/qt/qt_common/helpers.hpp
+++ b/qt/qt_common/helpers.hpp
@@ -19,9 +19,9 @@ bool IsAltModifier(QMouseEvent const * const e);
 struct Hotkey
 {
   Hotkey() = default;
-  Hotkey(int key, char const * slot) : m_key(key), m_slot(slot) {}
+  Hotkey(QKeySequence const & key, char const * slot) : m_key(key), m_slot(slot) {}
 
-  int m_key = 0;
+  QKeySequence m_key = 0;
   char const * m_slot = nullptr;
 };
 

--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -25,6 +25,12 @@
 #include <QtGui/QAction>
 #include <QtWidgets/QMenu>
 
+// Fraction of the viewport for a move event
+static constexpr float kViewportFractionRoughMove = 0.2;
+
+// Fraction of the viewport for a small move event
+static constexpr float kViewportFractionSmoothMove = 0.1;
+
 namespace qt::common
 {
 //#define ENABLE_AA_SWITCH
@@ -61,12 +67,20 @@ void MapWidget::BindHotkeys(QWidget & parent)
       {Qt::Key_Equal, SLOT(ScalePlus())},
       {Qt::Key_Plus, SLOT(ScalePlus())},
       {Qt::Key_Minus, SLOT(ScaleMinus())},
-      {static_cast<int>(Qt::ALT) + static_cast<int>(Qt::Key_Equal), SLOT(ScalePlusLight())},
-      {static_cast<int>(Qt::ALT) + static_cast<int>(Qt::Key_Plus), SLOT(ScalePlusLight())},
-      {static_cast<int>(Qt::ALT) + static_cast<int>(Qt::Key_Minus), SLOT(ScaleMinusLight())},
+      {Qt::Key_Right, SLOT(MoveRight())},
+      {Qt::Key_Left, SLOT(MoveLeft())},
+      {Qt::Key_Up, SLOT(MoveUp())},
+      {Qt::Key_Down, SLOT(MoveDown())},
+      {Qt::ALT | Qt::Key_Equal, SLOT(ScalePlusLight())},
+      {Qt::ALT | Qt::Key_Plus, SLOT(ScalePlusLight())},
+      {Qt::ALT | Qt::Key_Minus, SLOT(ScaleMinusLight())},
+      {Qt::ALT | Qt::Key_Right, SLOT(MoveRightSmooth())},
+      {Qt::ALT | Qt::Key_Left, SLOT(MoveLeftSmooth())},
+      {Qt::ALT | Qt::Key_Up, SLOT(MoveUpSmooth())},
+      {Qt::ALT | Qt::Key_Down, SLOT(MoveDownSmooth())},
 #ifdef ENABLE_AA_SWITCH
-      {static_cast<int>(Qt::ALT) + static_cast<int>(Qt::Key_A), SLOT(AntialiasingOn())},
-      {static_cast<int>(Qt::ALT) + static_cast<int>(Qt::Key_S), SLOT(AntialiasingOff())},
+      {Qt::ALT | Qt::Key_A, SLOT(AntialiasingOn())},
+      {Qt::ALT | Qt::Key_S, SLOT(AntialiasingOff())},
 #endif
   };
 
@@ -117,6 +131,22 @@ void MapWidget::ScaleMinus() { m_framework.Scale(Framework::SCALE_MIN, true); }
 void MapWidget::ScalePlusLight() { m_framework.Scale(Framework::SCALE_MAG_LIGHT, true); }
 
 void MapWidget::ScaleMinusLight() { m_framework.Scale(Framework::SCALE_MIN_LIGHT, true); }
+
+void MapWidget::MoveRight() { m_framework.Move(-kViewportFractionRoughMove, 0, true); }
+
+void MapWidget::MoveRightSmooth() { m_framework.Move(-kViewportFractionSmoothMove, 0, true); }
+
+void MapWidget::MoveLeft() { m_framework.Move(kViewportFractionRoughMove, 0, true); }
+
+void MapWidget::MoveLeftSmooth() { m_framework.Move(kViewportFractionSmoothMove, 0, true); }
+
+void MapWidget::MoveUp() { m_framework.Move(0, -kViewportFractionRoughMove, true); }
+
+void MapWidget::MoveUpSmooth() { m_framework.Move(0, -kViewportFractionSmoothMove, true); }
+
+void MapWidget::MoveDown() { m_framework.Move(0, kViewportFractionRoughMove, true); }
+
+void MapWidget::MoveDownSmooth() { m_framework.Move(0, kViewportFractionSmoothMove, true); }
 
 void MapWidget::AntialiasingOn()
 {

--- a/qt/qt_common/map_widget.hpp
+++ b/qt/qt_common/map_widget.hpp
@@ -47,6 +47,15 @@ public slots:
   void ScaleMinus();
   void ScalePlusLight();
   void ScaleMinusLight();
+  void MoveRight();
+  void MoveRightSmooth();
+  void MoveLeft();
+  void MoveLeftSmooth();
+  void MoveUp();
+  void MoveUpSmooth();
+  void MoveDown();
+  void MoveDownSmooth();
+
 
   void ScaleChanged(int action);
   void SliderPressed();


### PR DESCRIPTION
I have created this PR that simply adds key bindings to the keyboard arrows. That way it is easy to navigate the map using only the keyboard.
Following the existing bindings for zoom +/- there are also bindings with the <Alt> modifier that produce a smaller change. For instance <Alt>+Left shifts the image by half of what Left arrow would do.