### PR TITLE
Use faster std::popcount

### DIFF
--- a/base/base_tests/bits_test.cpp
+++ b/base/base_tests/bits_test.cpp
@@ -1,51 +1,9 @@
 #include "testing/testing.hpp"
 
 #include "base/bits.hpp"
-#include "base/checked_cast.hpp"
 
 #include <cstdint>
 #include <cstdlib>
-#include <vector>
-
-namespace
-{
-template <typename T>
-uint32_t PopCountSimple(T x)
-{
-  uint32_t res = 0;
-  for (; x != 0; x >>= 1)
-  {
-    if (x & 1)
-      ++res;
-  }
-  return res;
-}
-}  // namespace
-
-UNIT_TEST(Popcount32)
-{
-  for (uint32_t i = 0; i < 10000; ++i)
-  {
-    TEST_EQUAL(bits::PopCount(i), PopCountSimple(i), (i));
-    TEST_EQUAL(bits::PopCount(0xC2000000 | i), PopCountSimple(0xC2000000 | i), (0xC2000000 | i));
-  }
-}
-
-UNIT_TEST(PopcountArray32)
-{
-  for (uint32_t j = 0; j < 2777; ++j)
-  {
-    std::vector<uint32_t> v(j / 10);
-    for (size_t i = 0; i < v.size(); ++i)
-      v[i] = ((uint32_t(rand()) & 255) << 24) + ((rand() & 255) << 16) +
-             ((rand() & 255) << 8) + (rand() & 255);
-    uint32_t expectedPopCount = 0;
-    for (size_t i = 0; i < v.size(); ++i)
-      expectedPopCount += PopCountSimple(v[i]);
-    TEST_EQUAL(bits::PopCount(v.empty() ? NULL : &v[0], base::checked_cast<uint32_t>(v.size())),
-               expectedPopCount, (j, v.size(), expectedPopCount));
-  }
-}
 
 UNIT_TEST(Select1Test)
 {
@@ -139,14 +97,6 @@ UNIT_TEST(NumUsedBits)
   TEST_EQUAL(bits::NumUsedBits(0xFFFFFFFFFFFFFFFFULL), 64, ());
   TEST_EQUAL(bits::NumUsedBits(0x0FABCDEF0FABCDEFULL), 60, ());
   TEST_EQUAL(bits::NumUsedBits(0x000000000000FDEFULL), 16, ());
-}
-
-UNIT_TEST(PopCount64)
-{
-  TEST_EQUAL(0, bits::PopCount(static_cast<uint64_t>(0x0)), ());
-  TEST_EQUAL(1, bits::PopCount(static_cast<uint64_t>(0x1)), ());
-  TEST_EQUAL(32, bits::PopCount(static_cast<uint64_t>(0xAAAAAAAA55555555)), ());
-  TEST_EQUAL(64, bits::PopCount(static_cast<uint64_t>(0xFFFFFFFFFFFFFFFF)), ());
 }
 
 UNIT_TEST(CeilLog)

--- a/base/base_tests/bits_test.cpp
+++ b/base/base_tests/bits_test.cpp
@@ -10,13 +10,6 @@ UNIT_TEST(Select1Test)
   TEST_EQUAL(0U, bits::select1(1, 1), ());
 }
 
