### PR TITLE
editor.config fine tuning

### DIFF
--- a/data/editor.config
+++ b/data/editor.config
@@ -680,7 +680,8 @@
       <type id="office-telecommunication" group="office">
         <include group="poi_internet" />
       </type>
-      <type id="place-farm">
+      <!-- Not addable because ambiguous with landuse=farmyard -->
+      <type id="place-farm" can_add="no">
         <include group="poi_internet" />
 <!--        <include field="wikipedia" />-->
       </type>
@@ -746,8 +747,7 @@
       <type id="shop-bakery" group="shop">
         <include group="poi_internet" />
       </type>
-      <!-- Not addable because ambiguous with shop=bakery -->
-      <type id="shop-pastry" group="shop" can_add="no">
+      <type id="shop-pastry" group="shop">
         <include group="poi_internet" />
       </type>
       <type id="shop-beauty">
@@ -935,7 +935,8 @@
       <type id="shop-appliance" group="shop">
         <include group="poi_internet" />
       </type>
-      <type id="shop-auction" group="shop">
+      <!-- Not addable, undocumented category with hardly any use -->
+      <type id="shop-auction" group="shop" can_add="no">
         <include group="poi_internet" />
       </type>
       <type id="shop-bathroom_furnishing" group="shop">


### PR DESCRIPTION
editor.config fine tuning:
- `place=farm` not addable because it's ambiguous with `landuse=farmyard`
- `shop=auction` not addable because it's an undocumented category with only 135 usages
- `shop=pastry` addable, I don't see any conflict with bakery