### PR TITLE
[Android] Import bookmarks fix

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -51,6 +51,9 @@
     <intent>
       <action android:name="android.intent.action.TTS_SERVICE"/>
     </intent>
+    <intent>
+      <action android:name="android.intent.action.OPEN_DOCUMENT_TREE"/>
+    </intent>
   </queries>
 
   <supports-screens


### PR DESCRIPTION
Bug reported here https://t.me/organicmaps/45053.

**Fix:** Added action `android.intent.action.OPEN_DOCUMENT_TREE` to the list of allowed queries.

Found this solution here: https://stackoverflow.com/questions/62535856/intent-resolveactivity-returns-null-in-api-30

Tested on Android 14.