### PR TITLE
[qt] Exclude service languages from map language menu

### DIFF
--- a/qt/preferences_dialog.cpp
+++ b/qt/preferences_dialog.cpp
@@ -115,7 +115,7 @@ namespace qt
       // So we ensure that it returns false here.
       mapLanguageComboBox->setStyleSheet("QComboBox { combobox-popup: 0; }");
       mapLanguageComboBox->setMaxVisibleItems(10);
-      StringUtf8Multilang::Languages const & supportedLanguages = StringUtf8Multilang::GetSupportedLanguages();
+      StringUtf8Multilang::Languages const & supportedLanguages = StringUtf8Multilang::GetSupportedLanguages(/* includeServiceLangs */ false);
       QStringList languagesList = QStringList();
       for (auto const & language : supportedLanguages)
         languagesList << QString::fromStdString(std::string(language.m_name));


### PR DESCRIPTION
Removes:
* Alternative name
* Old/Previous name

As pointed out in https://github.com/organicmaps/organicmaps/pull/9618#issuecomment-2469252648