### PR TITLE
[tools] Delete redundant macdeployqtfix submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "tools/kothic"]
   path = tools/kothic
   url = https://github.com/organicmaps/kothic.git
-[submodule "tools/macdeployqtfix"]
-  path = tools/macdeployqtfix
-  url = https://github.com/aurelien-rainone/macdeployqtfix.git
 [submodule "3party/protobuf/protobuf"]
   path = 3party/protobuf/protobuf
   url = https://github.com/organicmaps/protobuf.git

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -239,7 +239,6 @@ if (BUILD_DESIGNER)
     foreach(BUNDLE ${BUNDLE_FOLDER} ${BUNDLES})
       execute_process(
         COMMAND \"${QT_PATH}/bin/macdeployqt\" \"\${BUNDLE}\"
-        COMMAND find \"\${BUNDLE}/Contents/MacOS\" -type f -exec python \"${OMIM_ROOT}/tools/macdeployqtfix/macdeployqtfix.py\" -q -nl {} \"${QT_PATH}\" \\;
       )
     endforeach()
     foreach(BUNDLE ${BUNDLES})


### PR DESCRIPTION
This fix was only intended to be deployed until Qt 5.10.