### PR TITLE
[android] Cleanup unused annotation

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
@@ -596,7 +596,6 @@ public enum BookmarkManager
     return nativeGetBookmarkColor(bookmarkId);
   }
 
-  @Icon.BookmarkIconType
   public int getBookmarkIcon(@IntRange(from = 0) long bookmarkId)
   {
     return nativeGetBookmarkIcon(bookmarkId);
@@ -854,7 +853,6 @@ public enum BookmarkManager
   @Icon.PredefinedColor
   private static native int nativeGetBookmarkColor(@IntRange(from = 0) long bookmarkId);
 
-  @Icon.BookmarkIconType
   private static native int nativeGetBookmarkIcon(@IntRange(from = 0) long bookmarkId);
 
   @NonNull

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/Icon.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/Icon.java
@@ -69,7 +69,6 @@ public class Icon implements Parcelable
                                              toARGB(115, 115, 115), // gray
                                              toARGB(89, 115, 128) }; // bluegray
 
-  @interface BookmarkIconType {}
   static final int BOOKMARK_ICON_TYPE_NONE = 0;
 
   /// @note Important! Should be synced with kml/types.hpp/BookmarkIcon
@@ -113,10 +112,9 @@ public class Icon implements Parcelable
 
   @PredefinedColor
   private final int mColor;
-  @BookmarkIconType
   private final int mType;
 
-  public Icon(@PredefinedColor int color, @BookmarkIconType int type)
+  public Icon(@PredefinedColor int color, int type)
   {
     mColor = color;
     mType = type;


### PR DESCRIPTION
The annotation was half-deleted in https://github.com/organicmaps/organicmaps/pull/9523#discussion_r1802660683. Cleanup redundant leftovers.