### PR TITLE
Adjust bicycle routing weights and ETAs

### DIFF
--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -463,6 +463,8 @@ UNIT_TEST(UK_ForbidGates_WithoutAccess)
 
 UNIT_TEST(UK_Canterbury_AvoidDismount)
 {
+  /// @todo(pastk): the case is controversial, a user emailed "All cyclists in our town use this particular footway"
+  /// but we don't know if cyclists dismount there or just cycle through (ignoring the UK rules).
   // A shortcut via a footway is 305 meters, ETAs are similar, but cyclists prefer to ride!
   // Check the London_GreenwichTunnel case for when dismounting is reasonable as the detour is way too long.
   CalculateRouteAndTestRouteLength(GetVehicleComponents(VehicleType::Bicycle),

--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -352,24 +352,12 @@ UNIT_TEST(Belarus_StraightFootway)
       mercator::FromLatLon(53.876436, 30.3348084), 1613.34 /* expectedRouteMeters */);
 }
 
-UNIT_TEST(Spain_Madrid_ElevationsDetour)
+UNIT_TEST(Spain_Madrid_DedicatedCycleway)
 {
-  /// @todo(pastk): DELETE: there are no detours here atm, the second route is just a tad longer
-  /// and is of the same alt difference, so this test is currently useless
-  TRouteResult const r1 = CalculateRoute(GetVehicleComponents(VehicleType::Bicycle),
-                              mercator::FromLatLon(40.459616, -3.690031), {0., 0.},
-                              mercator::FromLatLon(40.4408171, -3.69261893));
-  TEST_EQUAL(r1.second, RouterResultCode::NoError, ());
-
-  TRouteResult const r2 = CalculateRoute(GetVehicleComponents(VehicleType::Bicycle),
-                              mercator::FromLatLon(40.459616, -3.690031), {0., 0.},
-                              mercator::FromLatLon(40.4403523, -3.69267444));
-  TEST_EQUAL(r2.second, RouterResultCode::NoError, ());
-
-  TEST(r1.first && r2.first, ());
-
-  TEST_LESS(r1.first->GetTotalDistanceMeters(), r2.first->GetTotalDistanceMeters(), ());
-  TEST_LESS(r1.first->GetTotalTimeSec(), r2.first->GetTotalTimeSec(), ());
+  // Check that OM uses dedicated "Carril bici del Paseo de la Castellana".
+  CalculateRouteAndTestRouteLength(GetVehicleComponents(VehicleType::Bicycle),
+      mercator::FromLatLon(40.459616, -3.690031), {0.0, 0.0},
+      mercator::FromLatLon(40.4403523, -3.69267444), 2283.89 /* expectedRouteMeters */);
 }
 
 UNIT_TEST(Seoul_ElevationDetour)

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -26,18 +26,20 @@
  *    and Platform::ResourcesDir() only once and then reuse it.
  *    Use GetCarComponents() or GetPedestrianComponents() with vector of maps parameter
  *    only if you want to test something on a special map set.
- * 2. Loading maps and calculating routes is a time consumption process.
+ * 2. Loading maps and calculating routes is a time consuming process.
  *    Do this only if you really need it.
  * 3. If you want to check that a turn is absent - use TestTurnCount.
  * 4. The easiest way to gather all the information for writing an integration test is
  *    - to put a break point in CalculateRoute() method;
- *    - to make a route with MapWithMe desktop application;
+ *    - to make a route with the desktop application;
  *    - to get all necessary parameters and result of the route calculation;
  *    - to place them into the test you're writing.
  * 5. The recommended way for naming tests for a route from one place to another one is
  *    <Country><City><Street1><House1><Street2><House2><Test time. TurnTest or RouteTest for the
  * time being>
