### PR TITLE
Warning fixes

### DIFF
--- a/drape_frontend/read_manager.cpp
+++ b/drape_frontend/read_manager.cpp
@@ -49,11 +49,11 @@ ReadManager::ReadManager(ref_ptr<ThreadsCommutator> commutator, MapDataProvider 
   , m_trafficEnabled(trafficEnabled)
   , m_isolinesEnabled(isolinesEnabled)
   , m_modeChanged(false)
+  , m_mapLangIndex(StringUtf8Multilang::kDefaultCode)
   , m_tasksPool(64, ReadMWMTaskFactory(m_model))
   , m_counter(0)
   , m_generationCounter(0)
   , m_userMarksGenerationCounter(0)
-  , m_mapLangIndex(StringUtf8Multilang::kDefaultCode)
 {
   Start();
 }

--- a/editor/editor_tests/osm_editor_test.cpp
+++ b/editor/editor_tests/osm_editor_test.cpp
@@ -246,7 +246,7 @@ void EditorTest::GetFeatureTypeInfoTest()
 
     auto const featuresAfter = editor.m_features.Get();
     auto const fti = editor.GetFeatureTypeInfo(*featuresAfter, ft.GetID().m_mwmId, ft.GetID().m_index);
-    TEST_NOT_EQUAL(fti, 0, ());
+    TEST_NOT_EQUAL(fti, nullptr, ());
     TEST_EQUAL(fti->m_object.GetID(), ft.GetID(), ());
   });
 }

