### PR TITLE
[core] Add "motorcycle_parking", "bicycle_parking", "charging_station", to IsOperatorOthersPoiChecker

### DIFF
--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -208,8 +208,8 @@ IsPostPoiChecker::IsPostPoiChecker()
 IsOperatorOthersPoiChecker::IsOperatorOthersPoiChecker()
 {
   Classificator const & c = classif();
-  for (char const * val : {"bicycle_rental", "bureau_de_change", "car_sharing", "car_rental", "fuel",
-                           "parking", "payment_terminal", "university", "vending_machine"})
+  for (char const * val : {"bicycle_rental", "bureau_de_change", "car_sharing", "car_rental", "fuel", "charging_station", 
+                           "parking", "motorcycle_parking", "bicycle_parking", "payment_terminal", "university", "vending_machine"})
     m_types.push_back(c.GetTypeByPath({"amenity", val}));
 }
 


### PR DESCRIPTION
Same as `amenity=parking` and `amenity=fuel`, we should also show operator for `amenity=motorcycle_parking`, `amenity=bicycle_parking`, and `amenity=charging_station`