### PR TITLE
[map] Remove Duration and File Rotation from the track recording

### DIFF
--- a/map/gps_track_collection.hpp
+++ b/map/gps_track_collection.hpp
@@ -2,7 +2,6 @@
 
 #include "platform/location.hpp"
 
-#include <chrono>
 #include <deque>
 #include <limits>
 #include <utility>
@@ -16,35 +15,18 @@ public:
   using TItem = location::GpsInfo;
 
   /// Constructor
-  /// @param maxSize - max number of items in collection
-  /// @param duration - duration in hours
-  GpsTrackCollection(size_t maxSize, std::chrono::hours duration);
+  GpsTrackCollection();
 
   /// Adds new point in the collection.
   /// @param item - item to be added.
-  /// @param evictedIds - output, which contains range of identifiers evicted items or
-  /// pair(kInvalidId,kInvalidId) if nothing was removed
   /// @returns the item unique identifier or kInvalidId if point has incorrect time.
-  size_t Add(TItem const & item, std::pair<size_t, size_t> & evictedIds);
+  size_t Add(TItem const & item);
 
   /// Adds set of new points in the collection.
   /// @param items - set of items to be added.
-  /// @param evictedIds - output, which contains range of identifiers evicted items or
-  /// pair(kInvalidId,kInvalidId) if nothing was removed
   /// @returns range of identifiers of added items or pair(kInvalidId,kInvalidId) if nothing was added
   /// @note items which does not conform to timestamp sequence, is not added.
-  std::pair<size_t, size_t> Add(std::vector<TItem> const & items,
-                                std::pair<size_t, size_t> & evictedIds);
-
-  /// Get current duration in hours
-  /// @returns current duration in hours
-  std::chrono::hours GetDuration() const;
-
-  /// Sets duration in hours.
-  /// @param duration - new duration value
-  /// @return range of item identifiers, which were removed or
-  /// pair(kInvalidId,kInvalidId) if nothing was removed
-  std::pair<size_t, size_t> SetDuration(std::chrono::hours duration);
+  std::pair<size_t, size_t> Add(std::vector<TItem> const & items);
 
   /// Removes all points from the collection.
   /// @param resetIds - if it is set to true, then new identifiers will start from 0,
@@ -58,13 +40,6 @@ public:
 
   /// Returns number of items in the collection
   size_t GetSize() const;
-
-  /// Returns range of timestamps of collection, where res.first is lower bound and
-  /// res.second is upper bound. If collection is empty, then returns pair(0, 0).
-  std::pair<double, double> GetTimestampRange() const;
-
-  /// Returns max size of collection
-  size_t GetMaxSize() const;
 
   /// Enumerates items in the collection.
   /// @param f - callable object, which is called with params - item and item id,
@@ -91,12 +66,8 @@ private:
   // range of identifiers of removed items
   std::pair<size_t, size_t> RemoveUntil(std::deque<TItem>::iterator i);
 
-  // Removes items extra by timestamp and max size
+  // Removes items extra by timestamp
   std::pair<size_t, size_t> RemoveExtraItems();
-
-  size_t const m_maxSize;
-
-  std::chrono::hours m_duration;
 
   std::deque<TItem> m_items;  // asc. sorted by timestamp
 

--- a/map/gps_track_storage.hpp
+++ b/map/gps_track_storage.hpp
@@ -21,9 +21,8 @@ public:
 
   /// Opens storage with track data.
   /// @param filePath - path to the file on disk
-  /// @param maxItemCount - max number of items in recycling file
   /// @exception OpenException if seek fails.
-  GpsTrackStorage(std::string const & filePath, size_t maxItemCount);
+  GpsTrackStorage(std::string const & filePath);
 
   /// Appends new point to the storage
   /// @param items - collection of gps track points.
@@ -42,23 +41,9 @@ public:
 private:
   DISALLOW_COPY_AND_MOVE(GpsTrackStorage);
 
-  void TruncFile();
   size_t GetFirstItemIndex() const;
 
   std::string const m_filePath;
-  size_t const m_maxItemCount;
   std::fstream m_stream;
