### PR TITLE
Prompt users for OSM login fix

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
@@ -372,7 +372,7 @@ public class EditorHostFragment extends BaseMwmToolbarFragment implements View.O
   private void showLoginDialog()
   {
     startActivity(new Intent(requireContext(), OsmLoginActivity.class));
-    Utils.navigateToParent(requireActivity());
+    requireActivity().finish();
   }
 
   private void saveNote()

--- a/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryActivity.java
+++ b/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryActivity.java
@@ -25,5 +25,6 @@ public class FeatureCategoryActivity extends BaseMwmFragmentActivity implements 
     intent.putExtra(EXTRA_FEATURE_CATEGORY, category);
     intent.putExtra(EditorActivity.EXTRA_NEW_OBJECT, true);
     startActivity(intent);
+    finish();
   }
 }


### PR DESCRIPTION
fixes  #9444

Now users are correctly prompted to login after editing. The problem was that navigateToParent() closed the login Activity directly after starting it.
Tested on Android 14 and 10.