### PR TITLE
[search] Fixed ranking, added some ES synonyms.

### DIFF
--- a/search/query_params.cpp
+++ b/search/query_params.cpp
@@ -24,8 +24,16 @@ map<string, vector<string>> const kSynonyms = {
     {"ne",   {"northeast"}},
     {"sw",   {"southwest"}},
     {"se",   {"southeast"}},
+
+    /// @todo Should not duplicate Street synonyms defined in StreetsSynonymsHolder (avoid useless double queries).
+    /// Remove "street" and "avenue" here, but should update GetNameScore.
     {"st",   {"saint", "street"}},
     {"dr",   {"doctor"}},
+
+    // widely used in LATAM, like "Ntra Sra Asuncion Zelaya"
+    {"ntra",  {"nuestra"}},
+    {"sra",   {"senora"}},
+    {"sta",   {"santa"}},
 
     {"al",    {"allee", "alle"}},
     {"ave",   {"avenue"}},
@@ -203,19 +211,21 @@ void QueryParams::AddSynonyms()
   {
     string const ss = ToUtf8(MakeLowerCase(token.GetOriginal()));
     auto const it = kSynonyms.find(ss);
-    if (it == kSynonyms.end())
-      continue;
-
-    for (auto const & synonym : it->second)
-      token.AddSynonym(synonym);
+    if (it != kSynonyms.end())
+    {
+      for (auto const & synonym : it->second)
+        token.AddSynonym(synonym);
+    }
   }
   if (m_hasPrefix)
   {
     string const ss = ToUtf8(MakeLowerCase(m_prefixToken.GetOriginal()));
     auto const it = kSynonyms.find(ss);
     if (it != kSynonyms.end())
+    {
       for (auto const & synonym : it->second)
         m_prefixToken.AddSynonym(synonym);
+    }
   }
 }
 

--- a/search/ranking_info.cpp
+++ b/search/ranking_info.cpp
@@ -443,8 +443,16 @@ double RankingInfo::GetErrorsMadePerToken() const
 
 NameScore RankingInfo::GetNameScore() const
 {
+  // See Pois_Rank test.
   if (!m_pureCats && Model::IsPoi(m_type) && m_classifType.poi <= PoiType::Attraction)
   {
+    // Promote POI's name rank if all tokens were matched with TYPE_SUBPOI/TYPE_COMPLEXPOI only.
+    for (int i = Model::TYPE_BUILDING; i < Model::TYPE_COUNT; ++i)
+    {
+      if (!m_tokenRanges[i].Empty())
+        return m_nameScore;
+    }
+
     // It's better for ranking when POIs would be equal by name score in the next cases:
 
     if (m_nameScore == NameScore::FULL_PREFIX)

--- a/search/search_quality/search_quality_tests/real_mwm_tests.cpp
+++ b/search/search_quality/search_quality_tests/real_mwm_tests.cpp
@@ -1432,4 +1432,20 @@ UNIT_CLASS_TEST(MwmTestsFixture, CompleteSearch_DistantMWMs)
   }
 }
 
+UNIT_CLASS_TEST(MwmTestsFixture, Synonyms)
+{
+  // Buenos Aires
+  ms::LatLon const center(-34.6073377, -58.4432843);
+  SetViewportAndLoadMaps(center);
+
+  {
+    auto request = MakeRequest("ntra sra de asuncion zelaya");
+    auto const & results = request->Results();
+    TEST_GREATER(results.size(), kPopularPoiResultsCount, ());
+
+    TEST_EQUAL(results[0].GetFeatureType(), classif().GetTypeByPath({"landuse", "residential"}), ());
+    TEST_EQUAL(results[0].GetString(), "Barrio Nuestra Señora de la Asunción", ());
+  }
+}
+
 } // namespace real_mwm_tests

--- a/search/search_quality/search_quality_tests/real_mwm_tests.cpp
+++ b/search/search_quality/search_quality_tests/real_mwm_tests.cpp
@@ -1104,6 +1104,15 @@ UNIT_CLASS_TEST(MwmTestsFixture, Pois_Rank)
       // name="Malabia XXX" - should take this name's rank
       EqualClassifType(Range(results, 0, 1), GetClassifTypes({{"railway", "station", "subway"}}));
     }
+
+    {
+      auto request = MakeRequest("Parque Ciudad");
+      auto const & results = request->Results();
+      TEST_GREATER(results.size(), kPopularPoiResultsCount, ());
+
+      /// @todo Actually, 2 parks should be the first, but (in test mode only), we have suburb and subway (*Parque*).
+      TEST_EQUAL(CountClassifType(Range(results, 0, 5), classif().GetTypeByPath({"leisure", "park"})), 2, ());
+    }
   }
 
   {


### PR DESCRIPTION
- "ntra, sra, sta" synonyms
- "Parque Ciudad" ranking. Fancy ranking because separate "parque" and "ciudad" tokens match suburbs and cities.