### PR TITLE
[ios] Fix Recently Deleted screen opening bug

### DIFF
--- a/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
@@ -161,7 +161,7 @@ final class BMCViewController: MWMViewController {
 
   private func openRecentlyDeleted() {
     let recentlyDeletedController = RecentlyDeletedCategoriesViewController(viewModel: RecentlyDeletedCategoriesViewModel(bookmarksManager: BookmarksManager.shared()))
-    MapViewController.topViewController().navigationController?.pushViewController(recentlyDeletedController, animated: true)
+    MapViewController.shared()?.navigationController?.pushViewController(recentlyDeletedController, animated: true)
   }
 }
 


### PR DESCRIPTION
Closes #9352 

The bug was caused by the 747b3553fb06bf4ff46165e8804a9eb119910080

The VieweControllers should be pushed from the `MapViewController`'s navigation controller.
The `topViewController` property shouldn't be used to push/pop on the main screens stack.


https://github.com/user-attachments/assets/3d38f22b-dae7-4b30-89f5-a86c566d50be

