### PR TITLE
return to map after edit->login

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
@@ -372,7 +372,7 @@ public class EditorHostFragment extends BaseMwmToolbarFragment implements View.O
   private void showLoginDialog()
   {
     startActivity(new Intent(requireContext(), OsmLoginActivity.class));
-    requireActivity().finish();
+    Utils.navigateToParent(requireActivity());
   }
 
   private void saveNote()


### PR DESCRIPTION
fixes #5727

When showing the login page after an edit users now get send back to the map after pressing back or logging in. Previously users were send back to the category list (see #5727).