### PR TITLE
Fixed parsing fractional seconds from ISO 8601 string timestamps

### DIFF
--- a/base/base_tests/timer_test.cpp
+++ b/base/base_tests/timer_test.cpp
@@ -31,6 +31,11 @@ UNIT_TEST(Timer_TimestampConversion)
   TEST_EQUAL(TimestampToString(1354482514), "2012-12-02T21:08:34Z", ());
 
   TEST_EQUAL(StringToTimestamp("1970-01-01T00:00:00Z"), 0, ());
+  TEST_EQUAL(StringToTimestamp("1970-01-01T00:00:00.1Z"), 0, ());
+  TEST_EQUAL(StringToTimestamp("1970-01-01T00:00:00.12Z"), 0, ());
+  TEST_EQUAL(StringToTimestamp("1970-01-01T00:00:00.123Z"), 0, ());
+  TEST_EQUAL(StringToTimestamp("1970-01-01T00:00:00.000009Z"), 0, ());
+  TEST_EQUAL(StringToTimestamp("2012-12-02T21:08:34"), 1354482514, ());
   TEST_EQUAL(StringToTimestamp("2012-12-02T21:08:34Z"), 1354482514, ());
   TEST_EQUAL(StringToTimestamp("2012-12-03T00:38:34+03:30"), 1354482514, ());
   TEST_EQUAL(StringToTimestamp("2012-12-02T11:08:34-10:00"), 1354482514, ());
@@ -49,7 +54,6 @@ UNIT_TEST(Timer_TimestampConversion)
   TEST_EQUAL(INVALID_TIME_STAMP, StringToTimestamp("2012-12-02"), ());
   TEST_EQUAL(INVALID_TIME_STAMP, StringToTimestamp("1970-01-01T"), ());
   TEST_EQUAL(INVALID_TIME_STAMP, StringToTimestamp("1970-01-01T21:"), ());
-  TEST_EQUAL(INVALID_TIME_STAMP, StringToTimestamp("1970-01-01T21:08:34"), ());
 
   TEST_EQUAL(INVALID_TIME_STAMP, StringToTimestamp("2000-00-02T11:08:34-10:00"), ());
   TEST_EQUAL(INVALID_TIME_STAMP, StringToTimestamp("2000-13-02T11:08:34-10:00"), ());


### PR DESCRIPTION
Fixes https://github.com/organicmaps/organicmaps/issues/9127

Note that fractional seconds are ignored/dropped, because POSIX time_t works only with integer seconds.