### PR TITLE
[core] [ios] [android] Raw track selection

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -931,13 +931,15 @@ Java_app_organicmaps_Framework_nativePlacePageActivationListener(JNIEnv *env, jc
     jni::TScopedLocalRef placePageDataRef(env, nullptr);
     if (info.IsTrack())
     {
-      auto const elevationInfo = frm()->GetBookmarkManager().MakeElevationInfo(info.GetTrackId());
-      placePageDataRef.reset(usermark_helper::CreateElevationInfo(env, elevationInfo));
+      // todo: (KK) implement elevation info handling for the proper track selection
+      auto const & track = frm()->GetBookmarkManager().GetTrack(info.GetTrackId());
+      auto const & elevationInfo = track->GetElevationInfo();
+      if (elevationInfo.has_value())
+        placePageDataRef.reset(usermark_helper::CreateElevationInfo(env, elevationInfo.value()));
     }
-    else
-    {
+    if (!placePageDataRef)
       placePageDataRef.reset(usermark_helper::CreateMapObject(env, info));
-    }
+
     env->CallVoidMethod(g_placePageActivationListener, activatedId, placePageDataRef.get());
   };
   auto const closePlacePage = [deactivateId]()

--- a/android/app/src/main/cpp/app/organicmaps/UserMarkHelper.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/UserMarkHelper.cpp
@@ -75,7 +75,7 @@ jobject CreateMapObject(JNIEnv * env, place_page::Info const & info, int mapObje
   jni::TScopedLocalRef jTitle(env, jni::ToJavaString(env, info.GetTitle()));
   jni::TScopedLocalRef jSecondaryTitle(env, jni::ToJavaString(env, info.GetSecondaryTitle()));
   jni::TScopedLocalRef jSubtitle(env, jni::ToJavaString(env, info.GetSubtitle()));
-  jni::TScopedLocalRef jAddress(env, jni::ToJavaString(env, info.GetAddress()));
+  jni::TScopedLocalRef jAddress(env, jni::ToJavaString(env, info.GetSecondarySubtitle()));
   jni::TScopedLocalRef jApiId(env, jni::ToJavaString(env, parseApi ? info.GetApiUrl() : ""));
   jni::TScopedLocalRef jWikiDescription(env, jni::ToJavaString(env, info.GetWikiDescription()));
   jobject mapObject =
@@ -119,7 +119,7 @@ jobject CreateBookmark(JNIEnv *env, const place_page::Info &info,
   jni::TScopedLocalRef jTitle(env, jni::ToJavaString(env, info.GetTitle()));
   jni::TScopedLocalRef jSecondaryTitle(env, jni::ToJavaString(env, info.GetSecondaryTitle()));
   jni::TScopedLocalRef jSubtitle(env, jni::ToJavaString(env, info.GetSubtitle()));
-  jni::TScopedLocalRef jAddress(env, jni::ToJavaString(env, info.GetAddress()));
+  jni::TScopedLocalRef jAddress(env, jni::ToJavaString(env, info.GetSecondarySubtitle()));
   jni::TScopedLocalRef jWikiDescription(env, jni::ToJavaString(env, info.GetWikiDescription()));
   jobject mapObject = env->NewObject(
           g_bookmarkClazz, ctorId, jFeatureId.get(), static_cast<jlong>(categoryId),
@@ -140,7 +140,7 @@ jobject CreateElevationPoint(JNIEnv * env, ElevationInfo::Point const & point)
   static jmethodID const pointCtorId =
       jni::GetConstructorID(env, pointClass, "(DI)V");
   return env->NewObject(pointClass, pointCtorId, static_cast<jdouble >(point.m_distance),
-                        static_cast<jint>(point.m_altitude));
+                        static_cast<jint>(point.m_point.GetAltitude()));
 }
 
 jobjectArray ToElevationPointArray(JNIEnv * env, ElevationInfo::Points const & points)
@@ -164,16 +164,14 @@ jobject CreateElevationInfo(JNIEnv * env, ElevationInfo const & info)
       jni::GetConstructorID(env, g_elevationInfoClazz, "(JLjava/lang/String;Ljava/lang/String;"
                                                        "[Lapp/organicmaps/bookmarks/data/ElevationInfo$Point;"
                                                        "IIIIIJ)V");
-  jni::TScopedLocalRef jName(env, jni::ToJavaString(env, info.GetName()));
   jni::TScopedLocalObjectArrayRef jPoints(env, ToElevationPointArray(env, info.GetPoints()));
-  return env->NewObject(g_elevationInfoClazz, ctorId, static_cast<jlong>(info.GetId()),
-                        jName.get(), jPoints.get(),
+  return env->NewObject(g_elevationInfoClazz, ctorId,
+                        jPoints.get(),
                         static_cast<jint>(info.GetAscent()),
                         static_cast<jint>(info.GetDescent()),
                         static_cast<jint>(info.GetMinAltitude()),
                         static_cast<jint>(info.GetMaxAltitude()),
-                        static_cast<jint>(info.GetDifficulty()),
-                        static_cast<jlong>(info.GetDuration()));
+                        static_cast<jint>(info.GetDifficulty()));
 }
 
 jobject CreateMapObject(JNIEnv * env, place_page::Info const & info)

