### PR TITLE
[ios] Fix image padding for buttons in right-to-left layout

### DIFF
--- a/iphone/Maps/Categories/UIButton+ImagePadding.swift
+++ b/iphone/Maps/Categories/UIButton+ImagePadding.swift
@@ -1,0 +1,12 @@
+extension UIButton {
+  @objc func setImagePadding(_ padding: CGFloat) {
+    let isRightToLeft = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft
+    if isRightToLeft {
+      self.contentEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: padding)
+      self.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: -2 * padding)
+    } else {
+      self.contentEdgeInsets = UIEdgeInsets(top: 0, left: padding, bottom: 0, right: 0)
+      self.imageEdgeInsets = UIEdgeInsets(top: 0, left: -2 * padding, bottom: 0, right: 0)
+    }
+  }
+}

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/MWMRoutePreview.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/MWMRoutePreview.mm
@@ -180,13 +180,13 @@ static CGFloat const kDrivingOptionsHeight = 48;
   }];
 
   if (state == MWMDrivingOptionsStateDefine) {
-    [MWMBaseRoutePreviewStatus setImagePadding:0.0 for:self.drivingOptionsButton];
+    [self.drivingOptionsButton setImagePadding:0.0];
     [self.drivingOptionsButton setImage:nil
                                forState:UIControlStateNormal];
     [self.drivingOptionsButton setTitle:L(@"define_to_avoid_btn").uppercaseString
                                forState:UIControlStateNormal];
   } else if (state == MWMDrivingOptionsStateChange) {
-    [MWMBaseRoutePreviewStatus setImagePadding:5.0 for:self.drivingOptionsButton];
+    [self.drivingOptionsButton setImagePadding:5.0];
     [self.drivingOptionsButton setImage:[UIImage imageNamed:@"ic_options_warning"]
                                forState:UIControlStateNormal];
     [self.drivingOptionsButton setTitle:L(@"change_driving_options_btn").uppercaseString

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/MWMRoutePreview.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/MWMRoutePreview.mm
@@ -4,6 +4,7 @@
 #import "MWMRouter.h"
 #import "UIButton+Orientation.h"
 #import "UIImageView+Coloring.h"
+#import "SwiftBridge.h"
 
 #include "platform/platform.hpp"
 
@@ -179,11 +180,13 @@ static CGFloat const kDrivingOptionsHeight = 48;
   }];
 
   if (state == MWMDrivingOptionsStateDefine) {
+    [MWMBaseRoutePreviewStatus setImagePadding:0.0 for:self.drivingOptionsButton];
     [self.drivingOptionsButton setImage:nil
                                forState:UIControlStateNormal];
     [self.drivingOptionsButton setTitle:L(@"define_to_avoid_btn").uppercaseString
                                forState:UIControlStateNormal];
   } else if (state == MWMDrivingOptionsStateChange) {
+    [MWMBaseRoutePreviewStatus setImagePadding:5.0 for:self.drivingOptionsButton];
     [self.drivingOptionsButton setImage:[UIImage imageNamed:@"ic_options_warning"]
                                forState:UIControlStateNormal];
     [self.drivingOptionsButton setTitle:L(@"change_driving_options_btn").uppercaseString

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/MWMiPadRoutePreview.xib
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/MWMiPadRoutePreview.xib
@@ -39,7 +39,6 @@
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Opi-yT-xIZ">
                             <rect key="frame" x="72.5" y="12" width="175" height="24"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
-                            <inset key="imageEdgeInsets" minX="-10" minY="0.0" maxX="0.0" maxY="0.0"/>
                             <state key="normal" title="DEFINE ROADS TO AVOID" image="ic_options_warning"/>
                             <connections>
                                 <action selector="onDrivingOptions:" destination="u2u-Vb-2eH" eventType="touchUpInside" id="x2p-AW-91V"/>
@@ -284,8 +283,6 @@
                                 </view>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NAs-km-8uw">
                                     <rect key="frame" x="20" y="12" width="127" height="24"/>
-                                    <inset key="contentEdgeInsets" minX="8" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                    <inset key="imageEdgeInsets" minX="-16" minY="0.0" maxX="0.0" maxY="0.0"/>
                                     <state key="normal" title="ManageRoute" image="ic_24px_manager"/>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="medium14:MWMBlack"/>

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/MWMiPhoneRoutePreview.xib
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/MWMiPhoneRoutePreview.xib
@@ -27,7 +27,6 @@
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZXA-Og-q2I">
                             <rect key="frame" x="72.5" y="12" width="175" height="24"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
-                            <inset key="imageEdgeInsets" minX="-10" minY="0.0" maxX="0.0" maxY="0.0"/>
                             <state key="normal" title="DEFINE ROADS TO AVOID" image="ic_options_warning"/>
                             <connections>
                                 <action selector="onDrivingOptions:" destination="aNH-vh-DPz" eventType="touchUpInside" id="jR1-dk-nNj"/>
@@ -239,8 +238,6 @@
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zzm-Yo-BvL">
                             <rect key="frame" x="81" y="8" width="127" height="32"/>
-                            <inset key="contentEdgeInsets" minX="8" minY="0.0" maxX="0.0" maxY="0.0"/>
-                            <inset key="imageEdgeInsets" minX="-16" minY="0.0" maxX="0.0" maxY="0.0"/>
                             <state key="normal" title="ManageRoute" image="ic_24px_manager"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="medium14:MWMBlack"/>
@@ -323,8 +320,6 @@
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="K37-2W-GE8">
                             <rect key="frame" x="20" y="10" width="127" height="24"/>
-                            <inset key="contentEdgeInsets" minX="8" minY="0.0" maxX="0.0" maxY="0.0"/>
-                            <inset key="imageEdgeInsets" minX="-16" minY="0.0" maxX="0.0" maxY="0.0"/>
                             <state key="normal" title="ManageRoute" image="ic_24px_manager"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="medium14:MWMBlack"/>

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/BaseRoutePreviewStatus.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/BaseRoutePreviewStatus.swift
@@ -83,8 +83,21 @@ final class BaseRoutePreviewStatus: SolidTouchView {
       })
     }
   }
