### PR TITLE
[Android] better logout icon

### DIFF
--- a/android/app/src/main/res/drawable/ic_logout.xml
+++ b/android/app/src/main/res/drawable/ic_logout.xml
@@ -1,10 +1,11 @@
 <vector
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:width="24dp"
-  android:height="24dp"
-  android:viewportWidth="24"
-  android:viewportHeight="24">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
   <path
-    android:fillColor="@android:color/white"
-    android:pathData="M10.09,15.59L11.5,17l5,-5 -5,-5 -1.41,1.41L12.67,11H3v2h9.67l-2.58,2.59zM19,3H5c-1.11,0 -2,0.9 -2,2v4h2V5h14v14H5v-4H3v4c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z" />
+      android:pathData="M200,840q-33,0 -56.5,-23.5T120,760v-560q0,-33 23.5,-56.5T200,120h280v80L200,200v560h280v80L200,840ZM640,680 L585,622 687,520L360,520v-80h327L585,338l55,-58 200,200 -200,200Z"
+      android:fillColor="@android:color/white"/>
 </vector>
+


### PR DESCRIPTION
new/old
![image1](https://github.com/user-attachments/assets/53e451a1-d01e-4753-b1ac-28a11f6e9f13)


from https://fonts.google.com/icons?selected=Material+Symbols+Outlined:logout:FILL@0;wght@400;GRAD@0;opsz@24&icon.size=24&icon.color=%23e8eaed


fixes https://github.com/organicmaps/organicmaps/issues/9272