### PR TITLE
[core] Add duration formatter

### DIFF
--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -555,6 +555,7 @@
     <string name="miles_per_hour">ميل/ساعة</string>
     <string name="hour">س</string>
     <string name="minute">د</string>
+    <string name="day">يوم</string>
     <string name="placepage_more_button">المزيد</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">الصور والتعليقات والحجز</string>

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -542,6 +542,7 @@
     <string name="miles_per_hour">mil/saat</string>
     <string name="hour">saat</string>
     <string name="minute">dəq</string>
+    <string name="day">gün</string>
     <string name="placepage_more_button">Digər</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Şəkillər, rəylər, rezervasiya</string>

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -541,6 +541,7 @@
     <string name="miles_per_hour">міль/г</string>
     <string name="hour">г</string>
     <string name="minute">хв</string>
+    <string name="day">д</string>
     <string name="placepage_more_button">Яшчэ</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Фота, водгукі, браніраванне</string>

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -501,6 +501,7 @@
     <string name="ft">фут</string>
     <string name="hour">ч</string>
     <string name="minute">мин</string>
+    <string name="day">д</string>
     <string name="placepage_more_button">Още</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Снимки, отзиви, резервация</string>

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -542,6 +542,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">h</string>
     <string name="minute">min</string>
+    <string name="day">d</string>
     <string name="placepage_more_button">Més</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Fotos, comentaris, reserves</string>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -519,6 +519,7 @@
     <string name="miles_per_hour">mil/h</string>
     <string name="hour">hod</string>
     <string name="minute">min</string>
+    <string name="day">d</string>
     <string name="placepage_more_button">Více</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Fotografie, recenze, rezervace</string>

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -511,6 +511,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">time</string>
     <string name="minute">min</string>
+    <string name="day">d</string>
     <string name="placepage_more_button">Mere</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Fotos, anmeldelser, booking</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -541,6 +541,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">h</string>
     <string name="minute">min</string>
+    <string name="day">d</string>
     <string name="placepage_more_button">Mehr</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Fotos, bewertungen, buchung</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -540,6 +540,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">h</string>
     <string name="minute">min</string>
+    <string name="day">d</string>
     <string name="placepage_more_button">Más</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Fotos, opiniones, reservas</string>

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -534,6 +534,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">h</string>
     <string name="minute">min</string>
+    <string name="day">p</string>
     <string name="placepage_more_button">Veel</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Fotod, arvustused, broneerimine</string>

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -540,6 +540,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">h</string>
     <string name="minute">min</string>
+    <string name="day">e</string>
     <string name="placepage_more_button">Gehiago</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Argazkiak, iritziak, erreserba</string>

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -506,6 +506,7 @@
     <string name="miles_per_hour">مایل بر ساعت (mph)</string>
     <string name="hour">ساعت</string>
     <string name="minute">دقیقه</string>
+    <string name="day">روز</string>
     <string name="placepage_more_button">بیشتر</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">عکس ها، نظرات، رزرو</string>

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -540,6 +540,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">t</string>
     <string name="minute">min</string>
+    <string name="day">pv</string>
     <string name="placepage_more_button">Lisää</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Kuvat, arvostelut, varaus</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -548,6 +548,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">h</string>
     <string name="minute">min</string>
+    <string name="day">j</string>
     <string name="placepage_more_button">Plus</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Photos, commentaires, réservations</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -407,6 +407,7 @@
     <string name="km">किमी</string>
     <string name="hour">घंटे</string>
     <string name="minute">मिनट</string>
+    <string name="day">दिन</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">तस्वीरें, समीक्षाएँ, बुकिंग</string>
     <!-- An explanation dialog shown when clicking on more_on_kayak link. -->

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -526,6 +526,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">ó</string>
     <string name="minute">p</string>
+    <string name="day">nap</string>
     <string name="placepage_more_button">Még</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Fényképek, vélemények, foglalás</string>

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -514,6 +514,7 @@
     <string name="miles_per_hour">mpj</string>
     <string name="hour">j</string>
     <string name="minute">mnt</string>
+    <string name="day">hr</string>
     <string name="placepage_more_button">Lainnya</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Foto, ulasan, pemesanan</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -526,6 +526,7 @@
     <string name="mi">mi</string>
     <string name="miles_per_hour">mph</string>
     <string name="minute">min</string>
+    <string name="day">g</string>
     <string name="placepage_more_button">Di più</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Foto, recensioni, prenotazioni</string>

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -537,6 +537,7 @@
     <string name="miles_per_hour">מייל לשעה</string>
     <string name="hour">ש׳</string>
     <string name="minute">ד׳</string>
+    <string name="day">י</string>
     <string name="placepage_more_button">עוד</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">תמונות, ביקורות, הזמנה</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -545,6 +545,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">時間</string>
     <string name="minute">分</string>
+    <string name="day">日</string>
     <string name="placepage_more_button">さらに詳しく</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">写真、レビュー、予約</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -512,6 +512,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">t</string>
     <string name="minute">min</string>
+    <string name="day">일</string>
     <string name="placepage_more_button">자세히</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">사진, 리뷰, 예약</string>

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -510,6 +510,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">तास</string>
     <string name="minute">मिनिट</string>
+    <string name="day">दि</string>
     <string name="placepage_more_button">अधिक</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">फोटोपुनरावलोकनेबुकिंगबुकिंग</string>

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -539,6 +539,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">t</string>
     <string name="minute">min</string>
+    <string name="day">d</string>
     <string name="placepage_more_button">Mer</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Bilder, anmeldelser, bestilling</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -539,6 +539,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">u</string>
     <string name="minute">min</string>
