### PR TITLE
Color of yellow road shields in dark mode #9676

### DIFF
--- a/data/styles/default/dark/style.mapcss
+++ b/data/styles/default/dark/style.mapcss
@@ -74,7 +74,7 @@ colors
   RoadShieldBlueBackground-color: #294C88;
   RoadShieldGreenBackground-color: #136C30;
   RoadShieldRedBackground-color: #9F1A17;
-  RoadShieldOrangeBackground-color: #136C30;
+  RoadShieldOrangeBackground-color: #FFBE00;
   PoiHotelTextOutline-color: #000000;
   PoiHotelTextOutline-opacity: 0.6;
   PoiDeletedMask-color: #FFFFFF;


### PR DESCRIPTION
I changed the color of the road shield in dark mode in `data/styles/default/dark/style.mapcss`  just like the color of the road shield in light mode (#FFBE00). 

Issue : #9676 