### PR TITLE
Always show rounded current speed

### DIFF
--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -202,7 +202,8 @@ double MpsToUnits(double metersPerSecond, Units units)
 std::string FormatSpeedNumeric(double metersPerSecond, Units units)
 {
   double const unitsPerHour = MpsToUnits(metersPerSecond, units);
-  return ToStringPrecision(unitsPerHour, unitsPerHour >= 10.0 ? 0 : 1);
+  double roundedValue = std::round(unitsPerHour);
+  return std::to_string(static_cast<int>(roundedValue));
 }
 
 std::string FormatOsmLink(double lat, double lon, int zoom)


### PR DESCRIPTION
The current speed is not very precise as it depends on the GPS location. Showing 3,4km/h is not very useful, as it can't be that precise.
This implementation rounds the current speed to the nearest full number, preventing these issues.
Closes #6570

Before:
![Screenshot_2024-09-22-14-04-54-10_10a7d9276315e62e56e7300dfec6be06](https://github.com/user-attachments/assets/177c1f11-052b-450e-96ae-23a538784f40)

After:

![Screenshot_20240922-140426_Debug Organic Maps](https://github.com/user-attachments/assets/47d848c5-046c-4411-a1bc-2d99765a762d)
