### PR TITLE
[core] [android] [ios] Add `menu` and `settings` URL types tot handle universal links from inapp events

### DIFF
--- a/android/app/src/main/java/app/organicmaps/api/RequestType.java
+++ b/android/app/src/main/java/app/organicmaps/api/RequestType.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.SOURCE)
-@IntDef({RequestType.INCORRECT, RequestType.MAP, RequestType.ROUTE, RequestType.SEARCH, RequestType.CROSSHAIR, RequestType.OAUTH2})
+@IntDef({RequestType.INCORRECT, RequestType.MAP, RequestType.ROUTE, RequestType.SEARCH, RequestType.CROSSHAIR, RequestType.OAUTH2, RequestType.MENU, RequestType.SETTINGS})
 public @interface RequestType
 {
   // Represents url_scheme::ParsedMapApi::UrlType from c++ part.
@@ -16,4 +16,6 @@ public @interface RequestType
   public static final int SEARCH = 3;
   public static final int CROSSHAIR = 4;
   public static final int OAUTH2 = 5;
+  public static final int MENU = 6;
+  public static final int SETTINGS = 7;
 }

--- a/android/app/src/main/java/app/organicmaps/car/util/IntentUtils.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/IntentUtils.java
@@ -96,6 +96,12 @@ public final class IntentUtils
       return;
     case RequestType.CROSSHAIR:
       Logger.e(TAG, "Crosshair API is not supported by Android Auto: " + uri);
+      return;
+    case RequestType.MENU:
+      Logger.e(TAG, "Menu API is not supported by Android Auto: " + uri);
+      return;
+    case RequestType.SETTINGS:
+      Logger.e(TAG, "Settings API is not supported by Android Auto: " + uri);
     }
   }
 

--- a/android/app/src/main/java/app/organicmaps/intent/Factory.java
+++ b/android/app/src/main/java/app/organicmaps/intent/Factory.java
@@ -141,6 +141,10 @@ public class Factory
 
           return true;
         }
+
+        // Menu and Settings url types should be implemented to support deeplinking.
+        case RequestType.MENU:
+        case RequestType.SETTINGS:
       }
 
       return false;

--- a/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.h
+++ b/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.h
@@ -8,7 +8,9 @@ typedef NS_ENUM(NSUInteger, DeeplinkUrlType) {
   DeeplinkUrlTypeRoute,
   DeeplinkUrlTypeSearch,
   DeeplinkUrlTypeCrosshair,
-  DeeplinkUrlTypeOAuth2
+  DeeplinkUrlTypeOAuth2,
+  DeeplinkUrlTypeMenu,
+  DeeplinkUrlTypeSettings
 };
 
 @interface DeepLinkParser : NSObject

--- a/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.mm
+++ b/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.mm
@@ -6,15 +6,18 @@
 
 static inline DeeplinkUrlType deeplinkUrlType(url_scheme::ParsedMapApi::UrlType type)
 {
+  using namespace url_scheme;
   switch (type)
-   {
-     case url_scheme::ParsedMapApi::UrlType::Incorrect: return DeeplinkUrlTypeIncorrect;
-     case url_scheme::ParsedMapApi::UrlType::Map: return DeeplinkUrlTypeMap;
-     case url_scheme::ParsedMapApi::UrlType::Route: return DeeplinkUrlTypeRoute;
-     case url_scheme::ParsedMapApi::UrlType::Search: return DeeplinkUrlTypeSearch;
-     case url_scheme::ParsedMapApi::UrlType::Crosshair: return DeeplinkUrlTypeCrosshair;
-     case url_scheme::ParsedMapApi::UrlType::OAuth2: return DeeplinkUrlTypeOAuth2;
-   }
+  {
+    case ParsedMapApi::UrlType::Incorrect: return DeeplinkUrlTypeIncorrect;
+    case ParsedMapApi::UrlType::Map: return DeeplinkUrlTypeMap;
+    case ParsedMapApi::UrlType::Route: return DeeplinkUrlTypeRoute;
+    case ParsedMapApi::UrlType::Search: return DeeplinkUrlTypeSearch;
+    case ParsedMapApi::UrlType::Crosshair: return DeeplinkUrlTypeCrosshair;
+    case ParsedMapApi::UrlType::OAuth2: return DeeplinkUrlTypeOAuth2;
+    case ParsedMapApi::UrlType::Menu: return DeeplinkUrlTypeMenu;
+    case ParsedMapApi::UrlType::Settings: return DeeplinkUrlTypeSettings;
+  }
 }
 
 @implementation DeepLinkParser

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
@@ -232,7 +232,7 @@ NSString *const kNavigationControlViewXibName = @"NavigationControlView";
 }
 
 - (IBAction)settingsButtonAction {
-  [[MapViewController sharedController] performSegueWithIdentifier:@"Map2Settings" sender:nil];
+  [[MapViewController sharedController] openSettings];
 }
 
 - (IBAction)stopRoutingButtonAction {

--- a/iphone/Maps/Classes/MapViewController.h
+++ b/iphone/Maps/Classes/MapViewController.h
@@ -24,6 +24,8 @@
 
 - (void)performAction:(NSString *_Nonnull)action;
 
+- (void)openMenu;
+- (void)openSettings;
 - (void)openMapsDownloader:(MWMMapDownloaderMode)mode;
 - (void)openEditor;
 - (void)openBookmarkEditor;

--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -37,6 +37,7 @@ NSString *const kDownloaderSegue = @"Map2MapDownloaderSegue";
 NSString *const kEditorSegue = @"Map2EditorSegue";
 NSString *const kUDViralAlertWasShown = @"ViralAlertWasShown";
 NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
+NSString *const kSettingsSegue = @"Map2Settings";
 }  // namespace
 
 @interface NSValueWrapper : NSObject
