### PR TITLE
[ios] Log app name and bundle id on the app start

### DIFF
--- a/iphone/Maps/main.mm
+++ b/iphone/Maps/main.mm
@@ -7,7 +7,7 @@ int main(int argc, char * argv[])
 {
   [MWMSettings initializeLogging];
   auto & p = GetPlatform();
-  LOG(LINFO, ("Organic Maps", p.Version(), "started, detected CPU cores:", p.CpuCores()));
+  LOG(LINFO, (p.Version(), "started, detected CPU cores:", p.CpuCores()));
 
   int retVal;
   @autoreleasepool

--- a/platform/platform_ios.mm
+++ b/platform/platform_ios.mm
@@ -163,9 +163,11 @@ std::string Platform::DeviceModel() const
 std::string Platform::Version() const
 {
   NSBundle * mainBundle = [NSBundle mainBundle];
+  NSString * appName = [mainBundle objectForInfoDictionaryKey:@"CFBundleName"];
+  NSString * bundleId = mainBundle.bundleIdentifier;
   NSString * version = [mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
   NSString * build = [mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
-  return std::string{version.UTF8String} + '-' + build.UTF8String + '-' + OMIM_OS_NAME;
+  return std::string{appName.UTF8String} + ' ' + std::string{bundleId.UTF8String} + ' ' + std::string{version.UTF8String} + '-' + build.UTF8String + '-' + OMIM_OS_NAME;
 }
 
 int32_t Platform::IntVersion() const


### PR DESCRIPTION
before:
`I(1) 0.03557 Maps/main.mm:10 main: Organic Maps 2022.11.17-0-ios started, detected CPU cores: 10`

after
`I(1) 0.02030 Maps/main.mm:10 main: Organic Maps (Debug) app.organicmaps.debug 2022.11.17-0-ios started, detected CPU cores: 10`