### PR TITLE
[Core] link to the Commons media viewer for single files

### DIFF
--- a/indexer/feature_meta.cpp
+++ b/indexer/feature_meta.cpp
@@ -15,6 +15,13 @@ char constexpr const * kBaseWikiUrl =
 #else
     ".wikipedia.org/wiki/";
 #endif
+
+char constexpr const * kBaseCommonsUrl =
+#ifdef OMIM_OS_MOBILE
+    "https://commons.m.wikimedia.org/wiki/";
+#else
+    "https://commons.wikimedia.org/wiki/";
+#endif
 } // namespace
 
 string Metadata::ToWikiURL(std::string v)
@@ -55,7 +62,12 @@ string Metadata::ToWikimediaCommonsURL(std::string const & v)
   if (v.empty())
     return v;
 
-  return "https://commons.wikimedia.org/wiki/" + v;
+  // Use the media viewer for single files
+  if (v.starts_with("File:"))
+    return kBaseCommonsUrl + v + "#/media/" + v;
+
+  // or standard if it's a category
+  return kBaseCommonsUrl + v;
 }
 
 // static


### PR DESCRIPTION
link goes from: https://commons.wikimedia.org/wiki/File:Cute_dog_(4985400144).jpg

to: https://commons.m.wikimedia.org/wiki/File:Cute_dog_(4985400144).jpg#/media/File:Cute_dog_(4985400144).jpg

the viewer is a bit nicer UX-wise