### PR TITLE
[Android] fix RTL in placepage

### DIFF
--- a/android/app/src/main/res/layout/place_page_capacity.xml
+++ b/android/app/src/main/res/layout/place_page_capacity.xml
@@ -16,6 +16,7 @@
 
   <TextView
     android:id="@+id/tv__place_capacity"
+    android:textAlignment="viewStart"
     style="@style/PlacePageMetadataText"
     tools:text="Capacity" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/place_page_cuisine.xml
+++ b/android/app/src/main/res/layout/place_page_cuisine.xml
@@ -18,6 +18,7 @@
 
   <TextView
     android:id="@+id/tv__place_cuisine"
+    android:textAlignment="viewStart"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textAppearance="@style/MwmTextAppearance.PlacePage"

--- a/android/app/src/main/res/layout/place_page_drive_through.xml
+++ b/android/app/src/main/res/layout/place_page_drive_through.xml
@@ -16,6 +16,7 @@
 
   <TextView
     android:id="@+id/tv__place_drive_through"
+    android:textAlignment="viewStart"
     style="@style/PlacePageMetadataText"
     tools:text="Drive-through" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/place_page_email.xml
+++ b/android/app/src/main/res/layout/place_page_email.xml
@@ -17,6 +17,7 @@
 
   <TextView
     android:id="@+id/tv__place_email"
+    android:textAlignment="viewStart"
     style="@style/PlacePageMetadataText"
     android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"
     tools:text="support@organicmaps.app" />

--- a/android/app/src/main/res/layout/place_page_entrance.xml
+++ b/android/app/src/main/res/layout/place_page_entrance.xml
@@ -13,6 +13,7 @@
 
   <TextView
     android:id="@+id/tv__place_entrance"
+    android:textAlignment="viewStart"
     style="@style/PlacePageMetadataText"
     tools:text="150 - 200"/>
 </LinearLayout>

--- a/android/app/src/main/res/layout/place_page_facebook.xml
+++ b/android/app/src/main/res/layout/place_page_facebook.xml
@@ -16,6 +16,7 @@
 
   <TextView
     android:id="@+id/tv__place_facebook_page"
+    android:textAlignment="viewStart"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"

--- a/android/app/src/main/res/layout/place_page_instagram.xml
+++ b/android/app/src/main/res/layout/place_page_instagram.xml
@@ -17,6 +17,7 @@
 
   <TextView
     android:id="@+id/tv__place_instagram_page"
+    android:textAlignment="viewStart"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"

--- a/android/app/src/main/res/layout/place_page_kayak.xml
+++ b/android/app/src/main/res/layout/place_page_kayak.xml
@@ -17,6 +17,7 @@
 
   <TextView
       android:id="@+id/tv__place_kayak"
+      android:textAlignment="viewStart"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:text="@string/more_on_kayak"

--- a/android/app/src/main/res/layout/place_page_latlon.xml
+++ b/android/app/src/main/res/layout/place_page_latlon.xml
@@ -16,6 +16,7 @@
 
   <TextView
     android:id="@+id/tv__place_latlon"
+    android:textAlignment="viewStart"
     style="@style/PlacePageMetadataText"
     tools:text="55.747, 37.616" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/place_page_level.xml
+++ b/android/app/src/main/res/layout/place_page_level.xml
@@ -16,6 +16,7 @@
 
   <TextView
     android:id="@+id/tv__place_level"
+    android:textAlignment="viewStart"
     style="@style/PlacePageMetadataText"
     tools:text="@string/level" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/place_page_line.xml
+++ b/android/app/src/main/res/layout/place_page_line.xml
@@ -16,6 +16,7 @@
 
   <TextView
     android:id="@+id/tv__place_line_page"
+    android:textAlignment="viewStart"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"

--- a/android/app/src/main/res/layout/place_page_network.xml
+++ b/android/app/src/main/res/layout/place_page_network.xml
@@ -16,6 +16,7 @@
 
   <TextView
     android:id="@+id/tv__place_network"
+    android:textAlignment="viewStart"
     style="@style/PlacePageMetadataText"
     tools:text="Network" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/place_page_open_in.xml
+++ b/android/app/src/main/res/layout/place_page_open_in.xml
@@ -17,6 +17,7 @@
 
   <TextView
     android:id="@+id/tv__place_open_in"
+    android:textAlignment="viewStart"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:text="@string/open_in_app"

--- a/android/app/src/main/res/layout/place_page_operator.xml
+++ b/android/app/src/main/res/layout/place_page_operator.xml
@@ -16,6 +16,7 @@
 
   <TextView
     android:id="@+id/tv__place_operator"
+    android:textAlignment="viewStart"
     style="@style/PlacePageMetadataText"
     tools:text="Operator" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/place_page_outdoor_seating.xml
+++ b/android/app/src/main/res/layout/place_page_outdoor_seating.xml
@@ -15,6 +15,7 @@
 
   <TextView
     android:id="@+id/tv__place_outdoor_seating"