--- a/generator/camera_info_collector.cpp
+++ b/generator/camera_info_collector.cpp
@@ -226,7 +226,7 @@ void CamerasInfoCollector::Camera::FindClosestSegmentWithGeometryIndex(FrozenDat
     auto const & p1 = polyline.GetPolyline().GetPoint(curSegment.m_ind);
     auto const & p2 = polyline.GetPolyline().GetPoint(curSegment.m_ind + 1);
 
-    if (AlmostEqualAbs(p1, p2, kEps))
+    if (base::AlmostEqualAbs(p1, p2, kEps))
       return;
 
     m2::ParametrizedSegment<m2::PointD> st(p1, p2);
@@ -270,7 +270,7 @@ std::optional<std::pair<double, uint32_t>> CamerasInfoCollector::Camera::FindMys
       if (found)
         return;
 
-      if (AlmostEqualAbs(m_data.m_center, pt, kCoordEqualityEps))
+      if (base::AlmostEqualAbs(m_data.m_center, pt, kCoordEqualityEps))
         found = true;
       else
         ++result;

--- a/generator/feature_helpers.hpp
+++ b/generator/feature_helpers.hpp
@@ -56,7 +56,7 @@ inline bool ArePointsEqual(Point const & p1, Point const & p2)
 template <>
 inline bool ArePointsEqual<m2::PointD>(m2::PointD const & p1, m2::PointD const & p2)
 {
-  return AlmostEqualULPs(p1, p2);
+  return base::AlmostEqualULPs(p1, p2);
 }
 
 class DistanceToSegmentWithRectBounds

--- a/generator/generator_tests/collector_boundary_postcode_tests.cpp
+++ b/generator/generator_tests/collector_boundary_postcode_tests.cpp
@@ -126,7 +126,7 @@ bool CheckPostcodeExists(unordered_map<string, vector<m2::PointD>> const & data,
 
   for (size_t i = 0; i < geometry.size(); ++i)
   {
-    if (!m2::AlmostEqualAbs(geometry[i], it->second[i], kMwmPointAccuracy))
+    if (!base::AlmostEqualAbs(geometry[i], it->second[i], kMwmPointAccuracy))
       return false;
   }
 

--- a/generator/generator_tests/collector_routing_city_boundaries_tests.cpp
+++ b/generator/generator_tests/collector_routing_city_boundaries_tests.cpp
@@ -123,7 +123,7 @@ bool CheckPolygonExistance(std::vector<std::vector<m2::PointD>> const & polygons
 
     for (size_t i = 0; i < polygon.size(); ++i)
     {
-      if (!m2::AlmostEqualAbs(polygon[i], polygonToFind[i], 1e-6))
+      if (!base::AlmostEqualAbs(polygon[i], polygonToFind[i], 1e-6))
       {
         same = false;
         break;

--- a/generator/generator_tests/mini_roundabout_tests.cpp
+++ b/generator/generator_tests/mini_roundabout_tests.cpp
@@ -55,7 +55,7 @@ void TestRunCmpPoints(std::vector<m2::PointD> const & pointsFact,
   TEST_EQUAL(pointsFact.size(), pointsPlan.size(), ());
   TEST_GREATER(pointsFact.size(), 2, ());
   for (size_t i = 0; i < pointsFact.size(); ++i)
-    TEST(m2::AlmostEqualAbs(pointsFact[i], pointsPlan[i], kMwmPointAccuracy), ());
+    TEST(base::AlmostEqualAbs(pointsFact[i], pointsPlan[i], kMwmPointAccuracy), ());
 }
 
 void TestRunCmpNumbers(double val1, double val2)
@@ -97,7 +97,7 @@ UNIT_TEST(TrimSegment_Vertical)
   double const dist = 1.0;
   m2::PointD const point = GetPointAtDistFromTarget(a /* source */, b /* target */, dist);
   m2::PointD const pointPlan(2.0, 2.0);
-  TEST(m2::AlmostEqualAbs(point, pointPlan, kMwmPointAccuracy), ());
+  TEST(base::AlmostEqualAbs(point, pointPlan, kMwmPointAccuracy), ());
 }
 
 UNIT_TEST(TrimSegment_VerticalNegative)
@@ -107,7 +107,7 @@ UNIT_TEST(TrimSegment_VerticalNegative)
   double const dist = 4.0;
   m2::PointD const point = GetPointAtDistFromTarget(a /* source */, b /* target */, dist);
   m2::PointD const pointPlan(-3.0, 2.0);
-  TEST(m2::AlmostEqualAbs(point, pointPlan, kMwmPointAccuracy), ());
+  TEST(base::AlmostEqualAbs(point, pointPlan, kMwmPointAccuracy), ());
 }
 
 UNIT_TEST(TrimSegment_ExceptionalCase)
@@ -116,7 +116,7 @@ UNIT_TEST(TrimSegment_ExceptionalCase)
   m2::PointD const b(2.0, 3.0);
   double const dist = 10.0;
   m2::PointD const point = GetPointAtDistFromTarget(a /* source */, b /* target */, dist);
-  TEST(m2::AlmostEqualAbs(point, a, kMwmPointAccuracy), ());
+  TEST(base::AlmostEqualAbs(point, a, kMwmPointAccuracy), ());
 }
 
 UNIT_TEST(PointToCircle_ZeroMeridian)

--- a/generator/generator_tests/raw_generator_test.cpp
+++ b/generator/generator_tests/raw_generator_test.cpp
@@ -928,7 +928,7 @@ UNIT_TEST(MiniRoundabout_Connectivity)
     {
       for (auto const & p : roundabout)
       {
-        if (m2::AlmostEqualAbs(p, pt, kMwmPointAccuracy))
+        if (base::AlmostEqualAbs(p, pt, kMwmPointAccuracy))
           return true;
       }
       return false;

--- a/generator/mini_roundabout_transformer.cpp
+++ b/generator/mini_roundabout_transformer.cpp
@@ -46,7 +46,7 @@ feature::FeatureBuilder::PointSeq::iterator GetIterOnRoad(m2::PointD const & poi
 {
   return std::find_if(road.begin(), road.end(), [&point](m2::PointD const & pointOnRoad)
   {
-    return m2::AlmostEqualAbs(pointOnRoad, point, kMwmPointAccuracy);
+    return base::AlmostEqualAbs(pointOnRoad, point, kMwmPointAccuracy);
   });
 }
 } // namespace
@@ -149,7 +149,7 @@ MiniRoundaboutTransformer::PointsT MiniRoundaboutTransformer::CreateSurrogateRoa
       *itPointOnSurrogateRoad /* source */, roundaboutOnRoad.m_location /* target */,
       m_radiusMercator /* dist */);
 
-  if (m2::AlmostEqualAbs(nextPointOnSurrogateRoad, *itPointOnSurrogateRoad, kMwmPointAccuracy))
+  if (base::AlmostEqualAbs(nextPointOnSurrogateRoad, *itPointOnSurrogateRoad, kMwmPointAccuracy))
     return {};
 
   AddPointToCircle(roundaboutCircle, nextPointOnSurrogateRoad);
@@ -174,7 +174,7 @@ bool MiniRoundaboutTransformer::AddRoundaboutToRoad(RoundaboutUnit const & round
       GetPointAtDistFromTarget(*itPointNearRoundabout /* source */, roundaboutCenter /* target */,
                                m_radiusMercator /* dist */);
 
-  if (isMiddlePoint && !m2::AlmostEqualAbs(nextPointOnRoad, *itPointNearRoundabout, kMwmPointAccuracy))
+  if (isMiddlePoint && !base::AlmostEqualAbs(nextPointOnRoad, *itPointNearRoundabout, kMwmPointAccuracy))
   {
     auto surrogateRoad = CreateSurrogateRoad(roundaboutOnRoad, roundaboutCircle, road, itPointUpd);
     if (surrogateRoad.size() < 2)

--- a/geometry/calipers_box.cpp
+++ b/geometry/calipers_box.cpp
@@ -151,7 +151,7 @@ bool CalipersBox::HasPoint(PointD const & p, double eps) const
   case 0:
     return false;
   case 1:
-    return AlmostEqualAbs(m_points[0], p, eps);
+    return base::AlmostEqualAbs(m_points[0], p, eps);
   case 2:
     return IsPointOnSegmentEps(p, m_points[0], m_points[1], eps);
   }

--- a/geometry/geometry_tests/bounding_box_tests.cpp
+++ b/geometry/geometry_tests/bounding_box_tests.cpp
@@ -1,23 +1,20 @@
 #include "testing/testing.hpp"
 
 #include "geometry/bounding_box.hpp"
-#include "geometry/point2d.hpp"
 
-using namespace m2;
-
-namespace
+namespace bounding_box_tests
 {
 UNIT_TEST(BoundingBox_Smoke)
 {
   {
-    BoundingBox bbox;
+    m2::BoundingBox bbox;
 
     TEST(!bbox.HasPoint(0, 0), ());
     TEST(!bbox.HasPoint(-1, 1), ());
   }
 
   {
-    BoundingBox bbox;
+    m2::BoundingBox bbox;
 
     bbox.Add(0, 0);
     TEST(bbox.HasPoint(0, 0), ());
@@ -33,4 +30,4 @@ UNIT_TEST(BoundingBox_Smoke)
     TEST(bbox.HasPoint(0.5, 0.5), ());
   }
 }
-}  // namespace
+}  // namespace bounding_box_tests

--- a/geometry/geometry_tests/diamond_box_tests.cpp
+++ b/geometry/geometry_tests/diamond_box_tests.cpp
@@ -1,21 +1,18 @@
 #include "testing/testing.hpp"
 
 #include "geometry/diamond_box.hpp"
-#include "geometry/point2d.hpp"
 
-using namespace m2;
-
-namespace
+namespace diamond_box_tests
 {
 UNIT_TEST(DiamondBox_Smoke)
 {
   {
-    DiamondBox dbox;
+    m2::DiamondBox dbox;
     TEST(!dbox.HasPoint(0, 0), ());
   }
 
   {
-    DiamondBox dbox;
+    m2::DiamondBox dbox;
     dbox.Add(0, 0);
     TEST(dbox.HasPoint(0, 0), ());
     TEST(!dbox.HasPoint(0, 1), ());
@@ -32,7 +29,7 @@ UNIT_TEST(DiamondBox_Smoke)
   }
 
   {
-    DiamondBox dbox;
+    m2::DiamondBox dbox;
 
     dbox.Add(0, 1);
     dbox.Add(0, -1);
@@ -50,4 +47,4 @@ UNIT_TEST(DiamondBox_Smoke)
     TEST(!dbox.HasPoint(-0.51, -0.51), ());
   }
 }
-}  // namespace
+}  // namespace diamond_box_tests

--- a/geometry/geometry_tests/line2d_tests.cpp
+++ b/geometry/geometry_tests/line2d_tests.cpp
@@ -42,7 +42,7 @@ UNIT_TEST(LineIntersection_Smoke)
     Line2D const rhs(Segment2D(PointD(-10, 0), PointD(-9, 10)));
     auto const result = Intersect(lhs, rhs);
     TEST_EQUAL(result.m_type, Type::One, ());
-    TEST(AlmostEqualAbs(result.m_point, PointD(0, 100), kEps), (result.m_point));
+    TEST(base::AlmostEqualAbs(result.m_point, PointD(0, 100), kEps), (result.m_point));
   }
 }
 }  // namespace line2d_tests

