### PR TITLE
[Android] Fix browser triggering in Android 14

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -54,6 +54,11 @@
     <intent>
       <action android:name="android.intent.action.OPEN_DOCUMENT_TREE"/>
     </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <category android:name="android.intent.category.BROWSABLE" />
+      <data android:scheme="https" />
+    </intent>
   </queries>
 
   <supports-screens


### PR DESCRIPTION
After @RedAuburn  PR https://github.com/organicmaps/organicmaps/pull/9332 was merged new issue appeared on Android 10+.

When user tries to login using OAuth2 (only for Google flavored builds) he sees error "Web browser is not available".

**Fix:** allow browser intent explicitly for Android 10+ in AndroidManifest. See details https://stackoverflow.com/a/70988018

This issue is simmilar to https://github.com/organicmaps/organicmaps/pull/9263. We should test PRs on a wider range of Android versions.