-  size_t m_itemCount; // current number of items in file, read note
-
-  // NOTE
-  // New items append to the end of file, when file become too big, it is truncated.
-  // Here 'silly window sindrome' is possible: for example max file size is 100k items,
-  // and 99k items are filled, when 2k items is coming, then 98k items is copying to the tmp file
-  // which replaces origin file, and 2k added to the new file. Next time, when 1k items
-  // is comming, then again file truncated. That means that trunc will happens every time.
-  // Similar problem in TCP called 'silly window sindrome'.
-  // To prevent that problem, max file size can be 2 x m_maxItemCount items, when current number of items m_itemCount
-  // exceed 2 x m_maxItemCount, then second half of file - m_maxItemCount items is copying to the tmp file,
-  // which replaces origin file. That means that trunc will happens only then new m_maxItemCount items will be
-  // added but not every time.
+  size_t m_itemCount;
 };

--- a/map/gps_tracker.cpp
+++ b/map/gps_tracker.cpp
@@ -15,10 +15,6 @@ namespace
 {
 
 char const kEnabledKey[] = "GpsTrackingEnabled";
-char const kDurationHours[] = "GpsTrackingDuration";
-uint32_t constexpr kDefaultDurationHours = 24;
-
-size_t constexpr kMaxItemCount = 100000; // > 24h with 1point/s
 
 inline std::string GetFilePath()
 {
@@ -38,20 +34,6 @@ inline void SetSettingsIsEnabled(bool enabled)
   settings::Set(kEnabledKey, enabled);
 }
 
-inline hours GetSettingsDuration()
-{
-  uint32_t duration;
-  if (!settings::Get(kDurationHours, duration))
-    duration = kDefaultDurationHours;
-  return hours(duration);
-}
-
-inline void SetSettingsDuration(hours duration)
-{
-  uint32_t const hours = static_cast<uint32_t>(duration.count());
-  settings::Set(kDurationHours, hours);
-}
-
 } // namespace
 
 GpsTracker & GpsTracker::Instance()
@@ -62,7 +44,7 @@ GpsTracker & GpsTracker::Instance()
 
 GpsTracker::GpsTracker()
   : m_enabled(GetSettingsIsEnabled())
-  , m_track(GetFilePath(), kMaxItemCount, GetSettingsDuration(), std::make_unique<GpsTrackFilter>())
+  , m_track(GetFilePath(), std::make_unique<GpsTrackFilter>())
 {
 }
 
@@ -81,17 +63,6 @@ void GpsTracker::SetEnabled(bool enabled)
 bool GpsTracker::IsEnabled() const
 {
   return m_enabled;
-}
-
-void GpsTracker::SetDuration(hours duration)
-{
-  SetSettingsDuration(duration);
-  m_track.SetDuration(duration);
-}
-
-hours GpsTracker::GetDuration() const
-{
-  return m_track.GetDuration();
 }
 
 bool GpsTracker::IsEmpty() const

--- a/map/gps_tracker.hpp
+++ b/map/gps_tracker.hpp
@@ -3,7 +3,6 @@
 #include "map/gps_track.hpp"
 
 #include <atomic>
-#include <chrono>
 #include <functional>
 #include <utility>
 #include <vector>
@@ -16,11 +15,8 @@ public:
   bool IsEnabled() const;
   void SetEnabled(bool enabled);
 
-  std::chrono::hours GetDuration() const;
   bool IsEmpty() const;
   size_t GetTrackSize() const;
