### PR TITLE
[routing] Allow to pass cycle-barrier if bicycle=no is not specified

### DIFF
--- a/data/test_data/osm/cycle_barrier.osm
+++ b/data/test_data/osm/cycle_barrier.osm
@@ -7,6 +7,7 @@
   <node id='3866183425' timestamp='2021-06-12T10:45:14Z' uid='3172019' user='nurdafur' visible='true' version='2' changeset='106248484' lat='47.5209057' lon='8.7888206' />
   <node id='8827179695' timestamp='2021-06-12T10:45:14Z' uid='3172019' user='nurdafur' visible='true' version='1' changeset='106248484' lat='47.5207872' lon='8.7873177'>
     <tag k='barrier' v='cycle_barrier' />
+    <tag k='bicycle' v='no' />
   </node>
   <way id='953707247' timestamp='2021-06-12T10:45:14Z' uid='3172019' user='nurdafur' visible='true' version='1' changeset='106248484'>
     <nd ref='432645019' />

--- a/generator/generator_tests/road_access_test.cpp
+++ b/generator/generator_tests/road_access_test.cpp
@@ -537,4 +537,26 @@ UNIT_CLASS_TEST(TestAccessFixture, Locked)
   }
 }
 
+UNIT_CLASS_TEST(TestAccessFixture, CycleBarrier)
+{
+  CreateCollectors();
+
+  AddWay(MakeOsmElementWithNodes(1, {{"highway", "track"}},
+                                 OsmElement::EntityType::Way, {10, 11, 12}));
+  AddNode(MakeOsmElement(10, {{"barrier", "cycle_barrier"}},
+                         OsmElement::EntityType::Node));
+  AddNode(MakeOsmElement(11, {{"barrier", "cycle_barrier"}, {"bicycle", "dismount"}},
+                         OsmElement::EntityType::Node));
+  AddNode(MakeOsmElement(12, {{"barrier", "cycle_barrier"}, {"bicycle", "no"}},
+                         OsmElement::EntityType::Node));
+  Finish();
+  auto const bicycle = Get(VehicleType::Bicycle);
+  TEST_EQUAL(bicycle.GetAccessWithoutConditional({1, 0}),
+             make_pair(RoadAccess::Type::Yes, RoadAccess::Confidence::Sure), ());
+  TEST_EQUAL(bicycle.GetAccessWithoutConditional({1, 1}),
+             make_pair(RoadAccess::Type::Yes, RoadAccess::Confidence::Sure), ());
+  TEST_EQUAL(bicycle.GetAccessWithoutConditional({1, 2}),
+             make_pair(RoadAccess::Type::No, RoadAccess::Confidence::Sure), ());
+}
+
 }  // namespace road_access_test

--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -122,7 +122,6 @@ TagMapping const kBicycleTagMapping = {
 };
 
 TagMapping const kBicycleBarriersTagMapping = {
-    {OsmElement::Tag("barrier", "cycle_barrier"), RoadAccess::Type::No},
     {OsmElement::Tag("barrier", "gate"), RoadAccess::Type::Private},
     // TODO (@gmoryes) The types below should be added.
     //  {OsmElement::Tag("barrier", "kissing_gate"), RoadAccess::Type::Private},


### PR DESCRIPTION
fixes #3920, fixes #9233
Block barrier=cycle_barrier only for bicycle=no case
I added unit tests, could anyone help me with testing please - as I understand it is required to build maps with new generator code?