+    android:textAlignment="viewStart"
     style="@style/PlacePageMetadataText"
     android:text="@string/outdoor_seating"/>
 </LinearLayout>

--- a/android/app/src/main/res/layout/place_page_phone_item.xml
+++ b/android/app/src/main/res/layout/place_page_phone_item.xml
@@ -18,6 +18,7 @@
 
   <TextView
     android:id="@+id/tv__place_phone"
+    android:textAlignment="viewStart"
     style="@style/PlacePageMetadataText"
     android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"
     tools:text="+1 234 567-89-00"/>

--- a/android/app/src/main/res/layout/place_page_placename.xml
+++ b/android/app/src/main/res/layout/place_page_placename.xml
@@ -25,12 +25,14 @@
   <TextView
     android:id="@+id/tv__place_address"
     style="@style/PlacePageMetadataText"
+    android:textAlignment="viewStart"
     android:layout_above="@id/anchor_center"
     android:layout_toEndOf="@id/iv__place_name"
     tools:text="Sample place"/>
 
   <TextView
     android:id="@+id/tv__place_post_address"
+    android:textAlignment="viewStart"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_alignStart="@id/tv__place_address"

--- a/android/app/src/main/res/layout/place_page_preview.xml
+++ b/android/app/src/main/res/layout/place_page_preview.xml
@@ -14,6 +14,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:baselineAligned="false"
+    android:layoutDirection="ltr"
     android:orientation="horizontal">
     <include
       android:id="@+id/downloader_status_frame"
@@ -27,6 +28,7 @@
     <LinearLayout
       android:id="@+id/title_container"
       android:layout_width="0dp"
+      android:layoutDirection="locale"
       android:layout_height="wrap_content"
       android:layout_marginStart="@dimen/margin_base"
       android:layout_marginEnd="@dimen/margin_base"
@@ -34,6 +36,7 @@
       android:orientation="vertical">
       <TextView
         android:id="@+id/tv__title"
+        android:textAlignment="viewStart"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:ellipsize="end"
@@ -45,6 +48,7 @@
         tools:text="Title" />
       <TextView
         android:id="@+id/tv__secondary_title"
+        android:textAlignment="viewStart"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_quarter"
@@ -57,6 +61,7 @@
         tools:text="Secondary Title" />
       <TextView
         android:id="@+id/tv__subtitle"
+        android:textAlignment="viewStart"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_quarter"
@@ -67,6 +72,7 @@
         tools:text="Subtitle, very very very very very very very long" />
       <TextView
         android:id="@+id/tv__address"
+        android:textAlignment="viewStart"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_quarter"
@@ -75,6 +81,7 @@
         tools:text="Lenina str, 10" />
       <TextView
         android:id="@+id/tv__downloader_details"
+        android:textAlignment="viewStart"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_quarter"

--- a/android/app/src/main/res/layout/place_page_twitter.xml
+++ b/android/app/src/main/res/layout/place_page_twitter.xml
@@ -17,6 +17,7 @@
 
   <TextView
     android:id="@+id/tv__place_twitter_page"
+    android:textAlignment="viewStart"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"

--- a/android/app/src/main/res/layout/place_page_vk.xml
+++ b/android/app/src/main/res/layout/place_page_vk.xml
@@ -17,6 +17,7 @@
 
   <TextView
     android:id="@+id/tv__place_vk_page"
+    android:textAlignment="viewStart"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"

--- a/android/app/src/main/res/layout/place_page_website.xml
+++ b/android/app/src/main/res/layout/place_page_website.xml
@@ -17,6 +17,7 @@
 
   <TextView
     android:id="@+id/tv__place_website"
+    android:textAlignment="viewStart"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"

--- a/android/app/src/main/res/layout/place_page_website_menu.xml
+++ b/android/app/src/main/res/layout/place_page_website_menu.xml
@@ -22,6 +22,7 @@
 
     <TextView
       android:id="@+id/tv__place_website_menu"
+      android:textAlignment="viewStart"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/view_menu"
@@ -29,6 +30,7 @@
 
     <TextView
         android:id="@+id/tv__place_website_menu_subtitle"
+        android:textAlignment="viewStart"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"

--- a/android/app/src/main/res/layout/place_page_wikimedia.xml
+++ b/android/app/src/main/res/layout/place_page_wikimedia.xml
@@ -16,8 +16,9 @@
 
   <TextView
     android:id="@+id/tv__place_wikimedia"
+    android:textAlignment="viewStart"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"
-    android:text="osm.org"/>
+    android:text="@string/wikimedia_commons"/>
 </LinearLayout>


### PR DESCRIPTION
fixes rtl in place page items, keeps top buttons in ltr order while making text rtl

![image1](https://github.com/user-attachments/assets/bb08a5d2-d637-40d7-84b3-cd84f36546a4)