- * 6. It's a good idea to use short routes for testing turns. The thing is geometry of long routes
+ * 6. Add a comment to describe what this particular test is testing (e.g. "respect the bicycle=no tag").
+ *    And add a ref to a Github issue if applicable.
+ * 7. It's a good idea to use short routes for testing turns. The thing is geometry of long routes
  *    could be changed from one dataset to another. The shorter the route the less is the chance it's changed.
  */
 

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -26,33 +26,37 @@ using namespace routing;
 HighwayBasedFactors const kDefaultFactors = GetOneFactorsForBicycleAndPedestrianModel();
 
 SpeedKMpH constexpr kSpeedOffroadKMpH = {1.5 /* weight */, 3.0 /* eta */};
-SpeedKMpH constexpr kSpeedDismountKMpH = {2.0 /* weight */, 2.0 /* eta */};
-SpeedKMpH constexpr kSpeedOnFootwayKMpH = {5.0 /* weight */, 7.0 /* eta */};
+SpeedKMpH constexpr kSpeedDismountKMpH = {2.0 /* weight */, 4.0 /* eta */};
+// Applies only to contries where cycling is allowed on footways (by default the above dismount speed is used).
+SpeedKMpH constexpr kSpeedOnFootwayKMpH = {8.0 /* weight */, 10.0 /* eta */};
 
 HighwayBasedSpeeds const kDefaultSpeeds = {
     // {highway class : InOutCitySpeedKMpH(in city(weight, eta), out city(weight eta))}
-    /// @see Russia_UseTrunk for Trunk weights.
-    {HighwayType::HighwayTrunk, InOutCitySpeedKMpH(SpeedKMpH(5.5, 18.0))},
-    {HighwayType::HighwayTrunkLink, InOutCitySpeedKMpH(SpeedKMpH(5.5, 18.0))},
-    {HighwayType::HighwayPrimary, InOutCitySpeedKMpH(SpeedKMpH(10.0, 18.0), SpeedKMpH(14.0, 18.0))},
-    {HighwayType::HighwayPrimaryLink, InOutCitySpeedKMpH(SpeedKMpH(10.0, 18.0), SpeedKMpH(14.0, 18.0))},
-    {HighwayType::HighwaySecondary, InOutCitySpeedKMpH(SpeedKMpH(15.0, 18.0), SpeedKMpH(20.0, 18.0))},
-    {HighwayType::HighwaySecondaryLink, InOutCitySpeedKMpH(SpeedKMpH(15.0, 18.0), SpeedKMpH(20.0, 18.0))},
-    {HighwayType::HighwayTertiary, InOutCitySpeedKMpH(SpeedKMpH(15.0, 18.0), SpeedKMpH(20.0, 18.0))},
-    {HighwayType::HighwayTertiaryLink, InOutCitySpeedKMpH(SpeedKMpH(15.0, 18.0), SpeedKMpH(20.0, 18.0))},
-    {HighwayType::HighwayUnclassified, InOutCitySpeedKMpH(SpeedKMpH(12.0, 18.0))},
+    // Note that roads with hwtag=yesbicycle get high speed of 0.9 * Cycleway.
+    /// @see Russia_UseTrunk test for Trunk weights.
+    {HighwayType::HighwayTrunk, InOutCitySpeedKMpH(SpeedKMpH(7.0, 17.0), SpeedKMpH(9.0, 19.0))},
+    // Presence of link roads usually means that connected roads are high traffic.
+    // And complex intersections themselves are not nice for cyclists. We can't
+    // easily extrapolate this to the main roads, but at least penalize the link roads a bit.
+    // https://github.com/organicmaps/organicmaps/pull/9692#discussion_r1851442568
+    {HighwayType::HighwayTrunkLink, InOutCitySpeedKMpH(SpeedKMpH(6.0, 17.0), SpeedKMpH(8.0, 19.0))},
+    {HighwayType::HighwayPrimary, InOutCitySpeedKMpH(SpeedKMpH(10.0, 17.0), SpeedKMpH(12.0, 19.0))},
+    {HighwayType::HighwayPrimaryLink, InOutCitySpeedKMpH(SpeedKMpH(8.0, 17.0), SpeedKMpH(11.0, 19.0))},
+    {HighwayType::HighwaySecondary, InOutCitySpeedKMpH(SpeedKMpH(13.0, 17.0), SpeedKMpH(15.0, 19.0))},
+    {HighwayType::HighwaySecondaryLink, InOutCitySpeedKMpH(SpeedKMpH(11.0, 17.0), SpeedKMpH(13.0, 19.0))},
+    {HighwayType::HighwayTertiary, InOutCitySpeedKMpH(SpeedKMpH(14.0, 17.0), SpeedKMpH(17.0, 19.0))},
+    {HighwayType::HighwayTertiaryLink, InOutCitySpeedKMpH(SpeedKMpH(13.0, 17.0), SpeedKMpH(16.0, 19.0))},
+    {HighwayType::HighwayUnclassified, InOutCitySpeedKMpH(SpeedKMpH(13.0, 17.0), SpeedKMpH(15.0, 19.0))},
+    {HighwayType::HighwayResidential, InOutCitySpeedKMpH(SpeedKMpH(12.0, 14.0), SpeedKMpH(14.0, 17.0))},
+    {HighwayType::HighwayService, InOutCitySpeedKMpH(SpeedKMpH(13.0, 15.0), SpeedKMpH(15.0, 17.0))},
+    {HighwayType::HighwayRoad, InOutCitySpeedKMpH(SpeedKMpH(11.0, 15.0), SpeedKMpH(14.0, 17.0))},
 
-    // https://github.com/organicmaps/organicmaps/issues/3881
-    // Set equal speeds here to avoid useless detours via service roads (Batumi_AvoidServiceDetour test).
-    {HighwayType::HighwayService, InOutCitySpeedKMpH(SpeedKMpH(10.0, 14.0))},
-    {HighwayType::HighwayResidential, InOutCitySpeedKMpH(SpeedKMpH(10.0, 14.0))},
+    {HighwayType::HighwayTrack, InOutCitySpeedKMpH(SpeedKMpH(8.0, 12.0), SpeedKMpH(10.0, 14.0))},
+    {HighwayType::HighwayPath, InOutCitySpeedKMpH(SpeedKMpH(6.0, 10.0), SpeedKMpH(7.0, 12.0))},
+    {HighwayType::HighwayBridleway, InOutCitySpeedKMpH(SpeedKMpH(4.0, 10.0), SpeedKMpH(5.0, 12.0))},
 
-    {HighwayType::HighwayRoad, InOutCitySpeedKMpH(SpeedKMpH(10.0, 12.0))},
-    {HighwayType::HighwayTrack, InOutCitySpeedKMpH(SpeedKMpH(8.0, 12.0))},
-    {HighwayType::HighwayPath, InOutCitySpeedKMpH(SpeedKMpH(6.0, 12.0))},
-    {HighwayType::HighwayBridleway, InOutCitySpeedKMpH(SpeedKMpH(4.0, 12.0))},
-    {HighwayType::HighwayCycleway, InOutCitySpeedKMpH(SpeedKMpH(30.0, 20.0))},
-    {HighwayType::HighwayLivingStreet, InOutCitySpeedKMpH(SpeedKMpH(7.0, 8.0))},
+    {HighwayType::HighwayCycleway, InOutCitySpeedKMpH(SpeedKMpH(21.0, 18.0), SpeedKMpH(23.0, 20.0))},
+    {HighwayType::HighwayLivingStreet, InOutCitySpeedKMpH(SpeedKMpH(12.0, 10.0), SpeedKMpH(14.0, 12.0))},
     // Steps have obvious inconvenience of a bike in hands.
     {HighwayType::HighwaySteps, InOutCitySpeedKMpH(SpeedKMpH(1.0, 1.0))},
     {HighwayType::HighwayPedestrian, InOutCitySpeedKMpH(kSpeedDismountKMpH)},
@@ -140,14 +144,14 @@ HighwayBasedSpeeds PreferFootwaysToRoads()
   HighwayBasedSpeeds res = kDefaultSpeeds;
 
   // Decrease secondary/tertiary weight speed (-20% from default).
-  InOutCitySpeedKMpH roadSpeed = InOutCitySpeedKMpH(SpeedKMpH(12.0, 18.0), SpeedKMpH(16.0, 18.0));
+  InOutCitySpeedKMpH roadSpeed = InOutCitySpeedKMpH(SpeedKMpH(11.0, 17.0), SpeedKMpH(16.0, 19.0));
   res.Replace(HighwayType::HighwaySecondary, roadSpeed);
   res.Replace(HighwayType::HighwaySecondaryLink, roadSpeed);
   res.Replace(HighwayType::HighwayTertiary, roadSpeed);
   res.Replace(HighwayType::HighwayTertiaryLink, roadSpeed);
 
   // Increase footway speed to make bigger than other roads (+20% from default roads).
-  InOutCitySpeedKMpH footSpeed = InOutCitySpeedKMpH(SpeedKMpH(18.0, 18.0), SpeedKMpH(20.0, 18.0));
+  InOutCitySpeedKMpH footSpeed = InOutCitySpeedKMpH(SpeedKMpH(17.0, 12.0), SpeedKMpH(20.0, 15.0));
   res.Replace(HighwayType::HighwayPedestrian, footSpeed);
   res.Replace(HighwayType::HighwayFootway, footSpeed);
 
@@ -170,10 +174,13 @@ VehicleModel::SurfaceInitList const kBicycleSurface = {
   // {{surfaceType}, {weightFactor, etaFactor}}
   {{"psurface", "paved_good"}, {1.0, 1.0}},
   {{"psurface", "paved_bad"}, {0.8, 0.8}},
-  {{"psurface", "unpaved_good"}, {1.0, 1.0}},
+  {{"psurface", "unpaved_good"}, {0.9, 0.9}},
   {{"psurface", "unpaved_bad"}, {0.3, 0.3}},
   // no dedicated cycleway, doesn't mean that bicycle is not allowed, just lower weight
-  {{"hwtag", "nocycleway"}, {0.8, 0.8}},
+  // But why? If nocycleway is tagged explicitly means there is no cycling infra for sure.
+  // Otherwise there is a small chance cycling infra is present though not mapped?
+  /// @todo(pastk): this heuristic is controversial, maybe remove completely?
+  {{"hwtag", "nocycleway"}, {0.95, 0.95}},
 };
 }  // namespace bicycle_model
 

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -27,7 +27,7 @@ HighwayBasedFactors const kDefaultFactors = GetOneFactorsForBicycleAndPedestrian
 
 SpeedKMpH constexpr kSpeedOffroadKMpH = {1.5 /* weight */, 3.0 /* eta */};
 SpeedKMpH constexpr kSpeedDismountKMpH = {2.0 /* weight */, 4.0 /* eta */};