--- a/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
@@ -900,6 +900,7 @@ Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeSetElevationActivePoin
 {
   auto & bm = frm()->GetBookmarkManager();
   bm.SetElevationActivePoint(static_cast<kml::TrackId>(trackId),
+                             {0,0}, // todo(KK): replace with coordinates from the elevation profile point to show selection mark on the track
                              static_cast<double>(distanceInMeters));
 }
 

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -831,7 +831,8 @@ static KmlFileType convertFileTypeToCore(MWMKmlFileType fileType) {
 }
 
 - (void)setElevationActivePoint:(double)distance trackId:(uint64_t)trackId {
-  self.bm.SetElevationActivePoint(trackId, distance);
+  // TODO: Pass correct coordinates to show mark point on the map
+  self.bm.SetElevationActivePoint(trackId, {0,0}, distance);
 }
 
 - (void)setElevationActivePointChanged:(uint64_t)trackId callback:(ElevationPointChangedBlock)callback {

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
@@ -103,7 +103,7 @@ NSString * GetLocalizedMetadataValueString(MapObject::MetadataID metaID, std::st
 
     _atm = rawData.HasAtm() ? NSLocalizedString(@"type.amenity.atm", nil) : nil;
 
-    _address = rawData.GetAddress().empty() ? nil : @(rawData.GetAddress().c_str());
+    _address = rawData.GetSecondarySubtitle().empty() ? nil : @(rawData.GetSecondarySubtitle().c_str());
     _coordFormats = @[@(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::LatLonDMS).c_str()),
                       @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::LatLonDecimal).c_str()),
                       @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::OLCFull).c_str()),

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePagePreviewData+Core.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePagePreviewData+Core.h
@@ -6,7 +6,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PlacePagePreviewData (Core)
 
-- (instancetype)initWithElevationInfo:(ElevationInfo const &)elevationInfo;
 - (instancetype)initWithRawData:(place_page::Info const &)rawData;
 
 @end

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePagePreviewData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePagePreviewData.mm
@@ -50,14 +50,6 @@ static PlacePageDataSchedule convertOpeningHours(std::string_view rawOH)
 
 @implementation PlacePagePreviewData (Core)
 
-- (instancetype)initWithElevationInfo:(ElevationInfo const &)elevationInfo {
-  self = [super init];
-  if (self) {
-     _title = @(elevationInfo.GetName().c_str());
-  }
-  return self;
-}
-
 - (instancetype)initWithRawData:(place_page::Info const &)rawData {
   self = [super init];
   if (self) {
@@ -65,7 +57,7 @@ static PlacePageDataSchedule convertOpeningHours(std::string_view rawOH)
     _secondaryTitle = rawData.GetSecondaryTitle().empty() ? nil : @(rawData.GetSecondaryTitle().c_str());
     _subtitle = rawData.GetSubtitle().empty() ? nil : @(rawData.GetSubtitle().c_str());
     _coordinates = @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::LatLonDMS).c_str());
-    _address = rawData.GetAddress().empty() ? nil : @(rawData.GetAddress().c_str());
+    _address = rawData.GetSecondarySubtitle().empty() ? nil : @(rawData.GetSecondarySubtitle().c_str());
     _isMyPosition = rawData.IsMyPosition();
     //_isPopular = rawData.GetPopularity() > 0;
     _schedule = convertOpeningHours(rawData.GetOpeningHours());

