### PR TITLE
[ios] Clear track on the screen after stopping recording it

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1721,6 +1721,8 @@ void Framework::StopTrackRecording()
   auto & tracker = GpsTracker::Instance();
   tracker.Disconnect();
   tracker.SetEnabled(false);
+  if (m_drapeEngine)
+    m_drapeEngine->ClearGpsTrackPoints();
 }
 
 void Framework::SaveTrackRecordingWithName(std::string const & name)


### PR DESCRIPTION
Fixes https://github.com/organicmaps/organicmaps/issues/9213

The current state looks inconsistent from the UX point of view. Either a track should be cleared (as it is done in this PR), or a proper "Pause Recording" functionality should be implemented (for Pause the track is not cleared neither on pausing it nor when recording starts again).