+    <string name="day">d</string>
     <string name="placepage_more_button">Meer</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Foto\'s, beoordelingen, boeken</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -543,6 +543,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">godz</string>
     <string name="minute">min</string>
+    <string name="day">d</string>
     <string name="placepage_more_button">Więcej</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Zdjęcia, opinie, rezerwacja</string>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -493,6 +493,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">h</string>
     <string name="minute">min</string>
+    <string name="day">dia</string>
     <string name="placepage_more_button">Mais</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Fotos, avaliações, reservas</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -524,6 +524,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">h</string>
     <string name="minute">min</string>
+    <string name="day">dia</string>
     <string name="placepage_more_button">Mais</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Fotos, comentários, reservas</string>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -525,6 +525,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">h</string>
     <string name="minute">min</string>
+    <string name="day">z</string>
     <string name="placepage_more_button">Mai mult</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Fotografii, comentarii, rezervări</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -548,6 +548,7 @@
     <string name="miles_per_hour">ми/ч</string>
     <string name="hour">ч</string>
     <string name="minute">мин</string>
+    <string name="day">д</string>
     <string name="placepage_more_button">Ещё</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Фотографии, отзывы, бронирование</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -541,6 +541,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">hod</string>
     <string name="minute">min</string>
+    <string name="day">d</string>
     <string name="placepage_more_button">Viac</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Fotografie, recenzie, rezervácie</string>

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -511,6 +511,7 @@
     <string name="miles_per_hour">mi/tim</string>
     <string name="hour">tim</string>
     <string name="minute">min</string>
+    <string name="day">d</string>
     <string name="placepage_more_button">Mer</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Foton, recensioner, bokning</string>

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -515,6 +515,7 @@
     <string name="miles_per_hour">ไมล์/ชม.</string>
     <string name="hour">ชม.</string>
     <string name="minute">น.</string>
+    <string name="day">วัน</string>
     <string name="placepage_more_button">เพิ่มเติม</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">รูปภาพ รีวิว การจอง</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -545,6 +545,7 @@
     <string name="miles_per_hour">saatte mil</string>
     <string name="hour">sa</string>
     <string name="minute">dk</string>
+    <string name="day">g</string>
     <string name="placepage_more_button">Diğer</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Fotoğraflar, yorumlar, rezervasyon</string>

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -545,6 +545,7 @@
     <string name="miles_per_hour">ми/год</string>
     <string name="hour">год</string>
     <string name="minute">хв</string>
+    <string name="day">д</string>
     <string name="placepage_more_button">Ще</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Фото, відгуки, бронювання</string>

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -513,6 +513,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">giờ</string>
     <string name="minute">phút</string>
+    <string name="day">ngày</string>
     <string name="placepage_more_button">Bổ sung</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Hình ảnh, đánh giá, đặt phòng</string>

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -553,6 +553,7 @@
     <string name="miles_per_hour">英哩每小時</string>
     <string name="hour">小時</string>
     <string name="minute">分鐘</string>
+    <string name="day">天</string>
     <string name="placepage_more_button">更多</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">照片、評論、預訂</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -553,6 +553,7 @@
     <string name="miles_per_hour">英里每小时</string>
     <string name="hour">小时</string>
     <string name="minute">分钟</string>
+    <string name="day">天</string>
     <string name="placepage_more_button">更多</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">照片、评论、预订</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -570,6 +570,7 @@
     <string name="miles_per_hour">mph</string>
     <string name="hour">h</string>
     <string name="minute">min</string>
+    <string name="day">d</string>
     <string name="placepage_more_button">More</string>
     <!-- A referral link on the place page for some hotels -->
     <string name="more_on_kayak">Photos, reviews, booking</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -17940,6 +17940,50 @@
     zh-Hans = 分钟
     zh-Hant = 分鐘
 
+  [day]
+    tags = android,ios
+    en = d
+    af = d
+    ar = يوم
+    az = gün
+    be = д
+    bg = д
+    ca = d
+    cs = d
+    da = d
+    de = d
+    es = d
+    et = p
+    eu = e
+    fa = روز
+    fi = pv
+    fr = j
+    he = י
+    hi = दिन
+    hu = nap
+    id = hr
+    it = g
+    ja = 日
+    ko = 일
+    lt = d
+    lv = d
+    mr = दि
+    nb = d
+    nl = d
+    pl = d
+    pt = dia
+    pt-BR = dia
+    ro = z
+    ru = д
+    sk = d
+    sv = d
+    th = วัน
+    tr = g
+    uk = д
+    vi = ngày
+    zh-Hans = 天
+    zh-Hant = 天
+
   [placepage_more_button]
     tags = android,ios
     en = More

--- a/iphone/CoreApi/CoreApi.xcodeproj/project.pbxproj
+++ b/iphone/CoreApi/CoreApi.xcodeproj/project.pbxproj
@@ -91,7 +91,9 @@
 		ED965B102CD67A470049E39E /* DistanceFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = ED965B092CD67A470049E39E /* DistanceFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED965B132CD67A9B0049E39E /* AltitudeFormatter.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED965B122CD67A9B0049E39E /* AltitudeFormatter.mm */; };
 		ED965B142CD67A9B0049E39E /* AltitudeFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = ED965B112CD67A9B0049E39E /* AltitudeFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ED965B162CD67ABA0049E39E /* DateTimeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED965B152CD67ABA0049E39E /* DateTimeFormatter.swift */; };
