### PR TITLE
Editor refactoring

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/editor/Editor.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/Editor.cpp
@@ -149,7 +149,8 @@ Java_app_organicmaps_editor_Editor_nativeHasWifi(JNIEnv *, jclass)
 JNIEXPORT void JNICALL
 Java_app_organicmaps_editor_Editor_nativeSetHasWifi(JNIEnv *, jclass, jboolean hasWifi)
 {
-  g_editableMapObject.SetInternet(hasWifi ? feature::Internet::Wlan : feature::Internet::Unknown);
+  if (hasWifi != (g_editableMapObject.GetInternet() == feature::Internet::Wlan))
+    g_editableMapObject.SetInternet(hasWifi ? feature::Internet::Wlan : feature::Internet::Unknown);
 }
 
 JNIEXPORT jboolean JNICALL
@@ -362,7 +363,11 @@ Java_app_organicmaps_editor_Editor_nativeStartEdit(JNIEnv *, jclass)
 {
   ::Framework * frm = g_framework->NativeFramework();
   if (!frm->HasPlacePageInfo())
+  {
+    ASSERT(g_editableMapObject.GetEditingLifecycle() == osm::EditingLifecycle::CREATED,
+           ("PlacePageInfo should only be empty for new features."));
     return;
+  }
 
   place_page::Info const & info = g_framework->GetPlacePageInfo();
   CHECK(frm->GetEditableMapObject(info.GetID(), g_editableMapObject), ("Invalid feature in the place page."));

--- a/coding/string_utf8_multilang.cpp
+++ b/coding/string_utf8_multilang.cpp
@@ -167,6 +167,35 @@ std::vector<std::string_view> const * StringUtf8Multilang::GetTransliteratorsIds
   return &kLanguages[langCode].m_transliteratorsIds;
 }
 
+std::string StringUtf8Multilang::GetOSMTagByCode(uint8_t const langCode)
+{
+  std::string_view lang = StringUtf8Multilang::GetLangByCode(langCode);
+  if (lang == "int_name" || lang == "alt_name" || lang == "old_name")
+    return std::string{lang};
+  else if (lang == "default")
+    return "name";
+  else if (!lang.empty())
+    return std::string{"name:"}.append(lang);
+  else
+  {
+    ASSERT_FAIL(("Language can not be an empty string"));
+    return "";
+  }
+}
+
+uint8_t StringUtf8Multilang::GetCodeByOSMTag(std::string const & name)
+{
+  std::string lang;
+  if (name.starts_with("name:"))
+    lang = name.substr(5);
+  else if (name == "name")
+    lang = "default";
+  else
+    lang = name;
+
+  return StringUtf8Multilang::GetLangIndex(lang);
+}
+
 size_t StringUtf8Multilang::GetNextIndex(size_t i) const
 {
   ++i;

--- a/coding/string_utf8_multilang.hpp
+++ b/coding/string_utf8_multilang.hpp
@@ -109,6 +109,9 @@ public:
   /// @returns nullptr if langCode is invalid.
   static std::vector<std::string_view> const * GetTransliteratorsIdsByCode(int8_t langCode);
 
+  static std::string GetOSMTagByCode(uint8_t const langCode);
+  static uint8_t GetCodeByOSMTag(std::string const & name);
+
   inline bool operator==(StringUtf8Multilang const & rhs) const { return m_s == rhs.m_s; }
   inline bool operator!=(StringUtf8Multilang const & rhs) const { return !(*this == rhs); }
 

--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -105,7 +105,7 @@ bool NeedsUpload(string const & uploadStatus)
          uploadStatus != kMatchedFeatureIsEmpty;
 }
 