-
-  void SetDuration(std::chrono::hours duration);
 
   using TGpsTrackDiffCallback =
       std::function<void(std::vector<std::pair<size_t, location::GpsInfo>> && toAdd,

--- a/map/map_tests/gps_track_collection_test.cpp
+++ b/map/map_tests/gps_track_collection_test.cpp
@@ -31,20 +31,15 @@ UNIT_TEST(GpsTrackCollection_Simple)
   double const timestamp = t;
   LOG(LINFO, ("Timestamp", ctime(&t), timestamp));
 
-  GpsTrackCollection collection(100, hours(24));
+  GpsTrackCollection collection;
 
   std::map<size_t, location::GpsInfo> data;
-
-  TEST_EQUAL(100, collection.GetMaxSize(), ());
 
   for (size_t i = 0; i < 50; ++i)
   {
     auto info = MakeGpsTrackInfo(timestamp + i, ms::LatLon(-90 + i, -180 + i), i);
-    std::pair<size_t, size_t> evictedIds;
-    size_t addedId = collection.Add(info, evictedIds);
+    size_t addedId = collection.Add(info);
     TEST_EQUAL(addedId, i, ());
-    TEST_EQUAL(evictedIds.first, GpsTrackCollection::kInvalidId, ());
-    TEST_EQUAL(evictedIds.second, GpsTrackCollection::kInvalidId, ());
     data[addedId] = info;
   }
 
@@ -64,165 +59,6 @@ UNIT_TEST(GpsTrackCollection_Simple)
   auto res = collection.Clear();
   TEST_EQUAL(res.first, 0, ());
   TEST_EQUAL(res.second, 49, ());
-
-  TEST_EQUAL(0, collection.GetSize(), ());
-}
-
-UNIT_TEST(GpsTrackCollection_EvictedByTimestamp)
-{
-  time_t const t = system_clock::to_time_t(system_clock::now());
-  double const timestamp = t;
-  LOG(LINFO, ("Timestamp", ctime(&t), timestamp));
-
-  double const timestamp_1h = timestamp + 60 * 60;
-  double const timestamp_25h = timestamp + 25 * 60 * 60;
-
-  GpsTrackCollection collection(100, hours(24));
-
-  std::pair<size_t, size_t> evictedIds;
-  size_t addedId = collection.Add(MakeGpsTrackInfo(timestamp, ms::LatLon(-90, -180), 1), evictedIds);
-  TEST_EQUAL(addedId, 0, ());
-  TEST_EQUAL(evictedIds.first, GpsTrackCollection::kInvalidId, ());
-  TEST_EQUAL(evictedIds.second, GpsTrackCollection::kInvalidId, ());
-
-  addedId = collection.Add(MakeGpsTrackInfo(timestamp_1h, ms::LatLon(90, 180), 2), evictedIds);
-  TEST_EQUAL(addedId, 1, ());
-  TEST_EQUAL(evictedIds.first, GpsTrackCollection::kInvalidId, ());
-  TEST_EQUAL(evictedIds.second, GpsTrackCollection::kInvalidId, ());
-
-  TEST_EQUAL(2, collection.GetSize(), ());
-
-  auto lastInfo = MakeGpsTrackInfo(timestamp_25h, ms::LatLon(45, 60), 3);
-  addedId = collection.Add(lastInfo, evictedIds);
-  TEST_EQUAL(addedId, 2, ());
-  TEST_EQUAL(evictedIds.first, 0, ());
-  TEST_EQUAL(evictedIds.second, 1, ());
-
-  TEST_EQUAL(1, collection.GetSize(), ());
-
-  collection.ForEach([&](location::GpsInfo const & info, size_t id)->bool
-  {
-    TEST_EQUAL(id, 2, ());
-    TEST_EQUAL(info.m_latitude, lastInfo.m_latitude, ());
-    TEST_EQUAL(info.m_longitude, lastInfo.m_longitude, ());
-    TEST_EQUAL(info.m_speed, lastInfo.m_speed, ());
-    TEST_EQUAL(info.m_timestamp, lastInfo.m_timestamp, ());
-    return true;
-  });
-
-  auto res = collection.Clear();
-  TEST_EQUAL(res.first, 2, ());
-  TEST_EQUAL(res.second, 2, ());
-
-  TEST_EQUAL(0, collection.GetSize(), ());
-}
-
-UNIT_TEST(GpsTrackCollection_EvictedByCount)
-{
-  time_t const t = system_clock::to_time_t(system_clock::now());
-  double const timestamp = t;
-  LOG(LINFO, ("Timestamp", ctime(&t), timestamp));
-
-  GpsTrackCollection collection(100, hours(24));
-
-  std::map<size_t, location::GpsInfo> data;
-
-  TEST_EQUAL(100, collection.GetMaxSize(), ());
-
-  for (size_t i = 0; i < 100; ++i)
-  {
-    auto info = MakeGpsTrackInfo(timestamp + i, ms::LatLon(-90 + i, -180 + i), i);
-    std::pair<size_t, size_t> evictedIds;
-    size_t addedId = collection.Add(info, evictedIds);
-    TEST_EQUAL(addedId, i, ());
-    TEST_EQUAL(evictedIds.first, GpsTrackCollection::kInvalidId, ());
-    TEST_EQUAL(evictedIds.second, GpsTrackCollection::kInvalidId, ());
-    data[addedId] = info;
-  }
-
-  TEST_EQUAL(100, collection.GetSize(), ());
-
-  auto info = MakeGpsTrackInfo(timestamp + 100, ms::LatLon(45, 60), 110);
-  std::pair<size_t, size_t> evictedIds;
-  size_t addedId = collection.Add(info, evictedIds);
-  TEST_EQUAL(addedId, 100, ());
-  TEST_EQUAL(evictedIds.first, 0, ());
-  TEST_EQUAL(evictedIds.second, 0, ());
-  data[addedId] = info;
-
-  TEST_EQUAL(100, collection.GetSize(), ());
-
-  data.erase(0);
-
-  collection.ForEach([&data](location::GpsInfo const & info, size_t id)->bool
-  {
-    TEST(data.end() != data.find(id), ());
-    location::GpsInfo const & originInfo = data[id];
-    TEST_EQUAL(info.m_latitude, originInfo.m_latitude, ());
-    TEST_EQUAL(info.m_longitude, originInfo.m_longitude, ());
-    TEST_EQUAL(info.m_speed, originInfo.m_speed, ());
-    TEST_EQUAL(info.m_timestamp, originInfo.m_timestamp, ());
-    return true;
-  });
-
-  auto res = collection.Clear();
-  TEST_EQUAL(res.first, 1, ());
-  TEST_EQUAL(res.second, 100, ());
-
-  TEST_EQUAL(0, collection.GetSize(), ());
-}
-
-UNIT_TEST(GpsTrackCollection_EvictedByTimestamp2)
-{
-  time_t const t = system_clock::to_time_t(system_clock::now());
-  double const timestamp = t;
-  LOG(LINFO, ("Timestamp", ctime(&t), timestamp));
-
-  double const timestamp_12h = timestamp + 12 * 60 * 60;
-  double const timestamp_35h = timestamp + 35 * 60 * 60;
-
-  GpsTrackCollection collection(1000, hours(24));
-
-  TEST_EQUAL(1000, collection.GetMaxSize(), ());
-
-  for (size_t i = 0; i < 500; ++i)
-  {
-    auto info = MakeGpsTrackInfo(timestamp + i, ms::LatLon(-90 + i, -180 + i), i);
-    std::pair<size_t, size_t> evictedIds;
-    size_t addedId = collection.Add(info, evictedIds);
-    TEST_EQUAL(addedId, i, ());
-    TEST_EQUAL(evictedIds.first, GpsTrackCollection::kInvalidId, ());
-    TEST_EQUAL(evictedIds.second, GpsTrackCollection::kInvalidId, ());
-  }
-
-  auto time = collection.GetTimestampRange();
-
-  TEST_EQUAL(500, collection.GetSize(), ());
-
-  for (size_t i = 0; i < 500; ++i)
-  {
-    auto info = MakeGpsTrackInfo(timestamp_12h + i, ms::LatLon(-90 + i, -180 + i), i);
-    std::pair<size_t, size_t> evictedIds;
-    size_t addedId = collection.Add(info, evictedIds);
-    TEST_EQUAL(addedId, 500 + i, ());
-    TEST_EQUAL(evictedIds.first, GpsTrackCollection::kInvalidId, ());
-    TEST_EQUAL(evictedIds.second, GpsTrackCollection::kInvalidId, ());
-  }
-
-  time = collection.GetTimestampRange();
-
-  TEST_EQUAL(1000, collection.GetSize(), ());
-
-  auto info = MakeGpsTrackInfo(timestamp_35h, ms::LatLon(45, 60), 110);
-  std::pair<size_t, size_t> evictedIds;
-  size_t addedId = collection.Add(info, evictedIds);
-  TEST_EQUAL(addedId, 1000, ());
-  TEST_EQUAL(evictedIds.first, 0, ());
-  TEST_EQUAL(evictedIds.second, 499, ());
-
-  auto res = collection.Clear();
-  TEST_EQUAL(res.first, 500, ());
-  TEST_EQUAL(res.second, 1000, ());
 
   TEST_EQUAL(0, collection.GetSize(), ());
 }