-// Applies only to contries where cycling is allowed on footways (by default the above dismount speed is used).
+// Applies only to countries where cycling is allowed on footways (by default the above dismount speed is used).
 SpeedKMpH constexpr kSpeedOnFootwayKMpH = {8.0 /* weight */, 10.0 /* eta */};
 
 HighwayBasedSpeeds const kDefaultSpeeds = {
@@ -176,8 +176,8 @@ VehicleModel::SurfaceInitList const kBicycleSurface = {
   {{"psurface", "paved_bad"}, {0.8, 0.8}},
   {{"psurface", "unpaved_good"}, {0.9, 0.9}},
   {{"psurface", "unpaved_bad"}, {0.3, 0.3}},
-  // no dedicated cycleway, doesn't mean that bicycle is not allowed, just lower weight
-  // But why? If nocycleway is tagged explicitly means there is no cycling infra for sure.
+  // No dedicated cycleway doesn't mean that bicycle is not allowed, just lower weight.
+  // If nocycleway is tagged explicitly then there is no cycling infra for sure.
   // Otherwise there is a small chance cycling infra is present though not mapped?
   /// @todo(pastk): this heuristic is controversial, maybe remove completely?
   {{"hwtag", "nocycleway"}, {0.95, 0.95}},

--- a/routing_common/routing_common_tests/vehicle_model_test.cpp
+++ b/routing_common/routing_common_tests/vehicle_model_test.cpp
@@ -366,6 +366,10 @@ UNIT_CLASS_TEST(VehicleModelTest, BicycleModel_Speeds)
     {cycleway, unpavedBad},
     {path, unpavedGood}, // Its controversial what is preferrable: a good path or a bad cycleway
     {path, yesBicycle, unpavedBad},
+    /// @todo(pastk): "nobicycle" is ignored in speed calculation atm, the routing is just forbidden there.
+    /// But "nobicycle" should result in a dismount speed instead, see https://github.com/organicmaps/organicmaps/issues/9784
+    // {footway, c.GetTypeByPath({"hwtag", "nobicycle"})},
+    // {path, c.GetTypeByPath({"hwtag", "nobicycle"})},
     {path, unpavedBad},
   };
 

--- a/routing_common/routing_common_tests/vehicle_model_test.cpp
+++ b/routing_common/routing_common_tests/vehicle_model_test.cpp
@@ -351,7 +351,6 @@ UNIT_CLASS_TEST(VehicleModelTest, BicycleModel_Smoke)
 UNIT_CLASS_TEST(VehicleModelTest, BicycleModel_Speeds)
 {
   auto const & model = BicycleModel::AllLimitsInstance();
-  auto const & c = classif();
   auto const p = DefaultParams();
 
   std::vector<std::vector<uint32_t>> const highways = {
@@ -363,12 +362,10 @@ UNIT_CLASS_TEST(VehicleModelTest, BicycleModel_Speeds)
     {path, yesBicycle}, // TODO: unpaved by default, so should be lower than shared footways or cycleways, but is equal
     {cycleway, pavedBad},
     {footway, yesBicycle, pavedBad},
+    {footway}, // If allowed in the region.
     {cycleway, unpavedBad},
+    {path, unpavedGood}, // Its controversial what is preferrable: a good path or a bad cycleway
     {path, yesBicycle, unpavedBad},
-    {path, unpavedGood}, // TODO: should be faster than bad surface cycleway (mtb?), but weight is less while eta is faster
-    {footway},
-    {footway, c.GetTypeByPath({"hwtag", "nobicycle"})}, // TODO: should be lower than previous, but is equal
-    // {path, c.GetTypeByPath({"hwtag", "nobicycle"})}, //TODO: should be lower than previous, but is higher
     {path, unpavedBad},
   };
 


### PR DESCRIPTION
A big review of weights and ETAs.

I've reviewed all the current integration tests - seems like some of them lost their value over time due to map changes or too similar to other tests. @vng I want to proceed and delete such tests, but first please review my comments in case I've missed something.

Then I've added a bunch of new tests.

Out of scope: some cases are not fixable by weights alone
- https://github.com/organicmaps/organicmaps/issues/9748

Cases solved:
- closes https://github.com/organicmaps/organicmaps/issues/7934
- closes https://github.com/organicmaps/organicmaps/issues/7954
- closes https://github.com/organicmaps/organicmaps/issues/1772
- closes https://github.com/organicmaps/organicmaps/issues/4059
- closes https://github.com/organicmaps/organicmaps/issues/6027

Improves:
- https://github.com/organicmaps/organicmaps/issues/3316#issuecomment-2452680022
- https://github.com/organicmaps/organicmaps/issues/2253
- https://github.com/organicmaps/organicmaps/issues/1201#issuecomment-946042937