--- a/iphone/CoreApi/CoreApi/PlacePageData/ElevationProfile/ElevationProfileData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/ElevationProfile/ElevationProfileData.mm
@@ -25,17 +25,15 @@ static ElevationDifficulty convertDifficulty(uint8_t difficulty) {
                            myPosition:(double)myPosition {
   self = [super init];
   if (self) {
-    _trackId = elevationInfo.GetId();
     _ascent = elevationInfo.GetAscent();
     _descent = elevationInfo.GetDescent();
     _maxAttitude = elevationInfo.GetMaxAltitude();
     _minAttitude = elevationInfo.GetMinAltitude();
     _difficulty = convertDifficulty(elevationInfo.GetDifficulty());
-    _trackTime = elevationInfo.GetDuration();
     NSMutableArray *pointsArray = [NSMutableArray array];
     for (auto const &p : elevationInfo.GetPoints()) {
       ElevationHeightPoint *point = [[ElevationHeightPoint alloc] initWithDistance:p.m_distance
-                                                                       andAltitude:p.m_altitude];
+                                                                       andAltitude:p.m_point.GetAltitude()];
       [pointsArray addObject:point];
     }
     _points = [pointsArray copy];

--- a/iphone/CoreApi/CoreApi/PlacePageData/PlacePageData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/PlacePageData.mm
@@ -63,16 +63,10 @@ static PlacePageRoadType convertRoadType(RoadWarningMarkType roadType) {
     }
 
     if (rawData().IsTrack()) {
-      auto const &bm = GetFramework().GetBookmarkManager();
-      auto const &trackId = rawData().GetTrackId();
-      auto const &elevationInfo = bm.MakeElevationInfo(trackId);
-      _elevationProfileData = [[ElevationProfileData alloc] initWithElevationInfo:elevationInfo
-                                                                      activePoint:bm.GetElevationActivePoint(trackId)
-                                                                       myPosition:bm.GetElevationMyPosition(trackId)];
-      _previewData = [[PlacePagePreviewData alloc] initWithElevationInfo:elevationInfo];
-    } else {
-      _previewData = [[PlacePagePreviewData alloc] initWithRawData:rawData()];
+      // TODO: (KK) implement init with a track
+      _infoData = nil;
     }
+    _previewData = [[PlacePagePreviewData alloc] initWithRawData:rawData()];
 
     auto const &countryId = rawData().GetCountryId();
     if (!countryId.empty()) {

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -1073,8 +1073,7 @@ void BookmarkManager::OnTrackDeselected()
 
   auto es = GetEditSession();
   auto * trackSelectionMark = GetMarkForEdit<TrackSelectionMark>(markId);
-  auto const isVisible = IsVisible(GetTrack(m_selectedTrackId)->GetGroupId());
-  trackSelectionMark->SetIsVisible(isVisible);
+  trackSelectionMark->SetIsVisible(false);
 
   m_selectedTrackId = kml::kInvalidTrackId;
 }

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -812,15 +812,6 @@ std::string BookmarkManager::GetLocalizedRegionAddress(m2::PointD const & pt)
   return m_regionAddressGetter->GetLocalizedRegionAddress(pt);
 }
 
-ElevationInfo BookmarkManager::MakeElevationInfo(kml::TrackId trackId) const
-{
-  CHECK_THREAD_CHECKER(m_threadChecker, ());
-  auto const track = GetTrack(trackId);
-  CHECK(track != nullptr, ());
-
-  return ElevationInfo(*track);
-}
-
 void BookmarkManager::UpdateElevationMyPosition(kml::TrackId const & trackId)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -407,8 +407,6 @@ public:
   static std::string GetSortedByTimeBlockName(SortedByTimeBlockType blockType);
   std::string GetLocalizedRegionAddress(m2::PointD const & pt);
 
-  ElevationInfo MakeElevationInfo(kml::TrackId trackId) const;
-
   void SetElevationActivePoint(kml::TrackId const & trackId, double distanceInMeters);
   // Returns distance from the start of the track to active point in meters.
   double GetElevationActivePoint(kml::TrackId const & trackId) const;

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -407,7 +407,7 @@ public:
   static std::string GetSortedByTimeBlockName(SortedByTimeBlockType blockType);
   std::string GetLocalizedRegionAddress(m2::PointD const & pt);
 
-  void SetElevationActivePoint(kml::TrackId const & trackId, double distanceInMeters);
+  void SetElevationActivePoint(kml::TrackId const & trackId, m2::PointD pt, double distanceInMeters);
   // Returns distance from the start of the track to active point in meters.
   double GetElevationActivePoint(kml::TrackId const & trackId) const;
 
@@ -425,7 +425,6 @@ public:
   Track::TrackSelectionInfo GetTrackSelectionInfo(kml::TrackId const & trackId) const;
 
   void SetTrackSelectionInfo(Track::TrackSelectionInfo const & trackSelectionInfo, bool notifyListeners);
-  void SetDefaultTrackSelection(kml::TrackId trackId, bool showInfoSign);
   void OnTrackSelected(kml::TrackId trackId);
   void OnTrackDeselected();
 

--- a/map/elevation_info.cpp
+++ b/map/elevation_info.cpp
@@ -1,71 +1,57 @@
 #include "map/elevation_info.hpp"
 
+#include "base/logging.hpp"
+
 #include "geometry/mercator.hpp"
 
-#include "base/string_utils.hpp"
-
-namespace
+ElevationInfo::ElevationInfo(kml::MultiGeometry const & geometry)
 {
-static uint8_t constexpr kMaxDifficulty = ElevationInfo::Difficulty::Hard;
-
-std::string const kAscentKey = "ascent";
-std::string const kDescentKey = "descent";
-std::string const kLowestPointKey = "lowest_point";
-std::string const kHighestPointKey = "highest_point";
-std::string const kDifficultyKey = "difficulty";
-std::string const kDurationKey = "duration";
-
-template <typename T>
-void FillProperty(kml::Properties const & properties, std::string const & key, T & value)
-{
-  auto const it = properties.find(key);
-  if (it == properties.cend())
-    LOG(LERROR, ("Property not found for key:", key));
-  else
+  double distance = 0;
+  // Concatenate all segments.
+  for (size_t lineIndex = 0; lineIndex < geometry.m_lines.size(); ++lineIndex)
   {
-    if (!strings::to_any(it->second, value))
-      LOG(LERROR, ("Conversion is not possible for key", key, "string representation is", it->second));
+    auto const & line = geometry.m_lines[lineIndex];
+    if (line.empty())
+    {
+      LOG(LWARNING, ("Empty line in elevation info"));
+      continue;
+    }
+
+    if (lineIndex == 0)
+    {
+      m_minAltitude = line.front().GetAltitude();
+      m_maxAltitude = m_minAltitude;
+    }
+
+    if (lineIndex > 0)
+      m_segmentsDistances.emplace_back(distance);
+
+    for (size_t pointIndex = 0; pointIndex < line.size(); ++pointIndex)
+    {
+      auto const & currentPoint = line[pointIndex];
+      auto const & currentPointAltitude = currentPoint.GetAltitude();
+      if (currentPointAltitude < m_minAltitude)
+        m_minAltitude = currentPointAltitude;
+      if (currentPointAltitude > m_maxAltitude)
+        m_maxAltitude = currentPointAltitude;
+
+      if (pointIndex == 0)
+      {
+        m_points.emplace_back(currentPoint, distance);
+        continue;
+      }
+
+      auto const & previousPoint = line[pointIndex - 1];
+      distance += mercator::DistanceOnEarth(previousPoint.GetPoint(), currentPoint.GetPoint());
+      m_points.emplace_back(currentPoint, distance);
+
+      auto const deltaAltitude = currentPointAltitude - previousPoint.GetAltitude();
+      if (deltaAltitude > 0)
+        m_ascent += deltaAltitude;
+      else
+        m_descent -= deltaAltitude;
+    }
   }
-}
-}  // namespace
-
-ElevationInfo::ElevationInfo(Track const & track)
-  : m_id(track.GetId())
-  , m_name(track.GetName())
-{
-  // (Distance, Elevation) chart doesn't have a sence for multiple track's geometry.
-  auto const & points = track.GetSingleGeometry();
-  if (points.empty())
-    return;
-
-  m_points.reserve(points.size());
-  m_points.emplace_back(0, points[0].GetAltitude());
-  double distance = 0.0;
-  for (size_t i = 1; i < points.size(); ++i)
-  {
-    distance += mercator::DistanceOnEarth(points[i - 1].GetPoint(), points[i].GetPoint());
-    m_points.emplace_back(distance, points[i].GetAltitude());
-  }
-
-  auto const & properties = track.GetData().m_properties;
-
-  FillProperty(properties, kAscentKey, m_ascent);
-  FillProperty(properties, kDescentKey, m_descent);
-  FillProperty(properties, kLowestPointKey, m_minAltitude);
-  FillProperty(properties, kHighestPointKey, m_maxAltitude);
-
-  uint8_t difficulty;
-  FillProperty(properties, kDifficultyKey, difficulty);
-
-  if (difficulty > kMaxDifficulty)
-  {
-    LOG(LWARNING, ("Invalid difficulty value", m_difficulty, "in track", track.GetName()));
-    m_difficulty = Difficulty ::Unknown;
-  }
-  else
-  {
-    m_difficulty = static_cast<Difficulty>(difficulty);
-  }
-
-  FillProperty(properties, kDurationKey, m_duration);
+  /// @todo(KK) Implement difficulty calculation.
+  m_difficulty = Difficulty::Unknown;
 }

--- a/map/elevation_info.hpp
+++ b/map/elevation_info.hpp
@@ -1,28 +1,28 @@
 #pragma once
 
-#include "map/track.hpp"
+#include "kml/types.hpp"
 
 #include "geometry/point_with_altitude.hpp"
+#include "geometry/latlon.hpp"
 
 #include <cstdint>
 #include <string>
 #include <vector>
 
-class ElevationInfo
+struct ElevationInfo
 {
 public:
   struct Point
   {
-    Point(double distance, geometry::Altitude altitude)
-      : m_distance(distance), m_altitude(altitude)
-    {
-    }
-
-    double m_distance;
-    geometry::Altitude m_altitude;
+    Point(geometry::PointWithAltitude point, double distance)
+    : m_point(point), m_distance(distance)
+    {}
+    const geometry::PointWithAltitude m_point;
+    const double m_distance;
   };
 
   using Points = std::vector<Point>;
+  using SegmentsDistances = std::vector<double>;
 
   enum Difficulty : uint8_t
   {
@@ -33,35 +33,31 @@ public:
   };
 
   ElevationInfo() = default;
-  explicit ElevationInfo(Track const & track);
+  explicit ElevationInfo(kml::MultiGeometry const & geometry);
 
-  kml::TrackId GetId() const { return m_id; };
-  std::string const & GetName() const { return m_name; }
   size_t GetSize() const { return m_points.size(); };
   Points const & GetPoints() const { return m_points; };
-  uint16_t GetAscent() const { return m_ascent; }
-  uint16_t GetDescent() const { return m_descent; }
-  uint16_t GetMinAltitude() const { return m_minAltitude; }
-  uint16_t GetMaxAltitude() const { return m_maxAltitude; }
+  uint32_t GetAscent() const { return m_ascent; }
+  uint32_t GetDescent() const { return m_descent; }
+  geometry::Altitude GetMinAltitude() const { return m_minAltitude; }
+  geometry::Altitude GetMaxAltitude() const { return m_maxAltitude; }
   uint8_t GetDifficulty() const { return m_difficulty; }
-  uint32_t GetDuration() const { return m_duration; }
+  SegmentsDistances const & GetSegmentsDistances() const { return m_segmentsDistances; };
 
 private:
-  kml::TrackId m_id = kml::kInvalidTrackId;
-  std::string m_name;
   // Points with distance from start of the track and altitude.
   Points m_points;
   // Ascent in meters.
-  uint16_t m_ascent = 0;
+  uint32_t m_ascent = 0;
   // Descent in meters.
-  uint16_t m_descent = 0;
+  uint32_t m_descent = 0;
   // Altitude in meters.
-  uint16_t m_minAltitude = 0;
+  geometry::Altitude m_minAltitude = 0;
   // Altitude in meters.
-  uint16_t m_maxAltitude = 0;
+  geometry::Altitude m_maxAltitude = 0;
   // Some digital difficulty level with value in range [0-kMaxDifficulty]
   // or kInvalidDifficulty when difficulty is not found or incorrect.
   Difficulty m_difficulty = Difficulty::Unknown;
-  // Duration in seconds.
-  uint32_t m_duration = 0;
+  // Distances to the start of each segment.
+  SegmentsDistances m_segmentsDistances;
 };

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -657,7 +657,9 @@ void Framework::FillTrackInfo(Track const & track, m2::PointD const & trackPoint
 {
   info.SetTrackId(track.GetId());
   info.SetBookmarkCategoryId(track.GetGroupId());
+  info.SetBookmarkCategoryName(GetBookmarkManager().GetCategoryName(track.GetGroupId()));
   info.SetMercator(trackPoint);
+  info.SetTitlesForTrack(track);
 }
 
 search::ReverseGeocoder::Address Framework::GetAddressAtPoint(m2::PointD const & pt) const

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -885,20 +885,25 @@ void Framework::ShowTrack(kml::TrackId trackId)
 {
   auto & bm = GetBookmarkManager();
   auto const track = bm.GetTrack(trackId);
-  if (track == nullptr)
-    return;
+
+  StopLocationFollow();
 
   auto rect = track->GetLimitRect();
   ExpandRectForPreview(rect);
 
-  StopLocationFollow();
-  ShowRect(rect);
+  place_page::BuildInfo info;
+  info.m_trackId = trackId;
+  info.m_mercator = rect.Center();
 
-  auto es = GetBookmarkManager().GetEditSession();
+  m_currentPlacePageInfo = BuildPlacePageInfo(info);
+
+  auto es = bm.GetEditSession();
   es.SetIsVisible(track->GetGroupId(), true /* visible */);
 
-  if (track->IsInteractive())
-    bm.SetDefaultTrackSelection(trackId, true /* showInfoSign */);
+  if (m_drapeEngine)
+    m_drapeEngine->SetModelViewCenter(rect.Center(), scales::GetScaleLevel(rect), true /* isAnim */, true /* trackVisibleViewport */);
+
+  ActivateMapSelection();
 }
 
 void Framework::ShowBookmarkCategory(kml::MarkGroupId categoryId, bool animation)
@@ -915,15 +920,6 @@ void Framework::ShowBookmarkCategory(kml::MarkGroupId categoryId, bool animation
 
   auto es = bm.GetEditSession();
   es.SetIsVisible(categoryId, true /* visible */);
-
-  auto const & trackIds = bm.GetTrackIds(categoryId);
-  for (auto trackId : trackIds)
-  {
-    if (!bm.GetTrack(trackId)->IsInteractive())
-      continue;
-    bm.SetDefaultTrackSelection(trackId, true /* showInfoSign */);
-    break;
-  }
 }
 
 void Framework::ShowFeature(FeatureID const & featureId)
@@ -2229,11 +2225,22 @@ place_page::Info Framework::BuildPlacePageInfo(place_page::BuildInfo const & bui
   FeatureID selectedFeature = buildInfo.m_featureId;
   auto const isFeatureMatchingEnabled = buildInfo.IsFeatureMatchingEnabled();
 
+  // @TODO: (KK) Enable track selection.
+  // The isTrackSelectionEnabled should be removed to enable the track selection when the UI will be implemented.
+  const bool isTrackSelectionEnabled = false;
   // Using VisualParams inside FindTrackInTapPosition/GetDefaultTapRect requires drapeEngine.
-  if (m_drapeEngine != nullptr && buildInfo.IsTrackMatchingEnabled() &&
+  if (isTrackSelectionEnabled && m_drapeEngine != nullptr && buildInfo.IsTrackMatchingEnabled() &&
       !(isFeatureMatchingEnabled && selectedFeature.IsValid()))
   {
-    auto const trackSelectionInfo = FindTrackInTapPosition(buildInfo);
+    Track::TrackSelectionInfo trackSelectionInfo;
+    if (buildInfo.m_trackId != kml::kInvalidTrackId)
+    {
+      auto const & track = *GetBookmarkManager().GetTrack(buildInfo.m_trackId);
+      auto rect = track.GetLimitRect();
+      track.UpdateSelectionInfo(track.GetLimitRect(), trackSelectionInfo);
+    }
+    else
+      trackSelectionInfo = FindTrackInTapPosition(buildInfo);
     if (trackSelectionInfo.m_trackId != kml::kInvalidTrackId)
     {
       BuildTrackPlacePage(trackSelectionInfo, outInfo);

--- a/map/map_tests/CMakeLists.txt
+++ b/map/map_tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SRC
   search_api_tests.cpp
   transliteration_test.cpp
   working_time_tests.cpp
+  elevation_info_tests.cpp
 )
 
 omim_add_test(${PROJECT_NAME} ${SRC} REQUIRE_QT REQUIRE_SERVER)

--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -1155,7 +1155,7 @@ UNIT_CLASS_TEST(Runner, TrackParsingTest_1)
   for (auto const trackId : bmManager.GetTrackIds(catId))
   {
     auto const * track = bmManager.GetTrack(trackId);
-    auto const & geom = track->GetSingleGeometry();
+    auto const & geom = track->GetGeometry();
 
     TEST_EQUAL(geom[0].GetAltitude(), altitudes[i], ());
     TEST_EQUAL(names[i], track->GetName(), ());

--- a/map/map_tests/elevation_info_tests.cpp
+++ b/map/map_tests/elevation_info_tests.cpp
@@ -1,0 +1,136 @@
+#include "testing/testing.hpp"
+
+#include "map/elevation_info.hpp"
+
+#include "geometry/point_with_altitude.hpp"
+#include "geometry/mercator.hpp"
+
+#include "kml/types.hpp"
+
+namespace geometry
+{
+using namespace geometry;
+
+UNIT_TEST(ElevationInfo_EmptyMultiGeometry)
+{
+  ElevationInfo ei;
+  TEST_EQUAL(0, ei.GetSize(), ());
+  TEST_EQUAL(0, ei.GetAscent(), ());
+  TEST_EQUAL(0, ei.GetDescent(), ());
+  TEST_EQUAL(ei.GetMinAltitude(), kDefaultAltitudeMeters, ());
+  TEST_EQUAL(ei.GetMaxAltitude(), kDefaultAltitudeMeters, ());
+}
+
+UNIT_TEST(ElevationInfo_FromMultiGeometry)
+{
+  kml::MultiGeometry geometry;
+  auto const point1 = PointWithAltitude({0.0, 0.0}, 100);
+  auto const point2 = PointWithAltitude({1.0, 1.0}, 150);
+  auto const point3 = PointWithAltitude({2.0, 2.0}, 50);
+  geometry.AddLine({
+    point1,
+    point2,
+    point3
+  });
+  ElevationInfo ei(geometry);
+
+  TEST_EQUAL(3, ei.GetSize(), ());
+  TEST_EQUAL(ei.GetMinAltitude(), 50, ());
+  TEST_EQUAL(ei.GetMaxAltitude(), 150, ());
+  TEST_EQUAL(ei.GetAscent(), 50, ()); // Ascent from 100 -> 150
+  TEST_EQUAL(ei.GetDescent(), 100, ()); // Descent from 150 -> 50
+
+  double distance = 0;
+  TEST_EQUAL(ei.GetPoints()[0].m_distance, distance, ());
+  distance += mercator::DistanceOnEarth(point1, point2);
+  TEST_EQUAL(ei.GetPoints()[1].m_distance, distance, ());
+  distance += mercator::DistanceOnEarth(point2, point3);
+  TEST_EQUAL(ei.GetPoints()[2].m_distance, distance, ());
+}
+
+UNIT_TEST(ElevationInfo_NoAltitudePoints)
+{
+  kml::MultiGeometry geometry;
+  geometry.AddLine({
+    PointWithAltitude({0.0, 0.0}),
+    PointWithAltitude({1.0, 1.0}),
+    PointWithAltitude({2.0, 2.0})
+  });
+  ElevationInfo ei(geometry);
+
+  TEST_EQUAL(3, ei.GetSize(), ());
+  TEST_EQUAL(ei.GetMinAltitude(), kDefaultAltitudeMeters, ());
+  TEST_EQUAL(ei.GetMaxAltitude(), kDefaultAltitudeMeters, ());
+  TEST_EQUAL(ei.GetAscent(), 0, ());
+  TEST_EQUAL(ei.GetDescent(), 0, ());
+}
+
+UNIT_TEST(ElevationInfo_MultipleLines)
+{
+  kml::MultiGeometry geometry;
+  geometry.AddLine({
+    PointWithAltitude({0.0, 0.0}, 100),
+    PointWithAltitude({1.0, 1.0}, 150),
+    PointWithAltitude({1.0, 1.0}, 140)
+  });
+  geometry.AddLine({
+    PointWithAltitude({2.0, 2.0}, 50),
+    PointWithAltitude({3.0, 3.0}, 75),
+    PointWithAltitude({3.0, 3.0}, 60)
+  });
+  geometry.AddLine({
+    PointWithAltitude({4.0, 4.0}, 200),
+    PointWithAltitude({5.0, 5.0}, 250)
+  });
+  ElevationInfo ei(geometry);
+
+  TEST_EQUAL(8, ei.GetSize(), ());
+  TEST_EQUAL(ei.GetMinAltitude(), 50, ());
+  TEST_EQUAL(ei.GetMaxAltitude(), 250, ());
+  TEST_EQUAL(ei.GetAscent(), 125, ()); // Ascent from 100 -> 150, 50 -> 75, 200 -> 250
+  TEST_EQUAL(ei.GetDescent(), 25, ()); // Descent from 150 -> 140, 75 -> 60
+}
+
+UNIT_TEST(ElevationInfo_SegmentDistances)
+{
+  kml::MultiGeometry geometry;
+  geometry.AddLine({
+    geometry::PointWithAltitude({0.0, 0.0}),
+    geometry::PointWithAltitude({1.0, 0.0})
+  });
+  geometry.AddLine({
+    geometry::PointWithAltitude({2.0, 0.0}),
+    geometry::PointWithAltitude({3.0, 0.0})
+  });
+  geometry.AddLine({
+    geometry::PointWithAltitude({4.0, 0.0}),
+    geometry::PointWithAltitude({5.0, 0.0})
+  });
+
+  ElevationInfo ei(geometry);
+  auto const & segmentDistances = ei.GetSegmentsDistances();
+  auto const points = ei.GetPoints();
+
+  TEST_EQUAL(segmentDistances.size(), 2, ());
+  TEST_EQUAL(segmentDistances[0], ei.GetPoints()[2].m_distance, ());
+  TEST_EQUAL(segmentDistances[1], ei.GetPoints()[4].m_distance, ());
+}
+
+UNIT_TEST(ElevationInfo_PositiveAndNegativeAltitudes)
+{
+  kml::MultiGeometry geometry;
+  geometry.AddLine({
+    PointWithAltitude({0.0, 0.0}, -10),
+    PointWithAltitude({1.0, 1.0}, 20),
+    PointWithAltitude({2.0, 2.0}, -5),
+    PointWithAltitude({3.0, 3.0}, 15)
+  });
+  ElevationInfo ei(geometry);
+
+  TEST_EQUAL(4, ei.GetSize(), ());
+  TEST_EQUAL(ei.GetMinAltitude(), -10, ());
+  TEST_EQUAL(ei.GetMaxAltitude(), 20, ());
+  TEST_EQUAL(ei.GetAscent(), 50, ()); // Ascent from -10 -> 20 and -5 -> 15
+  TEST_EQUAL(ei.GetDescent(), 25, ()); // Descent from 20 -> -5
+}
+} // namespace geometry

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -10,6 +10,8 @@
 #include "platform/measurement_utils.hpp"
 #include "platform/preferred_languages.hpp"
 #include "platform/utm_mgrs_utils.hpp"
+#include "platform/distance.hpp"
+#include "platform/duration.hpp"
 
 #include "geometry/mercator.hpp"
 
@@ -244,6 +246,20 @@ void Info::SetCustomName(std::string const & name)
     m_uiTitle = name;
 
   m_customName = name;
+}
+
+void Info::SetTitlesForTrack(Track const & track)
+{
+  m_uiTitle = track.GetName();
+  m_uiSubtitle = m_bookmarkCategoryName;
+
+  std::vector<std::string> statistics;
+  auto const length = track.GetLengthMeters();
+  auto const duration = track.GetDurationInSeconds();
+  statistics.push_back(platform::Distance::CreateFormatted(length).ToString());
+  if (duration > 0)
+    statistics.push_back(platform::Duration(duration).GetPlatformLocalizedString());
+  m_uiTrackStatistics = strings::JoinStrings(statistics, feature::kFieldsSeparator);
 }
 
 void Info::SetCustomNames(std::string const & title, std::string const & subtitle)

--- a/map/place_page_info.hpp
+++ b/map/place_page_info.hpp
@@ -133,7 +133,7 @@ public:
   std::string const & GetSecondaryTitle() const { return m_uiSecondaryTitle; };
   /// Convenient wrapper for type, cuisines, elevation, stars, wifi etc.
   std::string const & GetSubtitle() const { return m_uiSubtitle; };
-  std::string const & GetAddress() const { return m_uiAddress; }
+  std::string const & GetSecondarySubtitle() const { return !m_uiTrackStatistics.empty() ? m_uiTrackStatistics : m_uiAddress; };
   std::string const & GetWikiDescription() const { return m_description; }
   /// @returns coordinate in DMS format if isDMS is true
   std::string GetFormattedCoordinate(CoordinatesFormat format) const;
@@ -141,6 +141,7 @@ public:
   /// UI setters
   void SetCustomName(std::string const & name);
   void SetTitlesForBookmark();
+  void SetTitlesForTrack(Track const & track);
   void SetCustomNames(std::string const & title, std::string const & subtitle);
   void SetCustomNameWithCoordinates(m2::PointD const & mercator, std::string const & name);
   void SetAddress(std::string && address) { m_address = std::move(address); }
@@ -227,6 +228,7 @@ private:
   std::string m_uiSubtitle;
   std::string m_uiSecondaryTitle;
   std::string m_uiAddress;
+  std::string m_uiTrackStatistics;
   std::string m_description;
   /// Booking rating string
   std::string m_localizedRatingString;

--- a/map/track.hpp
+++ b/map/track.hpp
@@ -11,6 +11,7 @@
 class Track : public df::UserLineMark
 {
   using Base = df::UserLineMark;
+  using Lengths = std::vector<double>;
 
 public:
   Track(kml::TrackData && data);
@@ -66,20 +67,16 @@ public:
 
   bool GetPoint(double distanceInMeters, m2::PointD & pt) const;
 
-  /// @name This functions are valid only for the single line geometry.
-  /// @{
   kml::MultiGeometry::LineT GetGeometry() const;
-
   bool HasAltitudes() const;
 
 private:
-  std::vector<double> GetLengthsImpl() const;
-  /// @}
+  std::vector<Lengths> GetLengthsImpl() const;
   m2::RectD GetLimitRectImpl() const;
 
   void CacheDataForInteraction() const;
 
-  double GetLengthMetersImpl(kml::MultiGeometry::LineT const & line, size_t ptIdx) const;
+  double GetLengthMetersImpl(size_t lineIndex, size_t ptIdx) const;
 
   kml::TrackData m_data;
   kml::MarkGroupId m_groupID = kml::kInvalidMarkGroupId;
@@ -87,7 +84,7 @@ private:
 
   struct InteractionData
   {
-    std::vector<double> m_lengths;
+    std::vector<Lengths> m_lengths;
     m2::RectD m_limitRect;
   };
   mutable std::optional<InteractionData> m_interactionData;

--- a/map/track.hpp
+++ b/map/track.hpp
@@ -2,6 +2,8 @@
 
 #include "kml/types.hpp"
 
+#include "map/elevation_info.hpp"
+
 #include "drape_frontend/user_marks_provider.hpp"
 
 #include <string>
@@ -11,7 +13,7 @@ class Track : public df::UserLineMark
   using Base = df::UserLineMark;
 
 public:
-  Track(kml::TrackData && data, bool interactive);
+  Track(kml::TrackData && data);
 
   kml::MarkGroupId GetGroupId() const override { return m_groupID; }
 
@@ -27,8 +29,8 @@ public:
 
   m2::RectD GetLimitRect() const;
   double GetLengthMeters() const;
-  bool IsInteractive() const;
-
+  double GetDurationInSeconds() const;
+  std::optional<ElevationInfo> GetElevationInfo() const;
   std::pair<m2::PointD, double> GetCenterPoint() const;
 
   struct TrackSelectionInfo
@@ -66,26 +68,29 @@ public:
 
   /// @name This functions are valid only for the single line geometry.
   /// @{
-  kml::MultiGeometry::LineT const & GetSingleGeometry() const;
+  kml::MultiGeometry::LineT GetGeometry() const;
+
+  bool HasAltitudes() const;
+
 private:
   std::vector<double> GetLengthsImpl() const;
   /// @}
   m2::RectD GetLimitRectImpl() const;
 
-  void CacheDataForInteraction();
-  bool HasAltitudes() const;
+  void CacheDataForInteraction() const;
 
   double GetLengthMetersImpl(kml::MultiGeometry::LineT const & line, size_t ptIdx) const;
 
   kml::TrackData m_data;
   kml::MarkGroupId m_groupID = kml::kInvalidMarkGroupId;
+  mutable std::optional<ElevationInfo> m_elevationInfo;
 
   struct InteractionData
   {
     std::vector<double> m_lengths;
     m2::RectD m_limitRect;
   };
-  std::optional<InteractionData> m_interactionData;
+  mutable std::optional<InteractionData> m_interactionData;
 
   mutable bool m_isDirty = true;
 };

--- a/xcode/map/map.xcodeproj/project.pbxproj
+++ b/xcode/map/map.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		BBD9E2C71EE9D01900DF189A /* routing_mark.hpp in Headers */ = {isa = PBXBuildFile; fileRef = BBD9E2C51EE9D01900DF189A /* routing_mark.hpp */; };
 		BBFC7E3A202D29C000531BE7 /* user_mark_layer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BBFC7E38202D29BF00531BE7 /* user_mark_layer.cpp */; };
 		BBFC7E3B202D29C000531BE7 /* user_mark_layer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = BBFC7E39202D29BF00531BE7 /* user_mark_layer.hpp */; };
+		ED49D74C2CEF3D69004AF27E /* elevation_info_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ED49D74B2CEF3CE3004AF27E /* elevation_info_tests.cpp */; };
 		F6B283031C1B03320081957A /* gps_track_collection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6B282FB1C1B03320081957A /* gps_track_collection.cpp */; };
 		F6B283041C1B03320081957A /* gps_track_collection.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F6B282FC1C1B03320081957A /* gps_track_collection.hpp */; };
 		F6B283051C1B03320081957A /* gps_track_filter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6B282FD1C1B03320081957A /* gps_track_filter.cpp */; };
