### PR TITLE
[drape] Fix track rendering performance issues

### DIFF
--- a/drape_frontend/gps_track_renderer.cpp
+++ b/drape_frontend/gps_track_renderer.cpp
@@ -204,6 +204,7 @@ void GpsTrackRenderer::RenderTrack(ref_ptr<dp::GraphicsContext> context, ref_ptr
     double const currentScaleGtoP = 1.0 / screen.GetScale();
     double const radiusMercator = m_radius / currentScaleGtoP;
     double const diameterMercator = 2.0 * radiusMercator;
+    double const step = diameterMercator + kDistanceScalar * diameterMercator;
 
     // Update points' positions and colors.
     ASSERT(!m_renderData.empty(), ());
@@ -231,6 +232,8 @@ void GpsTrackRenderer::RenderTrack(ref_ptr<dp::GraphicsContext> context, ref_ptr
     {
       m2::Spline::iterator it;
       it.Attach(m_pointsSpline);
+      auto const fullLength = it.GetFullLength();
+      double lengthFromStart = 0.0;
       while (!it.BeginAgain())
       {
         m2::PointD const pt = it.m_pos;
@@ -238,8 +241,7 @@ void GpsTrackRenderer::RenderTrack(ref_ptr<dp::GraphicsContext> context, ref_ptr
                             pt.x + radiusMercator, pt.y + radiusMercator);
         if (screen.ClipRect().IsIntersect(pointRect))
         {
-          dp::Color const color = CalculatePointColor(it.GetIndex(), pt,
-                                                      it.GetLength(), it.GetFullLength());
+          dp::Color const color = CalculatePointColor(it.GetIndex(), pt, lengthFromStart, fullLength);
           m2::PointD const convertedPt = MapShape::ConvertToLocal(pt, m_pivot, kShapeCoordScalar);
           m_handlesCache[cacheIndex].first->SetPoint(m_handlesCache[cacheIndex].second,
                                                      convertedPt, m_radius, color);
@@ -254,7 +256,8 @@ void GpsTrackRenderer::RenderTrack(ref_ptr<dp::GraphicsContext> context, ref_ptr
             return;
           }
         }
-        it.Advance(diameterMercator + kDistanceScalar * diameterMercator);
+        lengthFromStart += step;
+        it.Advance(step);
       }
 
 #ifdef GPS_TRACK_SHOW_RAW_POINTS

--- a/drape_frontend/gps_track_renderer.cpp
+++ b/drape_frontend/gps_track_renderer.cpp
@@ -114,7 +114,7 @@ void GpsTrackRenderer::UpdatePoints(std::vector<GpsTrackPoint> const & toAdd,
       m_pointsSpline.AddPoint(m_points[i].m_point);
   }
 
-  m_needUpdate = true;
+  m_needUpdate = wasChanged;
 }
 
 size_t GpsTrackRenderer::GetAvailablePointsCount() const

--- a/geometry/spline.cpp
+++ b/geometry/spline.cpp
@@ -174,11 +174,6 @@ void Spline::iterator::Advance(double step)
     AdvanceForward(step);
 }
 
-double Spline::iterator::GetLength() const
-{
-  return std::accumulate(m_spl->m_length.begin(), m_spl->m_length.begin() + m_index, m_dist);
-}
-
 double Spline::iterator::GetFullLength() const
 {
   return m_spl->GetLength();

--- a/geometry/spline.hpp
+++ b/geometry/spline.hpp
@@ -22,7 +22,6 @@ public:
     void Attach(Spline const & spl);
     void Advance(double step);
     bool BeginAgain() const;
-    double GetLength() const;
     double GetFullLength() const;
 
     size_t GetIndex() const;


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/9488

This PR contains 3 small fixes to increase the track drawing performance:
1. during the iteration the track length for the current point is calculated and stored in the property
2. `GetFullLength` is moved out of iteration scope because it is not changed
3. skip drawing iteration when there is nothing changed during the `UpdatePoints` call

Profiling results:
[track_recording_rendering.trace.zip](https://github.com/user-attachments/files/17330000/track_recording_rendering.trace.zip)

<img width="1730" alt="image" src="https://github.com/user-attachments/assets/4ebfe0c0-fa90-4898-8388-ca030d6ca908">
<img width="1729" alt="image" src="https://github.com/user-attachments/assets/8b82d00d-2c48-4fc5-9ac8-4d3906a1265a">