--- a/geometry/geometry_tests/parametrized_segment_tests.cpp
+++ b/geometry/geometry_tests/parametrized_segment_tests.cpp
@@ -53,17 +53,17 @@ UNIT_TEST(ParametrizedSegment2D_DegenerateSection)
 UNIT_TEST(ParametrizedSegment2D_ClosestPoint)
 {
   using P = m2::PointD;
- 
+
   P arr[][4] =
   {
     { P(3, 4), P(0, 0), P(10, 0), P(3, 0) },
     { P(3, 4), P(0, 0), P(0, 10), P(0, 4) },
- 
+
     { P(3, 5), P(2, 2), P(5, 5), P(4, 4) },
     { P(5, 3), P(2, 2), P(5, 5), P(4, 4) },
     { P(2, 4), P(2, 2), P(5, 5), P(3, 3) },
     { P(4, 2), P(2, 2), P(5, 5), P(3, 3) },
- 
+
     { P(5, 6), P(2, 2), P(5, 5), P(5, 5) },
     { P(1, 0), P(2, 2), P(5, 5), P(2, 2) }
   };
@@ -71,6 +71,6 @@ UNIT_TEST(ParametrizedSegment2D_ClosestPoint)
   for (size_t i = 0; i < ARRAY_SIZE(arr); ++i)
   {
     m2::ParametrizedSegment<P> segment(arr[i][1], arr[i][2]);
-    TEST(m2::AlmostEqualULPs(segment.ClosestPointTo(arr[i][0]), arr[i][3]), (i));
+    TEST(base::AlmostEqualULPs(segment.ClosestPointTo(arr[i][0]), arr[i][3]), (i));
   }
 }

