### PR TITLE
Add aliases for Police (#9674)

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -9618,7 +9618,7 @@ cs:4bezpečnost
 de:Polizeiwache|Polizei
 fr:Poste de police|Commissariat
 hi:3थाना
-it:Posto di polizia
+it:Posto di polizia|6Commissariato|5Questura|4Caserma|4Guardia|5Carabinieri
 ja:1屯所|ポリス|交番|お巡りさん|おまわりさん|通報
 ko:보안대
 pl:Policja|komisariat|posterunek

--- a/data/categories.txt
+++ b/data/categories.txt
@@ -9618,7 +9618,7 @@ cs:4bezpečnost
 de:Polizeiwache|Polizei
 fr:Poste de police|Commissariat
 hi:3थाना
-it:Posto di polizia|6Commissariato|5Questura|4Caserma|4Guardia|5Carabinieri
+it:6Commissariato|5Questura|4Caserma|4Guardia|5Carabinieri
 ja:1屯所|ポリス|交番|お巡りさん|おまわりさん|通報
 ko:보안대
 pl:Policja|komisariat|posterunek


### PR DESCRIPTION
This temporarily fixes #9674.

I still believe that this search should be done on the `operator=` tag. Until this is done, this works good enough to find police emergency services locations, even if they don't exactly match the query.

This might also match queries by users searching for "Guardia di Finanza", which is a dedicated branch of the Italian authorities for finance, but they are still a military organ of the government which interacts with the citizens like "Carabinieri". 

This **could** be removed, but it would also exclude "Guardia Costiera" which is the branch dedicated to sea emergencies.
 