+		ED965B222CD8F5AA0049E39E /* DurationFormatter.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED965B212CD8F5AA0049E39E /* DurationFormatter.mm */; };
+		ED965B232CD8F5AA0049E39E /* DurationFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = ED965B202CD8F5AA0049E39E /* DurationFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED965B2A2CDA1C440049E39E /* DateTimeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED965B282CDA159C0049E39E /* DateTimeFormatter.swift */; };
 		EDC4E3512C5D222D009286A2 /* RecentlyDeletedCategory.mm in Sources */ = {isa = PBXBuildFile; fileRef = EDC4E34E2C5D222D009286A2 /* RecentlyDeletedCategory.mm */; };
 		EDC4E3522C5D222D009286A2 /* RecentlyDeletedCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = EDC4E34F2C5D222D009286A2 /* RecentlyDeletedCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EDC4E3532C5D222D009286A2 /* RecentlyDeletedCategory+Core.h in Headers */ = {isa = PBXBuildFile; fileRef = EDC4E3502C5D222D009286A2 /* RecentlyDeletedCategory+Core.h */; };
@@ -189,7 +191,9 @@
 		ED965B0A2CD67A470049E39E /* DistanceFormatter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DistanceFormatter.mm; sourceTree = "<group>"; };
 		ED965B112CD67A9B0049E39E /* AltitudeFormatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AltitudeFormatter.h; sourceTree = "<group>"; };
 		ED965B122CD67A9B0049E39E /* AltitudeFormatter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AltitudeFormatter.mm; sourceTree = "<group>"; };
-		ED965B152CD67ABA0049E39E /* DateTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTimeFormatter.swift; sourceTree = "<group>"; };
+		ED965B202CD8F5AA0049E39E /* DurationFormatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DurationFormatter.h; sourceTree = "<group>"; };
+		ED965B212CD8F5AA0049E39E /* DurationFormatter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DurationFormatter.mm; sourceTree = "<group>"; };
+		ED965B282CDA159C0049E39E /* DateTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTimeFormatter.swift; sourceTree = "<group>"; };
 		EDC4E34E2C5D222D009286A2 /* RecentlyDeletedCategory.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RecentlyDeletedCategory.mm; sourceTree = "<group>"; };
 		EDC4E34F2C5D222D009286A2 /* RecentlyDeletedCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RecentlyDeletedCategory.h; sourceTree = "<group>"; };
 		EDC4E3502C5D222D009286A2 /* RecentlyDeletedCategory+Core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RecentlyDeletedCategory+Core.h"; sourceTree = "<group>"; };
@@ -434,11 +438,13 @@
 		ED965B0B2CD67A470049E39E /* Formatting */ = {
 			isa = PBXGroup;
 			children = (
-				ED965B152CD67ABA0049E39E /* DateTimeFormatter.swift */,
 				ED965B112CD67A9B0049E39E /* AltitudeFormatter.h */,
 				ED965B122CD67A9B0049E39E /* AltitudeFormatter.mm */,
 				ED965B092CD67A470049E39E /* DistanceFormatter.h */,
 				ED965B0A2CD67A470049E39E /* DistanceFormatter.mm */,
+				ED965B282CDA159C0049E39E /* DateTimeFormatter.swift */,
+				ED965B202CD8F5AA0049E39E /* DurationFormatter.h */,
+				ED965B212CD8F5AA0049E39E /* DurationFormatter.mm */,
 			);
 			path = Formatting;
 			sourceTree = "<group>";
@@ -506,6 +512,7 @@
 				47942D9C237D927800DEFAE3 /* PlacePageBookmarkData.h in Headers */,
 				EDC4E3522C5D222D009286A2 /* RecentlyDeletedCategory.h in Headers */,
 				47942D72237CC40B00DEFAE3 /* OpeningHours.h in Headers */,
+				ED965B232CD8F5AA0049E39E /* DurationFormatter.h in Headers */,
 				ED0B1FF42CAAE3FF006E31A4 /* DeepLinkInAppFeatureHighlightData.h in Headers */,
 				47942D6B237CC3D600DEFAE3 /* PlacePageData.h in Headers */,
 				47D609DC234FE625008ECC47 /* MWMBookmarksObserver.h in Headers */,
@@ -593,7 +600,6 @@
 				47942D88237CCA8800DEFAE3 /* PlacePagePreviewData.mm in Sources */,
 				47942D9D237D927800DEFAE3 /* PlacePageBookmarkData.mm in Sources */,
 				47942D86237CC55500DEFAE3 /* MWMOpeningHoursCommon.mm in Sources */,
-				ED965B162CD67ABA0049E39E /* DateTimeFormatter.swift in Sources */,
 				9974CA2A23DF1968003FE824 /* ElevationProfileData.mm in Sources */,
 				47942D82237CC52A00DEFAE3 /* MWMOpeningHours.mm in Sources */,
 				ED965B132CD67A9B0049E39E /* AltitudeFormatter.mm in Sources */,
@@ -616,12 +622,14 @@
 				472602A924092C5B00731135 /* MWMGeoUtil.mm in Sources */,
 				47F701F0238C86F000D18E95 /* PlacePageButtonsData.mm in Sources */,
 				9940622123EAC57900493D1A /* ElevationHeightPoint.m in Sources */,
+				ED965B2A2CDA1C440049E39E /* DateTimeFormatter.swift in Sources */,
 				47EEAFF42350CEDB005CF316 /* AppInfo.mm in Sources */,
 				47E8163623B1889C008FD836 /* MWMStorage.mm in Sources */,
 				ED965B0D2CD67A470049E39E /* DistanceFormatter.mm in Sources */,
 				EDC4E3512C5D222D009286A2 /* RecentlyDeletedCategory.mm in Sources */,
 				47CA68DE2502022400671019 /* MWMBookmark.mm in Sources */,
 				9957FAE9237AE5B000855F48 /* Logger.mm in Sources */,
+				ED965B222CD8F5AA0049E39E /* DurationFormatter.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iphone/CoreApi/CoreApi/CoreApi.h
+++ b/iphone/CoreApi/CoreApi/CoreApi.h
@@ -30,6 +30,7 @@ FOUNDATION_EXPORT const unsigned char CoreApiVersionString[];
 #import <CoreApi/RecentlyDeletedCategory.h>
 #import "CoreApi/DistanceFormatter.h"
 #import "CoreApi/AltitudeFormatter.h"
+#import "CoreApi/DurationFormatter.h"
 
 #pragma mark - Place Page
 

--- a/iphone/CoreApi/CoreApi/Formatting/DateTimeFormatter.swift
+++ b/iphone/CoreApi/CoreApi/Formatting/DateTimeFormatter.swift
@@ -2,19 +2,7 @@ import Foundation
 
 @objcMembers
 public final class DateTimeFormatter: NSObject {
-  private static let timeFormatter: DateComponentsFormatter = {
-    let formatter = DateComponentsFormatter()
-    formatter.allowedUnits = [.day, .hour, .minute]
-    formatter.unitsStyle = .short
-    formatter.maximumUnitCount = 2
-    formatter.zeroFormattingBehavior = .dropAll
-    return formatter
-  }()
   private static let dateFormatter = DateFormatter()
-
-  public static func durationString(from timeInterval: TimeInterval) -> String {
-    timeFormatter.string(from: timeInterval) ?? ""
-  }
 
   public static func dateString(from date: Date, dateStyle: DateFormatter.Style, timeStyle: DateFormatter.Style) -> String {
     DateFormatter.localizedString(from: date, dateStyle: dateStyle, timeStyle: timeStyle)

--- a/iphone/CoreApi/CoreApi/Formatting/DurationFormatter.h
+++ b/iphone/CoreApi/CoreApi/Formatting/DurationFormatter.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DurationFormatter: NSObject
+
++ (NSString *)durationStringFromTimeInterval:(NSTimeInterval)timeInterval NS_SWIFT_NAME(durationString(from:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iphone/CoreApi/CoreApi/Formatting/DurationFormatter.mm
+++ b/iphone/CoreApi/CoreApi/Formatting/DurationFormatter.mm
@@ -1,0 +1,12 @@
+#import "DurationFormatter.h"
+
+#include "platform/duration.hpp"
+
+@implementation DurationFormatter
+
++ (NSString *)durationStringFromTimeInterval:(NSTimeInterval)timeInterval {
+  auto const duration = platform::Duration(static_cast<int>(timeInterval));
+  return [NSString stringWithCString:duration.GetPlatformLocalizedString().c_str() encoding:NSUTF8StringEncoding];
+}
+
+@end

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
@@ -7,7 +7,7 @@
 
 #import <AudioToolbox/AudioServices.h>
 #import <CoreApi/Framework.h>
-#import <CoreApi/CoreApi-Swift.h>
+#import <CoreApi/DurationFormatter.h>
 
 #include "routing/following_info.hpp"
 #include "routing/turns.hpp"
@@ -142,7 +142,7 @@ NSArray<MWMRouterTransitStepInfo *> *buildRouteTransitSteps(NSArray<MWMRoutePoin
 
   auto result = [[NSMutableAttributedString alloc] initWithString:@""];
   if (self.showEta) {
-    NSString * eta = [DateTimeFormatter durationStringFrom:self.timeToTarget];
+    NSString * eta = [DurationFormatter durationStringFromTimeInterval:self.timeToTarget];
     [result appendAttributedString:[[NSMutableAttributedString alloc] initWithString:eta attributes:primaryAttributes]];
     [result appendAttributedString:MWMNavigationDashboardEntity.estimateDot];
   }

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationControlView.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationControlView.swift
@@ -136,7 +136,7 @@ final class NavigationControlView: SolidTouchView, MWMTextToSpeechObserver, MapO
       ]
 
     if timePageControl.currentPage == 0 {
-      timeLabel.text = DateTimeFormatter.durationString(from: TimeInterval(info.timeToTarget))
+      timeLabel.text = DurationFormatter.durationString(from: TimeInterval(info.timeToTarget))
     } else {
       timeLabel.text = info.arrival
     }

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "د";
 
+"day" = "يوم";
+
 "placepage_more_button" = "المزيد";
 
 "book_button" = "حجز";

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "dəq";
 
+"day" = "gün";
+
 "placepage_more_button" = "Digər";
 
 "book_button" = "Rezervasyon";

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "хв";
 
+"day" = "д";
+
 "placepage_more_button" = "Яшчэ";
 
 "book_button" = "Забраніраваць";

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "мин";
 
+"day" = "д";
+
 "placepage_more_button" = "Още";
 
 "book_button" = "Резервиране";

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "Més";
 
 "book_button" = "Reserva";

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "Více";
 
 "book_button" = "Rezervace";

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "Mere";
 
 "book_button" = "Book";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "Mehr";
 
 "book_button" = "Buchen";

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "Περισσότερα";
 
 "book_button" = "Κράτηση";

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "More";
 
 "book_button" = "Book";

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "More";
 
 "book_button" = "Book";

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "Más";
 
 "book_button" = "Reservar";

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "Más";
 
 "book_button" = "Reservar";

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "p";
+
 "placepage_more_button" = "Veel";
 
 "book_button" = "Reserveeri";

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "e";
+
 "placepage_more_button" = "Gehiago";
 
 "book_button" = "Erreserba";

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "دقیقه";
 
+"day" = "روز";
+
 "placepage_more_button" = "بیشتر";
 
 "book_button" = "رزرو";

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "pv";
+
 "placepage_more_button" = "Lisää";
 
 "book_button" = "Varaa";

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "j";
+
 "placepage_more_button" = "Plus";
 
 "book_button" = "Réserver";

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "ד׳";
 
+"day" = "י";
+
 "placepage_more_button" = "עוד";
 
 "book_button" = "הזמנה";

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "मिनट";
 
+"day" = "दिन";
+
 "placepage_more_button" = "More";
 
 "book_button" = "Book";

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "p";
 
+"day" = "nap";
+
 "placepage_more_button" = "Még";
 
 "book_button" = "Foglalás";

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "mnt";
 
+"day" = "hr";
+
 "placepage_more_button" = "Lainnya";
 
 "book_button" = "Pesan";

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "g";
+
 "placepage_more_button" = "Di più";
 
 "book_button" = "Prenota";

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "分";
 
+"day" = "日";
+
 "placepage_more_button" = "さらに詳しく";
 
 "book_button" = "予約";

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "일";
+
 "placepage_more_button" = "자세히";
 
 "book_button" = "예약";

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "मिनिट";
 
+"day" = "दि";
+
 "placepage_more_button" = "अधिक";
 
 "book_button" = "पुस्तक";

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "Mer";
 
 "book_button" = "Bestill";

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "Meer";
 
 "book_button" = "Boek";

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "Więcej";
 
 "book_button" = "Zarezerwuj";

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "dia";
+
 "placepage_more_button" = "Mais";
 
 "book_button" = "Reservar";

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "dia";
+
 "placepage_more_button" = "Mais";
 
 "book_button" = "Reservas";

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "z";
+
 "placepage_more_button" = "Mai mult";
 
 "book_button" = "Rezervare";

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "мин";
 
+"day" = "д";
+
 "placepage_more_button" = "Ещё";
 
 "book_button" = "Забронировать";

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "Viac";
 
 "book_button" = "Rezervovať";

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "Mer";
 
 "book_button" = "Boka";

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "min";
 
+"day" = "d";
+
 "placepage_more_button" = "More";
 
 "book_button" = "Book";

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "น.";
 
+"day" = "วัน";
+
 "placepage_more_button" = "เพิ่มเติม";
 
 "book_button" = "จอง";

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "dk";
 
+"day" = "g";
+
 "placepage_more_button" = "Diğer";
 
 "book_button" = "Rezervasyon";

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "хв";
 
+"day" = "д";
+
 "placepage_more_button" = "Ще";
 
 "book_button" = "Забронювати";

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "phút";
 
+"day" = "ngày";
+
 "placepage_more_button" = "Bổ sung";
 
 "book_button" = "Đặt trước";

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "分钟";
 
+"day" = "天";
+
 "placepage_more_button" = "更多";
 
 "book_button" = "预定";

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -795,6 +795,8 @@
 
 "minute" = "分鐘";
 
+"day" = "天";
+
 "placepage_more_button" = "更多";
 
 "book_button" = "預定";

--- a/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfilePresenter.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfilePresenter.swift
@@ -62,7 +62,7 @@ extension ElevationProfilePresenter: ElevationProfilePresenterProtocol {
     }
 
     if data.trackTime != 0 {
-      let eta = DateTimeFormatter.durationString(from: TimeInterval(data.trackTime))
+      let eta = DurationFormatter.durationString(from: TimeInterval(data.trackTime))
       view?.isTimeHidden = false
       view?.setTrackTime("\(eta)")
     } else {

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -13,6 +13,8 @@ set(SRC
   country_file.hpp
   distance.cpp
   distance.hpp
+  duration.cpp
+  duration.hpp
   downloader_defines.hpp
   downloader_utils.cpp
   downloader_utils.hpp

--- a/platform/duration.cpp
+++ b/platform/duration.cpp
@@ -1,0 +1,132 @@
+#include "duration.hpp"
+
+/// @todo(KK): move the formatting code from the platform namespace
+namespace platform
+{
+namespace
+{
+using std::chrono::duration_cast, std::chrono::seconds, std::chrono::minutes, std::chrono::hours, std::chrono::days;
+
+static constexpr std::string_view kNoSpace = "";
+
+unsigned long SecondsToUnits(seconds duration, Duration::Units unit)
+{
+  switch (unit)
+  {
+    case Duration::Units::Days: return duration_cast<days>(duration).count();
+    case Duration::Units::Hours: return duration_cast<hours>(duration).count();
+    case Duration::Units::Minutes: return duration_cast<minutes>(duration).count();
+    default: UNREACHABLE();
+  }
+}
+
+seconds UnitsToSeconds(long value, Duration::Units unit)
+{
+  switch (unit)
+  {
+    case Duration::Units::Days: return days(value);
+    case Duration::Units::Hours: return hours(value);
+    case Duration::Units::Minutes: return minutes(value);
+    default: UNREACHABLE();
+  }
+}
+
+std::string_view GetUnitSeparator(Locale const & locale)
+{
+  static constexpr auto kEmptyNumberUnitSeparatorLocales = std::array
+  {
+    "en", "de", "fr", "he", "fa", "ja", "ko", "mr", "th", "tr", "vi", "zh"
+  };
+  bool const isEmptySeparator = std::find(std::begin(kEmptyNumberUnitSeparatorLocales), std::end(kEmptyNumberUnitSeparatorLocales), locale.m_language) != std::end(kEmptyNumberUnitSeparatorLocales);
+  return isEmptySeparator ? kNoSpace : kNarrowNonBreakingSpace;
+}
+
+std::string_view GetUnitsGroupingSeparator(Locale const & locale)
+{
+  static constexpr auto kEmptyGroupingSeparatorLocales = std::array
+  {
+    "ja", "zh"
+  };
+  bool const isEmptySeparator = std::find(std::begin(kEmptyGroupingSeparatorLocales), std::end(kEmptyGroupingSeparatorLocales), locale.m_language) != std::end(kEmptyGroupingSeparatorLocales);
+  return isEmptySeparator ? kNoSpace : kNonBreakingSpace;
+}
+
+constexpr bool IsUnitsOrderValid(std::initializer_list<Duration::Units> units) {
+  auto it = units.begin();
+  auto prev = *it;
+  ++it;
+  for (; it != units.end(); ++it) {
+    if (static_cast<int>(*it) <= static_cast<int>(prev))
+      return false;
+    prev = *it;
+  }
+  return true;
+}
+}
+
+Duration::Duration(unsigned long seconds) : m_seconds(seconds)
+{}
+
+std::string Duration::GetLocalizedString(std::initializer_list<Units> units, Locale const & locale) const
+{
+  return GetString(std::move(units), GetUnitSeparator(locale), GetUnitsGroupingSeparator(locale));
+}
+
+std::string Duration::GetPlatformLocalizedString() const
+{
+  static auto const kCurrentUnitSeparator = GetUnitSeparator(GetCurrentLocale());
+  static auto const kCurrentGroupingSeparator = GetUnitsGroupingSeparator(GetCurrentLocale());
+  return GetString({Units::Days, Units::Hours, Units::Minutes}, kCurrentUnitSeparator, kCurrentGroupingSeparator);
+}
+
+std::string Duration::GetString(std::initializer_list<Units> units, std::string_view unitSeparator, std::string_view groupingSeparator) const
+{
+  ASSERT(units.size(), ());
+  ASSERT(IsUnitsOrderValid(units), ());
+
+  if (m_seconds.count() == 0)
+    return std::to_string(0U).append(unitSeparator).append(GetUnitsString(Units::Minutes));
+
+  std::string formattedTime;
+  seconds remainingSeconds = m_seconds;
+
+  for (auto const unit : units)
+  {
+    const unsigned long unitsCount = SecondsToUnits(remainingSeconds, unit);
+    if (unitsCount > 0)
+    {
+      if (!formattedTime.empty())
+        formattedTime.append(groupingSeparator);
+      formattedTime.append(std::to_string(unitsCount).append(unitSeparator).append(GetUnitsString(unit)));
+      remainingSeconds -= UnitsToSeconds(unitsCount, unit);
+    }
+  }
+  return formattedTime;
+}
+
+std::string Duration::GetUnitsString(Units unit)
+{
+  constexpr std::string_view kStringsMinute = "minute";
+  constexpr std::string_view kStringsHour = "hour";
+  constexpr std::string_view kStringsDay = "day";
+
+  switch (unit)
+  {
+    case Units::Minutes: return platform::GetLocalizedString(std::string(kStringsMinute));
+    case Units::Hours: return platform::GetLocalizedString(std::string(kStringsHour));
+    case Units::Days: return platform::GetLocalizedString(std::string(kStringsDay));
+    default: UNREACHABLE();
+  }
+}
+
+std::string DebugPrint(Duration::Units units)
+{
+  switch (units)
+  {
+    case Duration::Units::Days: return "d";
+    case Duration::Units::Hours: return "h";
+    case Duration::Units::Minutes: return "m";
+    default: UNREACHABLE();
+  }
+}
+}  // namespace platform

--- a/platform/duration.hpp
+++ b/platform/duration.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "platform/localization.hpp"
+
+#include <string>
+#include <set>
+#include <chrono>
+
+namespace platform
+{
+
+class Duration
+{
+public:
+  enum class Units
+  {
+    Days = 0,
+    Hours = 1,
+    Minutes = 2,
+  };
+
+  explicit Duration(unsigned long seconds);
+
+  static std::string GetUnitsString(Units unit);
+
+  std::string GetLocalizedString(std::initializer_list<Units> units, Locale const & locale) const;
+  std::string GetPlatformLocalizedString() const;
+
+private:
+  const std::chrono::seconds m_seconds;
+
+  std::string GetString(std::initializer_list<Units> units, std::string_view unitSeparator, std::string_view groupingSeparator) const;
+};
+
+std::string DebugPrint(Duration::Units units);
+
+}  // namespace platform

--- a/platform/platform_tests/CMakeLists.txt
+++ b/platform/platform_tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SRC
   apk_test.cpp
   country_file_tests.cpp
   distance_tests.cpp
+  duration_tests.cpp
   downloader_tests/downloader_test.cpp
   downloader_utils_tests.cpp
   get_text_by_id_tests.cpp

--- a/platform/platform_tests/duration_tests.cpp
+++ b/platform/platform_tests/duration_tests.cpp
@@ -1,0 +1,109 @@
+#include "testing/testing.hpp"
+
+#include "platform/duration.hpp"
+
+#include <chrono>
+
+namespace platform
+{
+using std::chrono::duration_cast, std::chrono::seconds, std::chrono::minutes, std::chrono::hours, std::chrono::days;
+
+struct TestData
+{
+  struct Duration
+  {
+    days m_days;
+    hours m_hours;
+    minutes m_minutes;
+    std::string result;
+
+    Duration(long days, long hours, long minutes, std::string const & result)
+    : m_days(days), m_hours(hours), m_minutes(minutes), result(result)
+    {}
+
+    long Seconds() const
+    {
+      return (duration_cast<seconds>(m_days) +
+              duration_cast<seconds>(m_hours) +
+              duration_cast<seconds>(m_minutes)).count();
+    }
+  };
+
+  Locale m_locale;
+  std::vector<Duration> m_duration;
+
+  constexpr TestData(Locale locale, std::vector<Duration> duration)
+  : m_locale(locale), m_duration(duration)
+  {}
+};
+
+Locale GetLocale(std::string const & language)
+{
+  Locale locale;
+  locale.m_language = language;
+  return locale;
+}
+/*
+ Localized string cannot be retrieved from the app target bundle during the tests execution
+ and the platform::GetLocalizedString will return the same string as the input ("minute", "hour" etc).
+ This is why the expectation strings are not explicit.
+ */
+
+auto const m = Duration::GetUnitsString(Duration::Units::Minutes);
+auto const h = Duration::GetUnitsString(Duration::Units::Hours);
+auto const d = Duration::GetUnitsString(Duration::Units::Days);
+
+UNIT_TEST(Duration_AllUnits)
+{
+  TestData const testData[] = {
+    {GetLocale("en"),
+      {
+        {0, 0, 0,     "0" + m},
+        {0, 0, 1,     "1" + m},
+        {0, 0, 60,    "1" + h},
+        {0, 0, 123,   "2" + h + kNonBreakingSpace + "3" + m},
+        {0, 3, 0,     "3" + h},
+        {0, 24, 0,    "1" + d},
+        {4, 0, 0,     "4" + d},
+        {1, 2, 3,     "1" + d + kNonBreakingSpace + "2" + h + kNonBreakingSpace + "3" + m},
+        {1, 0, 15,    "1" + d + kNonBreakingSpace + "15" + m},
+        {0, 15, 1,    "15" + h + kNonBreakingSpace + "1" + m},
+        {1, 15, 0,    "1" + d + kNonBreakingSpace + "15" + h},
+        {15, 0, 10,   "15" + d + kNonBreakingSpace + "10" + m},
+        {15, 15, 15,  "15" + d + kNonBreakingSpace + "15" + h + kNonBreakingSpace + "15" + m}
+      }
+    },
+  };
+
+  for (auto const & data : testData)
+  {
+    for (auto const & dataDuration : data.m_duration)
+    {
+      auto const duration = Duration(dataDuration.Seconds());
+      auto durationStr = duration.GetLocalizedString({Duration::Units::Days, Duration::Units::Hours, Duration::Units::Minutes}, data.m_locale);
+      TEST_EQUAL(durationStr, dataDuration.result, ());
+    }
+  }
+}
+
+UNIT_TEST(Duration_Localization)
+{
+  TestData const testData[] = {
+    // en
+    {GetLocale("en"), {{1, 2, 3,  "1" + d + kNonBreakingSpace + "2" + h + kNonBreakingSpace + "3" + m}}},
+    // ru (narrow spacing between number and unit)
+    {GetLocale("ru"), {{1, 2, 3, "1" + kNarrowNonBreakingSpace + d + kNonBreakingSpace + "2" + kNarrowNonBreakingSpace + h + kNonBreakingSpace + "3" + kNarrowNonBreakingSpace + m}}},
+    // zh (no spacings)
+    {GetLocale("zh"), {{1, 2, 3, "1" + d + "2" + h + "3" + m}}}
+  };
+
+  for (auto const & data : testData)
+  {
+    for (auto const & duration : data.m_duration)
+    {
+      auto const durationStr = Duration(duration.Seconds()).GetLocalizedString({Duration::Units::Days, Duration::Units::Hours, Duration::Units::Minutes}, data.m_locale);
+      TEST_EQUAL(durationStr, duration.result, ());
+    }
+  }
+}
+}  // namespace platform

