### PR TITLE
[android] Minor fixes.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,11 +84,12 @@ def osName = System.properties['os.name'].toLowerCase()
 project.ext.appId = 'app.organicmaps'
 project.ext.appName = 'Organic Maps'
 
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(17))
-  }
-}
+// I have Java 21 installed, but this doesn't work on MacOS.
+//java {
+//  toolchain {
+//    languageVersion.set(JavaLanguageVersion.of(17))
+//  }
+//}
 
 android {
   namespace 'app.organicmaps'

--- a/android/app/src/main/java/app/organicmaps/util/SharedPropertiesUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/SharedPropertiesUtils.java
@@ -51,10 +51,12 @@ public final class SharedPropertiesUtils
    */
   public static void emulateBadExternalStorage(@NonNull Context context) throws IOException
   {
-    SharedPreferences prefs = PreferenceManager
-        .getDefaultSharedPreferences(MwmApplication.from(context));
+    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(MwmApplication.from(context));
     String key = MwmApplication.from(context).getString(R.string.pref_emulate_bad_external_storage);
-    if (prefs.getBoolean(key, false)) {
+    if (prefs.getBoolean(key, false))
+    {
+      // Emulate one time only -> reset setting to run normally next time.
+      prefs.edit().putBoolean(key, false).apply();
       throw new IOException("Bad external storage error injection");
     }
   }


### PR DESCRIPTION
@rtsisyk Take a look. I don't understand why we need gradle java toolchain entry, but it doesn't work now on MacOS.

```
vng@Viktars-MacBook-Pro android % gradle --version

Welcome to Gradle 8.11!

Here are the highlights of this release:
 - Parallel load and store for Configuration Cache
 - Java compilation errors at the end of the build output
 - Consolidated report for warnings and deprecations

For more details see https://docs.gradle.org/8.11/release-notes.html


------------------------------------------------------------
Gradle 8.11
------------------------------------------------------------

Build time:    2024-11-11 13:58:01 UTC
Revision:      b2ef976169a05b3c76d04f0fa76a940859f96fa4

Kotlin:        2.0.20
Groovy:        3.0.22
Ant:           Apache Ant(TM) version 1.10.14 compiled on August 16 2023
Launcher JVM:  21.0.3 (JetBrains s.r.o. 21.0.3+-79915917-b509.11)
Daemon JVM:    /Applications/Android Studio.app/Contents/jbr/Contents/Home (no JDK specified, using current Java home)
OS:            Mac OS X 15.1 aarch64
```