--- a/map/map_tests/gps_track_test.cpp
+++ b/map/map_tests/gps_track_test.cpp
@@ -92,8 +92,7 @@ UNIT_TEST(GpsTrack_Simple)
   double const timestamp = t;
   LOG(LINFO, ("Timestamp", ctime(&t), timestamp));
 
-  size_t const maxItemCount = 100000;
-  size_t const writeItemCount = 50000; // less than 24h
+  size_t const writeItemCount = 50000;
 
   vector<location::GpsInfo> points;
   points.reserve(writeItemCount);
@@ -102,7 +101,7 @@ UNIT_TEST(GpsTrack_Simple)
 
   // Store points
   {
-    GpsTrack track(filePath, maxItemCount, hours(24));
+    GpsTrack track(filePath);
 
     track.AddPoints(points);
 
@@ -128,7 +127,7 @@ UNIT_TEST(GpsTrack_Simple)
 
   // Restore points
   {
-    GpsTrack track(filePath, maxItemCount, hours(24));
+    GpsTrack track(filePath);
 
     GpsTrackCallback callback;
 
@@ -149,57 +148,5 @@ UNIT_TEST(GpsTrack_Simple)
       TEST_EQUAL(points[i].m_longitude, callback.m_toAdd[i].second.m_longitude, ());
     }
   }
