### PR TITLE
[ios] Prevent location updates from pausing in the background during navigation or track recording.

### DIFF
--- a/iphone/Maps/Core/Location/MWMLocationManager.mm
+++ b/iphone/Maps/Core/Location/MWMLocationManager.mm
@@ -444,7 +444,7 @@ void setShowLocationAlert(BOOL needShow) {
     _locationManager = [[CLLocationManager alloc] init];
     _locationManager.delegate = self;
     [MWMLocationManager refreshGeoModeSettingsFor:_locationManager geoMode:self.geoMode];
-    _locationManager.pausesLocationUpdatesAutomatically = YES;
+    _locationManager.pausesLocationUpdatesAutomatically = NO;
     _locationManager.headingFilter = 3.0;
   }
   return _locationManager;


### PR DESCRIPTION
As [documentation says](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/locationmanagerdidresumelocationupdates(_:)?language=objc):
> Core Location does not resume updates automatically after it pauses them.

We can [disable the pausing](https://developer.apple.com/documentation/corelocation/cllocationmanager/pauseslocationupdatesautomatically?language=objc) when the track recording or the navigation mode is enabled.
> After a pause occurs, it’s your responsibility to restart location services again when you determine that they’re needed.