--- a/xcode/platform/platform.xcodeproj/project.pbxproj
+++ b/xcode/platform/platform.xcodeproj/project.pbxproj
@@ -114,6 +114,10 @@
 		D5B191CF2386C7E4009CD0D6 /* http_uploader_background.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D5B191CE2386C7E4009CD0D6 /* http_uploader_background.hpp */; };
 		EB60B4DC204C130300E4953B /* network_policy_ios.mm in Sources */ = {isa = PBXBuildFile; fileRef = EB60B4DB204C130300E4953B /* network_policy_ios.mm */; };
 		EB60B4DE204C175700E4953B /* network_policy_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = EB60B4DD204C175700E4953B /* network_policy_ios.h */; };
+		ED965B252CD8F72E0049E39E /* duration.hpp in Headers */ = {isa = PBXBuildFile; fileRef = ED965B242CD8F72A0049E39E /* duration.hpp */; };
+		ED965B272CD8F7810049E39E /* duration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ED965B262CD8F77D0049E39E /* duration.cpp */; };
+		ED965B472CDA52DB0049E39E /* duration_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ED965B462CDA4EC00049E39E /* duration_tests.cpp */; };
+		ED965B482CDA575B0049E39E /* duration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ED965B262CD8F77D0049E39E /* duration.cpp */; };
 		F6DF73581EC9EAE700D8BA0B /* string_storage_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6DF73561EC9EAE700D8BA0B /* string_storage_base.cpp */; };
 		F6DF73591EC9EAE700D8BA0B /* string_storage_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6DF73561EC9EAE700D8BA0B /* string_storage_base.cpp */; };
 		F6DF735A1EC9EAE700D8BA0B /* string_storage_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6DF73561EC9EAE700D8BA0B /* string_storage_base.cpp */; };
