### PR TITLE
#8773 - On restart, show the search history tab, if search history exists

### DIFF
--- a/android/app/src/main/java/app/organicmaps/search/SearchFragment.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchFragment.java
@@ -3,6 +3,7 @@ package app.organicmaps.search;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.location.Location;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -22,6 +23,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.viewpager.widget.ViewPager;
 import app.organicmaps.Framework;
 import app.organicmaps.MwmActivity;
+import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmFragment;
 import app.organicmaps.bookmarks.data.FeatureId;
@@ -299,8 +301,10 @@ public class SearchFragment extends BaseMwmFragment
 
     SearchEngine.INSTANCE.addListener(this);
 
+    SharedPreferences preferences = MwmApplication.prefs(requireContext());
+    int lastSelectedTabPosition = preferences.getInt(Config.KEY_PREF_LAST_SEARCHED_TAB, 0);
     if (SearchRecents.getSize() == 0 && Config.isSearchHistoryEnabled())
-      pager.setCurrentItem(TabAdapter.Tab.CATEGORIES.ordinal());
+      pager.setCurrentItem(lastSelectedTabPosition);
 
     tabAdapter.setTabSelectedListener(tab -> mToolbarController.deactivate());
 

--- a/android/app/src/main/java/app/organicmaps/search/TabAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/search/TabAdapter.java
@@ -1,6 +1,7 @@
 package app.organicmaps.search;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.util.SparseArray;
 import android.view.View;
 
@@ -11,6 +12,8 @@ import androidx.fragment.app.FragmentPagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
 import com.google.android.material.tabs.TabLayout;
+
+import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
 import app.organicmaps.util.Graphics;
 import app.organicmaps.util.Config;
@@ -91,6 +94,9 @@ class TabAdapter extends FragmentPagerAdapter
     @Override
     public void onTabSelected(TabLayout.Tab tab)
     {
+      SharedPreferences.Editor editor = MwmApplication.prefs(mContext).edit();
+      editor.putInt(Config.KEY_PREF_LAST_SEARCHED_TAB, tab.getPosition());
+      editor.apply();
       super.onTabSelected(tab);
       Graphics.tint(mContext, tab.getIcon(), androidx.appcompat.R.attr.colorAccent);
     }
@@ -151,7 +157,9 @@ class TabAdapter extends FragmentPagerAdapter
     ViewPager.OnPageChangeListener listener = new PageChangedListener(tabs);
     mPager.addOnPageChangeListener(listener);
     tabs.setOnTabSelectedListener(new OnTabSelectedListenerForViewPager(mPager));
-    listener.onPageSelected(0);
+    SharedPreferences preferences = MwmApplication.prefs(mPager.getContext());
+    int lastSelectedTabPosition = preferences.getInt(Config.KEY_PREF_LAST_SEARCHED_TAB, 0);
+    listener.onPageSelected(lastSelectedTabPosition);
   }
 
   void setTabSelectedListener(OnTabSelectedListener listener)

--- a/android/app/src/main/java/app/organicmaps/util/Config.java
+++ b/android/app/src/main/java/app/organicmaps/util/Config.java
@@ -7,7 +7,6 @@ import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.preference.PreferenceManager;
 import app.organicmaps.BuildConfig;
-import app.organicmaps.MwmActivity;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
 
@@ -35,6 +34,8 @@ public final class Config
   private static final String KEY_MISC_AGPS_TIMESTAMP = "AGPSTimestamp";
   private static final String KEY_DONATE_URL = "DonateUrl";
   private static final String KEY_PREF_SEARCH_HISTORY = "SearchHistoryEnabled";
+
+  public static final String KEY_PREF_LAST_SEARCHED_TAB = "LastSearchTab";
 
   /**
    * The total number of app launches.


### PR DESCRIPTION
Fix to address #8773:

Calculate search recents list size correctly to set the correct tab in the SearchFragment's layout depending on whether or not, a search history exists.

On app restart, if a search history exists, the search history tab is shown instead of the categories tab, to achieve expected behavior.

Thanks!