### PR TITLE
[ios] Fix: New bookmark list placement

### DIFF
--- a/iphone/Maps/Bookmarks/Categories/BMCViewModel/BMCDefaultViewModel.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCViewModel/BMCDefaultViewModel.swift
@@ -128,8 +128,8 @@ extension BMCDefaultViewModel {
       return
     }
 
-    categories.append(manager.category(withId: manager.createCategory(withName: name)))
-    view?.insert(at: [IndexPath(row: categories.count - 1, section: section)])
+    categories.insert(manager.category(withId: manager.createCategory(withName: name)), at: 0)
+    view?.insert(at: [IndexPath(row: 0, section: section)])
   }
 
   func deleteCategory(at index: Int) {


### PR DESCRIPTION
* Fixes #9205 

Description:
- New row was being inserted at the end of the section, Should be on the top
- `getCategories()` function sorts the categories to update the table data source

| Before | After |
|--------|--------|
| https://github.com/user-attachments/assets/5454116e-ffbe-47dc-a808-7dd009fc7375 | https://github.com/user-attachments/assets/9a01b65d-22a9-4e64-930a-60d7795692a9 |

