### PR TITLE
After deleting the last track in a category, the category itself is now deleted

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
@@ -66,6 +66,11 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
               !mDataSource.getData().getDescription().isEmpty());
     }
 
+    void invalidate()
+    {
+      mDataSource.invalidate();
+    }
+
     public abstract int getSectionsCount();
     public abstract boolean isEditable(int sectionIndex);
     public abstract boolean hasTitle(int sectionIndex);
@@ -154,6 +159,9 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
     @Override
     public void onDelete(@NonNull SectionPosition pos)
     {
+      // we must invalidate datasource before calculate sections
+      invalidate();
+
       calculateSections();
     }
 

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/CategoryDataSource.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/CategoryDataSource.java
@@ -34,4 +34,10 @@ public class CategoryDataSource extends RecyclerView.AdapterDataObserver impleme
     if (index >= 0)
       mCategory = categories.get(index);
   }
+
+  @Override
+  public void invalidate()
+  {
+    onChanged();
+  }
 }

--- a/android/app/src/main/java/app/organicmaps/content/DataSource.java
+++ b/android/app/src/main/java/app/organicmaps/content/DataSource.java
@@ -6,4 +6,6 @@ public interface DataSource<D>
 {
   @NonNull
   D getData();
+
+  void invalidate();
 }


### PR DESCRIPTION
The issue was caused by calling RecyclerView.AdapterDataObserver.onChanged() at an unexpected time.

I decided not to modify the onChanged() method because it works with a cached version of the native object. To prevent the developer from having to think about when to invalidate the DataSource, I integrated it into the already existing onDelete.

This PR is an alternative to: https://github.com/organicmaps/organicmaps/pull/9189.