### PR TITLE
[android] Ban Vulkan for Mali-T* devices with a custom ROM.

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/Framework.hpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.hpp
@@ -99,7 +99,7 @@ namespace android
     void OnCompassUpdated(location::CompassInfo const & info, bool forceRedraw);
 
     bool CreateDrapeEngine(JNIEnv * env, jobject jSurface, int densityDpi, bool firstLaunch,
-                           bool launchByDeepLink, uint32_t appVersionCode);
+                           bool launchByDeepLink, uint32_t appVersionCode, bool isCustomROM);
     bool IsDrapeEngineCreated() const;
     void UpdateDpi(int dpi);
     bool DestroySurfaceOnDetach();

--- a/android/app/src/main/cpp/app/organicmaps/Map.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Map.cpp
@@ -27,10 +27,11 @@ Java_app_organicmaps_Map_nativeCreateEngine(JNIEnv * env, jclass,
                                             jobject surface, jint density,
                                             jboolean firstLaunch,
                                             jboolean isLaunchByDeepLink,
-                                            jint appVersionCode)
+                                            jint appVersionCode,
+                                            jboolean isCustomROM)
 {
   return g_framework->CreateDrapeEngine(env, surface, density, firstLaunch, isLaunchByDeepLink,
-                                        base::asserted_cast<uint32_t>(appVersionCode));
+                                        base::asserted_cast<uint32_t>(appVersionCode), isCustomROM);
 }
 
 JNIEXPORT jboolean JNICALL

--- a/android/app/src/main/cpp/app/organicmaps/vulkan/android_vulkan_context_factory.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/vulkan/android_vulkan_context_factory.cpp
@@ -86,7 +86,7 @@ public:
 };
 }  // namespace
 