-XMLFeature GetMatchingFeatureFromOSM(osm::ChangesetWrapper & cw, osm::EditableMapObject & o)
+XMLFeature GetMatchingFeatureFromOSM(osm::ChangesetWrapper & cw, const osm::EditableMapObject & o)
 {
   ASSERT_NOT_EQUAL(o.GetGeomType(), feature::GeomType::Line,
                    ("Line features are not supported yet."));
@@ -227,6 +227,7 @@ bool Editor::Save(FeaturesContainer const & features) const
       // and meta fields are enough.
       XMLFeature xf =
           editor::ToXML(fti.m_object, true /* type serializing helps during migration */);
+      xf.SetEditJournal(fti.m_object.GetJournal());
       xf.SetMWMFeatureIndex(index.first);
       if (!fti.m_street.empty())
         xf.SetTagValue(kAddrStreetTag, fti.m_street);
@@ -473,6 +474,16 @@ std::optional<osm::EditableMapObject> Editor::GetEditedFeature(FeatureID const &
   return featureInfo->m_object;
 }
 
+std::optional<osm::EditJournal> Editor::GetEditedFeatureJournal(FeatureID const & fid) const
+{
+  auto const features = m_features.Get();
+  auto const * featureInfo = GetFeatureTypeInfo(*features, fid.m_mwmId, fid.m_index);
+  if (featureInfo == nullptr)
+    return {};
+
+  return featureInfo->m_object.GetJournal();
+}
+
 bool Editor::GetEditedFeatureStreet(FeatureID const & fid, string & outFeatureStreet) const
 {
   auto const features = m_features.Get();
@@ -613,110 +624,219 @@ void Editor::UploadChanges(string const & oauthToken, ChangesetTags tags,
         // TODO(a): Use UploadInfo as part of FeatureTypeInfo.
         UploadInfo uploadInfo = {fti.m_uploadAttemptTimestamp, fti.m_uploadStatus, fti.m_uploadError};
 
+        LOG(LDEBUG, ("Content of editJournal:\n", fti.m_object.GetJournal().JournalToString()));
+
+        // Don't use new editor for Legacy Objects
+        auto const & journalHistory = fti.m_object.GetJournal().GetJournalHistory();
+        bool useNewEditor = journalHistory.empty() || journalHistory.front().journalEntryType != JournalEntryType::LegacyObject;
+
         try
         {
-          switch (fti.m_status)
+          if (useNewEditor)
           {
-          case FeatureStatus::Untouched: CHECK(false, ("It's impossible.")); continue;
-          case FeatureStatus::Obsolete: continue;  // Obsolete features will be deleted by OSMers.
-          case FeatureStatus::Created:
-          {
-            XMLFeature feature = editor::ToXML(fti.m_object, true);
-            if (!fti.m_street.empty())
-              feature.SetTagValue(kAddrStreetTag, fti.m_street);
+            LOG(LDEBUG, ("New Editor used\n"));
 
-            ASSERT_EQUAL(feature.GetType(), XMLFeature::Type::Node,
-                         ("Linear and area features creation is not supported yet."));
-            try
+            switch (fti.m_status)
             {
-              auto const center = fti.m_object.GetMercator();
-              // Throws, see catch below.
-              XMLFeature osmFeature = changeset.GetMatchingNodeFeatureFromOSM(center);
+              case FeatureStatus::Untouched:
+                CHECK(false, ("It's impossible."));
+                continue;
+              case FeatureStatus::Obsolete:
+                continue;  // Obsolete features will be deleted by OSMers.
+              case FeatureStatus::Created: // fallthrough
+              case FeatureStatus::Modified:
+              {
+                std::list<JournalEntry> const & journal = fti.m_object.GetJournal().GetJournal();
 
-              // If we are here, it means that object already exists at the given point.
-              // To avoid nodes duplication, merge and apply changes to it instead of creating a new one.
-              XMLFeature const osmFeatureCopy = osmFeature;
-              osmFeature.ApplyPatch(feature);
-              // Check to avoid uploading duplicates into OSM.
-              if (osmFeature == osmFeatureCopy)
-              {
-                LOG(LWARNING, ("Local changes are equal to OSM, feature has not been uploaded.", osmFeatureCopy));
-                // Don't delete this local change right now for user to see it in profile.
-                // It will be automatically deleted by migration code on the next maps update.
+                switch (fti.m_object.GetEditingLifecycle())
+                {
+                  case EditingLifecycle::CREATED:
+                  {
+                    // Generate XMLFeature for new object
+                    JournalEntry const & createEntry = journal.front();
+                    ASSERT(createEntry.journalEntryType == JournalEntryType::ObjectCreated,("First item should have type ObjectCreated"));
+                    ObjCreateData const & objCreateData = std::get<ObjCreateData>(createEntry.data);
+                    XMLFeature feature = editor::TypeToXML(objCreateData.type, objCreateData.geomType, objCreateData.mercator);
+
+                    // Check if place already exists
+                    bool mergeSameLocation = false;
+                    try
+                    {
+                      XMLFeature osmFeature = changeset.GetMatchingNodeFeatureFromOSM(objCreateData.mercator);
+                      if (objCreateData.mercator == osmFeature.GetMercatorCenter()) {
+                        changeset.AddChangesetTag("info:merged_same_location", "yes");
+                        feature = osmFeature;
+                        mergeSameLocation = true;
+                      }
+                      else
+                      {
+                        changeset.AddChangesetTag("info:feature_close_by", "yes");
+                      }
+                    }
+                    catch (ChangesetWrapper::OsmObjectWasDeletedException const &) {}
+                    catch (ChangesetWrapper::EmptyFeatureException const &) {}
+
+                    // Add tags to XMLFeature
+                    UpdateXMLFeatureTags(feature, journal);
+
+                    // Upload XMLFeature to OSM
+                    LOG(LDEBUG, ("CREATE Feature (newEditor)", feature));
+                    changeset.AddChangesetTag("info:new_editor", "yes");
+                    if (!mergeSameLocation)
+                      changeset.Create(feature);
+                    else
+                      changeset.Modify(feature);
+                    break;
+                  }
+
+                  case EditingLifecycle::MODIFIED:
+                  {
+                    // Load existing OSM object (Throws, see catch below)
+                    XMLFeature feature = GetMatchingFeatureFromOSM(changeset, fti.m_object);
+
+                    // Update tags of XMLFeature
+                    UpdateXMLFeatureTags(feature, journal);
+
+                    // Upload XMLFeature to OSM
+                    LOG(LDEBUG, ("MODIFIED Feature (newEditor)", feature));
+                    changeset.AddChangesetTag("info:new_editor", "yes");
+                    changeset.Modify(feature);
+                    break;
+                  }
+
+                  case EditingLifecycle::IN_SYNC:
+                  {
+                    CHECK(false, ("Object already IN_SYNC should not be here"));
+                    continue;
+                  }
+                }
+                break;
               }
-              else
-              {
-                LOG(LDEBUG, ("Create case: uploading patched feature", osmFeature));
-                changeset.AddChangesetTag("info:features_merged", "yes");
-                changeset.Modify(osmFeature);
-              }
-            }
-            catch (ChangesetWrapper::OsmObjectWasDeletedException const &)
-            {
-              // Object was never created by anyone else - it's safe to create it.
-              changeset.Create(feature);
-            }
-            catch (ChangesetWrapper::EmptyFeatureException const &)
-            {
-              // There is another node nearby, but it should be safe to create a new one.
-              changeset.Create(feature);
-            }
-            catch (...)
-            {
-              // Pass network or other errors to outside exception handler.
-              throw;
+              case FeatureStatus::Deleted:
+                auto const originalObjectPtr = GetOriginalMapObject(fti.m_object.GetID());
+                if (!originalObjectPtr)
+                {
+                  LOG(LERROR, ("A feature with id", fti.m_object.GetID(), "cannot be loaded."));
+                  GetPlatform().RunTask(Platform::Thread::Gui,[this, fid = fti.m_object.GetID()]() {
+                    RemoveFeatureIfExists(fid);
+                  });
+                  continue;
+                }
+                changeset.Delete(GetMatchingFeatureFromOSM(changeset, *originalObjectPtr));
+                break;
             }
           }
-          break;
-
-          case FeatureStatus::Modified:
+          else // Use old editor
           {
-            // Do not serialize feature's type to avoid breaking OSM data.
-            // TODO: Implement correct types matching when we support modifying existing feature types.
-            XMLFeature feature = editor::ToXML(fti.m_object, false);
-            if (!fti.m_street.empty())
-              feature.SetTagValue(kAddrStreetTag, fti.m_street);
+            // Todo: Remove old editor after transition period
+            switch (fti.m_status)
+            {
+              case FeatureStatus::Untouched: CHECK(false, ("It's impossible.")); continue;
+              case FeatureStatus::Obsolete: continue;  // Obsolete features will be deleted by OSMers.
+              case FeatureStatus::Created:
+              {
+                XMLFeature feature = editor::ToXML(fti.m_object, true);
+                if (!fti.m_street.empty())
+                  feature.SetTagValue(kAddrStreetTag, fti.m_street);
 
-            auto const originalObjectPtr = GetOriginalMapObject(fti.m_object.GetID());
-            if (!originalObjectPtr)
-            {
-              LOG(LERROR, ("A feature with id", fti.m_object.GetID(), "cannot be loaded."));
-              GetPlatform().RunTask(Platform::Thread::Gui, [this, fid = fti.m_object.GetID()]() {
-                RemoveFeatureIfExists(fid);
-              });
-              continue;
-            }
+                ASSERT_EQUAL(feature.GetType(), XMLFeature::Type::Node,
+                             ("Linear and area features creation is not supported yet."));
+                try
+                {
+                  auto const center = fti.m_object.GetMercator();
+                  // Throws, see catch below.
+                  XMLFeature osmFeature = changeset.GetMatchingNodeFeatureFromOSM(center);
 
-            XMLFeature osmFeature = GetMatchingFeatureFromOSM(changeset, *originalObjectPtr);
-            XMLFeature const osmFeatureCopy = osmFeature;
-            osmFeature.ApplyPatch(feature);
-            // Check to avoid uploading duplicates into OSM.
-            if (osmFeature == osmFeatureCopy)
-            {
-              LOG(LWARNING, ("Local changes are equal to OSM, feature has not been uploaded.", osmFeatureCopy));
-              // Don't delete this local change right now for user to see it in profile.
-              // It will be automatically deleted by migration code on the next maps update.
-            }
-            else
-            {
-              LOG(LDEBUG, ("Uploading patched feature", osmFeature));
-              changeset.Modify(osmFeature);
-            }
-          }
-          break;
+                  // If we are here, it means that object already exists at the given point.
+                  // To avoid nodes duplication, merge and apply changes to it instead of creating a new one.
+                  XMLFeature const osmFeatureCopy = osmFeature;
+                  osmFeature.ApplyPatch(feature);
+                  // Check to avoid uploading duplicates into OSM.
+                  if (osmFeature == osmFeatureCopy)
+                  {
+                    LOG(LWARNING,("Local changes are equal to OSM, feature has not been uploaded.", osmFeatureCopy));
+                    // Don't delete this local change right now for user to see it in profile.
+                    // It will be automatically deleted by migration code on the next maps update.
+                  }
+                  else
+                  {
+                    LOG(LDEBUG, ("Create case: uploading patched feature", osmFeature));
+                    changeset.AddChangesetTag("info:old_editor", "yes");
+                    changeset.AddChangesetTag("info:features_merged", "yes");
+                    changeset.Modify(osmFeature);
+                  }
+                }
+                catch (ChangesetWrapper::OsmObjectWasDeletedException const &)
+                {
+                  // Object was never created by anyone else - it's safe to create it.
+                  changeset.AddChangesetTag("info:old_editor", "yes");
+                  changeset.Create(feature);
+                }
+                catch (ChangesetWrapper::EmptyFeatureException const &)
+                {
+                  // There is another node nearby, but it should be safe to create a new one.
+                  changeset.AddChangesetTag("info:old_editor", "yes");
+                  changeset.Create(feature);
+                }
+                catch (...)
+                {
+                  // Pass network or other errors to outside exception handler.
+                  throw;
+                }
+              }
+                break;
 
-          case FeatureStatus::Deleted:
-            auto const originalObjectPtr = GetOriginalMapObject(fti.m_object.GetID());
-            if (!originalObjectPtr)
-            {
-              LOG(LERROR, ("A feature with id", fti.m_object.GetID(), "cannot be loaded."));
-              GetPlatform().RunTask(Platform::Thread::Gui, [this, fid = fti.m_object.GetID()]() {
-                RemoveFeatureIfExists(fid);
-              });
-              continue;
+              case FeatureStatus::Modified:
+              {
+                // Do not serialize feature's type to avoid breaking OSM data.
+                // TODO: Implement correct types matching when we support modifying existing feature types.
+                XMLFeature feature = editor::ToXML(fti.m_object, false);
+                if (!fti.m_street.empty())
+                  feature.SetTagValue(kAddrStreetTag, fti.m_street);
+
+                auto const originalObjectPtr = GetOriginalMapObject(fti.m_object.GetID());
+                if (!originalObjectPtr)
+                {
+                  LOG(LERROR, ("A feature with id", fti.m_object.GetID(), "cannot be loaded."));
+                  GetPlatform().RunTask(Platform::Thread::Gui,[this, fid = fti.m_object.GetID()]() {
+                                          RemoveFeatureIfExists(fid);
+                                        });
+                  continue;
+                }
+
+                XMLFeature osmFeature = GetMatchingFeatureFromOSM(changeset, *originalObjectPtr);
+                XMLFeature const osmFeatureCopy = osmFeature;
+                osmFeature.ApplyPatch(feature);
+                // Check to avoid uploading duplicates into OSM.
+                if (osmFeature == osmFeatureCopy)
+                {
+                  LOG(LWARNING,("Local changes are equal to OSM, feature has not been uploaded.", osmFeatureCopy));
+                  // Don't delete this local change right now for user to see it in profile.
+                  // It will be automatically deleted by migration code on the next maps update.
+                }
+                else
+                {
+                  LOG(LDEBUG, ("Uploading patched feature", osmFeature));
+                  changeset.AddChangesetTag("info:old_editor", "yes");
+                  changeset.Modify(osmFeature);
+                }
+              }
+                break;
+
+              case FeatureStatus::Deleted:
+                auto const originalObjectPtr = GetOriginalMapObject(fti.m_object.GetID());
+                if (!originalObjectPtr)
+                {
+                  LOG(LERROR, ("A feature with id", fti.m_object.GetID(), "cannot be loaded."));
+                  GetPlatform().RunTask(Platform::Thread::Gui,[this, fid = fti.m_object.GetID()]() {
+                                          RemoveFeatureIfExists(fid);
+                                        });
+                  continue;
+                }
+                changeset.AddChangesetTag("info:old_editor", "yes");
+                changeset.Delete(GetMatchingFeatureFromOSM(changeset, *originalObjectPtr));
+                break;
             }
-            changeset.Delete(GetMatchingFeatureFromOSM(changeset, *originalObjectPtr));
-            break;
           }
           uploadInfo.m_uploadStatus = kUploaded;
           uploadInfo.m_uploadError.clear();
@@ -804,15 +924,29 @@ void Editor::SaveUploadedInformation(FeatureID const & fid, UploadInfo const & u
   fti.m_uploadStatus = uploadInfo.m_uploadStatus;
   fti.m_uploadError = uploadInfo.m_uploadError;
 
+  if (!NeedsUpload(uploadInfo.m_uploadStatus))
+    fti.m_object.ClearJournal();
+
   SaveTransaction(editableFeatures);
 }
 
 bool Editor::FillFeatureInfo(FeatureStatus status, XMLFeature const & xml, FeatureID const & fid,
                              FeatureTypeInfo & fti) const
 {
+  EditJournal journal = xml.GetEditJournal();
+
+  // Do not load Legacy Objects form Journal
+  auto const & journalHistory = journal.GetJournalHistory();
+  bool loadFromJournal = journalHistory.empty() || journalHistory.front().journalEntryType != JournalEntryType::LegacyObject;
+
+  LOG(LDEBUG, ("loadFromJournal: ", loadFromJournal));
+
   if (status == FeatureStatus::Created)
   {
-    editor::FromXML(xml, fti.m_object);
+    if (loadFromJournal)
+      fti.m_object.ApplyEditsFromJournal(journal);
+    else
+      editor::FromXML(xml, fti.m_object);
   }
   else
   {
@@ -824,9 +958,14 @@ bool Editor::FillFeatureInfo(FeatureStatus status, XMLFeature const & xml, Featu
     }
 
     fti.m_object = *originalObjectPtr;
-    editor::ApplyPatch(xml, fti.m_object);
+
+    if (loadFromJournal)
+      fti.m_object.ApplyEditsFromJournal(journal);
+    else
+      editor::ApplyPatch(xml, fti.m_object);
   }
 
+  fti.m_object.SetJournal(std::move(journal));
   fti.m_object.SetID(fid);
   fti.m_street = xml.GetTagValue(kAddrStreetTag);
 
@@ -988,6 +1127,7 @@ bool Editor::CreatePoint(uint32_t type, m2::PointD const & mercator, MwmId const
   outFeature.SetEditableProperties(GetEditablePropertiesForTypes(outFeature.GetTypes()));
   // Only point type features can be created at the moment.
   outFeature.SetPointType();
+  outFeature.MarkAsCreated(type, feature::GeomType::Point, mercator);
   return true;
 }
 
@@ -1210,6 +1350,27 @@ bool Editor::IsFeatureUploadedImpl(FeaturesContainer const & features, MwmId con
 {
   auto const * info = GetFeatureTypeInfo(features, mwmId, index);
   return info && info->m_uploadStatus == kUploaded;
+}
+
+void Editor::UpdateXMLFeatureTags(editor::XMLFeature & feature, std::list<JournalEntry> const & journal)
+{
+  for (JournalEntry const & entry: journal)
+  {
+    switch (entry.journalEntryType)
+    {
+      case JournalEntryType::TagModification:
+      {
+        TagModData const & tagModData = std::get<TagModData>(entry.data);
+        feature.UpdateOSMTag(tagModData.key, tagModData.new_value);
+        break;
+      }
+      case JournalEntryType::ObjectCreated:
+        break;
+      case JournalEntryType::LegacyObject:
+        ASSERT_FAIL(("Legacy Objects can not be edited with the new editor"));
+        break;
+    }
+  }
 }
 
 string DebugPrint(Editor::SaveResult saveResult)

--- a/editor/osm_editor.hpp
+++ b/editor/osm_editor.hpp
@@ -8,6 +8,7 @@
 #include "editor/xml_feature.hpp"
 
 #include "indexer/editable_map_object.hpp"
+#include "indexer/edit_journal.hpp"
 #include "indexer/feature.hpp"
 #include "indexer/feature_source.hpp"
 #include "indexer/mwm_set.hpp"
@@ -131,6 +132,9 @@ public:
   /// @returns empty object if feature wasn't edited.
   std::optional<osm::EditableMapObject> GetEditedFeature(FeatureID const & fid) const;
 
+  /// @returns empty object if feature wasn't edited.
+  std::optional<osm::EditJournal> GetEditedFeatureJournal(FeatureID const & fid) const;
+
   /// @returns false if feature wasn't edited.
   /// @param outFeatureStreet is valid only if true was returned.
   bool GetEditedFeatureStreet(FeatureID const & fid, std::string & outFeatureStreet) const;
@@ -234,6 +238,8 @@ private:
   static FeatureStatus GetFeatureStatusImpl(FeaturesContainer const & features, MwmId const & mwmId, uint32_t index);
 
   static bool IsFeatureUploadedImpl(FeaturesContainer const & features, MwmId const & mwmId, uint32_t index);
+
+  void UpdateXMLFeatureTags(editor::XMLFeature & feature, std::list<JournalEntry> const & journal);
 
   /// Deleted, edited and created features.
   base::AtomicSharedPtr<FeaturesContainer> m_features;

--- a/editor/xml_feature.hpp
+++ b/editor/xml_feature.hpp
@@ -2,6 +2,8 @@
 
 #include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"
+#include "indexer/feature_decl.hpp"
+#include "indexer/edit_journal.hpp"
 
 #include "coding/string_utf8_multilang.hpp"
 
@@ -27,6 +29,7 @@ DECLARE_EXCEPTION(NoLatLon, XMLFeatureError);
 DECLARE_EXCEPTION(NoXY, XMLFeatureError);
 DECLARE_EXCEPTION(NoTimestamp, XMLFeatureError);
 DECLARE_EXCEPTION(NoHeader, XMLFeatureError);
+DECLARE_EXCEPTION(InvalidJournalEntry, XMLFeatureError);
 
 class XMLFeature
 {
@@ -161,6 +164,9 @@ public:
 
   std::string GetUploadError() const;
   void SetUploadError(std::string const & error);
+
+  osm::EditJournal GetEditJournal() const;
+  void SetEditJournal(osm::EditJournal const & journal);
   //@}
 
   bool HasAnyTags() const;
@@ -178,6 +184,9 @@ public:
   std::string GetTagValue(std::string_view key) const;
   void SetTagValue(std::string_view key, std::string_view value);
   void RemoveTag(std::string_view key);
+
+  /// Wrapper for SetTagValue and RemoveTag, avoids duplication for similar alternative osm tags
+  void UpdateOSMTag(std::string_view key, std::string_view value);
 
   std::string GetAttribute(std::string const & key) const;
   void SetAttribute(std::string const & key, std::string const & value);
@@ -202,6 +211,9 @@ void ApplyPatch(XMLFeature const & xml, osm::EditableMapObject & object);
 /// Useful for applying modifications to existing OSM features, to avoid issues when someone
 /// has changed a type in OSM, but our users uploaded invalid outdated type after modifying feature.
 XMLFeature ToXML(osm::EditableMapObject const & object, bool serializeType);
+
+/// Used to generate XML for created objects in the new editor
+XMLFeature TypeToXML(uint32_t type, feature::GeomType geomType, m2::PointD mercator);
 
 /// Creates new feature, including geometry and types.
 /// @Note: only nodes (points) are supported at the moment.

--- a/indexer/CMakeLists.txt
+++ b/indexer/CMakeLists.txt
@@ -51,6 +51,8 @@ set(SRC
   drules_selector_parser.hpp
   drules_struct.pb.cc
   drules_struct.pb.h
+  edit_journal.cpp
+  edit_journal.hpp
   editable_map_object.cpp
   editable_map_object.hpp
   fake_feature_ids.cpp

--- a/indexer/edit_journal.cpp
+++ b/indexer/edit_journal.cpp
@@ -1,0 +1,125 @@
+#include "indexer/edit_journal.hpp"
+
+#include "base/control_flow.hpp"
+#include "base/string_utils.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <regex>
+#include <sstream>
+
+namespace osm
+{
+  std::list<JournalEntry> const & EditJournal::GetJournal() const
+  {
+    return m_journal;
+  }
+
+  osm::EditingLifecycle EditJournal::GetEditingLifecycle() const
+  {
+    if (m_journal.empty())
+      return EditingLifecycle::IN_SYNC;
+
+    else if (m_journal.front().journalEntryType == JournalEntryType::ObjectCreated)
+      return EditingLifecycle::CREATED;
+
+    return EditingLifecycle::MODIFIED;
+  }
+
+  void EditJournal::AddTagChange(std::string key, std::string old_value, std::string new_value)
+  {
+    LOG(LDEBUG, ("Key ", key, "changed from \"", old_value, "\" to \"", new_value, "\""));
+    AddJournalEntry({JournalEntryType::TagModification, time(nullptr), TagModData{std::move(key), std::move(old_value), std::move(new_value)}});
+  }
+
+  void EditJournal::MarkAsCreated(uint32_t type, feature::GeomType geomType, m2::PointD mercator)
+  {
+    ASSERT(m_journal.empty(), ("Only empty journals can be marked as created"));
+    LOG(LDEBUG, ("Object of type ", classif().GetReadableObjectName(type), " created"));
+    AddJournalEntry({JournalEntryType::ObjectCreated, time(nullptr), osm::ObjCreateData{type, geomType, mercator}});
+  }
+
+  void EditJournal::AddJournalEntry(JournalEntry entry)
+  {
+    m_journal.push_back(std::move(entry));
+  }
+
+  void EditJournal::Clear()
+  {
+    for (JournalEntry & entry : m_journal)
+      m_journalHistory.push_back(std::move(entry));
+
+    m_journal = {};
+  }
+
+  std::list<JournalEntry> const & EditJournal::GetJournalHistory() const
+  {
+    return m_journalHistory;
+  }
+
+  void EditJournal::AddJournalHistoryEntry(JournalEntry entry)
+  {
+    m_journalHistory.push_back(std::move(entry));
+  }
+
+  std::string EditJournal::JournalToString() const
+  {
+    std::string string;
+    std::for_each(m_journal.begin(), m_journal.end(), [&](auto const & journalEntry) {
+      string += ToString(journalEntry) + "\n";
+    });
+    return string;
+  }
+
+  std::string EditJournal::ToString(osm::JournalEntry const & journalEntry)
+  {
+    switch (journalEntry.journalEntryType)
+    {
+      case osm::JournalEntryType::TagModification:
+      {
+        TagModData const & tagModData = std::get<TagModData>(journalEntry.data);
+        return ToString(journalEntry.journalEntryType)
+            .append(": Key ").append(tagModData.key)
+            .append(" changed from \"").append(tagModData.old_value)
+            .append("\" to \"").append(tagModData.new_value).append("\"");
+      }
+      case osm::JournalEntryType::ObjectCreated:
+      {
+        ObjCreateData const & objCreatedData = std::get<ObjCreateData>(journalEntry.data);
+        return ToString(journalEntry.journalEntryType)
+            .append(": ").append(classif().GetReadableObjectName(objCreatedData.type))
+            .append(" (").append(std::to_string(objCreatedData.type)).append(")");
+      }
+      case osm::JournalEntryType::LegacyObject:
+      {
+        LegacyObjData const & legacyObjData = std::get<LegacyObjData>(journalEntry.data);
+        return ToString(journalEntry.journalEntryType)
+            .append(": version=\"").append(legacyObjData.version).append("\"");
+      }
+    }
+  }
+
+  std::string EditJournal::ToString(osm::JournalEntryType journalEntryType)
+  {
+    switch (journalEntryType)
+    {
+      case osm::JournalEntryType::TagModification:
+        return "TagModification";
+      case osm::JournalEntryType::ObjectCreated:
+        return "ObjectCreated";
+      case osm::JournalEntryType::LegacyObject:
+        return "LegacyObject";
+    }
+  }
+
+  std::optional<JournalEntryType> EditJournal::TypeFromString(std::string const & entryType) {
+    if (entryType == "TagModification")
+      return JournalEntryType::TagModification;
+    else if (entryType == "ObjectCreated")
+      return JournalEntryType::ObjectCreated;
+    else if (entryType == "LegacyObject")
+      return JournalEntryType::LegacyObject;
+    else
+      return {};
+  }
+}

--- a/indexer/edit_journal.hpp
+++ b/indexer/edit_journal.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "indexer/feature_decl.hpp"
+#include "indexer/feature_meta.hpp"
+#include "indexer/feature_utils.hpp"
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace osm
+{
+  enum class JournalEntryType
+  {
+    TagModification,
+    ObjectCreated,
+    LegacyObject,   //object without full journal history, used for transition to new editor
+    //Possible future values: ObjectDeleted, ObjectDisused, ObjectNotDisused, LocationChanged, FeatureTypeChanged
+  };
+
+  struct TagModData
+  {
+    std::string key;
+    std::string old_value;
+    std::string new_value;
+  };
+
+  struct ObjCreateData
+  {
+    uint32_t type;
+    feature::GeomType geomType;
+    m2::PointD mercator;
+  };
+
+  struct LegacyObjData
+  {
+    std::string version;
+  };
+
+  struct JournalEntry
+  {
+    JournalEntryType journalEntryType = JournalEntryType::TagModification;
+    time_t timestamp;
+    std::variant<TagModData, ObjCreateData, LegacyObjData> data;
+  };
+
+  /// Used to determine whether existing OSM object should be updated or new one created
+  enum class EditingLifecycle
+  {
+    CREATED,      //newly created and not synced with OSM
+    MODIFIED,     //modified and not synced with OSM
+    IN_SYNC       //synced with OSM (including never edited)
+  };
+
+  class EditJournal
+  {
+    std::list<JournalEntry> m_journal{};
+    std::list<JournalEntry> m_journalHistory{};
+
+  public:
+    std::list<JournalEntry> const & GetJournal() const;
+
+    osm::EditingLifecycle GetEditingLifecycle() const;
+
+    /// Log object edits in the journal
+    void AddTagChange(std::string key, std::string old_value, std::string new_value);
+
+    /// Log object creation in the journal
+    void MarkAsCreated(uint32_t type, feature::GeomType geomType, m2::PointD mercator);
+
+    void AddJournalEntry(JournalEntry entry);
+
+    /// Clear Journal and move content to journalHistory, used after upload to OSM
+    void Clear();
+
+    std::list<JournalEntry> const & GetJournalHistory() const;
+
+    void AddJournalHistoryEntry(JournalEntry entry);
+
+    std::string JournalToString() const;
+
+    static std::string ToString(osm::JournalEntry const & journalEntry);
+
+    static std::string ToString(osm::JournalEntryType journalEntryType);
+
+    static std::optional<JournalEntryType> TypeFromString(std::string const & entryType);
+  };
+}

--- a/indexer/editable_map_object.hpp
+++ b/indexer/editable_map_object.hpp
@@ -5,6 +5,7 @@
 #include "indexer/feature_meta.hpp"
 #include "indexer/feature_utils.hpp"
 #include "indexer/map_object.hpp"
+#include "indexer/edit_journal.hpp"
 
 #include "coding/string_utf8_multilang.hpp"
 
@@ -129,6 +130,16 @@ public:
   static bool ValidateLevel(std::string const & level);
   static bool ValidateName(std::string const & name);
 
+  /// Journal that stores changes to map object
+  EditJournal const & GetJournal() const;
+  void SetJournal(EditJournal && editJournal);
+  EditingLifecycle GetEditingLifecycle() const;
+  void MarkAsCreated(uint32_t type, feature::GeomType geomType, m2::PointD mercator);
+  void ClearJournal();
+  void ApplyEditsFromJournal(EditJournal const & journal);
+  void ApplyJournalEntry(JournalEntry const & entry);
+  void LogDiffInJournal(EditableMapObject const & unedited_emo);
+
   /// Check whether langCode can be used as default name.
   static bool CanUseAsDefaultName(int8_t const langCode, std::vector<int8_t> const & nativeMwmLanguages);
 
@@ -144,5 +155,6 @@ private:
   LocalizedStreet m_street;
   std::vector<LocalizedStreet> m_nearbyStreets;
   EditableProperties m_editableProperties;
+  osm::EditJournal m_journal;
 };
 }  // namespace osm

--- a/indexer/feature_data.hpp
+++ b/indexer/feature_data.hpp
@@ -73,6 +73,17 @@ namespace feature
       m_types[m_size++] = type;
     }
 
+    void SafeAdd(uint32_t type)
+    {
+      if (!Has(type))
+      {
+        if (m_size < kMaxTypesCount)
+          Add(type);
+        else
+          LOG(LWARNING, ("Type could not be added, MaxTypesCount exceeded"));
+      }
+    }
+
     GeomType GetGeomType() const { return m_geomType; }
 
     size_t Size() const { return m_size; }

--- a/indexer/feature_decl.cpp
+++ b/indexer/feature_decl.cpp
@@ -8,14 +8,31 @@ namespace feature
 {
 std::string DebugPrint(GeomType type)
 {
+  return ToString(type);
+}
+
+std::string ToString(GeomType type)
+{
   switch (type)
   {
-  case GeomType::Undefined: return "Undefined";
-  case GeomType::Point: return "Point";
-  case GeomType::Line: return "Line";
-  case GeomType::Area: return "Area";
+    case GeomType::Undefined: return "Undefined";
+    case GeomType::Point: return "Point";
+    case GeomType::Line: return "Line";
+    case GeomType::Area: return "Area";
   }
   UNREACHABLE();
+}
+
+GeomType TypeFromString(std::string type)
+{
+  if (type == "Point")
+    return GeomType::Point;
+  else if (type == "Line")
+    return GeomType::Line;
+  else if (type == "Area")
+    return GeomType::Area;
+  else
+    return GeomType::Undefined;
 }
 }  // namespace feature
 

--- a/indexer/feature_decl.hpp
+++ b/indexer/feature_decl.hpp
@@ -17,6 +17,10 @@ enum class GeomType : int8_t
 };
 
 std::string DebugPrint(GeomType type);
+
+std::string ToString(GeomType type);
+
+GeomType TypeFromString(std::string type);
 }  // namespace feature
 
 uint32_t constexpr kInvalidFeatureId = std::numeric_limits<uint32_t>::max();

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -3013,12 +3013,25 @@ bool Framework::GetEditableMapObject(FeatureID const & fid, osm::EditableMapObje
     SetHostingBuildingAddress(FindBuildingAtPoint(feature::GetCenter(*ft)), dataSource, coder, emo);
   }
 
+  auto optJournal = editor.GetEditedFeatureJournal(fid);
+  if (optJournal)
+    emo.SetJournal(std::move(*optJournal));
+
   return true;
 }
 
 osm::Editor::SaveResult Framework::SaveEditedMapObject(osm::EditableMapObject emo)
 {
   auto & editor = osm::Editor::Instance();
+
+  // Update EditJournal
+  osm::EditableMapObject unedited_emo;
+  if (emo.GetEditingLifecycle() == osm::EditingLifecycle::CREATED && emo.GetJournal().GetJournal().size() == 1)
+    unedited_emo = {};
+  else
+    CHECK(GetEditableMapObject(emo.GetID(), unedited_emo), ("Loading unedited EditableMapObject failed."));
+
+  emo.LogDiffInJournal(unedited_emo);
 
   ms::LatLon issueLatLon;
 

--- a/xcode/indexer/indexer.xcodeproj/project.pbxproj
+++ b/xcode/indexer/indexer.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		456E1B181F90E5B7009C32E1 /* cities_boundaries_serdes.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 456E1B141F90E5B6009C32E1 /* cities_boundaries_serdes.hpp */; };
 		456E1B1B1F90E5B7009C32E1 /* city_boundary.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 456E1B171F90E5B7009C32E1 /* city_boundary.hpp */; };
 		467F34202BCAB6DE00CDC7DE /* yes_no_unknown.h in Headers */ = {isa = PBXBuildFile; fileRef = 467F341F2BCAB6DE00CDC7DE /* yes_no_unknown.h */; };
+		46CB685D2CBC17F2003E40AB /* edit_journal.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 46CB685B2CBC17F2003E40AB /* edit_journal.hpp */; };
+		46CB685E2CBC17F2003E40AB /* edit_journal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46CB685C2CBC17F2003E40AB /* edit_journal.cpp */; };
 		56C74C1C1C749E4700B71B9F /* categories_holder_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56C74C121C749E4700B71B9F /* categories_holder_loader.cpp */; };
 		56C74C1D1C749E4700B71B9F /* categories_holder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56C74C131C749E4700B71B9F /* categories_holder.cpp */; };
 		56C74C1E1C749E4700B71B9F /* categories_holder.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56C74C141C749E4700B71B9F /* categories_holder.hpp */; };