-
+  
+  @objc static func setImagePadding(_ padding: CGFloat, for button: UIButton) {
+    let isRightToLeft = UIView.userInterfaceLayoutDirection(for: button.semanticContentAttribute) == .rightToLeft
+    if(isRightToLeft){
+      button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: padding)
+      button.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: -2 * padding)
+    }
+    else {
+      button.contentEdgeInsets = UIEdgeInsets(top: 0, left: padding, bottom: 0, right: 0)
+      button.imageEdgeInsets = UIEdgeInsets(top: 0, left: -2 * padding, bottom: 0, right: 0)
+    }
+  }
+  
   private func configManageRouteButton(_ button: UIButton) {
+    BaseRoutePreviewStatus.setImagePadding(8, for: button)
     button.setTitle(L("planning_route_manage_route"), for: .normal)
   }
 

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/BaseRoutePreviewStatus.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/BaseRoutePreviewStatus.swift
@@ -84,19 +84,8 @@ final class BaseRoutePreviewStatus: SolidTouchView {
     }
   }
 
-  @objc static func setImagePadding(_ padding: CGFloat, for button: UIButton) {
-    let isRightToLeft = UIView.userInterfaceLayoutDirection(for: button.semanticContentAttribute) == .rightToLeft
-    if isRightToLeft {
-      button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: padding)
-      button.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: -2 * padding)
-    } else {
-      button.contentEdgeInsets = UIEdgeInsets(top: 0, left: padding, bottom: 0, right: 0)
-      button.imageEdgeInsets = UIEdgeInsets(top: 0, left: -2 * padding, bottom: 0, right: 0)
-    }
-  }
-
   private func configManageRouteButton(_ button: UIButton) {
-    BaseRoutePreviewStatus.setImagePadding(8, for: button)
+    button.setImagePadding(8)
     button.setTitle(L("planning_route_manage_route"), for: .normal)
   }
 

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/BaseRoutePreviewStatus.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/BaseRoutePreviewStatus.swift
@@ -83,19 +83,18 @@ final class BaseRoutePreviewStatus: SolidTouchView {
       })
     }
   }
-  
+
   @objc static func setImagePadding(_ padding: CGFloat, for button: UIButton) {
     let isRightToLeft = UIView.userInterfaceLayoutDirection(for: button.semanticContentAttribute) == .rightToLeft
-    if(isRightToLeft){
+    if isRightToLeft {
       button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: padding)
       button.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: -2 * padding)
-    }
-    else {
+    } else {
       button.contentEdgeInsets = UIEdgeInsets(top: 0, left: padding, bottom: 0, right: 0)
       button.imageEdgeInsets = UIEdgeInsets(top: 0, left: -2 * padding, bottom: 0, right: 0)
     }
   }
