### PR TITLE
[platform] fix: Correct the broken macro condition

### DIFF
--- a/platform/trace.hpp
+++ b/platform/trace.hpp
@@ -44,7 +44,7 @@ public:
 };
 }  // namespace platform
 
-#ifdef ENABLE_TRACE && OMIM_OS_ANDROID
+#if defined(ENABLE_TRACE) && defined(OMIM_OS_ANDROID)
 #define TRACE_SECTION(section) platform::TraceSection ___section(section)
 #define TRACE_COUNTER(name, value) platform::Trace::Instance().SetCounter(name, value)
 #else


### PR DESCRIPTION
The current macro condition is incorrect,
and also generates the following compiler warning:

````
patform/trace.hpp:47:21: warning: extra tokens at end of #ifdef directive
   47 | #ifdef ENABLE_TRACE && OMIM_OS_ANDROID
      |                     ^~
````