### PR TITLE
Removed % URL encoding from inline links

### DIFF
--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -510,7 +510,7 @@
 	<!-- Hint of the input field in the OSM note section of the editor -->
 	<string name="editor_note_hint">Décrivez les erreurs sur la carte ou les éléments qui ne peuvent pas être modifiés avec Organic Maps.</string>
 	<!-- Information about OSM at the top of the editing page -->
-	<string name="editor_about_osm">Vos modifications sont téléchargées dans la base de données publique &lt;a href="https://wiki.openstreetmap.org/wiki/FR:%%C3%%80_propos_d%E2%%80%%99OpenStreetMap">OpenStreetMap&lt;/a>. Veuillez ne pas ajouter d\'informations personnelles ou protégées par le droit d\'auteur.</string>
+	<string name="editor_about_osm">Vos modifications sont téléchargées dans la base de données publique <a href="https://wiki.openstreetmap.org/wiki/FR:À_propos_d’OpenStreetMap">OpenStreetMap</a>. Veuillez ne pas ajouter d\'informations personnelles ou protégées par le droit d\'auteur.</string>
 	<string name="editor_more_about_osm">En savoir plus sur OpenStreetMap</string>
 	<string name="editor_operator">Opérateur</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->
@@ -776,7 +776,7 @@
 	<!-- Translated Organic Maps site, add new translations here: https://github.com/organicmaps/organicmaps.github.io/tree/master/content -->
 	<string name="translated_om_site_url">https://organicmaps.app/fr/</string>
 	<!-- Link to OSM wiki for Editor, Profile and About pages -->
-	<string name="osm_wiki_about_url">https://wiki.openstreetmap.org/wiki/FR:%%C3%%80_propos_d%E2%%80%%99OpenStreetMap</string>
+	<string name="osm_wiki_about_url">https://wiki.openstreetmap.org/wiki/FR:À_propos_d’OpenStreetMap</string>
 	<!-- App Tip #00 -->
 	<string name="app_tip_00">Merci d\'utiliser nos cartes créées par la communauté !</string>
 	<!-- App tip #01 -->

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -501,7 +501,7 @@
 	<!-- Hint of the input field in the OSM note section of the editor -->
 	<string name="editor_note_hint">Beschrijf fouten op de kaart of dingen die niet bewerkt kunnen worden met Organic Maps</string>
 	<!-- Information about OSM at the top of the editing page -->
-	<string name="editor_about_osm">Uw bewerkingen worden geüpload naar de openbare &lt;a href="https://wiki.openstreetmap.org/wiki/NL:Wat_is_OpenStreetMap%3F">OpenStreetMap&lt;/a> database. Voeg geen persoonlijke of auteursrechtelijk beschermde informatie toe.</string>
+	<string name="editor_about_osm">Uw bewerkingen worden geüpload naar de openbare <a href="https://wiki.openstreetmap.org/wiki/NL:About">OpenStreetMap</a> database. Voeg geen persoonlijke of auteursrechtelijk beschermde informatie toe.</string>
 	<string name="editor_more_about_osm">Meer over OpenStreetMap</string>
 	<string name="editor_operator">Uitvoerder</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -516,7 +516,7 @@
 	<!-- Hint of the input field in the OSM note section of the editor -->
 	<string name="editor_note_hint">描述地圖中的錯誤或無法使用有機地圖編輯的內容</string>
 	<!-- Information about OSM at the top of the editing page -->
-	<string name="editor_about_osm">您的編輯內容將上傳至公用 &lt;a href="https://wiki.openstreetmap.org/wiki/Zh-hant:%1$E9%%97%%9C%2$E6%%96%%BCOpenStreetMap">OpenStreetMap&lt;/a> 資料庫。請不要添加個人或版權資訊。</string>
+	<string name="editor_about_osm">您的編輯內容將上傳至公用 <a href="https://wiki.openstreetmap.org/wiki/Zh-hant:關於OpenStreetMap">OpenStreetMap</a> 資料庫。請不要添加個人或版權資訊。</string>
 	<string name="editor_more_about_osm">關於 OpenStreetMap 的更多資訊</string>
 	<string name="editor_operator">經營者</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->