--- a/geometry/geometry_tests/point_test.cpp
+++ b/geometry/geometry_tests/point_test.cpp
@@ -66,32 +66,32 @@ UNIT_TEST(GetArrowPoints)
 {
   std::array<m2::PointF, 3> arrPntsFlt;
   m2::GetArrowPoints(m2::PointF(0, 0), m2::PointF(1, 0), 1.f, 1.f, arrPntsFlt);
-  TEST(m2::AlmostEqualULPs(arrPntsFlt[0], m2::PointF(1.f, 1.f)), ());
-  TEST(m2::AlmostEqualULPs(arrPntsFlt[1], m2::PointF(2.f, 0.f)), ());
-  TEST(m2::AlmostEqualULPs(arrPntsFlt[2], m2::PointF(1.f, -1.f)), ());
+  TEST(base::AlmostEqualULPs(arrPntsFlt[0], m2::PointF(1.f, 1.f)), ());
+  TEST(base::AlmostEqualULPs(arrPntsFlt[1], m2::PointF(2.f, 0.f)), ());
+  TEST(base::AlmostEqualULPs(arrPntsFlt[2], m2::PointF(1.f, -1.f)), ());
 
   std::array<m2::PointD, 3> arrPntsDbl;
   m2::GetArrowPoints(m2::PointD(-1., 2.), m2::PointD(-1., 100.), 2., 5., arrPntsDbl);
-  TEST(m2::AlmostEqualULPs(arrPntsDbl[0], m2::PointD(-3.f, 100.f)), ());
-  TEST(m2::AlmostEqualULPs(arrPntsDbl[1], m2::PointD(-1.f, 105.f)), ());
-  TEST(m2::AlmostEqualULPs(arrPntsDbl[2], m2::PointD(1.f, 100.f)), ());
+  TEST(base::AlmostEqualULPs(arrPntsDbl[0], m2::PointD(-3.f, 100.f)), ());
+  TEST(base::AlmostEqualULPs(arrPntsDbl[1], m2::PointD(-1.f, 105.f)), ());
+  TEST(base::AlmostEqualULPs(arrPntsDbl[2], m2::PointD(1.f, 100.f)), ());
 }
 
 UNIT_TEST(PointAtSegment)
 {
-  TEST(m2::AlmostEqualULPs(m2::PointAtSegment(m2::PointF(0, 0), m2::PointF(1, 0), 0.5f),
+  TEST(base::AlmostEqualULPs(m2::PointAtSegment(m2::PointF(0, 0), m2::PointF(1, 0), 0.5f),
                            m2::PointF(0.5f, 0.f)),
        ());
-  TEST(m2::AlmostEqualULPs(m2::PointAtSegment(m2::PointF(0, 0), m2::PointF(0, 1), 0.3f),
+  TEST(base::AlmostEqualULPs(m2::PointAtSegment(m2::PointF(0, 0), m2::PointF(0, 1), 0.3f),
                            m2::PointF(0.f, 0.3f)),
        ());
-  TEST(m2::AlmostEqualULPs(m2::PointAtSegment(m2::PointD(0., 0.), m2::PointD(30., 40.), 5.),
+  TEST(base::AlmostEqualULPs(m2::PointAtSegment(m2::PointD(0., 0.), m2::PointD(30., 40.), 5.),
                            m2::PointD(3., 4.)),
        ());
-  TEST(m2::AlmostEqualULPs(m2::PointAtSegment(m2::PointF(-3, -4), m2::PointF(-30, -40), 5.f),
+  TEST(base::AlmostEqualULPs(m2::PointAtSegment(m2::PointF(-3, -4), m2::PointF(-30, -40), 5.f),
                            m2::PointF(-6.f, -8.f)),
        ());
-  TEST(m2::AlmostEqualULPs(m2::PointAtSegment(m2::PointD(14., -48.), m2::PointD(70., -240.), 25.),
+  TEST(base::AlmostEqualULPs(m2::PointAtSegment(m2::PointD(14., -48.), m2::PointD(70., -240.), 25.),
                            m2::PointD(21., -72.)),
        ());
 }

--- a/geometry/geometry_tests/robust_test.cpp
+++ b/geometry/geometry_tests/robust_test.cpp
@@ -6,10 +6,9 @@
 
 #include <iterator>
 
-using namespace m2::robust;
-
-namespace
+namespace robust_test
 {
+using namespace m2::robust;
 using P = m2::PointD;
 
 template <typename TIt>
@@ -29,7 +28,6 @@ bool InsideTriangle(P const & p, P const ps[])
 {
   return IsPointInsideTriangle(p, ps[0], ps[1], ps[2]);
 }
-}  // namespace
 
 UNIT_TEST(OrientedS_Smoke)
 {
@@ -170,3 +168,4 @@ UNIT_TEST(PolygonSelfIntersections_TangentSmoke)
     CheckSelfIntersections(&arr[0], arr + ARRAY_SIZE(arr), false);
   }
 }
+}  // namespace robust_test

--- a/geometry/geometry_tests/segment2d_tests.cpp
+++ b/geometry/geometry_tests/segment2d_tests.cpp
@@ -13,7 +13,7 @@ void TestIntersectionResult(IntersectionResult const & result, IntersectionResul
     PointD const & expectedPoint)
 {
   TEST_EQUAL(result.m_type, expectedType, ());
-  TEST(AlmostEqualAbs(result.m_point, expectedPoint, kEps), (result.m_point, expectedPoint, kEps));
+  TEST(base::AlmostEqualAbs(result.m_point, expectedPoint, kEps), (result.m_point, expectedPoint, kEps));
 }
 
 bool TestSegmentsIntersect(PointD a, PointD b, PointD c, PointD d)

--- a/geometry/point_with_altitude.cpp
+++ b/geometry/point_with_altitude.cpp
@@ -44,7 +44,7 @@ PointWithAltitude MakePointWithAltitudeForTesting(m2::PointD const & point)
 
 bool AlmostEqualAbs(PointWithAltitude const & lhs, PointWithAltitude const & rhs, double eps)
 {
-  return AlmostEqualAbs(lhs.GetPoint(), rhs.GetPoint(), eps) && lhs.GetAltitude() == rhs.GetAltitude();
+  return base::AlmostEqualAbs(lhs.GetPoint(), rhs.GetPoint(), eps) && lhs.GetAltitude() == rhs.GetAltitude();
 }
 }  // namespace geometry
 

--- a/geometry/polygon.hpp
+++ b/geometry/polygon.hpp
@@ -50,7 +50,7 @@ size_t FindSingleStrip(size_t n, IsVisibleF isVisible)
 template <typename IterT> bool TestPolygonPreconditions(IterT beg, IterT end)
 {
   ASSERT_GREATER(std::distance(beg, end), 2, ());
-  ASSERT(!AlmostEqualULPs(*beg, *(--end)), ());
+  ASSERT(!base::AlmostEqualULPs(*beg, *(--end)), ());
   return true;
 }
 #endif

--- a/indexer/indexer_tests/cities_boundaries_serdes_tests.cpp
+++ b/indexer/indexer_tests/cities_boundaries_serdes_tests.cpp
@@ -36,13 +36,13 @@ void TestEqual(vector<PointD> const & lhs, vector<PointD> const & rhs, double ep
 {
   TEST_EQUAL(lhs.size(), rhs.size(), (lhs, rhs));
   for (size_t i = 0; i < lhs.size(); ++i)
-    TEST(AlmostEqualAbs(lhs[i], rhs[i], eps), (lhs, rhs));
+    TEST(base::AlmostEqualAbs(lhs[i], rhs[i], eps), (lhs, rhs));
 }
 
 void TestEqual(BoundingBox const & lhs, BoundingBox const & rhs, double eps)
 {
-  TEST(AlmostEqualAbs(lhs.Min(), rhs.Min(), eps), (lhs, rhs));
-  TEST(AlmostEqualAbs(lhs.Max(), rhs.Max(), eps), (lhs, rhs));
+  TEST(base::AlmostEqualAbs(lhs.Min(), rhs.Min(), eps), (lhs, rhs));
+  TEST(base::AlmostEqualAbs(lhs.Max(), rhs.Max(), eps), (lhs, rhs));
 }
 
 void TestEqual(CalipersBox const & lhs, CalipersBox const & rhs, double eps)

--- a/kml/serdes_gpx.cpp
+++ b/kml/serdes_gpx.cpp
@@ -280,7 +280,7 @@ void GpxParser::Pop(std::string_view tag)
   if (tag == gpx::kTrkPt || tag == gpx::kRtePt)
   {
     m2::PointD const p = mercator::FromLatLon(m_lat, m_lon);
-    if (m_line.empty() || !AlmostEqualAbs(m_line.back().GetPoint(), p, kMwmPointAccuracy))
+    if (m_line.empty() || !base::AlmostEqualAbs(m_line.back().GetPoint(), p, kMwmPointAccuracy))
     {
       m_line.emplace_back(p, m_altitude);
       m_timestamps.emplace_back(m_timestamp);

--- a/map/bookmark_helpers.cpp
+++ b/map/bookmark_helpers.cpp
@@ -256,7 +256,7 @@ void RemoveDuplicatedTrackPoints(std::unique_ptr<kml::FileData> & data)
         // We don't expect vertical surfaces, so do not compare heights here.
         // Will get a lot of duplicating points otherwise after import some user KMLs.
         // https://github.com/organicmaps/organicmaps/issues/3895
-        if (validLine.empty() || !AlmostEqualAbs(validLine.back().GetPoint(), currPoint.GetPoint(), kMwmPointAccuracy))
+        if (validLine.empty() || !base::AlmostEqualAbs(validLine.back().GetPoint(), currPoint.GetPoint(), kMwmPointAccuracy))
         {
           validLine.push_back(currPoint);
           if (hasTimestamps)

--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -377,7 +377,7 @@ UNIT_TEST(Bookmarks_Getting)
   fm.ShowRect(m2::RectD(0, 0, 80, 40));
 
   // This is not correct because Framework::OnSize doesn't work until SetRenderPolicy is called.
-  //TEST(m2::AlmostEqualULPs(m2::PointD(400, 200), pixC), (pixC));
+  //TEST(base::AlmostEqualUlps(m2::PointD(400, 200), pixC), (pixC));
 
   BookmarkManager & bmManager = fm.GetBookmarkManager();
   bmManager.EnableTestMode(true);

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -396,12 +396,11 @@ double Route::GetPolySegAngle(size_t ind) const
   {
     p2 = m_poly.GetPolyline().GetPoint(i);
   }
-  while (m2::AlmostEqualULPs(p1, p2) && ++i < polySz);
+  while (base::AlmostEqualULPs(p1, p2) && ++i < polySz);
   return (i == polySz) ? 0 : base::RadToDeg(ang::AngleTo(p1, p2));
 }
 
-bool Route::MatchLocationToRoute(location::GpsInfo & location,
-                                 location::RouteMatchingInfo & routeMatchingInfo) const
+bool Route::MatchLocationToRoute(location::GpsInfo & location, location::RouteMatchingInfo & routeMatchingInfo) const
 {
   if (!IsValid())
     return false;

--- a/routing/routing_tests/position_accumulator_tests.cpp
+++ b/routing/routing_tests/position_accumulator_tests.cpp
@@ -20,7 +20,7 @@ UNIT_CLASS_TEST(PositionAccumulator, Smoke)
   PushNextPoint({0.00005, 0.0});
   PushNextPoint({0.0001, 0.0});
   TEST_EQUAL(GetPointsForTesting().size(), 2, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.0001, 0.0), kEps), (GetDirection()));
+  TEST(base::AlmostEqualAbs(GetDirection(), m2::PointD(0.0001, 0.0), kEps), (GetDirection()));
   TEST(base::AlmostEqualAbs(GetTrackLengthMForTesting(), 11.13, kEpsMeters),
        (GetTrackLengthMForTesting()));
 }
@@ -36,7 +36,7 @@ UNIT_CLASS_TEST(PositionAccumulator, GoodSegment)
   for (signed i = -15; i <= 0; ++i)
     PushNextPoint({kStepShortButValid * i, 0.0});
   TEST_EQUAL(GetPointsForTesting().size(), 2, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(9 * kStepShortButValid, 0.0), kEps),
+  TEST(base::AlmostEqualAbs(GetDirection(), m2::PointD(9 * kStepShortButValid, 0.0), kEps),
        (GetDirection()));
   TEST(base::AlmostEqualAbs(GetTrackLengthMForTesting(), 10.02, kEpsMeters),
        (GetTrackLengthMForTesting()));
@@ -46,7 +46,7 @@ UNIT_CLASS_TEST(PositionAccumulator, GoodSegment)
     PushNextPoint({kStepGood * i, 0.0});
 
   TEST_EQUAL(GetPointsForTesting().size(), 8, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.0007, 0.0), kEps), (GetDirection()));
+  TEST(base::AlmostEqualAbs(GetDirection(), m2::PointD(0.0007, 0.0), kEps), (GetDirection()));
   TEST(base::AlmostEqualAbs(GetTrackLengthMForTesting(), 77.92, kEpsMeters),
        (GetTrackLengthMForTesting()));
 }
@@ -60,7 +60,7 @@ UNIT_CLASS_TEST(PositionAccumulator, RemovingOutdated)
     PushNextPoint({kStep * i, 0.0});
 
   TEST_EQUAL(GetPointsForTesting().size(), 8, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.0007, 0.0), kEps), (GetDirection()));
+  TEST(base::AlmostEqualAbs(GetDirection(), m2::PointD(0.0007, 0.0), kEps), (GetDirection()));
 }
 
 // Test on adding segments longer than |PositionAccumulator::kMaxValidSegmentLengthM|
@@ -77,9 +77,9 @@ UNIT_CLASS_TEST(PositionAccumulator, LongSegment)
   // |PositionAccumulator::kMinValidSegmentLengthM|, so the point is added.
   PushNextPoint({0.0012, 0.0});
   TEST_EQUAL(GetPointsForTesting().size(), 2, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.0002, 0.0), kEps), (GetDirection()));
