### PR TITLE
[docker] Docker container

### DIFF
--- a/docker/run_ubuntu.sh
+++ b/docker/run_ubuntu.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+DOCKER_IMAGE_NAME="organicmaps/ubuntu"
+
+THIS_SCRIPT_PATH=$(cd "$(dirname "$0")"; pwd -P) || exit 1
+OM_PATH="${THIS_SCRIPT_PATH}/../"
+
+# Need to change directory to OM_PATH to be able to use it inside the container
+cd "${OM_PATH}" || exit 1
+docker build -t ${DOCKER_IMAGE_NAME} -f "${OM_PATH}"/docker/ubuntu/Dockerfile .
+# Switch back to the original directory
+cd - || exit 1
+
+docker run \
+  -it \
+  --hostname organicmaps \
+  -v "${OM_PATH}":"/organicmaps" \
+  --workdir "/organicmaps" \
+  ${DOCKER_IMAGE_NAME}

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:24.04
+
+LABEL authors="https://github.com/organicmaps"
+
+SHELL ["/bin/bash", "-c"]
+
+USER root
+
+ENV CLANG_VERSION=18
+ENV GCC_VERSION=14
+
+RUN apt-get update -y
+RUN apt-get install -y \
+    cmake \
+    ninja-build \
+    libgl1-mesa-dev \
+    libglvnd-dev \
+    libharfbuzz-dev \
+    qt6-base-dev \
+    libqt6svg6-dev \
+    qt6-positioning-dev \
+    libqt6positioning6-plugins \
+    libqt6positioning6 \
+    ccache \
+    clang-${CLANG_VERSION} \
+    clang++-${CLANG_VERSION} \
+    g++-${GCC_VERSION} \
+    gcc-${GCC_VERSION} \
+    python3 \
+    python3-pip
+
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION} 100
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} 100
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 100
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 100
+
+ENV CMAKE_C_COMPILER_LAUNCHER=ccache
+ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+COPY docker/ubuntu/env.sh /tmp
+RUN cat "/tmp/env.sh" >> "${HOME}/.bashrc"
+RUN rm /tmp/env.sh

--- a/docker/ubuntu/env.sh
+++ b/docker/ubuntu/env.sh
@@ -1,0 +1,12 @@
+select_gcc() {
+  export CC=gcc
+  export CXX=g++
+}
+
+select_clang() {
+  export CC=clang
+  export CXX=clang++
+}
+
+select_gcc
+# select_clang


### PR DESCRIPTION
Just a simple docker container.
The configuration is the same as on our Linux CI.
It could be useful when you're on macOS and you need to work with Linux build.

In future, it could be extended in many ways:
* Add prebuilt tools like translations, styles generators, generator tool
* Publish it on the docker hub and no need to build it manually every time
* Use it in our CI for different checks like if the translations are correct, if all styles are generated and so on

To run it just install the docker tool and run `run_ubuntu.sh` script.