@@ -781,7 +781,7 @@
 	<!-- Translated Organic Maps site, add new translations here: https://github.com/organicmaps/organicmaps.github.io/tree/master/content -->
 	<string name="translated_om_site_url">https://organicmaps.app/zh-Hans/</string>
 	<!-- Link to OSM wiki for Editor, Profile and About pages -->
-	<string name="osm_wiki_about_url">https://wiki.openstreetmap.org/wiki/Zh-hant:%1$E9%%97%%9C%2$E6%%96%%BCOpenStreetMap</string>
+	<string name="osm_wiki_about_url">https://wiki.openstreetmap.org/wiki/Zh-hant:關於OpenStreetMap</string>
 	<!-- App Tip #00 -->
 	<string name="app_tip_00">感謝您使用我們社區構建的地圖！</string>
 	<!-- App tip #01 -->

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -516,7 +516,7 @@
 	<!-- Hint of the input field in the OSM note section of the editor -->
 	<string name="editor_note_hint">描述地图上的错误或无法用有机地图编辑的内容</string>
 	<!-- Information about OSM at the top of the editing page -->
-	<string name="editor_about_osm">您的编辑内容将上传到公共&lt;a href="https://wiki.openstreetmap.org/wiki/Zh-hans:%1$E5%%85%%B3%2$E4%%BA%3$8E">OpenStreetMap&lt;/a>数据库。请勿添加个人或受版权保护的信息。</string>
+	<string name="editor_about_osm">您的编辑内容将上传到公共<a href="https://wiki.openstreetmap.org/wiki/Zh-hans:关于">OpenStreetMap</a>数据库。请勿添加个人或受版权保护的信息。</string>
 	<string name="editor_more_about_osm">关于 OpenStreetMap 的更多信息</string>
 	<string name="editor_operator">经营者</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->
@@ -781,7 +781,7 @@
 	<!-- Translated Organic Maps site, add new translations here: https://github.com/organicmaps/organicmaps.github.io/tree/master/content -->
 	<string name="translated_om_site_url">https://organicmaps.app/zh-Hans/</string>
 	<!-- Link to OSM wiki for Editor, Profile and About pages -->
-	<string name="osm_wiki_about_url">https://wiki.openstreetmap.org/wiki/Zh-hans:%1$E5%%85%%B3%2$E4%%BA%3$8E</string>
+	<string name="osm_wiki_about_url">https://wiki.openstreetmap.org/wiki/Zh-hans:关于</string>
 	<!-- App Tip #00 -->
 	<string name="app_tip_00">感谢您使用我们社区构建的地图！</string>
 	<!-- App tip #01 -->

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -16296,7 +16296,7 @@
     eu = Zure aldaketak <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> datu-base publikora kargatzen dira. Mesedez, ez gehitu informazio pertsonalik edo copyrightdun informaziorik.
     fa = ویرایش های شما در پایگاه داده عمومی <a href="https://wiki.openstreetmap.org/wiki/Fa:About_OpenStreetMap">OpenStreetMap</a> آپلود می شود. لطفا اطلاعات شخصی یا دارای حق چاپ را اضافه نکنید.
     fi = Muokkauksesi ladataan julkiseen <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>-tietokantaan. Älä lisää henkilökohtaisia tai tekijänoikeudella suojattuja tietoja.
