### PR TITLE
[Android] Rewrite insets handling logic for Downloader screen

### DIFF
--- a/android/app/src/main/java/app/organicmaps/downloader/BottomPanel.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/BottomPanel.java
@@ -1,15 +1,8 @@
 package app.organicmaps.downloader;
 
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.Button;
 
-import androidx.annotation.NonNull;
-import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
-import app.organicmaps.util.WindowInsetUtils;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import app.organicmaps.R;
 import app.organicmaps.util.StringUtils;
@@ -62,36 +55,6 @@ class BottomPanel
     });
 
     mButton = frame.findViewById(R.id.action);
-
-    ViewCompat.setOnApplyWindowInsetsListener(frame, new OnApplyWindowInsetsListener()
-    {
-      @NonNull
-      @Override
-      public WindowInsetsCompat onApplyWindowInsets(@NonNull View v, @NonNull WindowInsetsCompat insets)
-      {
-        Insets safeInsets = insets.getInsets(WindowInsetUtils.TYPE_SAFE_DRAWING);
-        int baseMargin = UiUtils.dimen(v.getContext(), R.dimen.margin_base);
-
-        ViewGroup.MarginLayoutParams fabParams = (ViewGroup.MarginLayoutParams) mFab.getLayoutParams();
-        ViewGroup.MarginLayoutParams buttonParams = (ViewGroup.MarginLayoutParams) mButton.getLayoutParams();
-
-        final boolean isButtonVisible = UiUtils.isVisible(mButton);
-
-        buttonParams.bottomMargin = safeInsets.bottom;
-        mButton.setPadding(safeInsets.left, mButton.getPaddingTop(), safeInsets.right, mButton.getPaddingBottom());
-
-        fabParams.rightMargin = safeInsets.right + baseMargin;
-        if (isButtonVisible)
-          fabParams.bottomMargin = baseMargin;
-        else
-          fabParams.bottomMargin = safeInsets.bottom + baseMargin;
-
-        mFab.requestLayout();
-        mButton.requestLayout();
-
-        return insets;
-      }
-    });
   }
 
   private void setUpdateAllState(UpdateInfo info)
@@ -161,5 +124,7 @@ class BottomPanel
     }
 
     UiUtils.showIf(show, mButton);
+
+    mFragment.requireView().requestApplyInsets();
   }
 }

