### PR TITLE
Add missing getopts option

### DIFF
--- a/tools/unix/build_omim.sh
+++ b/tools/unix/build_omim.sh
@@ -13,7 +13,7 @@ OPT_STANDALONE=
 OPT_COMPILE_DATABASE=
 OPT_LAUNCH_BINARY=
 OPT_NJOBS=
-while getopts ":cdrxtagjlpn:" opt; do
+while getopts ":cdrxtagjlp:n:" opt; do
   case $opt in
     a) OPT_STANDALONE=1 ;;
     c) OPT_CLEAN=1 ;;


### PR DESCRIPTION
This PR simply fixes a problem with option `-p`  of tools/unix/build_omim.sh.
If one uses the following command:
```
./tools/unix/build_omim.sh -p build -r desktop
```
an errors is shown. This PR fixes that.