-AndroidVulkanContextFactory::AndroidVulkanContextFactory(uint32_t appVersionCode, int sdkVersion)
+AndroidVulkanContextFactory::AndroidVulkanContextFactory(uint32_t appVersionCode, int sdkVersion, bool isCustomROM)
 {
   if (InitVulkan() == 0)
   {
@@ -165,8 +165,7 @@ AndroidVulkanContextFactory::AndroidVulkanContextFactory(uint32_t appVersionCode
   dp::SupportManager::Version driverVersion{VK_VERSION_MAJOR(gpuProperties.driverVersion),
                                             VK_VERSION_MINOR(gpuProperties.driverVersion),
                                             VK_VERSION_PATCH(gpuProperties.driverVersion)};
-  if (dp::SupportManager::Instance().IsVulkanForbidden(gpuProperties.deviceName, apiVersion,
-                                                       driverVersion))
+  if (dp::SupportManager::Instance().IsVulkanForbidden(gpuProperties.deviceName, apiVersion, driverVersion, isCustomROM))
   {
     LOG_ERROR_VK("GPU/Driver configuration is not supported.");
     return;

--- a/android/app/src/main/cpp/app/organicmaps/vulkan/android_vulkan_context_factory.hpp
+++ b/android/app/src/main/cpp/app/organicmaps/vulkan/android_vulkan_context_factory.hpp
@@ -18,7 +18,7 @@ namespace android
 class AndroidVulkanContextFactory : public dp::GraphicsContextFactory
 {
 public:
-  explicit AndroidVulkanContextFactory(uint32_t appVersionCode, int sdkVersion);
+  AndroidVulkanContextFactory(uint32_t appVersionCode, int sdkVersion, bool isCustomROM);
   ~AndroidVulkanContextFactory();
 
   bool IsVulkanSupported() const;

--- a/android/app/src/main/java/app/organicmaps/Map.java
+++ b/android/app/src/main/java/app/organicmaps/Map.java
@@ -10,6 +10,7 @@ import androidx.annotation.Nullable;
 import app.organicmaps.display.DisplayType;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.util.Config;
+import app.organicmaps.util.ROMUtils;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.concurrency.UiThread;
 import app.organicmaps.util.log.Logger;
@@ -170,7 +171,8 @@ public final class Map
     final LocationHelper locationHelper = LocationHelper.from(context);
 
     final boolean firstStart = locationHelper.isInFirstRun();
-    if (!nativeCreateEngine(surface, surfaceDpi, firstStart, mLaunchByDeepLink, BuildConfig.VERSION_CODE))
+    if (!nativeCreateEngine(surface, surfaceDpi, firstStart, mLaunchByDeepLink,
+                            BuildConfig.VERSION_CODE, ROMUtils.isCustomROM()))
     {
       if (mCallbackUnsupported != null)
         mCallbackUnsupported.report();
@@ -368,7 +370,8 @@ public final class Map
   private static native boolean nativeCreateEngine(Surface surface, int density,
                                                    boolean firstLaunch,
                                                    boolean isLaunchByDeepLink,
-                                                   int appVersionCode);
+                                                   int appVersionCode,
+                                                   boolean isCustomROM);
 
   private static native boolean nativeIsEngineCreated();
 

--- a/android/app/src/main/java/app/organicmaps/util/ROMUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/ROMUtils.java
@@ -1,0 +1,53 @@
+package app.organicmaps.util;
+
+import android.util.Log;
+
+import java.lang.reflect.Method;
+
+public class ROMUtils
+{
+  private static final String TAG = "ROMUtils";
+
+  public static boolean isCustomROM()
+  {
+    Method method = null;
+    try
+    {
+      Class<?> systemProperties = Class.forName("android.os.SystemProperties");
+      method = systemProperties.getMethod("get", String.class);
+    }
+    catch (Exception e)
+    {
+      Log.e(TAG, "Error getting SystemProperties:", e);
+    }
+
+    if (method == null)
+      return false;
+
+    // Check common custom ROM properties
+    String[] customROMIndicators = {
+            "ro.modversion",
+            "ro.cm.version", // LineageOS/CyanogenMod-specific
+            "ro.lineage.build.version", // LineageOS
+    };
+
+    for (String prop : customROMIndicators)
+    {
+      try
+      {
+        String value = (String) method.invoke(null, prop);
+        if (value != null && !value.isEmpty())
+        {
+          Log.d(TAG, "Custom ROM detected: " + prop + " = " + value);
+          return true;
+        }
+      }
+      catch (Exception e)
+      {
+        Log.e(TAG, "Error getting SystemProperties:", e);
+      }
+    }
+
+    return false;
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/util/ROMUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/ROMUtils.java
@@ -18,7 +18,7 @@ public class ROMUtils
     }
     catch (Exception e)
     {
-      Log.e(TAG, "Error getting SystemProperties:", e);
+      Log.e(TAG, "Error getting SystemProperties: ", e);
     }
 
     if (method == null)
@@ -44,7 +44,7 @@ public class ROMUtils
       }
       catch (Exception e)
       {
-        Log.e(TAG, "Error getting SystemProperties:", e);
+        Log.e(TAG, "Error invoking method: ", e);
       }
     }
 

--- a/android/app/src/main/java/app/organicmaps/util/log/LogsManager.java
+++ b/android/app/src/main/java/app/organicmaps/util/log/LogsManager.java
@@ -22,6 +22,7 @@ import androidx.core.content.ContextCompat;
 import app.organicmaps.BuildConfig;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
+import app.organicmaps.util.ROMUtils;
 import app.organicmaps.util.StringUtils;
 
 import net.jcip.annotations.ThreadSafe;
@@ -245,6 +246,7 @@ public final class LogsManager
     if (!StringUtils.toLowerCase(Build.MODEL).startsWith(StringUtils.toLowerCase(Build.MANUFACTURER)))
       sb.append(Build.MANUFACTURER).append(' ');
     sb.append(Build.MODEL).append(" (").append(Build.DEVICE).append(')');
+    sb.append("\nIs custom ROM: ").append(ROMUtils.isCustomROM());
     sb.append("\nSupported ABIs:");
     for (String abi : Build.SUPPORTED_ABIS)
       sb.append(' ').append(abi);

--- a/drape/graphics_context_factory.hpp
+++ b/drape/graphics_context_factory.hpp
@@ -33,8 +33,7 @@ public:
   template<typename T>
   T * CastFactory()
   {
-    ASSERT(dynamic_cast<T *>(m_factory) != nullptr, ());
-    return static_cast<T *>(m_factory);
+    return dynamic_cast<T *>(m_factory);
   }
 
   void WaitForInitialization(dp::GraphicsContext * context) override;

--- a/drape/support_manager.cpp
+++ b/drape/support_manager.cpp
@@ -107,7 +107,8 @@ bool SupportManager::IsVulkanForbidden()
   return forbidden;
 }
 
-bool SupportManager::IsVulkanForbidden(std::string const & deviceName, Version apiVersion, Version driverVersion)
+bool SupportManager::IsVulkanForbidden(std::string const & deviceName, Version apiVersion,
+                                       Version driverVersion, bool isCustomROM)
 {
   LOG(LINFO, ("Device =", deviceName, "API =", apiVersion, "Driver =", driverVersion));
 
@@ -117,17 +118,22 @@ bool SupportManager::IsVulkanForbidden(std::string const & deviceName, Version a
     "PowerVR Rogue G6110", "PowerVR Rogue GE8100", "PowerVR Rogue GE8300",
     // https://github.com/organicmaps/organicmaps/issues/5539
     "Adreno (TM) 418",
-
-    // https://github.com/organicmaps/organicmaps/issues/2739
-    // https://github.com/organicmaps/organicmaps/issues/9255
-    // SM-G930F (S7, heroltexx, hero2ltexx). Crash on vkCreateSwapchainKHR and we don't even get to SupportManager::Init.
-    /// @todo UPD: Crash on Android 14 (LineageOS), stock Android 12 works ok (with same api = 1.0.82; driver = 28.0.0).
-    "Mali-T880",
   };
 
   for (auto const d : kBannedDevices)
   {
     if (d == deviceName)
+      return true;
+  }
+
+  if (isCustomROM)
+  {
+    // Crash on LineageOS, stock Android works ok (with same api = 1.0.82; driver = 28.0.0).
+    // https://github.com/organicmaps/organicmaps/issues/2739
+    // https://github.com/organicmaps/organicmaps/issues/9255
+    // SM-G930F (S7, heroltexx, hero2ltexx). Crash on vkCreateSwapchainKHR and we don't even get to SupportManager::Init.
+    // SM-G920F (S6)
+    if (deviceName.starts_with("Mali-T"))
       return true;
   }
 

--- a/drape/support_manager.hpp
+++ b/drape/support_manager.hpp
@@ -39,7 +39,7 @@ public:
 
   using Version = std::array<uint32_t, 3>;
   static bool IsVulkanForbidden();
-  static bool IsVulkanForbidden(std::string const & deviceName, Version apiVersion, Version driverVersion);
+  static bool IsVulkanForbidden(std::string const & deviceName, Version apiVersion, Version driverVersion, bool isCustomROM);
   static bool IsVulkanTexturePartialUpdateBuggy(int sdkVersion, std::string const & deviceName,
                                                 Version apiVersion, Version driverVersion);
 


### PR DESCRIPTION
Follow up https://github.com/organicmaps/organicmaps/pull/9309

- Keep Vulkan renderer for SM-G930F (S7) with the stock Android.
- Ban Vulkan for old Androids (Mali-T*) like S7, S6 and lower with custom Androids (Lineage, Cyanogen).

"Custom ROM" means something not in stock for the device (was rooted and installed something else). ROMUtils.isCustomROM code is heuristic and was inspired by ChatGPT.