@@ -481,6 +482,13 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
 }
 
 #pragma mark - Open controllers
+- (void)openMenu {
+  [self.controlsManager.tabBarController onMenuButtonPressed:self];
+}
+
+- (void)openSettings {
+  [self performSegueWithIdentifier:kSettingsSegue sender:nil];
+}
 
 - (void)openMapsDownloader:(MWMMapDownloaderMode)mode {
   [self performSegueWithIdentifier:kDownloaderSegue sender:@(mode)];

--- a/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
+++ b/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
@@ -78,6 +78,7 @@
     // TODO(AB): Rewrite API so iOS and Android will call only one C++ method to clear/set API state.
     // This call is also required for DeepLinkParser.showMap, and it also clears old API points...
     let urlType = DeepLinkParser.parseAndSetApiURL(url)
+    LOG(.info, "URL type: \(urlType)")
     switch urlType {
     case .route:
       if let adapter = DeepLinkRouteStrategyAdapter(url) {
@@ -86,12 +87,10 @@
         return true
       }
       return false;
-
     case .map:
       DeepLinkParser.executeMapApiRequest()
       MapsAppDelegate.theApp().showMap()
       return true
-
     case .search:
       let sd = DeepLinkSearchData();
       let kSearchInViewportZoom: Int32 = 16;
@@ -111,17 +110,23 @@
         MWMMapViewControlsManager.manager()?.searchText(sd.query, forInputLocale: sd.locale)
       }
       return true
-
+    case .menu:
+      MapsAppDelegate.theApp().mapViewController.openMenu()
+      return true
+    case .settings:
+      MapsAppDelegate.theApp().mapViewController.openSettings()
+      return true
     case .crosshair:
       // Not supported on iOS.
       return false;
-      
     case .oAuth2:
       // TODO: support OAuth2
       return false;
-
     case .incorrect:
       // Invalid URL or API parameters.
+      return false;
+    @unknown default:
+      LOG(.critical, "Unknown URL type: \(urlType)")
       return false;
     }
   }

--- a/iphone/Maps/UI/BottomMenu/Menu/BottomMenuInteractor.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/BottomMenuInteractor.swift
@@ -62,7 +62,7 @@ extension BottomMenuInteractor: BottomMenuInteractorProtocol {
 
   func openSettings() {
     close()
-    mapViewController?.performSegue(withIdentifier: "Map2Settings", sender: nil)
+    mapViewController?.openSettings()
   }
 
   func shareLocation(cell: BottomMenuItemCell) {

--- a/map/mwm_url.cpp
+++ b/map/mwm_url.cpp
@@ -175,6 +175,16 @@ ParsedMapApi::UrlType ParsedMapApi::SetUrlAndParse(std::string const & raw)
 
       return m_requestType = UrlType::Crosshair;
     }
+    else if (type == "menu")
+    {
+      /// @todo(KK): Implement path parsing to highlight the specific menu item.
+      return m_requestType = UrlType::Menu;
+    }
+    else if (type == "settings")
+    {
+      /// @todo(KK): Implement path parsing to navigate to the specific settings page and highlight the specific item.
+      return m_requestType = UrlType::Settings;
+    }
     else if (type == "oauth2")
     {
       if (url.GetPath() != "osm/callback")
@@ -485,6 +495,8 @@ std::string DebugPrint(ParsedMapApi::UrlType type)
   case ParsedMapApi::UrlType::Search: return "Search";
   case ParsedMapApi::UrlType::Crosshair: return "Crosshair";
   case ParsedMapApi::UrlType::OAuth2: return "OAuth2";
+  case ParsedMapApi::UrlType::Menu: return "Menu";
+  case ParsedMapApi::UrlType::Settings: return "Settings";
   }
   UNREACHABLE();
 }

--- a/map/mwm_url.hpp
+++ b/map/mwm_url.hpp
@@ -46,6 +46,8 @@ public:
     Search = 3,
     Crosshair = 4,
     OAuth2 = 5,
+    Menu = 6,
+    Settings = 7
   };
 
   ParsedMapApi() = default;


### PR DESCRIPTION
To handle **InApp events in iOS** this PR:
1. adds `menu` and `settings` URL types to the core `url_scheme::ParsedMapApi::UrlType`
2. when a universal link or a deep link is triggered related screens in iOS will be opened
3. in Android no screens will be opened @organicmaps/android please review the changes that!
