### PR TITLE
Ruler router fix

### DIFF
--- a/routing/ruler_router.cpp
+++ b/routing/ruler_router.cpp
@@ -36,7 +36,7 @@ void RulerRouter::SetGuides(GuidesTracks && guides) { /*m_guides = GuidesConnect
     | 1     | 2      | 2               | 4             |
     | 2     | 2      | 3               | 4             |
     | 2     | F      | 4               | 6             |
-    | 2     | F      | 4               | 6             |
+    | F     | F      | 5               | 6             |
     +-------+--------+-----------------+---------------+
 
   Constraints:
@@ -91,18 +91,8 @@ RouterResultCode RulerRouter::CalculateRoute(Checkpoints const & checkpoints,
   vector<Route::SubrouteAttrs> subroutes;
   for(size_t i = 1; i < count; ++i)
   {
-    if (i < count-1)
-    {
-      // Note: endSegmentIdx in decreased in Route::IsSubroutePassed(size_t) method. See routing/route.cpp:448
-      subroutes.emplace_back(ToPointWA(points[i-1]), ToPointWA(points[i]), i*2-2, i*2);
-      subroutes.emplace_back(ToPointWA(points[i-1]), ToPointWA(points[i]), i*2-1, i*2);
-    }
-    else
-    {
-      // Duplicate last subroute attrs.
-      subroutes.emplace_back(ToPointWA(points[i-1]), ToPointWA(points[i]), i*2-2, i*2);
-      subroutes.emplace_back(ToPointWA(points[i-1]), ToPointWA(points[i]), i*2-2, i*2);
-    }
+    subroutes.emplace_back(ToPointWA(points[i-1]), ToPointWA(points[i]), i*2-2, i*2);
+    subroutes.emplace_back(ToPointWA(points[i-1]), ToPointWA(points[i]), i*2-1, i*2);
   }
 
   route.SetCurrentSubrouteIdx(checkpoints.GetPassedIdx());

--- a/routing/ruler_router.cpp
+++ b/routing/ruler_router.cpp
@@ -100,8 +100,8 @@ RouterResultCode RulerRouter::CalculateRoute(Checkpoints const & checkpoints,
     else
     {
       // Duplicate last subroute attrs.
-      subroutes.emplace_back(ToPointWA(points[i-1]), ToPointWA(points[i+1]), i*2-2, i*2);
-      subroutes.emplace_back(ToPointWA(points[i-1]), ToPointWA(points[i+1]), i*2-2, i*2);
+      subroutes.emplace_back(ToPointWA(points[i-1]), ToPointWA(points[i]), i*2-2, i*2);
+      subroutes.emplace_back(ToPointWA(points[i-1]), ToPointWA(points[i]), i*2-2, i*2);
     }
   }
 


### PR DESCRIPTION
Fix index pointing out of array bound. For some reason it worked for Android but reading some garbage. On iOS simulator it crashes ruller router.