-  
+
   private func configManageRouteButton(_ button: UIButton) {
     BaseRoutePreviewStatus.setImagePadding(8, for: button)
     button.setTitle(L("planning_route_manage_route"), for: .normal)

--- a/iphone/Maps/Images.xcassets/Search/Cells/ic_search_mode_list.imageset/Contents.json
+++ b/iphone/Maps/Images.xcassets/Search/Cells/ic_search_mode_list.imageset/Contents.json
@@ -1,24 +1,27 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
       "filename" : "Manager.png",
+      "idiom" : "universal",
+      "language-direction" : "left-to-right",
       "scale" : "1x"
     },
     {
-      "idiom" : "universal",
       "filename" : "Manager@2x.png",
+      "idiom" : "universal",
+      "language-direction" : "left-to-right",
       "scale" : "2x"
     },
     {
-      "idiom" : "universal",
       "filename" : "Manager@3x.png",
+      "idiom" : "universal",
+      "language-direction" : "left-to-right",
       "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
     "template-rendering-intent" : "template"

--- a/iphone/Maps/Images.xcassets/ic_24px_manager.imageset/Contents.json
+++ b/iphone/Maps/Images.xcassets/ic_24px_manager.imageset/Contents.json
@@ -1,13 +1,14 @@
 {
   "images" : [
     {
+      "filename" : "ic_24px_manager.pdf",
       "idiom" : "universal",
-      "filename" : "ic_24px_manager.pdf"
+      "language-direction" : "left-to-right"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
     "template-rendering-intent" : "template"

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -260,6 +260,7 @@
 		47F67D1521CAB21B0069754E /* MWMImageCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 47F67D1421CAB21B0069754E /* MWMImageCoder.m */; };
 		47F86CFF20C936FC00FEE291 /* TabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F86CFE20C936FC00FEE291 /* TabView.swift */; };
 		47F86D0120C93D8D00FEE291 /* TabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F86D0020C93D8D00FEE291 /* TabViewController.swift */; };
+		49AB95982CB2FE5300468EA2 /* UIButton+ImagePadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49AB95972CB2FE5300468EA2 /* UIButton+ImagePadding.swift */; };
 		4A300ED51C6DCFD400140018 /* countries-strings in Resources */ = {isa = PBXBuildFile; fileRef = 4A300ED31C6DCFD400140018 /* countries-strings */; };
 		4B4153B52BF9695500EE4B02 /* MWMTextToSpeechTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B4153B42BF9695500EE4B02 /* MWMTextToSpeechTests.mm */; };
 		4B83AE492C2E59F800B0C3BC /* TTSTester.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B83AE482C2E59F800B0C3BC /* TTSTester.mm */; };
@@ -1188,6 +1189,7 @@
 		47F701EC238C2F8400D18E95 /* location_util.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = location_util.h; sourceTree = "<group>"; };
 		47F86CFE20C936FC00FEE291 /* TabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabView.swift; sourceTree = "<group>"; };
 		47F86D0020C93D8D00FEE291 /* TabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewController.swift; sourceTree = "<group>"; };
+		49AB95972CB2FE5300468EA2 /* UIButton+ImagePadding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+ImagePadding.swift"; sourceTree = "<group>"; };
 		4A00DBDE1AB704C400113624 /* drules_proto_default_dark.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = drules_proto_default_dark.bin; path = ../../data/drules_proto_default_dark.bin; sourceTree = "<group>"; };
 		4A23D1561B8B4DD700D4EB6F /* drules_proto_default_light.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = drules_proto_default_light.bin; path = ../../data/drules_proto_default_light.bin; sourceTree = "<group>"; };
 		4A23D1571B8B4DD700D4EB6F /* resources-6plus_light */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "resources-6plus_light"; path = "../../data/resources-6plus_light"; sourceTree = "<group>"; };
@@ -2213,6 +2215,7 @@
 				471A7BB7247FE3C300A0D4C1 /* URL+Query.swift */,
 				EDC3573A2B7B5029001AE9CA /* CALayer+SetCorner.swift */,
 				ED79A5AC2BD7BA0F00952D1F /* UIApplication+LoadingOverlay.swift */,
+				49AB95972CB2FE5300468EA2 /* UIButton+ImagePadding.swift */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -4430,6 +4433,7 @@
 				99A614D523C8911A00D8D8D0 /* AuthStyleSheet.swift in Sources */,
 				99A906F123FA946E0005872B /* DifficultyViewRenderer.swift in Sources */,
 				F6E2FD5F1E097BA00083EBEC /* MWMMapDownloaderLargeCountryTableViewCell.m in Sources */,
+				49AB95982CB2FE5300468EA2 /* UIButton+ImagePadding.swift in Sources */,
 				99A906E523F6F7030005872B /* ActionBarViewController.swift in Sources */,
 				47B9065421C7FA400079C85E /* UIImageView+WebImage.m in Sources */,
 				F6E2FF481E097BA00083EBEC /* SettingsTableViewSelectableCell.swift in Sources */,


### PR DESCRIPTION
Fixes #7976 for buttons when an RTL script is used
Before | After
------ | -----
![sss](https://github.com/user-attachments/assets/c8cad23c-29a1-4063-9132-cd1c6218bffa) | ![ppp](https://github.com/user-attachments/assets/6f27dbfd-caf4-417e-a461-7cc84ade9db2)
