### PR TITLE
Save `TrackRecording`'s timestamps and altitudes

### DIFF
--- a/map/gps_track.cpp
+++ b/map/gps_track.cpp
@@ -94,6 +94,12 @@ void GpsTrack::Clear()
   ScheduleTask();
 }
 
+size_t GpsTrack::GetSize() const
+{
+  CHECK(m_collection != nullptr, ());
+  return m_collection->GetSize();
+}
+
 bool GpsTrack::IsEmpty() const
 {
   if (!m_collection)

--- a/map/gps_track.hpp
+++ b/map/gps_track.hpp
@@ -39,6 +39,7 @@ public:
   void Clear();
 
   bool IsEmpty() const;
+  size_t GetSize() const;
 
   /// Sets tracking duration in hours.
   /// @note Callback is called with 'toRemove' points, if some points were removed.

--- a/map/gps_tracker.cpp
+++ b/map/gps_tracker.cpp
@@ -99,6 +99,11 @@ bool GpsTracker::IsEmpty() const
   return m_track.IsEmpty();
 }
 
+size_t GpsTracker::GetTrackSize() const
+{
+  return m_track.GetSize();
+}
+
 void GpsTracker::Connect(TGpsTrackDiffCallback const & fn)
 {
   m_track.SetCallback(fn);

--- a/map/gps_tracker.hpp
+++ b/map/gps_tracker.hpp
@@ -18,6 +18,7 @@ public:
 
   std::chrono::hours GetDuration() const;
   bool IsEmpty() const;
+  size_t GetTrackSize() const;
 
   void SetDuration(std::chrono::hours duration);
 


### PR DESCRIPTION
This PR implements writing the `timestamps` and `altitudes` during the track recording.
It continues the https://github.com/organicmaps/organicmaps/pull/9140 