### PR TITLE
EN as additional search language in the editor

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/editor/Editor.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/Editor.cpp
@@ -406,8 +406,10 @@ Java_app_organicmaps_editor_Editor_nativeGetAllCreatableFeatureTypes(JNIEnv * en
                                                                          jstring jLang)
 {
   std::string const & lang = jni::ToNativeString(env, jLang);
-  GetFeatureCategories().AddLanguage(lang);
-  return jni::ToJavaStringArray(env, GetFeatureCategories().GetAllCreatableTypeNames());
+  auto & categories = GetFeatureCategories();
+  categories.AddLanguage(lang);
+  categories.AddLanguage("en");
+  return jni::ToJavaStringArray(env, categories.GetAllCreatableTypeNames());
 }
 
 JNIEXPORT jobjectArray JNICALL
@@ -416,9 +418,10 @@ Java_app_organicmaps_editor_Editor_nativeSearchCreatableFeatureTypes(JNIEnv * en
                                                                          jstring jLang)
 {
   std::string const & lang = jni::ToNativeString(env, jLang);
-  GetFeatureCategories().AddLanguage(lang);
-  return jni::ToJavaStringArray(env,
-                                GetFeatureCategories().Search(jni::ToNativeString(env, query)));
+  auto & categories = GetFeatureCategories();
+  categories.AddLanguage(lang);
+  categories.AddLanguage("en");
+  return jni::ToJavaStringArray(env, categories.Search(jni::ToNativeString(env, query)));
 }
 
 JNIEXPORT jobjectArray JNICALL

--- a/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorDataSource.mm
+++ b/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorDataSource.mm
@@ -50,6 +50,7 @@ std::string locale()
 {
   m_categories = GetFramework().GetEditorCategories();
   m_categories.AddLanguage(locale());
+  m_categories.AddLanguage("en");
 
   auto const & types = m_categories.GetAllCreatableTypeNames();
   m_categoriesList.reserve(types.size());


### PR DESCRIPTION
Added EN as an additional search language in the editor. So users can use englisch, as well as native words in the search. This makes the editor search more consistent with the search on the map (supports en + locale as well) and increases the changes of finding the category users are looking for.

--- 

Tested on Android, but **not** on iOS

The case when lang / locale() == "en" is not a problem as `NewFeatureCategories::AddLanguage` takes care of this case and adds each language only once.