+  TEST(base::AlmostEqualAbs(GetDirection(), m2::PointD(0.0002, 0.0), kEps), (GetDirection()));
   PushNextPoint({0.00201, 0.0}); // Longer than |PositionAccumulator::kMaxValidSegmentLengthM|.
   TEST_EQUAL(GetPointsForTesting().size(), 1, ());
-  TEST(m2::AlmostEqualAbs(GetDirection(), m2::PointD(0.0, 0.0), kEps), (GetDirection()));
+  TEST(base::AlmostEqualAbs(GetDirection(), m2::PointD(0.0, 0.0), kEps), (GetDirection()));
 }
 }  // namespace position_accumulator_tests

--- a/search/ranking_utils.hpp
+++ b/search/ranking_utils.hpp
@@ -165,7 +165,7 @@ struct NameScores
       m_errorsMade = ErrorsMade::Min(m_errorsMade, rhs.m_errorsMade);
   }
 
-  bool operator==(NameScores const & rhs)
+  bool operator==(NameScores const & rhs) const
   {
     return m_nameScore == rhs.m_nameScore && m_errorsMade == rhs.m_errorsMade &&
            m_isAltOrOldName == rhs.m_isAltOrOldName && m_matchedLength == rhs.m_matchedLength;


### PR DESCRIPTION
Also removed redundant m2::AlmostEqualAbs and m2::AlmostEqualULPs
Our testing macro requires the presence of base::AlmostEqualAbs and base::AlmostEqualULPs for any comparable type.
Duplicates in m2 namespace may lead to ambiguity in some cases.
