### PR TITLE
[ios] improve icloud sync logging

### DIFF
--- a/iphone/Maps/Core/iCloud/CloudDirectoryMonitor.swift
+++ b/iphone/Maps/Core/iCloud/CloudDirectoryMonitor.swift
@@ -159,6 +159,8 @@ private extension iCloudDocumentsMonitor {
     LOG(.debug, "Query did finish gathering")
     do {
       let currentContents = try Self.getCurrentContents(notification)
+      LOG(.info, "Cloud contents (\(currentContents.count)):")
+      currentContents.forEach { LOG(.info, $0.shortDebugDescription) }
       delegate?.didFinishGathering(currentContents)
     } catch {
       delegate?.didReceiveCloudMonitorError(error)
@@ -176,10 +178,12 @@ private extension iCloudDocumentsMonitor {
       This unnecessary updated should be skipped. */
       if changedContents != previouslyChangedContents {
         previouslyChangedContents = changedContents
-        LOG(.info, "Added to the cloud content: \n\(changedContents.added.shortDebugDescription)")
-        LOG(.info, "Updated in the cloud content: \n\(changedContents.updated.shortDebugDescription)")
-        LOG(.info, "Removed from the cloud content: \n\(changedContents.removed.shortDebugDescription)")
         let currentContents = try Self.getCurrentContents(notification)
+        LOG(.info, "Cloud contents (\(currentContents.count)):")
+        currentContents.forEach { LOG(.info, $0.shortDebugDescription) }
+        LOG(.info, "Added to the cloud content (\(changedContents.added.count)): \n\(changedContents.added.shortDebugDescription)")
+        LOG(.info, "Updated in the cloud content (\(changedContents.updated.count)): \n\(changedContents.updated.shortDebugDescription)")
+        LOG(.info, "Removed from the cloud content (\(changedContents.removed.count)): \n\(changedContents.removed.shortDebugDescription)")
         delegate?.didUpdate(currentContents, changedContents)
       }
     } catch {

--- a/iphone/Maps/Core/iCloud/MetadataItem.swift
+++ b/iphone/Maps/Core/iCloud/MetadataItem.swift
@@ -86,7 +86,7 @@ extension CloudMetadataItem {
 
 extension MetadataItem {
   var shortDebugDescription: String {
-    "\(fileName), lastModified: \(lastModificationDate)"
+    "fileName: \(fileName), lastModified: \(lastModificationDate)"
   }
 }
 

--- a/iphone/Maps/Core/iCloud/SynchronizaionManager.swift
+++ b/iphone/Maps/Core/iCloud/SynchronizaionManager.swift
@@ -106,7 +106,6 @@ final class iCloudSynchronizaionManager: NSObject {
 private extension iCloudSynchronizaionManager {
   // MARK: - Synchronization Lifecycle
   func startSynchronization() {
-    LOG(.info, "Start synchronization...")
     switch cloudDirectoryMonitor.state {
     case .started:
       LOG(.debug, "Synchronization is already started")
@@ -125,10 +124,10 @@ private extension iCloudSynchronizaionManager {
             case .failure(let error):
               self.processError(error)
             case .success(let localDirectoryUrl):
+              LOG(.info, "Start synchronization")
               self.fileWriter = SynchronizationFileWriter(fileManager: self.fileManager,
                                                           localDirectoryUrl: localDirectoryUrl,
                                                           cloudDirectoryUrl: cloudDirectoryUrl)
-              LOG(.debug, "Synchronization is started successfully")
             }
           }
         }

--- a/iphone/Maps/Core/iCloud/SynchronizationStateResolver.swift
+++ b/iphone/Maps/Core/iCloud/SynchronizationStateResolver.swift
@@ -71,11 +71,7 @@ final class iCloudSynchronizationStateResolver: SynchronizationStateResolver {
       outgoingEvents = resolveDidUpdateCloudContents(update)
     }
 
-    LOG(.info, "Cloud contents: \(currentCloudContents.count)")
-    currentCloudContents.sorted(by: { $0.fileName < $1.fileName }).forEach { LOG(.info, $0.shortDebugDescription) }
-    LOG(.info, "Local contents: \(currentLocalContents.count)")
-    currentLocalContents.sorted(by: { $0.fileName < $1.fileName }).forEach { LOG(.info, $0.shortDebugDescription) }
-    LOG(.info, "Events to process: \(outgoingEvents.count)")
+    LOG(.info, "Events to process (\(outgoingEvents.count)):")
     outgoingEvents.forEach { LOG(.info, $0) }
 
     return outgoingEvents


### PR DESCRIPTION
Content logging is moved closer to the source - to the monitor's didFinishGathering/didUpdate methods instead of state resolver.