-    fr = Vos modifications sont téléchargées dans la base de données publique <a href="https://wiki.openstreetmap.org/wiki/FR:%C3%80_propos_d%E2%80%99OpenStreetMap">OpenStreetMap</a>. Veuillez ne pas ajouter d'informations personnelles ou protégées par le droit d'auteur.
+    fr = Vos modifications sont téléchargées dans la base de données publique <a href="https://wiki.openstreetmap.org/wiki/FR:À_propos_d’OpenStreetMap">OpenStreetMap</a>. Veuillez ne pas ajouter d'informations personnelles ou protégées par le droit d'auteur.
     he = העריכות שלך מועלות למסד הנתונים הציבורי של <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>. נא לא להוסיף מידע אישי או מוגן בזכויות יוצרים.
     hi = आपके संपादन सार्वजनिक <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> डेटाबेस पर अपलोड किए जाते हैं। कृपया व्यक्तिगत या कॉपीराइट जानकारी न जोड़ें।
     hu = Az Ön szerkesztései feltöltődnek a nyilvános <a href="https://wiki.openstreetmap.org/wiki/Hu:Névjegy">OpenStreetMap</a> adatbázisba. Kérjük, ne adjon hozzá személyes vagy szerzői jogvédelem alatt álló információkat.
@@ -16307,7 +16307,7 @@
     lt = Jūsų pakeitimai įkeliami į viešą <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> duomenų bazę. Prašome nedėti asmeninės ar autorių teisėmis apsaugotos informacijos.
     mr = तुमची संपादने सार्वजनिक <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> डेटाबेसवर अपलोड केली जातात. कृपया वैयक्तिक किंवा कॉपीराइट केलेली माहिती जोडू नका.
     nb = Dine endringer lastes opp til den offentlige <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>-databasen. Vennligst ikke legg til personlig eller opphavsrettsbeskyttet informasjon.
-    nl = Uw bewerkingen worden geüpload naar de openbare <a href="https://wiki.openstreetmap.org/wiki/NL:Wat_is_OpenStreetMap%3F">OpenStreetMap</a> database. Voeg geen persoonlijke of auteursrechtelijk beschermde informatie toe.
+    nl = Uw bewerkingen worden geüpload naar de openbare <a href="https://wiki.openstreetmap.org/wiki/NL:About">OpenStreetMap</a> database. Voeg geen persoonlijke of auteursrechtelijk beschermde informatie toe.
     pl = Państwa zmiany są przesyłane do publicznej bazy danych <a href="https://wiki.openstreetmap.org/wiki/Pl:Wstęp">OpenStreetMap</a>. Prosimy nie dodawać informacji osobistych lub chronionych prawem autorskim.
     pt = As suas edições são carregadas para a base de dados pública <a href="https://wiki.openstreetmap.org/wiki/Pt:Sobre_o_OpenStreetMap">OpenStreetMap</a>. Por favor, não adicione informações pessoais ou protegidas por direitos de autor.
     pt-BR = As suas edições são enviadas à base de dados pública <a href="https://wiki.openstreetmap.org/wiki/Pt:Sobre_o_OpenStreetMap">OpenStreetMap</a>. Não adicione informações pessoais ou protegidas por direitos autorais.
@@ -16320,8 +16320,8 @@
     tr = Düzenlemeleriniz halka açık <a href="https://wiki.openstreetmap.org/wiki/Tr:About">OpenStreetMap</a> veritabanına yüklenir. Lütfen kişisel veya telif hakkıyla korunan bilgiler eklemeyin.
     uk = Ваші правки завантажуються до публічної бази даних <a href="https://wiki.openstreetmap.org/wiki/Uk:Про_проект">OpenStreetMap</a>. Будь ласка, не додавайте особисту або захищену авторським правом інформацію.
     vi = Các chỉnh sửa của bạn sẽ được tải lên cơ sở dữ liệu <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> công khai. Vui lòng không thêm thông tin cá nhân hoặc có bản quyền.
-    zh-Hans = 您的编辑内容将上传到公共<a href="https://wiki.openstreetmap.org/wiki/Zh-hans:%E5%85%B3%E4%BA%8E">OpenStreetMap</a>数据库。请勿添加个人或受版权保护的信息。
-    zh-Hant = 您的編輯內容將上傳至公用 <a href="https://wiki.openstreetmap.org/wiki/Zh-hant:%E9%97%9C%E6%96%BCOpenStreetMap">OpenStreetMap</a> 資料庫。請不要添加個人或版權資訊。
+    zh-Hans = 您的编辑内容将上传到公共<a href="https://wiki.openstreetmap.org/wiki/Zh-hans:关于">OpenStreetMap</a>数据库。请勿添加个人或受版权保护的信息。
+    zh-Hant = 您的編輯內容將上傳至公用 <a href="https://wiki.openstreetmap.org/wiki/Zh-hant:關於OpenStreetMap">OpenStreetMap</a> 資料庫。請不要添加個人或版權資訊。
 
   [editor_detailed_description_hint]
     tags = ios
