### PR TITLE
[tools] generate-localizations.sh: add -u to ignore unused string check

### DIFF
--- a/tools/python/clean_strings_txt.py
+++ b/tools/python/clean_strings_txt.py
@@ -396,8 +396,8 @@ if __name__ == "__main__":
 
     if args.validate:
         if find_unused():
-            print(
-                "ERROR: there are unused strings\n(run \"{0} -s\" to delete them)\nTerminating...".format(prog_name))
+            print("ERROR: there are unused strings (run \"{0} -s\" to delete them)".format(prog_name))
+            print("If you're running generate_localizations.sh, add -u to generate anyway.\nExiting...")
             exit(1)
         exit(0)
 


### PR DESCRIPTION
`-u` ("unused") is useful when you want to keep strings for future, but need to test stuff before using them in-app.

Also remove `-x` flag, unneeded and just spams the terminal
