### PR TITLE
[Docs] document outdoor style commands

### DIFF
--- a/docs/DEBUG_COMMANDS.md
+++ b/docs/DEBUG_COMMANDS.md
@@ -10,8 +10,10 @@ For more information, please see the source code at [`Framework::ParseSearchQuer
 
 ### Themes
 
-- `?dark` or `mapstyle:dark`: Enable night mode for the map view only. You may need to change the zoom level to fully apply the new mode.
-- `?light` or `mapstyle:light`: Enable light mode for the map view only. You may need to change the zoom level to fully apply the new mode.
+- `?dark` or `mapstyle:dark`: Enable night mode for the map view only. You may need to change the zoom level to reload the view.
+- `?light` or `mapstyle:light`: Enable light mode for the map view only. You may need to change the zoom level to reload the view.
+- `?odark` or `mapstyle:outdoors_dark`: Same as `?dark`, but using the outdoor variant.
+- `?olight` or `mapstyle:outdoors_light`: Same as `?light`, but using the outdoor variant.
 - `?vdark` or `mapstyle:vdark`: Same as `?dark`, but using the vehicle variant.
 - `?vlight` or `mapstyle:vlight`: Same as `?light`, but using the vehicle variant.
 


### PR DESCRIPTION
adds `?olight` and `?odark` to docs.