@@ -252,6 +256,9 @@
 		D5B191CE2386C7E4009CD0D6 /* http_uploader_background.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = http_uploader_background.hpp; sourceTree = "<group>"; };
 		EB60B4DB204C130300E4953B /* network_policy_ios.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = network_policy_ios.mm; sourceTree = "<group>"; };
 		EB60B4DD204C175700E4953B /* network_policy_ios.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = network_policy_ios.h; sourceTree = "<group>"; };
+		ED965B242CD8F72A0049E39E /* duration.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = duration.hpp; sourceTree = "<group>"; };
+		ED965B262CD8F77D0049E39E /* duration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = duration.cpp; sourceTree = "<group>"; };
+		ED965B462CDA4EC00049E39E /* duration_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = duration_tests.cpp; sourceTree = "<group>"; };
 		F6DF73561EC9EAE700D8BA0B /* string_storage_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_storage_base.cpp; sourceTree = "<group>"; };
 		F6DF73571EC9EAE700D8BA0B /* string_storage_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = string_storage_base.hpp; sourceTree = "<group>"; };
 		FAA8389026BB48E9002E54C6 /* libcppjansson.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libcppjansson.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -310,6 +317,7 @@
 		675340DE1C58C405002CF0D9 /* platform_tests */ = {
 			isa = PBXGroup;
 			children = (
+				ED965B462CDA4EC00049E39E /* duration_tests.cpp */,
 				168EFCC12A30EB7400F71EE8 /* distance_tests.cpp */,
 				675341001C58C4C9002CF0D9 /* apk_test.cpp */,
 				675341011C58C4C9002CF0D9 /* country_file_tests.cpp */,
@@ -374,6 +382,8 @@
 		6753437A1A3F5CF500A0A8C3 /* platform */ = {
 			isa = PBXGroup;
 			children = (
+				ED965B242CD8F72A0049E39E /* duration.hpp */,
+				ED965B262CD8F77D0049E39E /* duration.cpp */,
 				1669C83E2A30DCD200530AD1 /* distance.cpp */,
 				1669C83F2A30DCD200530AD1 /* distance.hpp */,
 				675343861A3F5D5900A0A8C3 /* apple_location_service.mm */,
@@ -516,6 +526,7 @@
 				34C624BE1DABCCD100510300 /* socket.hpp in Headers */,
 				D50B2296238591570056820A /* http_payload.hpp in Headers */,
 				675343C11A3F5D5A00A0A8C3 /* location_service.hpp in Headers */,
+				ED965B252CD8F72E0049E39E /* duration.hpp in Headers */,
 				67AB92DD1B7B3D7300AB5194 /* mwm_version.hpp in Headers */,
 				675343CA1A3F5D5A00A0A8C3 /* platform_unix_impl.hpp in Headers */,
 				675343D21A3F5D5A00A0A8C3 /* servers_list.hpp in Headers */,
@@ -685,6 +696,7 @@
 				6741250A1B4C00CC00A3E828 /* country_file.cpp in Sources */,
 				4564FA7F2094978D0043CCFB /* remote_file.cpp in Sources */,
 				674125081B4C00CC00A3E828 /* country_defines.cpp in Sources */,
+				ED965B272CD8F7810049E39E /* duration.cpp in Sources */,
 				EB60B4DC204C130300E4953B /* network_policy_ios.mm in Sources */,
 				6741250E1B4C00CC00A3E828 /* local_country_file.cpp in Sources */,
 				670E8C761BB318AB00094197 /* platform_ios.mm in Sources */,
@@ -727,6 +739,7 @@
 				6783389E1C6DE59200FD6263 /* platform_test.cpp in Sources */,
 				678338961C6DE59200FD6263 /* apk_test.cpp in Sources */,
 				678338991C6DE59200FD6263 /* jansson_test.cpp in Sources */,
+				ED965B482CDA575B0049E39E /* duration.cpp in Sources */,
 				6783389C1C6DE59200FD6263 /* location_test.cpp in Sources */,
 				678338981C6DE59200FD6263 /* get_text_by_id_tests.cpp in Sources */,
 				6783389A1C6DE59200FD6263 /* language_test.cpp in Sources */,
@@ -734,6 +747,7 @@
 				678338971C6DE59200FD6263 /* country_file_tests.cpp in Sources */,
 				678338951C6DE59200FD6263 /* testingmain.cpp in Sources */,
 				1669C8412A30DCD200530AD1 /* distance.cpp in Sources */,
+				ED965B472CDA52DB0049E39E /* duration_tests.cpp in Sources */,
 				44CAB5F62A1F926800819330 /* utm_mgrs_utils_tests.cpp in Sources */,
 				F6DF735A1EC9EAE700D8BA0B /* string_storage_base.cpp in Sources */,
 				168EFCC22A30EB7400F71EE8 /* distance_tests.cpp in Sources */,


### PR DESCRIPTION
This PR adds basic Duration formatting to the core and allows to get the duration string based on the provided time interval in seconds into the format: `X d Y h Z m`.
Zero values will be skipped to shorten the strings: `1 d 0 h 3 min` will be shown as `1 d 3 min`.

### TODO:
- [ ] implement this formatter to the Android
- [x] some locales shouldn't have spacings between the number and unit (jp, zh, fr...)

<img width="350" alt="image" src="https://github.com/user-attachments/assets/95d0ab1a-855c-4650-9fed-375dddea4559">
<img width="350" alt="image" src="https://github.com/user-attachments/assets/eb963563-2b07-44c5-a550-b8d35ee364a4">
<img width="350" alt="image" src="https://github.com/user-attachments/assets/ab6428c9-0b36-4888-b688-41722f83ea9c">
<img width="350" alt="image" src="https://github.com/user-attachments/assets/55e459b9-d4c5-4abb-be08-ac318df9adf3">
<img width="350" alt="image" src="https://github.com/user-attachments/assets/3ee45d41-f8e8-4b81-a600-b76b6a0c9d57">

