### PR TITLE
[ios][placepage] Add Go Map!! to Open in Another App

### DIFF
--- a/iphone/Maps/OMaps.plist
+++ b/iphone/Maps/OMaps.plist
@@ -100,6 +100,7 @@
 		<string>moovit</string>
 		<string>uber</string>
 		<string>waze</string>
+		<string>gomaposm</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/iphone/Maps/UI/PlacePage/Components/OpenInAppActionSheet/OpenInApplication.swift
+++ b/iphone/Maps/UI/PlacePage/Components/OpenInAppActionSheet/OpenInApplication.swift
@@ -9,6 +9,7 @@ enum OpenInApplication: Int, CaseIterable {
   case moovit
   case uber
   case waze
+  case goMap
 }
 
 extension OpenInApplication {
@@ -40,6 +41,8 @@ extension OpenInApplication {
       return "Uber"
     case .waze:
       return "Waze"
+    case .goMap:
+      return "Go Map!!"
     }
   }
 
@@ -66,6 +69,8 @@ extension OpenInApplication {
       return "uber://"
     case .waze:
       return "waze://"
+    case .goMap:
+      return "gomaposm://"
     }
   }
 
@@ -102,6 +107,8 @@ extension OpenInApplication {
       return "\(scheme)?client_id=&action=setPickup&pickup=my_location&dropoff[latitude]=\(latitude)&dropoff[longitude]=\(longitude)"
     case .waze:
       return "\(scheme)?ll=\(latitude),\(longitude)"
+    case .goMap:
+      return "\(scheme)edit?center=\(latitude),\(longitude)&zoom=\(zoomLevel)"
     }
   }
 }


### PR DESCRIPTION
This PR adds the [Go Map!!](https://github.com/bryceco/GoMap) editor to the Open in Another App button.

This is working fine using the web link scheme. However, then the button appears even if Go Map!! is not installed.
`https://gomaposm.com/edit?center=47.679056,-122.212559&zoom=21`


I have tried using the app scheme, but it doesn't seem to detect that the app is installed and the button doesn't show up. 
`gomaposm://edit?center=47.679056,-122.212559&zoom=21`

@bryceco Any idea why the `gomaposm://` scheme doesn't work?


* Fixes https://github.com/organicmaps/organicmaps/issues/9104