-}
-
-UNIT_TEST(GpsTrack_EvictedByAdd)
-{
-  string const filePath = GetGpsTrackFilePath();
-  SCOPE_GUARD(gpsTestFileDeleter, bind(FileWriter::DeleteFileX, filePath));
-  FileWriter::DeleteFileX(filePath);
-
-  time_t const t = system_clock::to_time_t(system_clock::now());
-  double const timestamp = t;
-  LOG(LINFO, ("Timestamp", ctime(&t), timestamp));
-
-  location::GpsInfo pt1 = Make(timestamp - 25 * 60 * 60, ms::LatLon(30.0, 45.0), 60.0);
-  location::GpsInfo pt2 = Make(timestamp, ms::LatLon(75.0, 90.0), 110.0);
-
-  GpsTrack track(filePath, 1000, hours(24));
-
-  GpsTrackCallback callback;
-  track.SetCallback(
-      bind(&GpsTrackCallback::OnUpdate, &callback, placeholders::_1, placeholders::_2));
-
-  track.AddPoint(pt1);
-
-  TEST(callback.WaitForCallback(kWaitForCallbackTimeout), ());
-
-  // Check pt1 was added
-  TEST_EQUAL(1, callback.m_toAdd.size(), ());
-  TEST_EQUAL(0, callback.m_toAdd[0].first, ());
-  TEST_EQUAL(pt1.m_timestamp, callback.m_toAdd[0].second.m_timestamp, ());
-  TEST_EQUAL(pt1.m_speed, callback.m_toAdd[0].second.m_speed, ());
-  TEST_EQUAL(pt1.m_latitude, callback.m_toAdd[0].second.m_latitude, ());
-  TEST_EQUAL(pt1.m_longitude, callback.m_toAdd[0].second.m_longitude, ());
-  // and nothing was evicted
-  TEST_EQUAL(callback.m_toRemove.first, GpsTrack::kInvalidId, ());
-  TEST_EQUAL(callback.m_toRemove.second, GpsTrack::kInvalidId, ());
-
-  callback.Reset();
-
-  track.AddPoint(pt2);
-
-  TEST(callback.WaitForCallback(kWaitForCallbackTimeout), ());
-
-  // Check pt2 was added
-  TEST_EQUAL(1, callback.m_toAdd.size(), ());
-  TEST_EQUAL(1, callback.m_toAdd[0].first, ());
-  TEST_EQUAL(pt2.m_timestamp, callback.m_toAdd[0].second.m_timestamp, ());
-  TEST_EQUAL(pt2.m_speed, callback.m_toAdd[0].second.m_speed, ());
-  TEST_EQUAL(pt2.m_latitude, callback.m_toAdd[0].second.m_latitude, ());
-  TEST_EQUAL(pt2.m_longitude, callback.m_toAdd[0].second.m_longitude, ());
-  // and pt1 was evicted as old
-  TEST_EQUAL(callback.m_toRemove.first, 0, ());
-  TEST_EQUAL(callback.m_toRemove.second, 0, ());
 }
 } // namespace gps_track_test


### PR DESCRIPTION
Related to the https://github.com/organicmaps/organicmaps/issues/8927

Because of the `RecentPath` feature (when the user can limit the recording duration) was fully replaced with the `TrackRecording` the file's tail shouldn't be truncated. As a user can record a track for more than 24h we shouldn't limit the file size and lose the user-generated data.
This is why the `Duration`, `TruncFile`, and `m_maxItemCount`- related code were removed.

The better idea is to notify the user using the blinking button + alert every 24h (as an example) that the track is still recorded.