@@ -238,6 +239,7 @@
 		BBD9E2C51EE9D01900DF189A /* routing_mark.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = routing_mark.hpp; sourceTree = "<group>"; };
 		BBFC7E38202D29BF00531BE7 /* user_mark_layer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = user_mark_layer.cpp; sourceTree = "<group>"; };
 		BBFC7E39202D29BF00531BE7 /* user_mark_layer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = user_mark_layer.hpp; sourceTree = "<group>"; };
+		ED49D74B2CEF3CE3004AF27E /* elevation_info_tests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = elevation_info_tests.cpp; sourceTree = "<group>"; };
 		F6B282FB1C1B03320081957A /* gps_track_collection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gps_track_collection.cpp; sourceTree = "<group>"; };
 		F6B282FC1C1B03320081957A /* gps_track_collection.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = gps_track_collection.hpp; sourceTree = "<group>"; };
 		F6B282FD1C1B03320081957A /* gps_track_filter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gps_track_filter.cpp; sourceTree = "<group>"; };
@@ -352,6 +354,7 @@
 				674A29EE1B26FD5F001A525C /* testingmain.cpp */,
 				BB421D6A1E8C0026005BFA4D /* transliteration_test.cpp */,
 				674A2A351B27011A001A525C /* working_time_tests.cpp */,
