### PR TITLE
[ios] fix the bookmark description jumping bug during editing

### DIFF
--- a/iphone/Maps/UI/EditBookmark/EditBookmarkViewController.swift
+++ b/iphone/Maps/UI/EditBookmark/EditBookmarkViewController.swift
@@ -222,9 +222,6 @@ extension EditBookmarkViewController: MWMNoteCellDelegate {
     UIView.setAnimationsEnabled(false)
     tableView.refresh()
     UIView.setAnimationsEnabled(true)
-    tableView.scrollToRow(at: IndexPath(item: 0, section: Sections.description.rawValue),
-                          at: .bottom,
-                          animated: true)
   }
 
   func cell(_ cell: MWMNoteCell, didFinishEditingWithText text: String) {


### PR DESCRIPTION
Closes #9722

The bug was caused by the `tableveiew` scrolling with animation to the section's bottom on every `textview` update.

Before:

https://github.com/user-attachments/assets/95d51088-08f4-45a5-bfc2-80d224d0c52c

After:

https://github.com/user-attachments/assets/cc7bbd21-763d-466a-a6e6-fd3d3abcfeb6



