### PR TITLE
Update POI info in place page after editing

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -3070,15 +3070,15 @@ osm::Editor::SaveResult Framework::SaveEditedMapObject(osm::EditableMapObject em
 
   auto const result = osm::Editor::Instance().SaveEditedFeature(emo);
 
-  // Automatically select newly created objects.
-  if (!m_currentPlacePageInfo)
-  {
-    place_page::BuildInfo info;
-    info.m_mercator = emo.GetMercator();
-    info.m_featureId = emo.GetID();
-    m_currentPlacePageInfo = BuildPlacePageInfo(info);
-    ActivateMapSelection();
-  }
+  // Automatically select newly created and edited objects.
+  if (m_currentPlacePageInfo)
+    DeactivateMapSelection();
+
+  place_page::BuildInfo info;
+  info.m_mercator = emo.GetMercator();
+  info.m_featureId = emo.GetID();
+  m_currentPlacePageInfo = BuildPlacePageInfo(info);
+  ActivateMapSelection();
 
   return result;
 }


### PR DESCRIPTION
fixes #2835 

Update POI info in the place page after editing an object. This PR first deselects the object and then re selects it in the same way it is done for created features.