+				ED49D74B2CEF3CE3004AF27E /* elevation_info_tests.cpp */,
 			);
 			name = map_tests;
 			path = ../../map/map_tests;
@@ -643,6 +646,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				671ED38E20D403B300D4317E /* chart_generator_tests.cpp in Sources */,
+				ED49D74C2CEF3D69004AF27E /* elevation_info_tests.cpp in Sources */,
 				67F183761BD5045700AB1840 /* bookmarks_test.cpp in Sources */,
 				FAA8387626BB3C17002E54C6 /* extrapolator_tests.cpp in Sources */,
 				BB421D6C1E8C0031005BFA4D /* transliteration_test.cpp in Sources */,


### PR DESCRIPTION
This PR:
1. Refactors the `Track`  
1.1. Add the `ElevationProfile` to the `Track`.
1.2. Remove the `interactive` property from the `Track` constructor and `IsInteractive` method because all the tracks should be interactive regardless of whether they have altitudes or not. 
The _old implementation_ doesn't allow to make track interactive during the initialization by passing false to the `IsInteractive` when there is no elevation data in the mwm data file (always)
https://github.com/organicmaps/organicmaps/blob/bbb32ef24f94357691ef7e6347f1e77e95ca9685/map/bookmark_manager.cpp#L2830-L2832
that prevents the interaction data caching:
https://github.com/organicmaps/organicmaps/blob/bbb32ef24f94357691ef7e6347f1e77e95ca9685/map/track.cpp#L65-L73
and because of the `m_interactionData` has never been initialized the `IsInterative` always returns `false` - it blocks all the tracks selection
https://github.com/organicmaps/organicmaps/blob/bbb32ef24f94357691ef7e6347f1e77e95ca9685/map/track.cpp#L175-L178
1.3. Caching of `len` and `rect` will be called only when PP is building and will not be called for showing the track/group in the map/ lengths for the BM list
1.4. Ele profile will be calculated only during the PP info building and caching
1.5. `GetDurationInSeconds` is added  to pass to the PP header
1.6. Fix `SetElevationActivePoint` and remove the `GetTrackPoint`. It allows passing the `track selection point` directly to the core (the old solution was to calculate the point coordinates based on the distance - it is quite expensive and complex logic because the mark's coordinates calculation may be called frequently when the user drags the chart view).

2. Refactor the `ElevtionProfile`
2.1. Filling with data properties is removed because there is no such data in the mwm file for tracks (at least for now)
2.2. The elevation profile can only be initialized with the `MultiGeometry` because the profile shouldn't know anything else except the coordinates points and altitudes.
2.3. Data for the elevation profile is calculated as a concatenation of all geometry segments (not the 1st one as in the old implementation - see the old method in track.cpp - `GetSingleGeometry` which was used to get the 1st line)
https://github.com/organicmaps/organicmaps/blob/5eef1ef00d2aee1e92b3520c061eeb0e3aab8f4e/map/elevation_info.cpp#L36-L39

3. Fill the PP header with Track's info (title + list name + length + duration)

~~This PR enables the track selection but doesn't contain any specific UI for iOS and Android. Only the warning fixes - see todos.~~

This PR disables the track selection.
The track selection should be enabled for ios and android as the the UI will be ready separately.

## TODO:
- [x] https://github.com/organicmaps/organicmaps/pull/9610 should be merged first
- [ ] Fix Android UI to remove the `coordinates`, `open in`, `save`, 'share button`, and any other bookmark-specific buttons (see screenshots) from the screen (should be implemented in separate PR).
- [x] iOS UI with elevation profile is ready and the PR is coming soon (should be implemented in separate PR).


### The screenshots are not valid because the track selection isn't enabled here.

<img width="302" alt="image" src="https://github.com/user-attachments/assets/f4a6a860-b1fa-4e6c-af00-3c87405c38bf">
<img width="299" alt="image" src="https://github.com/user-attachments/assets/a93c6734-5d5d-4ab3-b311-da02bf69b655">
<img width="467" alt="image" src="https://github.com/user-attachments/assets/b53612cf-1ac3-4406-af4c-03508191c6f6">