-UNIT_TEST(ROL)
-{
-  TEST_EQUAL(bits::ROL<uint32_t>(0), 0, ());
-  TEST_EQUAL(bits::ROL<uint32_t>(uint32_t(-1)), uint32_t(-1), ());
-  TEST_EQUAL(bits::ROL<uint8_t>(128 | 32 | 4), uint8_t(64 | 8 | 1), ());
-}
-
 UNIT_TEST(PerfectShuffle)
 {
   // 0010 0001 0100 0000

--- a/base/bits.hpp
+++ b/base/bits.hpp
@@ -8,48 +8,7 @@
 
 namespace bits
 {
-  // Count the number of 1 bits. Implementation: see Hacker's delight book.
-  inline uint32_t PopCount(uint32_t x) noexcept
-  {
-    x -= ((x >> 1) & 0x55555555);
-    x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
-    x = (x + (x >> 4)) & 0x0F0F0F0F;
-    x += (x >> 8);
-    x += (x >> 16);
-    return x & 0x3F;
-  }
-
-  inline uint32_t PopCount(uint8_t x) noexcept
-  {
-    return PopCount(static_cast<uint32_t>(x));
-  }
-
-  // Count the number of 1 bits in array p, length n bits.
-  // There is a better implementation at hackersdelight.org
-  inline uint32_t PopCount(uint32_t const * p, uint32_t n)
-  {
-    uint32_t s = 0;
-    for (uint32_t i = 0; i < n; i += 31)
-    {
-      uint32_t lim = (n < i + 31 ? n : i + 31);
-      uint32_t s8 = 0;
-      uint32_t x = 0;
-      for (uint32_t j = i; j < lim; ++j)
-      {
-        x = p[j];
-        x -= ((x >> 1) & 0x55555555);
-        x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
-        x = (x + (x >> 4)) & 0x0F0F0F0F;
-        s8 += x;
-      }
-      x = (s8 & 0x00FF00FF) + ((s8 >> 8) & 0x00FF00FF);
-      x = (x & 0x0000ffff) + (x >> 16);
-      s += x;
-    }
-    return s;
-  }
-
-  static const int SELECT1_ERROR = -1;
+  static constexpr int SELECT1_ERROR = -1;
 
   template <typename T> unsigned int select1(T x, unsigned int i)
   {
@@ -60,15 +19,6 @@ namespace bits
         if (--i == 0)
           return j;
     return static_cast<unsigned int>(SELECT1_ERROR);
-  }
-
-  inline uint32_t PopCount(uint64_t x) noexcept
-  {
-    x = x - ((x & 0xAAAAAAAAAAAAAAAA) >> 1);
-    x = (x & 0x3333333333333333) + ((x >> 2) & 0x3333333333333333);
-    x = (x + (x >> 4)) & 0x0F0F0F0F0F0F0F0F;
-    x = (x * 0x0101010101010101) >> 56;
-    return static_cast<uint32_t>(x);
   }
 
   inline uint8_t FloorLog(uint64_t x) noexcept
@@ -91,9 +41,6 @@ namespace bits
 
     return msb;
   }
-
-  // Will be implemented when needed.
-  uint64_t PopCount(uint64_t const * p, uint64_t n);
 
   template <typename T> T RoundLastBitsUpAndShiftRight(T x, T bits)
   {
@@ -182,8 +129,8 @@ namespace bits
     uint8_t * pData = static_cast<uint8_t *>(p);
     pData[offset >> 3] |= (1 << (offset & 7));
   }
-  
-  // Compute number of zero bits from the most significant bits side. 
+
+  // Compute number of zero bits from the most significant bits side.
   inline uint32_t NumHiZeroBits32(uint32_t n)
   {
     if (n == 0) return 32;
@@ -191,7 +138,7 @@ namespace bits
     while ((n & (uint32_t(1) << 31)) == 0) { ++result; n <<= 1; }
     return result;
   }
-  
+
   inline uint32_t NumHiZeroBits64(uint64_t n)
   {
     if (n == 0) return 64;
@@ -199,7 +146,7 @@ namespace bits
     while ((n & (uint64_t(1) << 63)) == 0) { ++result; n <<= 1; }
     return result;
   }
-  
+
   // Computes number of bits needed to store the number, it is not equal to number of ones.
   // E.g. if we have a number (in bit representation) 00001000b then NumUsedBits is 4.
   inline uint32_t NumUsedBits(uint64_t n)

--- a/base/bits.hpp
+++ b/base/bits.hpp
@@ -23,39 +23,7 @@ template <typename T> unsigned int select1(T x, unsigned int i)
 
 constexpr uint8_t FloorLog(uint64_t x) noexcept
 {
-#define CHECK_RSH(x, msb, offset) \
-  if (x >> offset)              \
-  {                             \
-    x >>= offset;               \
-    msb += offset;              \
-  }
-
-  uint8_t msb = 0;
-  CHECK_RSH(x, msb, 32);
-  CHECK_RSH(x, msb, 16);
-  CHECK_RSH(x, msb, 8);
-  CHECK_RSH(x, msb, 4);
-  CHECK_RSH(x, msb, 2);
-  CHECK_RSH(x, msb, 1);
-#undef CHECK_RSH
-
-  return msb;
-}
-
-template <typename T> T RoundLastBitsUpAndShiftRight(T x, T bits)
-{
-  return (x & ((1 << bits) - 1)) ? (x >> bits) + 1 : (x >> bits);
-}
-
-template <typename T> struct LogBitSizeOfType;
-template <> struct LogBitSizeOfType<uint8_t>  { enum { value = 3 }; };
-template <> struct LogBitSizeOfType<uint16_t> { enum { value = 4 }; };
-template <> struct LogBitSizeOfType<uint32_t> { enum { value = 5 }; };
-template <> struct LogBitSizeOfType<uint64_t> { enum { value = 6 }; };
-
-template <typename T> T ROL(T x)
-{
-  return (x << 1) | (x >> (sizeof(T) * 8 - 1));
+  return x == 0 ? 0 : std::bit_width(x) - 1;
 }
 
 template <typename T>
@@ -112,19 +80,19 @@ constexpr void BitwiseSplit(uint64_t v, uint32_t & x, uint32_t & y)
 }
 
 // Returns 1 if bit is set and 0 otherwise.
