### PR TITLE
[tests] Visual test for two missing Latin Extended-A characters

### DIFF
--- a/drape/drape_tests/glyph_mng_tests.cpp
+++ b/drape/drape_tests/glyph_mng_tests.cpp
@@ -272,6 +272,9 @@ UNIT_TEST(GlyphLoadingTest)
 
   constexpr int fontSize = 27;
 
+  renderer.SetString("Muḩāfaz̧at", fontSize, "en");
+  RunTestLoop("Latin Extended", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
+
   renderer.SetString("Строка", fontSize, "ru");
   RunTestLoop("ru", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
 


### PR DESCRIPTION
Related to #9688