### PR TITLE
After deleting the last track in a category, the category itself is n…

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
@@ -227,7 +227,6 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
   private void configureBookmarksListAdapter()
   {
     BookmarkListAdapter adapter = getBookmarkListAdapter();
-    adapter.registerAdapterDataObserver(mCategoryDataSource);
     adapter.setOnClickListener((v, position) -> onItemClick(position));
     adapter.setOnLongClickListener((v, position) -> onItemMore(position));
     adapter.setMoreListener((v, position) -> onItemMore(position));
@@ -603,6 +602,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
   private void onDeleteTrackSelected(long trackId)
   {
     BookmarkManager.INSTANCE.deleteTrack(trackId);
+    mCategoryDataSource.invalidate();
     getBookmarkListAdapter().onDelete(mSelectedPosition);
     getBookmarkListAdapter().notifyDataSetChanged();
   }
@@ -676,6 +676,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
     BookmarkInfo info = (BookmarkInfo) getBookmarkListAdapter().getItem(mSelectedPosition);
     adapter.onDelete(mSelectedPosition);
     BookmarkManager.INSTANCE.deleteBookmark(info.getBookmarkId());
+    mCategoryDataSource.invalidate();
     adapter.notifyDataSetChanged();
     if (mSearchMode)
       mNeedUpdateSorting = true;

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/CategoryDataSource.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/CategoryDataSource.java
@@ -6,8 +6,7 @@ import app.organicmaps.content.DataSource;
 
 import java.util.List;
 
-public class CategoryDataSource implements
-                                DataSource<BookmarkCategory>
+public class CategoryDataSource implements DataSource<BookmarkCategory>
 {
   @NonNull
   private BookmarkCategory mCategory;

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/CategoryDataSource.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/CategoryDataSource.java
@@ -1,14 +1,13 @@
 package app.organicmaps.bookmarks.data;
 
 import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.RecyclerView;
 
 import app.organicmaps.content.DataSource;
 
 import java.util.List;
 
-public class CategoryDataSource extends RecyclerView.AdapterDataObserver implements
-                                                                         DataSource<BookmarkCategory>
+public class CategoryDataSource implements
+                                DataSource<BookmarkCategory>
 {
   @NonNull
   private BookmarkCategory mCategory;
@@ -25,10 +24,8 @@ public class CategoryDataSource extends RecyclerView.AdapterDataObserver impleme
     return mCategory;
   }
 
-  @Override
-  public void onChanged()
+  public void invalidate()
   {
-    super.onChanged();
     List<BookmarkCategory> categories = BookmarkManager.INSTANCE.getCategories();
     int index = categories.indexOf(mCategory);
     if (index >= 0)


### PR DESCRIPTION
…ow deleted

The issue was caused by calling RecyclerView.AdapterDataObserver.onChanged() at an unexpected time.

This PR resolves two problems:

Excessive updates to the category object, which occurred with any interaction with the list (e.g., simply selecting the "Share" option). It enables updating the category as expected when something actually changes within it. I should note that the invalidate() method is implemented specifically in CategoryDataSource rather than at the DataSource interface level, to avoid complicating other DataSource implementations that don't require this logic.

This PR is an alternative to: https://github.com/organicmaps/organicmaps/pull/9189.