@@ -28953,7 +28953,7 @@
     el = https://wiki.openstreetmap.org/wiki/El:About_OpenStreetMap
     es = https://wiki.openstreetmap.org/wiki/ES:Acerca_de_OpenStreetMap
     fa = https://wiki.openstreetmap.org/wiki/Fa:About_OpenStreetMap
-    fr = https://wiki.openstreetmap.org/wiki/FR:%C3%80_propos_d%E2%80%99OpenStreetMap
+    fr = https://wiki.openstreetmap.org/wiki/FR:À_propos_d’OpenStreetMap
     hu = https://wiki.openstreetmap.org/wiki/Hu:Névjegy
     it = https://wiki.openstreetmap.org/wiki/IT:About
     ja = https://wiki.openstreetmap.org/wiki/JA:参加する
@@ -28964,8 +28964,8 @@
     ru = https://wiki.openstreetmap.org/wiki/RU:О_проекте
     tr = https://wiki.openstreetmap.org/wiki/Tr:About
     uk = https://wiki.openstreetmap.org/wiki/Uk:Про_проект
-    zh-Hans = https://wiki.openstreetmap.org/wiki/Zh-hans:%E5%85%B3%E4%BA%8E
-    zh-Hant = https://wiki.openstreetmap.org/wiki/Zh-hant:%E9%97%9C%E6%96%BCOpenStreetMap
+    zh-Hans = https://wiki.openstreetmap.org/wiki/Zh-hans:关于
+    zh-Hant = https://wiki.openstreetmap.org/wiki/Zh-hant:關於OpenStreetMap
 
   [comma_separated_pair]
     comment = A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -1261,7 +1261,7 @@
 "translated_om_site_url" = "https://organicmaps.app/fr/";
 
 /* Link to OSM wiki for Editor, Profile and About pages */
-"osm_wiki_about_url" = "https://wiki.openstreetmap.org/wiki/FR:%C3%80_propos_d%E2%80%99OpenStreetMap";
+"osm_wiki_about_url" = "https://wiki.openstreetmap.org/wiki/FR:À_propos_d’OpenStreetMap";
 
 /* App Tip #00 */
 "app_tip_00" = "Merci d'utiliser nos cartes créées par la communauté !";

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -1261,7 +1261,7 @@
 "translated_om_site_url" = "https://organicmaps.app/zh-Hans/";
 
 /* Link to OSM wiki for Editor, Profile and About pages */
-"osm_wiki_about_url" = "https://wiki.openstreetmap.org/wiki/Zh-hans:%E5%85%B3%E4%BA%8E";
+"osm_wiki_about_url" = "https://wiki.openstreetmap.org/wiki/Zh-hans:关于";
 
 /* App Tip #00 */
 "app_tip_00" = "感谢您使用我们社区构建的地图！";

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -1261,7 +1261,7 @@
 "translated_om_site_url" = "https://organicmaps.app/zh-Hans/";
 
 /* Link to OSM wiki for Editor, Profile and About pages */
-"osm_wiki_about_url" = "https://wiki.openstreetmap.org/wiki/Zh-hant:%E9%97%9C%E6%96%BCOpenStreetMap";
+"osm_wiki_about_url" = "https://wiki.openstreetmap.org/wiki/Zh-hant:關於OpenStreetMap";
 
 /* App Tip #00 */
 "app_tip_00" = "感謝您使用我們社區構建的地圖！";


### PR DESCRIPTION
URL encoding with % doesn't work and links were not clickable. I removed the encoding from the strings to fix the issue.

(See: https://github.com/organicmaps/organicmaps/pull/6173#issuecomment-2351060721)