@@ -303,6 +305,8 @@
 		456E1B141F90E5B6009C32E1 /* cities_boundaries_serdes.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cities_boundaries_serdes.hpp; sourceTree = "<group>"; };
 		456E1B171F90E5B7009C32E1 /* city_boundary.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = city_boundary.hpp; sourceTree = "<group>"; };
 		467F341F2BCAB6DE00CDC7DE /* yes_no_unknown.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = yes_no_unknown.h; sourceTree = "<group>"; };
+		46CB685B2CBC17F2003E40AB /* edit_journal.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = edit_journal.hpp; sourceTree = "<group>"; };
+		46CB685C2CBC17F2003E40AB /* edit_journal.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = edit_journal.cpp; sourceTree = "<group>"; };
 		56C74C121C749E4700B71B9F /* categories_holder_loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = categories_holder_loader.cpp; sourceTree = "<group>"; };
 		56C74C131C749E4700B71B9F /* categories_holder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = categories_holder.cpp; sourceTree = "<group>"; };
 		56C74C141C749E4700B71B9F /* categories_holder.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = categories_holder.hpp; sourceTree = "<group>"; };
@@ -603,6 +607,8 @@
 		6753409C1A3F53CB00A0A8C3 /* indexer */ = {
 			isa = PBXGroup;
 			children = (
+				46CB685B2CBC17F2003E40AB /* edit_journal.hpp */,
+				46CB685C2CBC17F2003E40AB /* edit_journal.cpp */,
 				30FE368A2AF994E600DAC107 /* kayak.cpp */,
 				30FE368B2AF994E600DAC107 /* kayak.hpp */,
 				34664CEE1D49FEC1003D7096 /* altitude_loader.cpp */,
@@ -796,6 +802,7 @@
 				675341001A3F540F00A0A8C3 /* cell_id.hpp in Headers */,
 				3D74ABBC1EA67C1E0063A898 /* ftypes_mapping.hpp in Headers */,
 				67BC92F51D21476500A4A378 /* string_slice.hpp in Headers */,
+				46CB685D2CBC17F2003E40AB /* edit_journal.hpp in Headers */,
 				F6F1DABE1F13D8B4006A69B7 /* ftraits.hpp in Headers */,
 				675341271A3F540F00A0A8C3 /* features_vector.hpp in Headers */,
 				408FE47624FEB95600F5D06D /* metadata_serdes.hpp in Headers */,
@@ -1010,6 +1017,7 @@
 				675341211A3F540F00A0A8C3 /* feature_utils.cpp in Sources */,
 				4099F6491FC7142A002A7B05 /* fake_feature_ids.cpp in Sources */,
 				FA7F9B85273F32680093EA08 /* validate_and_format_contacts.cpp in Sources */,
+				46CB685E2CBC17F2003E40AB /* edit_journal.cpp in Sources */,
 				675341231A3F540F00A0A8C3 /* feature_visibility.cpp in Sources */,
 				56C74C221C749E4700B71B9F /* search_delimiters.cpp in Sources */,
 				347F337B1C454242009758CC /* rank_table.cpp in Sources */,


### PR DESCRIPTION
fixes  #9129, fixes #8102, fixes #2298, fixes #6260, fixes #6292, fixes #9126, fixes #6939, fixes #9508, fixes #9311

This PR supersedes #9138 and adds a Journal to explicitly store which changes were submitted by the user. See #9129 for why his information is needed when uploading to OSM.

#### Approach
Edits are logged in the Journal. A log contains info like e.g. `Tag "website" changed from "www.organicmaps.app" to "organicmaps.app"` or `ObjectCreated, Type amenity-bench, Location ...`. When uploading, only the Journal entries are used do update the OSM object. After a successful upload, the Journal is cleared.

Saving and restoring the Journal after an app restart is implemented now.

For the transition phase to the new editing logic the old uploading code is still functional. The old code is used when the object was modified in a previous OM version.

#### Todo
- [x] Logging
    - [x] Add logging for all Tags
    - [x] Add logging for FeatureType
    - [x] Safe and Restore Data after App restart
- [x] New uploading logic
- [x] Transition from old OM versions

#### Bugs fixed
- #8102
- #2298
- #6260
- #6292
   - #9126

#### Testing
Tested with the OSM dev API, but only on Android.

#### Transition
The PR only affects new edits. Old edits from previous OM versions that were not uploaded yet use the old uploading code.

#### New features I keep in mind to not block anything
- Adding "komplex" Category types (#4523)
- Mark POI as disused
- POI category change (#3491)
- Add address POIs (#9199)
- Support editing POIs mapped as areas (#6727)

#### Follow up issues (Issues not addressed in this PR)
- #9043
- #9503
- Remove code of the old editor after some time (e.g. three months)