### PR TITLE
Fix: Rename “World Map” to “World Overview” as per issue #9334

### DIFF
--- a/android/app/src/main/java/app/organicmaps/car/screens/download/DownloaderHelpers.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/download/DownloaderHelpers.java
@@ -16,11 +16,11 @@ public final class DownloaderHelpers
 {
   static final String[] WORLD_MAPS = new String[]{"World", "WorldCoasts"};
 
-  // World maps may be missing only in the F-Droid build.
+  // World overviews may be missing only in the F-Droid build.
   @SuppressWarnings("ConstantConditions")
   public static boolean isWorldMapsDownloadNeeded()
   {
-    // TODO: Maps are asynchronously initialized in the core. If the initialization takes a significant amount of time, the downloader screen could potentially be displayed, even if the world maps are present.
+    // TODO: Maps are asynchronously initialized in the core. If the initialization takes a significant amount of time, the downloader screen could potentially be displayed, even if the world overviews are present.
     if (BuildConfig.FLAVOR.equals("fdroid"))
       return !CountryItem.fill(WORLD_MAPS[0]).present || !CountryItem.fill(WORLD_MAPS[1]).present;
     return false;

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -55,7 +55,7 @@
     <string name="disconnect_usb_cable">Please disconnect USB cable or insert memory card to use Organic Maps</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="not_enough_free_space_on_sdcard">Please free up some space on the SD card/USB storage first in order to use the app</string>
-    <string name="download_resources">Before you start using the app, please download the general world map to your device.
+    <string name="download_resources">Before you start using the app, please download the general world overview to your device.
 \nIt will use %s of storage.</string>
     <string name="download_resources_continue">Go to Map</string>
     <string name="downloading_country_can_proceed">Downloading %s. You can now
@@ -795,7 +795,7 @@
     <string name="elevation_profile_time">Time:</string>
     <string name="isolines_toast_zooms_1_10">Zoom in to explore isolines</string>
     <string name="downloader_loading_ios">Downloading</string>
-    <string name="download_map_title">Download the world map</string>
+    <string name="download_map_title">Download the world overview</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="disk_error">Unable to create folder and move files on internal device\'s memory or sdcard</string>
     <!-- Used in DownloadResources startup screen -->

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -1507,7 +1507,7 @@
 
   [download_resources]
     tags = android
-    en = Before you start using the app, please download the general world map to your device.\nIt will use %@ of storage.
+    en = Before you start using the app, please download the general world overview to your device.\nIt will use %@ of storage.
     af = Voordat u die toep begin gebruik, moet u asb. die algemene wêreldkaart na u toestel aflaai.\nDit sal %@ se spasie opneem.
     ar = قبل أن تبدأ باستخدام التطبيق، سنقوم بتنزيل خريطة العالم العامة على جهازك.\nستحتاج إلى %@ من البيانات.
     az = Başlamazdan əvvəl gəlin ümumi dünya xəritəsini cihazınıza endirək.\n%@ yer tələb olunur.
@@ -12186,7 +12186,7 @@
 
   [editor_done_dialog_1]
     tags = ios
-    en = You’ve changed the world map! Don't keep it to yourself; tell your friends and edit it together.
+    en = You’ve changed the world overview! Don't keep it to yourself; tell your friends and edit it together.
     af = U het die wêreldkaart verander! Moet dit nie vir uself hou nie; Vertel u vriende en wysig dit saam.
     ar = لقد ساهمت بتحسين خريطة العالم. لا تخفي ذلك! أخبر أصدقائك، وحسنوها معاً.
     az = Siz dünya xəritəsini dəyişdiniz. Gizlətməyin! Dostlarınıza deyin və birlikdə redaktə edin.
@@ -28186,7 +28186,7 @@
 
   [download_map_title]
     tags = android
-    en = Download the world map
+    en = Download the world overview
     af = Laai die wêreldkaart af
     ar = تنزيل خريطة العالم
     az = Dünya xəritəsini yükləyin

--- a/data/welcome.html
+++ b/data/welcome.html
@@ -9,7 +9,7 @@
     </style>
   </head>
   <body>
-    <center><h1>Offline World Map in your computer</h1></center>
+    <center><h1>Offline World Overview in your computer</h1></center>
     <p>Congratulations! You're just one step away from seeing your favourite cities and countries!</p>
     <p>Download them once and use everywhere - no internet access is needed.</p>
     <p>We'll try to keep you updated when new application versions and new map data become available.</p>

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -452,7 +452,7 @@ There is a matrix of different build variants:
 
 - _Flavor_:
   - `Web` is a light APK without any bundled maps.
-  - `Google` is a full Google Play store version including a low-zoom overview world map.
+  - `Google` is a full Google Play store version including a low-zoom overview world overview.
   - `Fdroid` is a version for publishing on the [F-Droid](https://f-droid.org/) open source apps store (no bundled maps and no Google services).
   - ...and other flavors like `Huawei`.
 

--- a/drape_frontend/line_shape.cpp
+++ b/drape_frontend/line_shape.cpp
@@ -475,7 +475,7 @@ void LineShape::Construct<SimpleSolidLineBuilder>(SimpleSolidLineBuilder & build
 
 bool LineShape::CanBeSimplified(int & lineWidth) const
 {
-  // Disable simplification for world map.
+  // Disable simplification for world overview.
   if (m_params.m_zoomLevel > 0 && m_params.m_zoomLevel <= scales::GetUpperCountryScale())
     return false;
 

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -126,7 +126,7 @@ DEFINE_string(srtm_path, "",
               "Path to srtm directory. If set, generates a section with altitude information "
               "about roads.");
 DEFINE_string(world_roads_path, "",
-              "Path to a file with roads that should end up on the world map. If set, generates a "
+              "Path to a file with roads that should end up on the world overview. If set, generates a "
               "section with these roads in World.mwm. The roads may be used to identify which mwm "
               "files are touched by an arbitrary route.");
 DEFINE_string(transit_path, "", "Path to directory with transit graphs in json.");

--- a/generator/tag_admixer.hpp
+++ b/generator/tag_admixer.hpp
@@ -114,7 +114,7 @@ public:
     else if (element.m_type == OsmElement::EntityType::Node &&
              m_capitals.find(element.m_id) != m_capitals.cend())
     {
-      // Our goal here - to make some capitals visible in World map.
+      // Our goal here - to make some capitals visible in World Overview.
       // The simplest way is to upgrade population to 45000,
       // according to our visibility rules in mapcss files.
       element.UpdateTagFn("population", [] (std::string & v)

--- a/generator/towns_dumper.cpp
+++ b/generator/towns_dumper.cpp
@@ -46,7 +46,7 @@ void TownsDumper::FilterTowns()
         [&top, &isUniq, &distanceThreshold](Town const & candidate)
         {
           // The idea behind that is to collect all capitals and unique major cities in 500 km radius
-          // for upgrading in World map visibility. See TOWNS_FILE usage.
+          // for upgrading in World overview visibility. See TOWNS_FILE usage.
           if (ms::DistanceOnEarth(top.point, candidate.point) < distanceThreshold)
             isUniq = false;
         });

--- a/generator/world_map_generator.hpp
+++ b/generator/world_map_generator.hpp
@@ -21,8 +21,8 @@
 
 #include "water_boundary_checker.hpp"
 
-/// Process FeatureBuilder for world map. Main functions:
-/// - check for visibility in world map
+/// Process FeatureBuilder for world overview. Main functions:
+/// - check for visibility in world overview
 /// - merge linear features
 template <class FeatureOutT>
 class WorldMapGenerator

--- a/indexer/feature_to_osm.cpp
+++ b/indexer/feature_to_osm.cpp
@@ -23,7 +23,7 @@ bool FeatureIdToGeoObjectIdOneWay::Load()
   auto const handle = indexer::FindWorld(m_dataSource);
   if (!handle.IsAlive())
   {
-    LOG(LWARNING, ("Can't find World map file."));
+    LOG(LWARNING, ("Can't find world overview file."));
     return false;
   }
 
@@ -34,7 +34,7 @@ bool FeatureIdToGeoObjectIdOneWay::Load()
 
   if (!cont.IsExist(FEATURE_TO_OSM_FILE_TAG))
   {
-    LOG(LWARNING, ("No cities fid bimap in the world map."));
+    LOG(LWARNING, ("No cities fid bimap in the world overview."));
     return false;
   }
 
@@ -46,7 +46,7 @@ bool FeatureIdToGeoObjectIdOneWay::Load()
   }
   catch (Reader::Exception const & e)
   {
-    LOG(LERROR, ("Can't read cities fid bimap from the world map:", e.Msg()));
+    LOG(LERROR, ("Can't read cities fid bimap from the world overview:", e.Msg()));
     return false;
   }
 
@@ -103,7 +103,7 @@ bool FeatureIdToGeoObjectIdTwoWay::Load()
   auto const handle = indexer::FindWorld(m_dataSource);
   if (!handle.IsAlive())
   {
-    LOG(LWARNING, ("Can't find World map file."));
+    LOG(LWARNING, ("Can't find world overview file."));
     return false;
   }
 
@@ -114,7 +114,7 @@ bool FeatureIdToGeoObjectIdTwoWay::Load()
 
   if (!cont.IsExist(FEATURE_TO_OSM_FILE_TAG))
   {
-    LOG(LWARNING, ("No cities fid bimap in the world map."));
+    LOG(LWARNING, ("No cities fid bimap in the world overview."));
     return false;
   }
 
@@ -126,7 +126,7 @@ bool FeatureIdToGeoObjectIdTwoWay::Load()
   }
   catch (Reader::Exception const & e)
   {
-    LOG(LERROR, ("Can't read cities fid bimap from the world map:", e.Msg()));
+    LOG(LERROR, ("Can't read cities fid bimap from the world overview:", e.Msg()));
     return false;
   }
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -567,7 +567,7 @@
 
 "editor_add_select_location" = "Location";
 
-"editor_done_dialog_1" = "You’ve changed the world map! Don't keep it to yourself; tell your friends and edit it together.";
+"editor_done_dialog_1" = "You’ve changed the world overview! Don't keep it to yourself; tell your friends and edit it together.";
 
 "share_with_friends" = "Share with friends";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-
+world overview
 /********** Strings **********/
 
 /* Button text (should be short) */
@@ -567,7 +567,7 @@
 
 "editor_add_select_location" = "Location";
 
-"editor_done_dialog_1" = "You’ve changed the world map! Don't keep it to yourself; tell your friends and edit it together.";
+"editor_done_dialog_1" = "You’ve changed the world overview! Don't keep it to yourself; tell your friends and edit it together.";
 
 "share_with_friends" = "Share with friends";
 

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -567,7 +567,7 @@
 
 "editor_add_select_location" = "जगह";
 
-"editor_done_dialog_1" = "You’ve changed the world map! Don't keep it to yourself; tell your friends and edit it together.";
+"editor_done_dialog_1" = "You’ve changed the world overview! Don't keep it to yourself; tell your friends and edit it together.";
 
 "share_with_friends" = "Share with friends";
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -567,7 +567,7 @@
 
 "editor_add_select_location" = "Location";
 
-"editor_done_dialog_1" = "You’ve changed the world map! Don't keep it to yourself; tell your friends and edit it together.";
+"editor_done_dialog_1" = "You’ve changed the world overview! Don't keep it to yourself; tell your friends and edit it together.";
 
 "share_with_friends" = "Share with friends";
 

--- a/packaging/app.organicmaps.desktop.metainfo.xml
+++ b/packaging/app.organicmaps.desktop.metainfo.xml
@@ -408,8 +408,8 @@
            <li>Fixed residential leisure garden area fills disappearing on some zoom levels</li>
            <li>Display house numbers regardless of buildings' sizes on zoom level 17</li>
            <li>Fine-tuned priorities of many POIs in the main style</li>
-           <li>Less "gaps" in highways on the World map</li>
-           <li>Removed very short ferry lines from the World map</li>
+           <li>Less "gaps" in highways on the world overview</li>
+           <li>Removed very short ferry lines from the world overview</li>
          </ul>
      </description>
    </release>
@@ -527,7 +527,7 @@
          </ul>
        <p>Styles:</p>
          <ul>
-           <li>Added ferry routes to the World map</li>
+           <li>Added ferry routes to the world overview</li>
            <li>Removed square background from parking icons</li>
            <li>Added separate icons for paid and private parking</li>
            <li>Made the bicycle parking icon differ more from the motorcycle one</li>
@@ -764,7 +764,7 @@
            <li>Improved, less bright icons in Night mode</li>
            <li>Fixed subway icons in some cities</li>
            <li>Properly draw barriers for areas and relations</li>
-           <li>Fixed duplicated names on the world map</li>
+           <li>Fixed duplicated names on the world overview</li>
            <li>Updated cave, mountain pass, peak, volcano, emergency phone, historic ship, ice cream, nightclub, music shop, stadium, video games icons</li>
            <li>Fixed wrong priorities of leisure=pitch, historic, post office</li>
            <li>More consistent filled/round icons (round means some kind of business/service)</li>
@@ -795,7 +795,7 @@
          <ul>
            <li>Fixed some improperly overlapping types</li>
            <li>Added highway=busway and physiotherapist</li>
-           <li>Islands and archipelagos are now visible on World Map</li>
+           <li>Islands and archipelagos are now visible on world overview</li>
            <li>Draw waterway=dam as background area</li>
            <li>Water draw priority is lesser now than pier</li>
            <li>Fixed leisure areas</li>

--- a/search/cities_boundaries_table.cpp
+++ b/search/cities_boundaries_table.cpp
@@ -46,7 +46,7 @@ bool CitiesBoundariesTable::Load()
   auto handle = FindWorld(m_dataSource);
   if (!handle.IsAlive())
   {
-    LOG(LWARNING, ("Can't find World map file."));
+    LOG(LWARNING, ("Can't find world overview file."));
     return false;
   }
 
@@ -62,7 +62,7 @@ bool CitiesBoundariesTable::Load()
 
   if (!cont.IsExist(CITIES_BOUNDARIES_FILE_TAG))
   {
-    LOG(LWARNING, ("No cities boundaries table in the world map."));
+    LOG(LWARNING, ("No cities boundaries table in the world overview."));
     return false;
   }
 
@@ -77,7 +77,7 @@ bool CitiesBoundariesTable::Load()
   }
   catch (Reader::Exception const & e)
   {
-    LOG(LERROR, ("Can't read cities boundaries table from the world map:", e.Msg()));
+    LOG(LERROR, ("Can't read cities boundaries table from the world overview:", e.Msg()));
     return false;
   }
 

--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -731,7 +731,7 @@ void Geocoder::CacheWorldLocalities()
   else
   {
     // This is strange situation, anyway.
-    LOG(LWARNING, ("Can't find World map file."));
+    LOG(LWARNING, ("Can't find World Overview file."));
   }
 }
 
@@ -1063,7 +1063,7 @@ void Geocoder::MatchCities(BaseContext & ctx)
         continue;
       }
 
-      // No need to search features in the World map.
+      // No need to search features in the World Overview.
       if (m_context->GetInfo()->GetType() == MwmInfo::WORLD)
         continue;
 


### PR DESCRIPTION
Renamed almost all world map's with world overview as per the suggestion.