--- a/android/app/src/main/java/app/organicmaps/downloader/DownloaderFragment.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/DownloaderFragment.java
@@ -9,6 +9,7 @@ import androidx.annotation.CallSuper;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.ViewCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import app.organicmaps.R;
@@ -125,6 +126,9 @@ public class DownloaderFragment extends BaseMwmRecyclerFragment<DownloaderAdapte
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState)
   {
     super.onViewCreated(view, savedInstanceState);
+
+    ViewCompat.setOnApplyWindowInsetsListener(view, new DownloaderInsetsListener(view));
+
     mSubscriberSlot = MapManager.nativeSubscribe(new MapManager.StorageCallback()
     {
       @Override

--- a/android/app/src/main/java/app/organicmaps/downloader/DownloaderInsetsListener.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/DownloaderInsetsListener.java
@@ -1,0 +1,96 @@
+package app.organicmaps.downloader;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.recyclerview.widget.RecyclerView;
+import app.organicmaps.R;
+import app.organicmaps.util.UiUtils;
+import app.organicmaps.util.WindowInsetUtils;
+
+final class DownloaderInsetsListener implements OnApplyWindowInsetsListener
+{
+
+  @NonNull
+  private final Context mContext;
+  @NonNull
+  private final View mToolbar;
+  @NonNull
+  private final View mFab;
+  @NonNull
+  private final View mButton;
+  @NonNull
+  private final RecyclerView mRecyclerView;
+
+  DownloaderInsetsListener(@NonNull View fragmentView)
+  {
+    mContext = fragmentView.getContext();
+    mToolbar = fragmentView.findViewById(R.id.toolbar);
+    mFab = fragmentView.findViewById(R.id.fab);
+    mButton = fragmentView.findViewById(R.id.action);
+    mRecyclerView = fragmentView.findViewById(R.id.recycler);
+    mRecyclerView.setClipToPadding(false);
+  }
+
+  @NonNull
+  @Override
+  public WindowInsetsCompat onApplyWindowInsets(@NonNull View v, @NonNull WindowInsetsCompat insets)
+  {
+    final Insets safeInsets = insets.getInsets(WindowInsetUtils.TYPE_SAFE_DRAWING);
+
+    mToolbar.setPadding(safeInsets.left, safeInsets.top, safeInsets.right, mToolbar.getPaddingBottom());
+
+    boolean isAnyButtonVisible = UiUtils.isVisible(mFab) || UiUtils.isVisible(mButton);
+    if (isAnyButtonVisible)
+      applyInsetsToButtons(safeInsets);
+
+    applyInsetsToRecyclerView(safeInsets, isAnyButtonVisible);
+
+    // have to consume all insets here, so child views won't handle them again
+    return WindowInsetsCompat.CONSUMED;
+  }
+
+  private void applyInsetsToButtons(Insets insets)
+  {
+    int baseMargin = UiUtils.dimen(mContext, R.dimen.margin_base);
+
+    ViewGroup.MarginLayoutParams fabParams = (ViewGroup.MarginLayoutParams) mFab.getLayoutParams();
+    ViewGroup.MarginLayoutParams buttonParams = (ViewGroup.MarginLayoutParams) mButton.getLayoutParams();
+
+    final boolean isButtonVisible = UiUtils.isVisible(mButton);
+
+    buttonParams.bottomMargin = insets.bottom;
+    mButton.setPadding(insets.left, mButton.getPaddingTop(), insets.right, mButton.getPaddingBottom());
+
+    fabParams.rightMargin = insets.right + baseMargin;
+    if (isButtonVisible)
+      fabParams.bottomMargin = baseMargin;
+    else
+      fabParams.bottomMargin = insets.bottom + baseMargin;
+
+    mFab.requestLayout();
+    mButton.requestLayout();
+  }
+
+  private void applyInsetsToRecyclerView(Insets insets, boolean isAnyButtonVisible)
+  {
+    int bottomInset = isAnyButtonVisible ? 0 : insets.bottom;
+
+    mRecyclerView.setPadding(
+        mRecyclerView.getPaddingLeft(),
+        mRecyclerView.getPaddingTop(),
+        mRecyclerView.getPaddingRight(),
+        bottomInset);
+
+    final ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) mRecyclerView.getLayoutParams();
+    layoutParams.rightMargin = insets.right;
+    layoutParams.leftMargin = insets.left;
+
+    mRecyclerView.requestLayout();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/help/CopyrightFragment.java
+++ b/android/app/src/main/java/app/organicmaps/help/CopyrightFragment.java
@@ -8,10 +8,12 @@ import android.view.ViewGroup;
 
 import androidx.annotation.Nullable;
 
+import androidx.core.view.ViewCompat;
 import app.organicmaps.R;
 import app.organicmaps.WebContainerDelegate;
 import app.organicmaps.base.BaseMwmFragment;
 import app.organicmaps.util.Constants;
+import app.organicmaps.util.WindowInsetUtils;
 
 public class CopyrightFragment extends BaseMwmFragment
 {
@@ -21,6 +23,8 @@ public class CopyrightFragment extends BaseMwmFragment
   public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
   {
     View root = inflater.inflate(R.layout.fragment_web_view_with_progress, container, false);
+
+    ViewCompat.setOnApplyWindowInsetsListener(root, WindowInsetUtils.PaddingInsetsListener.excludeTop());
 
     mDelegate = new WebContainerDelegate(root, Constants.Url.COPYRIGHT)
     {

--- a/android/app/src/main/java/app/organicmaps/help/FaqFragment.java
+++ b/android/app/src/main/java/app/organicmaps/help/FaqFragment.java
@@ -11,12 +11,14 @@ import android.view.ViewGroup;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.ViewCompat;
 import app.organicmaps.R;
 import app.organicmaps.WebContainerDelegate;
 import app.organicmaps.base.BaseMwmFragment;
 import app.organicmaps.util.Constants;
 import app.organicmaps.util.SharingUtils;
 import app.organicmaps.util.Utils;
+import app.organicmaps.util.WindowInsetUtils;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
@@ -52,6 +54,8 @@ public class FaqFragment extends BaseMwmFragment
   public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
   {
     View root = inflater.inflate(R.layout.fragment_prefs_faq, container, false);
+
+    ViewCompat.setOnApplyWindowInsetsListener(root, WindowInsetUtils.PaddingInsetsListener.excludeTop());
 
     new WebContainerDelegate(root, Constants.Url.FAQ)
     {

--- a/android/app/src/main/java/app/organicmaps/help/HelpFragment.java
+++ b/android/app/src/main/java/app/organicmaps/help/HelpFragment.java
@@ -23,7 +23,6 @@ import app.organicmaps.util.DateUtils;
 import app.organicmaps.util.Graphics;
 import app.organicmaps.util.SharingUtils;
 import app.organicmaps.util.Utils;
-import app.organicmaps.util.WindowInsetUtils;
 import app.organicmaps.util.WindowInsetUtils.ScrollableContentInsetsListener;
 
 public class HelpFragment extends BaseMwmFragment implements View.OnClickListener


### PR DESCRIPTION
Aims to fix #9423 by requesting insets when the state of buttons changes.

Found another issue with RecyclerView: since basic insets handling is spread across multiple classes, the RecyclerView handles incoming insets as well. This results in additional spacing when scrolled to the end.  
Decided to move all insets-related logic for the Downloader screen into a separate class, which consumes all insets.