### PR TITLE
[gpx] Skip incomplete segments.

### DIFF
--- a/data/test_data/gpx/color.gpx
+++ b/data/test_data/gpx/color.gpx
@@ -90,6 +90,10 @@
         <ele>75.59999</ele>
         <time>2013-03-08T09:05:06Z</time>
       </trkpt>
+      <trkpt lat="48.767" lon="-3.563">
+        <ele>77</ele>
+        <time>2013-03-08T09:05:07Z</time>
+      </trkpt>
     </trkseg>
 </trk>
 

--- a/data/test_data/gpx/export_test.gpx
+++ b/data/test_data/gpx/export_test.gpx
@@ -43,6 +43,9 @@
     <trkpt lat="48.209846" lon="16.376023">
       <ele>123</ele>
     </trkpt>
+    <trkpt lat="48.209503" lon="16.381065">
+      <ele>456</ele>
+    </trkpt>
   </trkseg>
 </trk>
 </gpx>

--- a/kml/kml_tests/gpx_tests.cpp
+++ b/kml/kml_tests/gpx_tests.cpp
@@ -271,7 +271,7 @@ UNIT_TEST(Color)
   TEST_EQUAL(red, dataFromFile.m_tracksData[0].m_layers[0].m_color.m_rgba, ());
   TEST_EQUAL(blue, dataFromFile.m_tracksData[1].m_layers[0].m_color.m_rgba, ());
   TEST_EQUAL(black, dataFromFile.m_tracksData[2].m_layers[0].m_color.m_rgba, ());
-  TEST_EQUAL(red, dataFromFile.m_tracksData[3].m_layers[0].m_color.m_rgba, ());
+  TEST_EQUAL(dataFromFile.m_tracksData.size(), 3, ());
 }
 
 UNIT_TEST(MultiTrackNames)

--- a/kml/serdes_gpx.cpp
+++ b/kml/serdes_gpx.cpp
@@ -290,10 +290,17 @@ void GpxParser::Pop(std::string_view tag)
   }
   else if (tag == gpx::kTrkSeg || tag == gpx::kRte)
   {
-    CheckAndCorrectTimestamps();
+    if (m_line.size() > 1)
+    {
+      CheckAndCorrectTimestamps();
 
-    m_geometry.m_lines.push_back(std::move(m_line));
-    m_geometry.m_timestamps.push_back(std::move(m_timestamps));
+      m_geometry.m_lines.push_back(std::move(m_line));
+      m_geometry.m_timestamps.push_back(std::move(m_timestamps));
+    }
+
+    // Clear segment (it may be incomplete).
+    m_line.clear();
+    m_timestamps.clear();
   }
   else if (tag == gpx::kWpt)
   {
@@ -332,8 +339,8 @@ void GpxParser::Pop(std::string_view tag)
         // Default gpx parser doesn't check points and timestamps count as the kml parser does.
         for (size_t lineIndex = 0; lineIndex < m_geometry.m_lines.size(); ++lineIndex)
         {
-          auto const & pointsSize = m_geometry.m_lines[lineIndex].size();
-          auto const & timestampsSize = m_geometry.m_timestamps[lineIndex].size();
+          auto const pointsSize = m_geometry.m_lines[lineIndex].size();
+          auto const timestampsSize = m_geometry.m_timestamps[lineIndex].size();
           ASSERT(!m_geometry.HasTimestampsFor(lineIndex) || pointsSize == timestampsSize, (pointsSize, timestampsSize));
         }
 #endif


### PR DESCRIPTION
@cyber-toad 

From user's gpx:
```
<trk>
  <name>Tag 5 (2)</name>
  <trkseg>
    <trkpt lat="50.6967272" lon="-2.7154925">
      <ele>80.81</ele>
      <time>2015-08-19T11:13:31Z</time>
      <name>Start: 12:13:31</name>
      <extensions><gpxtpx:TrackPointExtension><gpxtpx:speed>14.74</gpxtpx:speed></gpxtpx:TrackPointExtension></extensions>
    </trkpt>
  </trkseg>
  <trkseg>
    <trkpt lat="50.7008367" lon="-2.7273928">
      <ele>38.11</ele>
      <time>2015-08-19T11:14:37Z</time>
      <name>Start: 12:14:37</name>
      <extensions><gpxtpx:TrackPointExtension><gpxtpx:speed>11.24</gpxtpx:speed></gpxtpx:TrackPointExtension></extensions>
    </trkpt>
    <trkpt lat="50.7009689" lon="-2.7274845">
      <ele>29.10</ele>
      <time>2015-08-19T11:14:38Z</time>
      <extensions><gpxtpx:TrackPointExtension><gpxtpx:speed>9.83</gpxtpx:speed></gpxtpx:TrackPointExtension></extensions>
    </trkpt>
```