### PR TITLE
inside requestBatterySaverPermission, setCancelable(true) to the dialog

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -2129,7 +2129,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     dismissAlertDialog();
     final MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(this, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.power_save_dialog_title)
-        .setCancelable(false)
+        .setCancelable(true)
         .setMessage(R.string.power_save_dialog_summary)
         .setNegativeButton(R.string.not_now, (dialog, which) -> {
           Logger.d(POWER_MANAGEMENT_TAG, "The Power Save disclaimer was ignored");


### PR DESCRIPTION
Users often appreciate the ability to dismiss dialogs by pressing the back button or tapping outside the dialog, especially if the dialog content is not critical.

This is not a critical dialog, and the app still works even with the battery saver on. There's no reason to make it worse to start the navigation.

Do I have to set setOnDismissListener to do the same as setNegativeButton?