-constexpr uint8_t GetBit(void const * p, uint32_t offset)
+inline uint8_t GetBit(void const * p, uint32_t offset)
 {
   uint8_t const * pData = static_cast<uint8_t const *>(p);
   return (pData[offset >> 3] >> (offset & 7)) & 1;
 }
 
-constexpr void SetBitTo0(void * p, uint32_t offset)
+inline void SetBitTo0(void * p, uint32_t offset)
 {
   uint8_t * pData = static_cast<uint8_t *>(p);
   pData[offset >> 3] &= ~(1 << (offset & 7));
 }
 
-constexpr void SetBitTo1(void * p, uint32_t offset)
+inline void SetBitTo1(void * p, uint32_t offset)
 {
   uint8_t * pData = static_cast<uint8_t *>(p);
   pData[offset >> 3] |= (1 << (offset & 7));
@@ -135,7 +103,7 @@ constexpr uint32_t NumHiZeroBits32(uint32_t n)
 {
   if (n == 0) return 32;
   uint32_t result = 0;
-  while ((n & (uint32_t(1) << 31)) == 0) { ++result; n <<= 1; }
+  while ((n & (uint32_t{1} << 31)) == 0) { ++result; n <<= 1; }
   return result;
 }
 
@@ -143,7 +111,7 @@ constexpr uint32_t NumHiZeroBits64(uint64_t n)
 {
   if (n == 0) return 64;
   uint32_t result = 0;
-  while ((n & (uint64_t(1) << 63)) == 0) { ++result; n <<= 1; }
+  while ((n & (uint64_t{1} << 63)) == 0) { ++result; n <<= 1; }
   return result;
 }
 

--- a/base/bits.hpp
+++ b/base/bits.hpp
@@ -8,160 +8,160 @@
 
 namespace bits
 {
-  static constexpr int SELECT1_ERROR = -1;
+static constexpr int SELECT1_ERROR = -1;
 
-  template <typename T> unsigned int select1(T x, unsigned int i)
-  {
-    // TODO: Fast implementation of select1.
-    ASSERT(i > 0 && i <= sizeof(T) * 8, (i));
-    for (unsigned int j = 0; j < sizeof(T) * 8; x >>= 1, ++j)
-      if (x & 1)
-        if (--i == 0)
-          return j;
-    return static_cast<unsigned int>(SELECT1_ERROR);
+template <typename T> unsigned int select1(T x, unsigned int i)
+{
+  // TODO: Fast implementation of select1.
+  ASSERT(i > 0 && i <= sizeof(T) * 8, (i));
+  for (unsigned int j = 0; j < sizeof(T) * 8; x >>= 1, ++j)
+    if (x & 1)
+      if (--i == 0)
+        return j;
+  return static_cast<unsigned int>(SELECT1_ERROR);
+}
+
+constexpr uint8_t FloorLog(uint64_t x) noexcept
+{
+#define CHECK_RSH(x, msb, offset) \
+  if (x >> offset)              \
+  {                             \
+    x >>= offset;               \
+    msb += offset;              \
   }
 
-  inline uint8_t FloorLog(uint64_t x) noexcept
-  {
-#define CHECK_RSH(x, msb, offset) \
-    if (x >> offset)              \
-    {                             \
-      x >>= offset;               \
-      msb += offset;              \
-    }
-
-    uint8_t msb = 0;
-    CHECK_RSH(x, msb, 32);
-    CHECK_RSH(x, msb, 16);
-    CHECK_RSH(x, msb, 8);
-    CHECK_RSH(x, msb, 4);
-    CHECK_RSH(x, msb, 2);
-    CHECK_RSH(x, msb, 1);
+  uint8_t msb = 0;
+  CHECK_RSH(x, msb, 32);
+  CHECK_RSH(x, msb, 16);
+  CHECK_RSH(x, msb, 8);
+  CHECK_RSH(x, msb, 4);
+  CHECK_RSH(x, msb, 2);
+  CHECK_RSH(x, msb, 1);
 #undef CHECK_RSH
 
-    return msb;
-  }
+  return msb;
+}
 
-  template <typename T> T RoundLastBitsUpAndShiftRight(T x, T bits)
-  {
-    return (x & ((1 << bits) - 1)) ? (x >> bits) + 1 : (x >> bits);
-  }
+template <typename T> T RoundLastBitsUpAndShiftRight(T x, T bits)
+{
+  return (x & ((1 << bits) - 1)) ? (x >> bits) + 1 : (x >> bits);
+}
 
-  template <typename T> struct LogBitSizeOfType;
-  template <> struct LogBitSizeOfType<uint8_t>  { enum { value = 3 }; };
-  template <> struct LogBitSizeOfType<uint16_t> { enum { value = 4 }; };
-  template <> struct LogBitSizeOfType<uint32_t> { enum { value = 5 }; };
-  template <> struct LogBitSizeOfType<uint64_t> { enum { value = 6 }; };
+template <typename T> struct LogBitSizeOfType;
+template <> struct LogBitSizeOfType<uint8_t>  { enum { value = 3 }; };
+template <> struct LogBitSizeOfType<uint16_t> { enum { value = 4 }; };
+template <> struct LogBitSizeOfType<uint32_t> { enum { value = 5 }; };
+template <> struct LogBitSizeOfType<uint64_t> { enum { value = 6 }; };
 
-  template <typename T> T ROL(T x)
-  {
-    return (x << 1) | (x >> (sizeof(T) * 8 - 1));
-  }
+template <typename T> T ROL(T x)
+{
+  return (x << 1) | (x >> (sizeof(T) * 8 - 1));
+}
 
-  template <typename T>
-  std::make_unsigned_t<T> ZigZagEncode(T x)
-  {
-    static_assert(std::is_signed<T>::value, "Type should be signed");
-    return (x << 1) ^ (x >> (sizeof(x) * 8 - 1));
-  }
+template <typename T>
+std::make_unsigned_t<T> ZigZagEncode(T x)
+{
+  static_assert(std::is_signed<T>::value, "Type should be signed");
+  return (x << 1) ^ (x >> (sizeof(x) * 8 - 1));
+}
 
-  template <typename T>
-  std::make_signed_t<T> ZigZagDecode(T x)
-  {
-    static_assert(std::is_unsigned<T>::value, "Type should be unsigned.");
-    return (x >> 1) ^ -static_cast<std::make_signed_t<T>>(x & 1);
-  }
+template <typename T>
+std::make_signed_t<T> ZigZagDecode(T x)
+{
+  static_assert(std::is_unsigned<T>::value, "Type should be unsigned.");
+  return (x >> 1) ^ -static_cast<std::make_signed_t<T>>(x & 1);
+}
 
-  inline uint32_t PerfectShuffle(uint32_t x)
-  {
-    x = ((x & 0x0000FF00) << 8) | ((x >> 8) & 0x0000FF00) | (x & 0xFF0000FF);
-    x = ((x & 0x00F000F0) << 4) | ((x >> 4) & 0x00F000F0) | (x & 0xF00FF00F);
-    x = ((x & 0x0C0C0C0C) << 2) | ((x >> 2) & 0x0C0C0C0C) | (x & 0xC3C3C3C3);
-    x = ((x & 0x22222222) << 1) | ((x >> 1) & 0x22222222) | (x & 0x99999999);
-    return x;
-  }
+constexpr uint32_t PerfectShuffle(uint32_t x)
+{
+  x = ((x & 0x0000FF00) << 8) | ((x >> 8) & 0x0000FF00) | (x & 0xFF0000FF);
+  x = ((x & 0x00F000F0) << 4) | ((x >> 4) & 0x00F000F0) | (x & 0xF00FF00F);
+  x = ((x & 0x0C0C0C0C) << 2) | ((x >> 2) & 0x0C0C0C0C) | (x & 0xC3C3C3C3);
+  x = ((x & 0x22222222) << 1) | ((x >> 1) & 0x22222222) | (x & 0x99999999);
+  return x;
+}
 
-  inline uint32_t PerfectUnshuffle(uint32_t x)
-  {
-    x = ((x & 0x22222222) << 1) | ((x >> 1) & 0x22222222) | (x & 0x99999999);
-    x = ((x & 0x0C0C0C0C) << 2) | ((x >> 2) & 0x0C0C0C0C) | (x & 0xC3C3C3C3);
-    x = ((x & 0x00F000F0) << 4) | ((x >> 4) & 0x00F000F0) | (x & 0xF00FF00F);
-    x = ((x & 0x0000FF00) << 8) | ((x >> 8) & 0x0000FF00) | (x & 0xFF0000FF);
-    return x;
-  }
+constexpr uint32_t PerfectUnshuffle(uint32_t x)
+{
+  x = ((x & 0x22222222) << 1) | ((x >> 1) & 0x22222222) | (x & 0x99999999);
+  x = ((x & 0x0C0C0C0C) << 2) | ((x >> 2) & 0x0C0C0C0C) | (x & 0xC3C3C3C3);
+  x = ((x & 0x00F000F0) << 4) | ((x >> 4) & 0x00F000F0) | (x & 0xF00FF00F);
+  x = ((x & 0x0000FF00) << 8) | ((x >> 8) & 0x0000FF00) | (x & 0xFF0000FF);
+  return x;
+}
 
-  // Returns the integer that has the bits of |x| at even-numbered positions
-  // and the bits of |y| at odd-numbered positions without changing the
-  // relative order of bits coming from |x| and |y|.
-  // That is, if the bits of |x| are {x31, x30, ..., x0},
-  //         and the bits of |y| are {y31, y30, ..., y0},
-  // then the bits of the result are {y31, x31, y30, x30, ..., y0, x0}.
-  inline uint64_t BitwiseMerge(uint32_t x, uint32_t y)
-  {
-    uint32_t const hi = PerfectShuffle((y & 0xFFFF0000) | (x >> 16));
-    uint32_t const lo = PerfectShuffle(((y & 0xFFFF) << 16 ) | (x & 0xFFFF));
-    return (static_cast<uint64_t>(hi) << 32) + lo;
-  }
+// Returns the integer that has the bits of |x| at even-numbered positions
+// and the bits of |y| at odd-numbered positions without changing the
+// relative order of bits coming from |x| and |y|.
+// That is, if the bits of |x| are {x31, x30, ..., x0},
+//         and the bits of |y| are {y31, y30, ..., y0},
+// then the bits of the result are {y31, x31, y30, x30, ..., y0, x0}.
+constexpr uint64_t BitwiseMerge(uint32_t x, uint32_t y)
+{
+  uint32_t const hi = PerfectShuffle((y & 0xFFFF0000) | (x >> 16));
+  uint32_t const lo = PerfectShuffle(((y & 0xFFFF) << 16 ) | (x & 0xFFFF));
+  return (static_cast<uint64_t>(hi) << 32) + lo;
+}
 
-  inline void BitwiseSplit(uint64_t v, uint32_t & x, uint32_t & y)
-  {
-    uint32_t const hi = PerfectUnshuffle(static_cast<uint32_t>(v >> 32));
-    uint32_t const lo = PerfectUnshuffle(static_cast<uint32_t>(v & 0xFFFFFFFFULL));
-    x = ((hi & 0xFFFF) << 16) | (lo & 0xFFFF);
-    y = (hi & 0xFFFF0000) | (lo >> 16);
-  }
+constexpr void BitwiseSplit(uint64_t v, uint32_t & x, uint32_t & y)
+{
+  uint32_t const hi = PerfectUnshuffle(static_cast<uint32_t>(v >> 32));
+  uint32_t const lo = PerfectUnshuffle(static_cast<uint32_t>(v & 0xFFFFFFFFULL));
+  x = ((hi & 0xFFFF) << 16) | (lo & 0xFFFF);
+  y = (hi & 0xFFFF0000) | (lo >> 16);
+}
 
-  // Returns 1 if bit is set and 0 otherwise.
-  inline uint8_t GetBit(void const * p, uint32_t offset)
-  {
-    uint8_t const * pData = static_cast<uint8_t const *>(p);
-    return (pData[offset >> 3] >> (offset & 7)) & 1;
-  }
+// Returns 1 if bit is set and 0 otherwise.
+constexpr uint8_t GetBit(void const * p, uint32_t offset)
+{
+  uint8_t const * pData = static_cast<uint8_t const *>(p);
+  return (pData[offset >> 3] >> (offset & 7)) & 1;
+}
 
-  inline void SetBitTo0(void * p, uint32_t offset)
-  {
-    uint8_t * pData = static_cast<uint8_t *>(p);
-    pData[offset >> 3] &= ~(1 << (offset & 7));
-  }
+constexpr void SetBitTo0(void * p, uint32_t offset)
+{
+  uint8_t * pData = static_cast<uint8_t *>(p);
+  pData[offset >> 3] &= ~(1 << (offset & 7));
+}
 
-  inline void SetBitTo1(void * p, uint32_t offset)
-  {
-    uint8_t * pData = static_cast<uint8_t *>(p);
-    pData[offset >> 3] |= (1 << (offset & 7));
-  }
+constexpr void SetBitTo1(void * p, uint32_t offset)
+{
+  uint8_t * pData = static_cast<uint8_t *>(p);
+  pData[offset >> 3] |= (1 << (offset & 7));
+}
 
-  // Compute number of zero bits from the most significant bits side.
-  inline uint32_t NumHiZeroBits32(uint32_t n)
-  {
-    if (n == 0) return 32;
-    uint32_t result = 0;
-    while ((n & (uint32_t(1) << 31)) == 0) { ++result; n <<= 1; }
-    return result;
-  }
+// Compute number of zero bits from the most significant bits side.
+constexpr uint32_t NumHiZeroBits32(uint32_t n)
+{
+  if (n == 0) return 32;
+  uint32_t result = 0;
+  while ((n & (uint32_t(1) << 31)) == 0) { ++result; n <<= 1; }
+  return result;
+}
 
-  inline uint32_t NumHiZeroBits64(uint64_t n)
-  {
-    if (n == 0) return 64;
-    uint32_t result = 0;
-    while ((n & (uint64_t(1) << 63)) == 0) { ++result; n <<= 1; }
-    return result;
-  }
+constexpr uint32_t NumHiZeroBits64(uint64_t n)
+{
+  if (n == 0) return 64;
+  uint32_t result = 0;
+  while ((n & (uint64_t(1) << 63)) == 0) { ++result; n <<= 1; }
+  return result;
+}
 
-  // Computes number of bits needed to store the number, it is not equal to number of ones.
-  // E.g. if we have a number (in bit representation) 00001000b then NumUsedBits is 4.
-  inline uint32_t NumUsedBits(uint64_t n)
-  {
-    uint32_t result = 0;
-    while (n != 0) { ++result; n >>= 1; }
-    return result;
-  }
+// Computes number of bits needed to store the number, it is not equal to number of ones.
+// E.g. if we have a number (in bit representation) 00001000b then NumUsedBits is 4.
+constexpr uint32_t NumUsedBits(uint64_t n)
+{
+  uint32_t result = 0;
+  while (n != 0) { ++result; n >>= 1; }
+  return result;
+}
 
-  inline uint64_t GetFullMask(uint8_t numBits)
-  {
-    ASSERT_LESS_OR_EQUAL(numBits, 64, ());
-    return numBits == 64 ? std::numeric_limits<uint64_t>::max()
-                         : (static_cast<uint64_t>(1) << numBits) - 1;
-  }
+constexpr uint64_t GetFullMask(uint8_t numBits)
+{
+  ASSERT_LESS_OR_EQUAL(numBits, 64, ());
+  return numBits == 64 ? std::numeric_limits<uint64_t>::max()
+                       : (static_cast<uint64_t>(1) << numBits) - 1;
+}
 
-  inline bool IsPow2Minus1(uint64_t n) { return (n & (n + 1)) == 0; }
+constexpr bool IsPow2Minus1(uint64_t n) { return (n & (n + 1)) == 0; }
 }  // namespace bits

--- a/coding/compressed_bit_vector.cpp
+++ b/coding/compressed_bit_vector.cpp
@@ -3,9 +3,9 @@
 #include "coding/write_to_sink.hpp"
 
 #include "base/assert.hpp"
-#include "base/bits.hpp"
 
 #include <algorithm>
+#include <bit>
 
 namespace coding
 {
@@ -299,7 +299,7 @@ unique_ptr<DenseCBV> DenseCBV::BuildFromBitGroups(vector<uint64_t> && bitGroups)
   unique_ptr<DenseCBV> cbv(new DenseCBV());
   cbv->m_popCount = 0;
   for (size_t i = 0; i < bitGroups.size(); ++i)
-    cbv->m_popCount += bits::PopCount(bitGroups[i]);
+    cbv->m_popCount += std::popcount(bitGroups[i]);
   cbv->m_bitGroups = std::move(bitGroups);
   return cbv;
 }
@@ -326,7 +326,7 @@ unique_ptr<CompressedBitVector> DenseCBV::LeaveFirstSetNBits(uint64_t n) const
   for (size_t i = 0; i < m_bitGroups.size() && n != 0; ++i)
   {
     uint64_t group = m_bitGroups[i];
-    uint32_t const bits = bits::PopCount(group);
+    uint32_t const bits = std::popcount(group);
     if (bits <= n)
     {
       n -= bits;
@@ -445,7 +445,7 @@ unique_ptr<CompressedBitVector> CompressedBitVectorBuilder::FromBitGroups(
   uint64_t const maxBit = kBlockSize * (bitGroups.size() - 1) + bits::FloorLog(bitGroups.back());
   uint64_t popCount = 0;
   for (size_t i = 0; i < bitGroups.size(); ++i)
-    popCount += bits::PopCount(bitGroups[i]);
+    popCount += std::popcount(bitGroups[i]);
 
   if (DenseEnough(popCount, maxBit))
     return DenseCBV::BuildFromBitGroups(std::move(bitGroups));


### PR DESCRIPTION
Also removed buggy PopCount for arrays (it fails starting from n = 32 bits)

It's a polished/fixed version of @meenbeese 's #9088 , thanks for the inspiration!

Closes #9607
Closes #9088