### PR TITLE
WIP Migrate mapcss files from pseudo-tags to OM types

### DIFF
--- a/data/styles/default/include/Basemap.mapcss
+++ b/data/styles/default/include/Basemap.mapcss
@@ -30,450 +30,450 @@
 
 /* 2.LAND */
 
-area|z0-[natural=coastline],
-area|z0-[natural=land],
-area|z10-[place=islet]
+area|z0-|natural-coastline,
+area|z0-|natural-land,
+area|z10-|place-islet
 {fill-opacity: 1;}
 
-area|z0-[natural=coastline]
+area|z0-|natural-coastline
 {fill-color: @water;}
 
-area|z0-[natural=land],
-area|z10-[place=islet]
+area|z0-|natural-land,
+area|z10-|place-islet
 {fill-color: @background;}
 
 /* 3.BOUNDARIES */
 
-line|z2-[boundary=administrative]
+line|z2-|boundary-administrative
 {color: @border_country;opacity: 0.7;}
 
-line|z4[boundary=administrative][admin_level=3],
-line|z5-[boundary=administrative][admin_level=4]
+line|z4|boundary-administrative-3,
+line|z5-|boundary-administrative-4
 {color: @border_region;opacity: 0.7;}
 
 /* 3.1 Country */
 
-line|z2[boundary=administrative][admin_level=2]
+line|z2|boundary-administrative-2
 {width: 0.5;opacity: 0.5;}
-line|z3[boundary=administrative][admin_level=2]
+line|z3|boundary-administrative-2
 {width: 0.5;opacity: 0.6;}
-line|z4[boundary=administrative][admin_level=2]
+line|z4|boundary-administrative-2
 {width: 0.6;}
-line|z5[boundary=administrative][admin_level=2]
+line|z5|boundary-administrative-2
 {width: 0.8;}
-line|z6[boundary=administrative][admin_level=2]
+line|z6|boundary-administrative-2
 {width: 0.85;}
-line|z7[boundary=administrative][admin_level=2]
+line|z7|boundary-administrative-2
 {width: 1;}
-line|z8[boundary=administrative][admin_level=2]
+line|z8|boundary-administrative-2
 {width: 1.1;}
-line|z9-[boundary=administrative][admin_level=2]
+line|z9-|boundary-administrative-2
 {width: 1.4;}
 
 /* 3.2 Region */
 
-line|z4[boundary=administrative][admin_level=3]
+line|z4|boundary-administrative-3
 {width: 0.8; dashes: 0.9,0.4;}
 
-line|z5[boundary=administrative][admin_level=4]
+line|z5|boundary-administrative-4
 {width: 0.7; opacity: 0.8; dashes: 1.3,0.9;}
-line|z6[boundary=administrative][admin_level=4]
+line|z6|boundary-administrative-4
 {width: 0.8; dashes: 1.3,0.9;}
-line|z7-[boundary=administrative][admin_level=4]
+line|z7-|boundary-administrative-4
 {width: 0.9; dashes: 1.8,0.9;}
-line|z9[boundary=administrative][admin_level=4]
+line|z9|boundary-administrative-4
 {width: 1;}
-line|z10-[boundary=administrative][admin_level=4]
+line|z10-|boundary-administrative-4
 {width: 1.2;}
 
 
 /* 4.VEGETATION */
 
-area|z10-[landuse=forest],
-area|z10-[leisure=park],
-area|z12-[leisure=garden],
-area|z12-[landuse=grass],
-area|z12-[natural=grassland],
-area|z12-[leisure=golf_course],
-area|z12-[natural=heath],
-area|z12-[landuse=allotments],
-area|z12-[natural=bare_rock],
-area|z12-[natural=shingle],
-area|z11-[natural=scree],
-area|z12-[landuse=orchard],
-area|z12-[landuse=vineyard],
-area|z12-[landuse=meadow],
-area|z12-[landuse=recreation_ground],
-area|z12-[landuse=village_green],
-area|z12-[landuse=field],
-area|z12-[natural=scrub],
-area|z14-[leisure=miniature_golf],
-area|z16-[landuse=flowerbed],
+area|z10-|landuse-forest,
+area|z10-|leisure-park,
+area|z12-|leisure-garden,
+area|z12-|landuse-grass,
+area|z12-|natural-grassland,
+area|z12-|leisure-golf_course,
+area|z12-|natural-heath,
+area|z12-|landuse-allotments,
+area|z12-|natural-bare_rock,
+area|z12-|natural-shingle,
+area|z11-|natural-scree,
+area|z12-|landuse-orchard,
+area|z12-|landuse-vineyard,
+area|z12-|landuse-meadow,
+area|z12-|landuse-recreation_ground,
+area|z12-|landuse-village_green,
+area|z12-|landuse-field,
+area|z12-|natural-scrub,
+area|z14-|leisure-miniature_golf,
+area|z16-|landuse-flowerbed,
 {fill-opacity: 1;}
 
-area|z10-12[leisure=park],
+area|z10-12|leisure-park,
 {fill-color: @green0;}
-area|z13-15[leisure=park],
+area|z13-15|leisure-park,
 {fill-color: @green1;}
-area|z16-[leisure=park],
-area|z14-15[natural=scrub],
+area|z16-|leisure-park,
+area|z14-15|natural-scrub,
 {fill-color: @green2;}
-area|z16-[natural=scrub],
+area|z16-|natural-scrub,
 {fill-color: @green3;}
-area|z16-[landuse=flowerbed],
+area|z16-|landuse-flowerbed,
 {fill-color: @flowers;}
 
-area|z14-15[landuse=grass],
+area|z14-15|landuse-grass,
 {fill-color: @green0;}
-area|z10[landuse=forest],
-area|z16-[landuse=grass],
-area|z14-15[natural=grassland],
-area|z14-[leisure=golf_course],
-area|z14-[leisure=miniature_golf],
-area|z14-[natural=heath],
-area|z14-[landuse=allotments],
-area|z14-[landuse=orchard],
-area|z14-[landuse=vineyard],
-area|z14-15[landuse=meadow],
-area|z14-[landuse=recreation_ground],
-area|z14-[landuse=village_green],
-area|z14-[landuse=field],
+area|z10|landuse-forest,
+area|z16-|landuse-grass,
+area|z14-15|natural-grassland,
+area|z14-|leisure-golf_course,
+area|z14-|leisure-miniature_golf,
+area|z14-|natural-heath,
+area|z14-|landuse-allotments,
+area|z14-|landuse-orchard,
+area|z14-|landuse-vineyard,
+area|z14-15|landuse-meadow,
+area|z14-|landuse-recreation_ground,
+area|z14-|landuse-village_green,
+area|z14-|landuse-field,
 {fill-color: @green1;}
-area|z16-[natural=grassland],
-area|z16-[landuse=meadow],
+area|z16-|natural-grassland,
+area|z16-|landuse-meadow,
 {fill-color: @green1b;}
-area|z11-12[landuse=forest],
-area|z12[leisure=garden],
+area|z11-12|landuse-forest,
+area|z12|leisure-garden,
 {fill-color: @green2;}
-area|z13[landuse=forest],
-area|z13[leisure=garden],
+area|z13|landuse-forest,
+area|z13|leisure-garden,
 {fill-color: @green3;}
-area|z14[landuse=forest],
-area|z14[leisure=garden],
+area|z14|landuse-forest,
+area|z14|leisure-garden,
 {fill-color: @green4;}
-area|z15[landuse=forest],
-area|z15[leisure=garden],
+area|z15|landuse-forest,
+area|z15|leisure-garden,
 {fill-color: @green5;}
-area|z16-[landuse=forest],
-area|z16-[leisure=garden],
+area|z16-|landuse-forest,
+area|z16-|leisure-garden,
 {fill-color: @forest;}
 
-area|z12-[leisure=garden][garden:type=residential],
+area|z12-|leisure-garden-residential,
 {fill-color: @green0;}
-area|z16-[leisure=garden][garden:type=residential],
+area|z16-|leisure-garden-residential,
 {fill-color: @green1;}
-area|z17-[leisure=garden][garden:type=residential],
+area|z17-|leisure-garden-residential,
 {fill-color: @green2;}
 
-area|z12-13[landuse=grass],
-area|z12-13[natural=grassland],
-area|z12-13[leisure=golf_course],
-area|z12-13[natural=heath],
-area|z12-13[landuse=allotments],
-area|z12-13[landuse=orchard],
-area|z12-13[landuse=vineyard],
-area|z12-13[landuse=meadow],
-area|z12-13[landuse=recreation_ground],
-area|z12-13[landuse=village_green],
-area|z12-13[landuse=field],
-area|z12-13[natural=scrub],
+area|z12-13|landuse-grass,
+area|z12-13|natural-grassland,
+area|z12-13|leisure-golf_course,
+area|z12-13|natural-heath,
+area|z12-13|landuse-allotments,
+area|z12-13|landuse-orchard,
+area|z12-13|landuse-vineyard,
+area|z12-13|landuse-meadow,
+area|z12-13|landuse-recreation_ground,
+area|z12-13|landuse-village_green,
+area|z12-13|landuse-field,
+area|z12-13|natural-scrub,
 {fill-color: @green0;}
 
 /* Next types are hardcoded to have a hatching-style fill, see drape_frontend/stylist.cpp */
-area|z10-17[leisure=nature_reserve],
-area|z10-17[boundary=national_park],
-area|z10-17[boundary=protected_area][protect_class=1],
+area|z10-17|leisure-nature_reserve,
+area|z10-17|boundary-national_park,
+area|z10-17|boundary-protected_area-1,
 {fill-opacity: 0.2; fill-color: @green6;}
 
-area|z10-16[boundary=aboriginal_lands],
+area|z10-16|boundary-aboriginal_lands,
 {fill-opacity: 0.07; fill-color: @indigenous_lands;}
 
-area|z10-[landuse=military][military=danger_area],
+area|z10-|landuse-military-danger_area,
 {fill-opacity: 1.0; fill-color: @military;}
 
-area|z12-[landuse=military]
+area|z12-|landuse-military
 {fill-opacity: 0.5; fill-color: @military;}
 
-area|z12-[amenity=prison]
+area|z12-|amenity-prison
 {fill-opacity: 0.5; fill-color: @prison;}
 /* End of hardcoded */
 
-area|z11-[natural=scree],
-area|z12-[natural=shingle],
+area|z11-|natural-scree,
+area|z12-|natural-shingle,
 {fill-color: @scree;}
 
-area|z12-[natural=bare_rock],
+area|z12-|natural-bare_rock,
 {fill-color: @barerock;}
 
 /* 5.BEACH, GLACIER, DESERT, etc. */
 
-area|z0-[natural=glacier],
-area|z10-[natural=beach],
-area|z0-[natural=desert],
-area|z10-[leisure=beach_resort],
+area|z0-|natural-glacier,
+area|z10-|natural-beach,
+area|z0-|natural-desert,
+area|z10-|leisure-beach_resort,
 {fill-opacity: 1;}
 
-area|z0-[natural=glacier]
+area|z0-|natural-glacier
 {fill-color: @glacier;}
 
-area|z10-[natural=beach],
-area|z10-[leisure=beach_resort],
+area|z10-|natural-beach,
+area|z10-|leisure-beach_resort,
 {fill-color: @beach;}
 
-area|z0-[natural=desert],
+area|z0-|natural-desert,
 {fill-color: @desert;}
 
 /* 6.WATER */
 
-area|z0-[natural=water],
-area|z0-[waterway=dock],
-area|z0-[landuse=salt_pond],
-area|z12-[landuse=basin],
-area|z12-[landuse=reservoir],
+area|z0-|natural-water,
+area|z0-|waterway-dock,
+area|z0-|landuse-salt_pond,
+area|z12-|landuse-basin,
+area|z12-|landuse-reservoir,
 {fill-opacity: 1;}
-area|z15-[natural=water][tunnel],
+area|z15-|[natural=water][tunnel] /*NO-TYPE-MATCH*/,
 {fill-opacity: 0.15;}
 
-area|z11-[natural=wetland],
-area|z11-[leisure=marina],
-area|z13-[leisure=swimming_pool],
-area|z16-[amenity=fountain],
+area|z11-|natural-wetland,
+area|z11-|leisure-marina,
+area|z13-|leisure-swimming_pool,
+area|z16-|amenity-fountain,
 {fill-opacity: 1;}
 
-line|z10-[waterway=river],
-line|z13-[waterway=stream],
-line|z13-[waterway=canal],
-line|z13-[waterway=fish_pass],
-line|z13-[natural=strait],
+line|z10-|waterway-river,
+line|z13-|waterway-stream,
+line|z13-|waterway-canal,
+line|z13-|waterway-fish_pass,
+line|z13-|natural-strait,
 {opacity: 0.7; color: @river;}
 
 /* 6.1 Area water(lake,pond etc.) */
 
-area|z0-[natural=water][!tunnel],
-area|z0-[landuse=salt_pond],
-area|z0-[waterway=dock],
-area|z12-[landuse=basin],
-area|z12-[landuse=reservoir],
-area|z13-[leisure=swimming_pool],
-area|z15-[natural=water][tunnel],
-area|z16-[amenity=fountain],
+area|z0-|[natural=water][!tunnel] /*NO-TYPE-MATCH*/,
+area|z0-|landuse-salt_pond,
+area|z0-|waterway-dock,
+area|z12-|landuse-basin,
+area|z12-|landuse-reservoir,
+area|z13-|leisure-swimming_pool,
+area|z15-|[natural=water][tunnel] /*NO-TYPE-MATCH*/,
+area|z16-|amenity-fountain,
 {fill-color: @water;}
 
-area|z0-[natural=water][water=ditch],
-area|z0-[natural=water][water=drain],
-area|z0-[natural=water][water=wastewater],
+area|z0-|natural-water-ditch,
+area|z0-|natural-water-drain,
+area|z0-|natural-water-wastewater,
 {fill-color: none;}
 
-area|z13-[natural=water][water=ditch],
-area|z13-[natural=water][water=drain],
-area|z12-[natural=water][water=wastewater],
+area|z13-|natural-water-ditch,
+area|z13-|natural-water-drain,
+area|z12-|natural-water-wastewater,
 {fill-color: @water_bad;}
 
-area|z11-[natural=wetland]
+area|z11-|natural-wetland
 {fill-color: @wetland;}
 
 /* 6.2 Line water(river,canal etc.) */
 
-line|z10[waterway=river],
+line|z10|waterway-river,
 {width: 1;}
 
-line|z11-12[waterway=river],
+line|z11-12|waterway-river,
 {width: 1.2;}
 
-line|z13[waterway=river],
+line|z13|waterway-river,
 {width: 1.6;}
-line|z13[waterway=stream],
-line|z13[waterway=canal],
-line|z13[waterway=fish_pass],
-line|z13[natural=strait],
+line|z13|waterway-stream,
+line|z13|waterway-canal,
+line|z13|waterway-fish_pass,
+line|z13|natural-strait,
 {width: 0.7;}
-line|z13[waterway=stream][intermittent=yes]
+line|z13|waterway-stream-intermittent
 {width: 0.7;dashes: 2.7,2.7;}
 
-line|z14[waterway=river],
+line|z14|waterway-river,
 {width: 1.8;}
-line|z14[waterway=stream],
-line|z14[waterway=canal],
-line|z14[waterway=fish_pass],
-line|z14[natural=strait],
+line|z14|waterway-stream,
+line|z14|waterway-canal,
+line|z14|waterway-fish_pass,
+line|z14|natural-strait,
 {width: 1;}
-line|z14[waterway=stream][intermittent=yes]
+line|z14|waterway-stream-intermittent
 {width: 1;dashes: 2.7,2.7;}
 
-line|z15-[waterway=river],
+line|z15-|waterway-river,
 {width: 2.2;}
-line|z15-[waterway=stream],
-line|z15-[waterway=canal],
-line|z15-[waterway=fish_pass],
-line|z15-[natural=strait],
+line|z15-|waterway-stream,
+line|z15-|waterway-canal,
+line|z15-|waterway-fish_pass,
+line|z15-|natural-strait,
 {width: 1.6;}
-line|z15-[waterway=stream][intermittent=yes]
+line|z15-|waterway-stream-intermittent
 {width: 1.4;dashes: 4.95,4.95;}
 
-node|z16-[waterway=lock_gate],
+node|z16-|waterway-lock_gate,
 {icon-image: dot-m.svg;}
 
-line|z13-[waterway=ditch],
-line|z13-[waterway=drain],
+line|z13-|waterway-ditch,
+line|z13-|waterway-drain,
 {opacity: 0.7; color: @water_bad; width: 1.5; dashes: 2.7,2.7;}
-line|z16-[waterway=ditch],
-line|z16-[waterway=drain],
+line|z16-|waterway-ditch,
+line|z16-|waterway-drain,
 {width: 3;}
 
 /* Do not draw tunnel waterways */
-line[waterway][tunnel]
+line|[waterway][tunnel] /*NO-TYPE-MATCH*/
 {width: 0;}
 
 /* 7.LANDUSE */
 
-area|z10-[aeroway=aerodrome][aerodrome=international],
-area|z10-[aeroway=aerodrome],
-area|z14-[amenity=hospital],
-area|z14-[amenity=doctors],
-area|z14-[healthcare=laboratory],
-area|z14-[highway=pedestrian][area?],
-area|z14-[area:highway=pedestrian],
-area|z14-[highway=footway][area?],
-area|z14-[area:highway=footway],
-area|z14-[area:highway=living_street],
-area|z14-[amenity=grave_yard],
-area|z14-[landuse=cemetery],
-area|z14-[amenity=university],
-area|z15-[landuse=garages],
-area|z15-[landuse=industrial],
-area|z15-[landuse=construction],
-area|z15-[landuse=churchyard],
-area|z15-[landuse=landfill],
-area|z15-[landuse=railway],
-area|z15-[landuse=quarry],
-area|z15-[leisure=pitch],
-area|z15-[leisure=stadium],
-area|z15-[leisure=track][area?],
-area|z15-[amenity=parking],
-area|z15-[amenity=kindergarten],
-area|z15-[amenity=college],
-area|z15-[amenity=school],
-area|z15-[landuse=education],
-area|z16-[public_transport=platform],
-area|z16-[amenity=place_of_worship],
-area|z16-[railway=platform],
-area|z16-[leisure=playground],
+area|z10-|aeroway-aerodrome-international,
+area|z10-|aeroway-aerodrome,
+area|z14-|amenity-hospital,
+area|z14-|amenity-doctors,
+area|z14-|healthcare-laboratory,
+area|z14-|highway-pedestrian-area,
+area|z14-|area:highway-pedestrian,
+area|z14-|highway-footway-area,
+area|z14-|area:highway-footway,
+area|z14-|area:highway-living_street,
+area|z14-|amenity-grave_yard,
+area|z14-|landuse-cemetery,
+area|z14-|amenity-university,
+area|z15-|landuse-garages,
+area|z15-|landuse-industrial,
+area|z15-|landuse-construction,
+area|z15-|landuse-churchyard,
+area|z15-|landuse-landfill,
+area|z15-|landuse-railway,
+area|z15-|landuse-quarry,
+area|z15-|leisure-pitch,
+area|z15-|leisure-stadium,
+area|z15-|leisure-track-area,
+area|z15-|amenity-parking,
+area|z15-|amenity-kindergarten,
+area|z15-|amenity-college,
+area|z15-|amenity-school,
+area|z15-|landuse-education,
+area|z16-|public_transport-platform,
+area|z16-|amenity-place_of_worship,
+area|z16-|railway-platform,
+area|z16-|leisure-playground,
 {fill-opacity: 1;}
 
 /* 7.1 Industrial */
 
-area|z15-[landuse=industrial],
-area|z15-[landuse=construction],
-area|z15-[landuse=landfill],
-area|z15-[landuse=railway],
-area|z15-[landuse=quarry],
-area|z15-[landuse=garages],
+area|z15-|landuse-industrial,
+area|z15-|landuse-construction,
+area|z15-|landuse-landfill,
+area|z15-|landuse-railway,
+area|z15-|landuse-quarry,
+area|z15-|landuse-garages,
 {fill-color: @industrial;}
 
 /* 7.2 Hospital */
 
-area|z14-[amenity=hospital],
-area|z14-[amenity=doctors]
+area|z14-|amenity-hospital,
+area|z14-|amenity-doctors
 {fill-color: @hospital;}
 
 /* 7.3 University & Sport */
 
-area|z14-[amenity=university],
-area|z15-[amenity=college],
-area|z15-[amenity=school],
-area|z15-[amenity=kindergarten],
-area|z15-[landuse=education],
+area|z14-|amenity-university,
+area|z15-|amenity-college,
+area|z15-|amenity-school,
+area|z15-|amenity-kindergarten,
+area|z15-|landuse-education,
 {fill-color: @university;}
 
-area|z15-[leisure=pitch],
-area|z15-[leisure=track][area?],
-area|z16-[leisure=playground],
+area|z15-|leisure-pitch,
+area|z15-|leisure-track-area,
+area|z16-|leisure-playground,
 {fill-color: @sport2;}
 
-area|z15-[leisure=stadium]
+area|z15-|leisure-stadium
 {fill-color: @sport1;}
 
-area|z15-[leisure=sports_centre]
+area|z15-|leisure-sports_centre
 {fill-color: @sport0;}
 
-area|z14-[piste:type=snow_park],
+area|z14-|piste:type-snow_park,
 {fill-color: @piste; fill-opacity: 0.2;}
 
 /* 7.4 Cemetery */
 
-area|z14[landuse=cemetery],
-area|z14[amenity=grave_yard]
+area|z14|landuse-cemetery,
+area|z14|amenity-grave_yard
 {fill-color: @green2;fill-opacity: 0.85;}
 
-area|z15-[amenity=grave_yard],
-area|z15-[landuse=cemetery]
+area|z15-|amenity-grave_yard,
+area|z15-|landuse-cemetery
 {fill-color: @green2;}
 
-area|z16-[amenity=grave_yard],
-area|z16-[landuse=cemetery]
+area|z16-|amenity-grave_yard,
+area|z16-|landuse-cemetery
 {fill-color: @green3;}
 
 /* 7.5 Pedestrian areas */
 
-area|z14-[highway=pedestrian][area?],
-area|z14-[area:highway=pedestrian],
-area|z14-[highway=footway][area?],
-area|z14-[area:highway=footway],
-area|z14-[area:highway=living_street],
-area|z16-[public_transport=platform],
-area|z16-[railway=platform],
-area|z16-[amenity=place_of_worship]
+area|z14-|highway-pedestrian-area,
+area|z14-|area:highway-pedestrian,
+area|z14-|highway-footway-area,
+area|z14-|area:highway-footway,
+area|z14-|area:highway-living_street,
+area|z16-|public_transport-platform,
+area|z16-|railway-platform,
+area|z16-|amenity-place_of_worship
 {fill-color: @pedestrian_area;}
 
-area|z16-[highway=pedestrian][area?],
-area|z16-[area:highway=pedestrian],
-area|z16-[highway=footway][area?],
-area|z16-[area:highway=footway],
-area|z16-[area:highway=living_street],
+area|z16-|highway-pedestrian-area,
+area|z16-|area:highway-pedestrian,
+area|z16-|highway-footway-area,
+area|z16-|area:highway-footway,
+area|z16-|area:highway-living_street,
 {fill-color: @pedestrian_area_light;}
 
 /* 7.6 Airports */
 
-area|z10[aeroway=aerodrome][aerodrome=international],
-area|z10[aeroway=aerodrome],
+area|z10|aeroway-aerodrome-international,
+area|z10|aeroway-aerodrome,
 {fill-color: @aerodrome0;}
-area|z11[aeroway=aerodrome][aerodrome=international],
-area|z11[aeroway=aerodrome],
+area|z11|aeroway-aerodrome-international,
+area|z11|aeroway-aerodrome,
 {fill-color: @aerodrome1;}
-area|z12-[aeroway=aerodrome][aerodrome=international],
-area|z12-[aeroway=aerodrome]
+area|z12-|aeroway-aerodrome-international,
+area|z12-|aeroway-aerodrome
 {fill-color: @aerodrome2;}
-area|z13[aeroway=aerodrome][aerodrome=international],
-area|z13[aeroway=aerodrome]
+area|z13|aeroway-aerodrome-international,
+area|z13|aeroway-aerodrome
 {fill-color: @aerodrome3;}
-area|z14[aeroway=aerodrome][aerodrome=international],
-area|z14[aeroway=aerodrome]
+area|z14|aeroway-aerodrome-international,
+area|z14|aeroway-aerodrome
 {fill-color: @aerodrome4;}
-area|z15-19[aeroway=aerodrome][aerodrome=international],
-area|z15-19[aeroway=aerodrome]
+area|z15-19|aeroway-aerodrome-international,
+area|z15-19|aeroway-aerodrome
 {fill-color: @aerodrome5;}
 
 
 /* 7.7 Religion */
 
-area|z15-[landuse=churchyard]
+area|z15-|landuse-churchyard
 {fill-color: @background;}
 
 /* 7.8 Agricultural */
-area|z10-[landuse=farmland],
+area|z10-|landuse-farmland,
 {fill-color: @farmland; fill-opacity: 1;}
 
-area|z10-[landuse=farmyard],
+area|z10-|landuse-farmyard,
 {fill-color: @farmyard; fill-opacity: 1;}
 /* Parking */
 
-area|z15-[amenity=parking],
+area|z15-|amenity-parking,
 {fill-color: @parking;}
 
-area|z15-[amenity=parking][location=underground],
-area|z15-16[amenity=parking][access=private],
-area|z15-16[amenity=parking][parking=lane],
-area|z15-16[amenity=parking][parking=street_side],
+area|z15-|amenity-parking-underground,
+area|z15-16|amenity-parking-private,
+area|z15-16|amenity-parking-lane,
+area|z15-16|amenity-parking-street_side,
 {fill-color: none;}
 
 
@@ -481,109 +481,109 @@ area|z15-16[amenity=parking][parking=street_side],
 
 /* 8.1 Pier, dam, areal bridge, cutline */
 
-area|z12-[man_made=pier],
-area|z12-[man_made=breakwater],
+area|z12-|man_made-pier,
+area|z12-|man_made-breakwater,
 {fill-opacity: 1; fill-color: @background;}
 
-area|z14-[man_made=bridge],
+area|z14-|man_made-bridge,
 {fill-color: @bridge_background; fill-opacity: 0.8;}
 
 
-line|z14-[man_made=pier],
-line|z14-[man_made=breakwater],
+line|z14-|man_made-pier,
+line|z14-|man_made-breakwater,
 {width: 1.5;color: @background; opacity: 0.7;}
 
-line|z14-[waterway=dam],
-line|z14-[waterway=weir],
+line|z14-|waterway-dam,
+line|z14-|waterway-weir,
 {width: 1.5;color: @building1; opacity: 0.5;}
 
-line|z15[man_made=pier],
-line|z15[man_made=breakwater],
-line|z15[waterway=dam],
-line|z15[waterway=weir],
+line|z15|man_made-pier,
+line|z15|man_made-breakwater,
+line|z15|waterway-dam,
+line|z15|waterway-weir,
 {width: 2;}
 
-line|z16[man_made=pier],
-line|z16[man_made=breakwater],
-line|z16[waterway=dam],
-line|z16[waterway=weir],
+line|z16|man_made-pier,
+line|z16|man_made-breakwater,
+line|z16|waterway-dam,
+line|z16|waterway-weir,
 {width: 3;}
 
-line|z17[man_made=pier],
-line|z17[man_made=breakwater],
-line|z17[waterway=dam],
-line|z17[waterway=weir],
+line|z17|man_made-pier,
+line|z17|man_made-breakwater,
+line|z17|waterway-dam,
+line|z17|waterway-weir,
 {width: 4.5;}
 
-line|z18[man_made=pier],
-line|z18[man_made=breakwater],
-line|z18[waterway=dam],
-line|z18[waterway=weir],
+line|z18|man_made-pier,
+line|z18|man_made-breakwater,
+line|z18|waterway-dam,
+line|z18|waterway-weir,
 {width: 6;}
 
-line|z19-[man_made=pier],
-line|z19-[man_made=breakwater],
-line|z19-[waterway=dam],
-line|z19-[waterway=weir],
+line|z19-|man_made-pier,
+line|z19-|man_made-breakwater,
+line|z19-|waterway-dam,
+line|z19-|waterway-weir,
 {width: 8;}
 
-line|z14-[man_made=cutline],
+line|z14-|man_made-cutline,
 {width: 1;color: @green0; opacity: 0.4;}
-line|z15[man_made=cutline],
+line|z15|man_made-cutline,
 {width: 1.5;}
-line|z16[man_made=cutline],
+line|z16|man_made-cutline,
 {width: 2;}
-line|z17[man_made=cutline],
+line|z17|man_made-cutline,
 {width: 3;}
-line|z18[man_made=cutline],
+line|z18|man_made-cutline,
 {width: 4.5;}
-line|z19-[man_made=cutline],
+line|z19-|man_made-cutline,
 {width: 6;}
 
 
 /* 8.2 Building */
 
-area|z14[building],
-area|z14[waterway=dam],
+area|z14|building,
+area|z14|waterway-dam,
 {fill-color: @building0;fill-opacity: 0.5;}
 
-area|z15[building],
-area|z15[waterway=dam],
+area|z15|building,
+area|z15|waterway-dam,
 {fill-color: @building0;fill-opacity: 0.6;}
 
-area|z14-15[aeroway=terminal],
-area|z16[building],
-area|z16[building:part],
-area|z16[waterway=dam],
+area|z14-15|aeroway-terminal,
+area|z16|building,
+area|z16|building:part,
+area|z16|waterway-dam,
 {fill-color: @building0;fill-opacity: 0.8;casing-width: 1;casing-color: @building_border0;}
 
-area|z16-[aeroway=terminal],
-area|z17-[building],
-area|z17-[building:part],
-area|z17-[waterway=dam],
+area|z16-|aeroway-terminal,
+area|z17-|building,
+area|z17-|building:part,
+area|z17-|waterway-dam,
 {fill-color: @building1;casing-width: 1;casing-color: @building_border1;}
 
 
 /* 8.3 Barriers, cliffs */
 
-line|z16-[barrier=fence],
-line|z16-[barrier=wall],
+line|z16-|barrier-fence,
+line|z16-|barrier-wall,
 {color: @fence; width: 1; opacity: 0.5;}
-line|z17[barrier=fence],
-line|z17[barrier=wall],
+line|z17|barrier-fence,
+line|z17|barrier-wall,
 {width: 1.3; opacity: 0.6;}
-line|z18-[barrier=fence],
-line|z18-[barrier=wall],
+line|z18-|barrier-fence,
+line|z18-|barrier-wall,
 {width: 1.5; opacity: 0.8;}
 
 
-line|z16-[barrier=hedge],
+line|z16-|barrier-hedge,
 {color: @hedge; width: 1.6; opacity: 0.4;}
-line|z17[barrier=hedge],
+line|z17|barrier-hedge,
 {width: 2.2; opacity: 0.5;}
-line|z18[barrier=hedge],
+line|z18|barrier-hedge,
 {width: 3; opacity: 0.7;}
-line|z19-[barrier=hedge],
+line|z19-|barrier-hedge,
 {width: 4; opacity: 0.8;}
 
 
@@ -596,121 +596,121 @@ line|z19-[barrier=hedge],
   Set width = triangle height + base height.
 */
 
-line|z14-[barrier=city_wall],
-line|z14-[historic=citywalls],
+line|z14-|barrier-city_wall,
+line|z14-|historic-citywalls,
 {color: @building1; width: 2; opacity: 0.7;}
-line|z15[barrier=city_wall],
-line|z15[historic=citywalls],
+line|z15|barrier-city_wall,
+line|z15|historic-citywalls,
 {width: 2.8;}
-line|z16-[barrier=city_wall],
-line|z16-[historic=citywalls],
+line|z16-|barrier-city_wall,
+line|z16-|historic-citywalls,
 {color: @building0; width: 4.5; dashes: 3,3,1.5,3;}
-line|z17[barrier=city_wall],
-line|z17[historic=citywalls],
+line|z17|barrier-city_wall,
+line|z17|historic-citywalls,
 {width: 5.9; dashes: 4,4,1.9,4;}
-line|z18[barrier=city_wall],
-line|z18[historic=citywalls],
+line|z18|barrier-city_wall,
+line|z18|historic-citywalls,
 {width: 8.5; dashes: 6,6,2.5,6;}
-line|z19-[barrier=city_wall],
-line|z19-[historic=citywalls],
+line|z19-|barrier-city_wall,
+line|z19-|historic-citywalls,
 {width: 11; dashes: 8,8,3,8;}
 
 
-line|z14-[natural=cliff],
-line|z14-[natural=earth_bank],
+line|z14-|natural-cliff,
+line|z14-|natural-earth_bank,
 {color: @cliff; width: 2; dashes: 1.4,1.4; opacity: 0.4;}
-line|z15[natural=cliff],
-line|z15[natural=earth_bank],
+line|z15|natural-cliff,
+line|z15|natural-earth_bank,
 {width: 3; dashes: 1.5,1.5;}
-line|z16[natural=cliff],
-line|z16[natural=earth_bank],
+line|z16|natural-cliff,
+line|z16|natural-earth_bank,
 {width: 6.2; dashes: 3,3.5,4.5,1.2;}
-line|z17[natural=cliff],
-line|z17[natural=earth_bank],
+line|z17|natural-cliff,
+line|z17|natural-earth_bank,
 {width: 7.4; dashes: 3.5,5,6,1.4;}
-line|z18[natural=cliff],
-line|z18[natural=earth_bank],
+line|z18|natural-cliff,
+line|z18|natural-earth_bank,
 {width: 9.5; dashes: 4,6,8,1.5; opacity: 0.5;}
-line|z19-[natural=cliff],
-line|z19-[natural=earth_bank],
+line|z19-|natural-cliff,
+line|z19-|natural-earth_bank,
 {width: 11.9; dashes: 5,7,10,1.9; opacity: 0.5;}
 
 
-line|z16-[barrier=ditch],
+line|z16-|barrier-ditch,
 {width: 1.8; opacity: 0.7; color: @cliff; dashes: 0.9,0.9;}
 
 
-line|z16-[barrier=retaining_wall],
+line|z16-|barrier-retaining_wall,
 {color: @fence; width: 2.4; dashes: 2.8,1.4,1.4,1; opacity: 0.7;}
-line|z17[barrier=retaining_wall],
+line|z17|barrier-retaining_wall,
 {width: 3.2; dashes: 4,2,2,1.2;}
-line|z18-[barrier=retaining_wall],
+line|z18-|barrier-retaining_wall,
 {width: 4.5; dashes: 6,3,3,1.5;}
 
 
-line|z16-[man_made=embankment],
+line|z16-|man_made-embankment,
 {color: @building1; width: 3.5; dashes: 4,2,2,1.5; opacity: 0.7;}
-line|z17[man_made=embankment],
+line|z17|man_made-embankment,
 {width: 5; dashes: 6,3,3,2;}
-line|z18-[man_made=embankment],
+line|z18-|man_made-embankment,
 {width: 7; dashes: 8,4,4,3;}
 
 
 /* 9. ISOLINES */
 
-line|z11-[isoline=step_1000],
+line|z11-|isoline-step_1000,
 {color: @isoline1000;}
-line|z11-[isoline=step_500],
+line|z11-|isoline-step_500,
 {color: @isoline500;}
 
-line|z12-[isoline=step_100],
+line|z12-|isoline-step_100,
 {color: @isoline100;}
 
-line|z14-[isoline=step_50],
-line|z15-[isoline=zero],
+line|z14-|isoline-step_50,
+line|z15-|isoline-zero,
 {color: @isoline50;}
 
-line|z15-[isoline=step_10],
+line|z15-|isoline-step_10,
 {color: @isoline10;}
 
 
-line|z11[isoline=step_1000],
+line|z11|isoline-step_1000,
 {width: 0.8; opacity: 0.4;}
-line|z11[isoline=step_500],
+line|z11|isoline-step_500,
 {width: 0.8; opacity: 0.2;}
 
-line|z12-13[isoline=step_1000],
+line|z12-13|isoline-step_1000,
 {width: 1.0; opacity: 0.4;}
-line|z12-13[isoline=step_500],
+line|z12-13|isoline-step_500,
 {width: 0.8; opacity: 0.35;}
-line|z12-13[isoline=step_100],
+line|z12-13|isoline-step_100,
 {width: 0.8; opacity: 0.2;}
 
-line|z14-[isoline=step_1000],
+line|z14-|isoline-step_1000,
 {width: 1.2; opacity: 0.5;}
-line|z14-15[isoline=step_500],
+line|z14-15|isoline-step_500,
 {width: 1.0; opacity: 0.4;}
-line|z14-15[isoline=step_100],
+line|z14-15|isoline-step_100,
 {width: 0.8; opacity: 0.35;}
-line|z14-15[isoline=step_50],
+line|z14-15|isoline-step_50,
 {width: 0.8; opacity: 0.2;}
 
-line|z15[isoline=zero],
-line|z15[isoline=step_10],
+line|z15|isoline-zero,
+line|z15|isoline-step_10,
 {width: 0.8; opacity: 0.2;}
 
-line|z16-[isoline=step_500],
+line|z16-|isoline-step_500,
 {width: 1.2; opacity: 0.5;}
-line|z16-[isoline=step_100],
+line|z16-|isoline-step_100,
 {width: 1.0; opacity: 0.4;}
-line|z16-17[isoline=step_50],
+line|z16-17|isoline-step_50,
 {width: 0.8; opacity: 0.35;}
-line|z16-17[isoline=zero],
-line|z16-17[isoline=step_10],
+line|z16-17|isoline-zero,
+line|z16-17|isoline-step_10,
 {width: 0.8; opacity: 0.35;}
 
-line|z18-[isoline=step_50],
+line|z18-|isoline-step_50,
 {width: 1.0; opacity: 0.4;}
-line|z18-[isoline=zero],
-line|z18-[isoline=step_10],
+line|z18-|isoline-zero,
+line|z18-|isoline-step_10,
 {width: 0.8; opacity: 0.4;}

--- a/data/styles/default/include/Basemap_label.mapcss
+++ b/data/styles/default/include/Basemap_label.mapcss
@@ -33,358 +33,358 @@
 
 /* 2.CONTINENTS */
 
-*[place]
+*|place
 {text-position: center;}
 
-node|z1-2[place=continent],
+node|z1-2|place-continent,
 /* TODO: add to mapping
 node|z9-[place=archipelago],
 area|z9-[place=archipelago],
 */
-node|z9-[place=island],
-area|z9-[place=island],
-node|z14-[natural=cape],
-area|z14-[natural=cape],
-node|z14-[place=islet],
-area|z14-[place=islet],
+node|z9-|place-island,
+area|z9-|place-island,
+node|z14-|natural-cape,
+area|z14-|natural-cape,
+node|z14-|place-islet,
+area|z14-|place-islet,
 {text: name; text-color: @district_label;}
 
-node|z1-2[place=continent]
+node|z1-2|place-continent
 {font-size: 12;text-color: @country_label;max-width: 5;}
 
 /*
 node|z9-[place=archipelago],
 area|z9-[place=archipelago],
 */
-node|z9-[place=island],
-area|z9-[place=island],
+node|z9-|place-island,
+area|z9-|place-island,
 {font-size: 8;}
 
 /*
 node|z12-[place=archipelago],
 area|z12-[place=archipelago],
 */
-node|z12-[place=island],
-area|z12-[place=island]
+node|z12-|place-island,
+area|z12-|place-island
 {font-size: 9;}
 
 /*
 node|z14-[place=archipelago],
 area|z14-[place=archipelago],
 */
-node|z14-[place=island],
-area|z14-[place=island],
-node|z14-[place=islet],
-area|z14-[place=islet],
+node|z14-|place-island,
+area|z14-|place-island,
+node|z14-|place-islet,
+area|z14-|place-islet,
 {font-size: 10;}
 
 /*
 node|z16-[place=archipelago],
 area|z16-[place=archipelago],
 */
-node|z16-[place=island],
-area|z16-[place=island],
-node|z16-[place=islet],
-area|z16-[place=islet],
+node|z16-|place-island,
+area|z16-|place-island,
+node|z16-|place-islet,
+area|z16-|place-islet,
 {font-size: 12;}
 
-node|z14-[natural=cape],
-area|z14-[natural=cape]
+node|z14-|natural-cape,
+area|z14-|natural-cape
 {font-size: 8;text-color: @poi_label;}
 
 /* 3.COUNTRIES & STATES */
 
-node|z3-[place=country]
+node|z3-|place-country
 {text: name;text-color: @country_label;}
-node|z3-[place=country]::int_name
+node|z3-|place-country::int_name
 {text: int_name;text-color: @country_label;}
 
-node|z5[place=state][addr:country=US],
-node|z6-10[place=state]
+node|z5|place-state-USA,
+node|z6-10|place-state
 {text: name;text-color: @state_label;}
-node|z7-10[place=state]::int_name
+node|z7-10|place-state::int_name
 {text: int_name;text-color: @state_label;}
 
-node|z3[place=country]
+node|z3|place-country
 {font-size: 10;}
-node|z3[place=country]::int_name
+node|z3|place-country::int_name
 {font-size: 8;}
-node|z4[place=country]
+node|z4|place-country
 {font-size: 12;}
-node|z4[place=country]::int_name
+node|z4|place-country::int_name
 {font-size: 10;}
-node|z5[place=country]
+node|z5|place-country
 {font-size: 13;}
-node|z5[place=country]::int_name
+node|z5|place-country::int_name
 {font-size: 11;}
-node|z6[place=country]
+node|z6|place-country
 {font-size: 15;}
-node|z6[place=country]::int_name
+node|z6|place-country::int_name
 {font-size: 13;}
-node|z7[place=country]
+node|z7|place-country
 {font-size: 17;}
-node|z7[place=country]::int_name
+node|z7|place-country::int_name
 {font-size: 15;}
-node|z8[place=country]
+node|z8|place-country
 {font-size: 19;}
-node|z8[place=country]::int_name
+node|z8|place-country::int_name
 {font-size: 17;}
-node|z9-[place=country]
+node|z9-|place-country
 {font-size: 21;}
-node|z9-[place=country]::int_name
+node|z9-|place-country::int_name
 {font-size: 19;}
 
-node|z5[place=state][addr:country=US]
+node|z5|place-state-USA
 {font-size: 11;}
-node|z6-7[place=state]
+node|z6-7|place-state
 {font-size: 11;}
-node|z7[place=state]::int_name
+node|z7|place-state::int_name
 {font-size: 10;}
-node|z8-10[place=state]
+node|z8-10|place-state
 {font-size: 12;}
-node|z8-10[place=state]::int_name
+node|z8-10|place-state::int_name
 {font-size: 11;}
 
 /* 4.PLACES */
 
 /* 4.1 Cities */
 
-node|z4-[place=city][capital=2][population>=0],
-node|z4[place=city][capital!=2][population>=1000000],
-node|z5[place=city][capital!=2][population>=150000],
-node|z6[place=city][capital!=2][population>=50000],
-node|z7-8[place=city][capital!=2][population>=40000],
-node|z9-12[place=city][capital!=2],
-node|z13-[place=city][capital!=2][population<40000],
+node|z4-|place-city-capital-2[population>=0],
+node|z4|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=1000000],
+node|z5|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=150000],
+node|z6|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=50000],
+node|z7-8|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=40000],
+node|z9-12|[place=city][capital!=2] /*NO-TYPE-MATCH*/,
+node|z13-|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population<40000],
 {text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 1;text-halo-color: @label_halo_light;}
-node|z4-[place=city][capital=2][population>=0]::int_name,
-node|z4[place=city][capital!=2][population>=1000000]::int_name,
-node|z5[place=city][capital!=2][population>=150000]::int_name,
-node|z6[place=city][capital!=2][population>=50000]::int_name,
-node|z7-8[place=city][capital!=2][population>=40000]::int_name,
-node|z9-12[place=city][capital!=2]::int_name,
-node|z13-[place=city][capital!=2][population<40000]::int_name,
+node|z4-|place-city-capital-2[population>=0]::int_name,
+node|z4|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=1000000]::int_name,
+node|z5|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=150000]::int_name,
+node|z6|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=50000]::int_name,
+node|z7-8|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=40000]::int_name,
+node|z9-12|[place=city][capital!=2] /*NO-TYPE-MATCH*/::int_name,
+node|z13-|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population<40000]::int_name,
 {text: int_name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 1;text-halo-color: @label_halo_light;}
 
-node|z4[place=city][capital!=2][population>=1000000],
+node|z4|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=1000000],
 {font-size: 9;text-halo-opacity: 0.7;}
-node|z4[place=city][capital!=2][population>=1000000]::int_name
+node|z4|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=1000000]::int_name
 {font-size: 8;text-halo-opacity: 0.7;}
 
-node|z4-[place=city][capital=2][population>=0],
+node|z4-|place-city-capital-2[population>=0],
 {text-optional: false;}
 
-node|z4[place=city][capital=2][population>=0],
+node|z4|place-city-capital-2[population>=0],
 {icon-image: star-s.svg;text-offset: 1;font-size: 10;}
-node|z4[place=city][capital=2][population>=0]::int_name
+node|z4|place-city-capital-2[population>=0]::int_name
 {text-offset: 1;font-size: 9;}
 
-node|z5[place=city][capital!=2][population>=150000],
+node|z5|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=150000],
 {font-size: 10;text-halo-opacity: 0.6;}
-node|z5[place=city][capital!=2][population>=150000]::int_name
+node|z5|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=150000]::int_name
 {font-size: 9;text-halo-opacity: 0.6;}
-node|z5[place=city][capital=2][population>=0]
+node|z5|place-city-capital-2[population>=0]
 {icon-image: star-m.svg;text-offset: 1;font-size: 10.4;}
-node|z5[place=city][capital=2][population>=0]::int_name
+node|z5|place-city-capital-2[population>=0]::int_name
 {text-offset: 1;font-size: 9.4;}
 
-node|z6[place=city][capital!=2][population>=50000]
+node|z6|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=50000]
 {font-size: 10.4;text-halo-opacity: 0.6;}
-node|z6[place=city][capital!=2][population>=50000]::int_name
+node|z6|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=50000]::int_name
 {font-size: 9.4;text-halo-opacity: 0.6;}
-node|z6[place=city][capital=2][population>=0]
+node|z6|place-city-capital-2[population>=0]
 {icon-image: star-l.svg;text-offset: 1;font-size: 11.6;}
-node|z6[place=city][capital=2][population>=0]::int_name
+node|z6|place-city-capital-2[population>=0]::int_name
 {text-offset: 1;font-size: 10.6;}
 
-node|z7[place=city][capital!=2][population>=40000]
+node|z7|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=40000]
 {font-size: 10;text-halo-opacity: 0.8;}
-node|z7[place=city][capital!=2][population>=40000]::int_name
+node|z7|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=40000]::int_name
 {font-size: 9;text-halo-opacity: 0.8;}
-node|z7[place=city][capital=2][population>=0]
+node|z7|place-city-capital-2[population>=0]
 {icon-image: star-l.svg;text-offset: 1;font-size: 11;}
-node|z7[place=city][capital=2][population>=0]::int_name
+node|z7|place-city-capital-2[population>=0]::int_name
 {text-offset: 1;font-size: 10;}
 
-node|z8[place=city][capital!=2][population>=40000]
+node|z8|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=40000]
 {font-size: 10.5;}
-node|z8[place=city][capital!=2][population>=40000]::int_name
+node|z8|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=40000]::int_name
 {font-size: 9.5;}
-node|z8[place=city][capital=2][population>=0]
+node|z8|place-city-capital-2[population>=0]
 {icon-image: star-l.svg;text-offset: 1;font-size: 11.5;}
-node|z8[place=city][capital=2][population>=0]::int_name
+node|z8|place-city-capital-2[population>=0]::int_name
 {text-offset: 1;font-size: 10.5;}
 
-node|z9[place=city][capital=2][population>=0]
+node|z9|place-city-capital-2[population>=0]
 {icon-image: star-l.svg;text-offset: 1;font-size: 13;  text-halo-radius: 0.5;}
-node|z9[place=city][capital=2][population>=0]::int_name
+node|z9|place-city-capital-2[population>=0]::int_name
 {text-offset: 1;font-size: 12;text-halo-radius: 0.5;}
-node|z9[place=city][capital!=2][population>=0],
+node|z9|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=0],
 {font-size: 11;text-halo-radius: 0.5;}
-node|z9[place=city][capital!=2][population>=0]::int_name
+node|z9|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=0]::int_name
 {font-size: 10;text-halo-radius: 0.5;}
 
-node|z10[place=city][capital=2][population>=0]
+node|z10|place-city-capital-2[population>=0]
 {icon-image: star-l.svg;text-offset: 1;font-size: 13;}
-node|z10[place=city][capital=2][population>=0]::int_name
+node|z10|place-city-capital-2[population>=0]::int_name
 {text-offset: 1;font-size: 12;}
-node|z10[place=city][capital!=2][population>=0],
+node|z10|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=0],
 {font-size: 11;text-halo-radius: 0.9;}
-node|z10[place=city][capital!=2][population>=0]::int_name
+node|z10|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=0]::int_name
 {font-size: 10;text-halo-radius: 0.9;}
 
-node|z11[place=city][capital=2][population>=0]
+node|z11|place-city-capital-2[population>=0]
 {icon-image: star-l.svg;text-offset: 1;font-size: 12;}
-node|z11[place=city][capital=2][population>=0]::int_name
+node|z11|place-city-capital-2[population>=0]::int_name
 {text-offset: 1;font-size: 11;}
-node|z11[place=city][capital!=2][population>=0],
+node|z11|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=0],
 {font-size: 12;}
-node|z11[place=city][capital!=2][population>=0]::int_name
+node|z11|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=0]::int_name
 {font-size: 11;}
 
-node|z12[place=city][capital=2][population>=0]
+node|z12|place-city-capital-2[population>=0]
 {icon-image: star-l.svg;text-offset: 1;font-size: 13;}
-node|z12[place=city][capital=2][population>=0]::int_name
+node|z12|place-city-capital-2[population>=0]::int_name
 {text-offset: 1;font-size: 11;}
-node|z12[place=city][capital!=2][population>=0],
+node|z12|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=0],
 {font-size: 13;text-color: @label_medium;}
-node|z12[place=city][capital!=2][population>=0]::int_name
+node|z12|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population>=0]::int_name
 {font-size: 11;text-color: @label_medium;}
 
-node|z13-[place=city][capital=2][population>=0]
+node|z13-|place-city-capital-2[population>=0]
 {icon-image: star-l.svg;text-offset: 1;font-size: 14;text-color: @label_medium;}
-node|z13-[place=city][capital=2][population>=0]::int_name
+node|z13-|place-city-capital-2[population>=0]::int_name
 {text-offset: 1;font-size: 11;text-color: @label_medium;}
 
-node|z13-[place=city][capital!=2][population<40000],
+node|z13-|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population<40000],
 {font-size: 14;text-color: @label_medium;}
-node|z13-[place=city][capital!=2][population<40000]::int_name
+node|z13-|[place=city][capital!=2] /*NO-TYPE-MATCH*/[population<40000]::int_name
 {font-size: 12;text-color: @label_medium;}
 
 /* 4.2 Town */
 
-node|z8[place=town][population>=40000],
-node|z9[place=town][population>=20000],
+node|z8|place-town[population>=40000],
+node|z9|place-town[population>=20000],
 {text: name;text-color: @city_label;}
-node|z8[place=town][population>=40000]::int_name,
-node|z9[place=town][population>=20000]::int_name,
+node|z8|place-town[population>=40000]::int_name,
+node|z9|place-town[population>=20000]::int_name,
 {text:int_name;text-color: @city_label;}
 
-node|z10-[place=town],
+node|z10-|place-town,
 {text: name; text-color: @city_label; text-halo-radius: 1; text-halo-opacity: 0.8; text-halo-color: @label_halo_light;}
-node|z10-[place=town]::int_name,
+node|z10-|place-town::int_name,
 {text:int_name; text-color: @city_label; text-halo-radius: 1; text-halo-opacity: 0.8; text-halo-color: @label_halo_light;}
 
-node|z12-[place=town],
+node|z12-|place-town,
 {text-color: @label_medium;}
-node|z12-[place=town]::int_name,
+node|z12-|place-town::int_name,
 {text-color: @label_medium;}
 
-node|z8[place=town][population>=40000]
+node|z8|place-town[population>=40000]
 {font-size: 10;}
-node|z8[place=town][population>=40000]::int_name
+node|z8|place-town[population>=40000]::int_name
 {font-size: 9;}
 
-node|z9[place=town][population>=20000]
+node|z9|place-town[population>=20000]
 {font-size: 10;}
-node|z9[place=town][population>=20000]::int_name
+node|z9|place-town[population>=20000]::int_name
 {font-size: 9;}
 
-node|z10[place=town],
+node|z10|place-town,
 {font-size: 10;}
-node|z10[place=town]::int_name,
+node|z10|place-town::int_name,
 {font-size: 9;}
 
-node|z11[place=town],
+node|z11|place-town,
 {font-size: 11;}
-node|z11[place=town]::int_name,
+node|z11|place-town::int_name,
 {font-size: 10;}
 
-node|z12[place=town],
+node|z12|place-town,
 {font-size: 12;}
-node|z12[place=town]::int_name,
+node|z12|place-town::int_name,
 {font-size: 10;}
 
-node|z13-[place=town],
+node|z13-|place-town,
 {font-size: 14; text-halo-opacity: 1;}
-node|z13-[place=town]::int_name,
+node|z13-|place-town::int_name,
 {font-size: 12; text-halo-opacity: 1;}
 
 /* 4.3 Village */
 
-node|z11-[place=village]
+node|z11-|place-village
 {text: name;text-color: @city_label;text-halo-radius: 1;text-halo-opacity: 0.7;text-halo-color: @label_halo_light;}
-node|z11-[place=village]::int_name
+node|z11-|place-village::int_name
 {text:int_name;text-color: @city_label;text-halo-radius: 1;text-halo-opacity: 0.7;text-halo-color: @label_halo_light;}
-node|z13-[place=hamlet]
+node|z13-|place-hamlet
 {text: name;text-color: @city_label;text-halo-radius: 1;text-halo-opacity: 0.6;text-halo-color: @label_halo_light;}
 
-node|z11[place=village]
+node|z11|place-village
 {font-size: 10;}
-node|z11[place=village]::int_name
+node|z11|place-village::int_name
 {font-size: 9;}
 
-node|z12[place=village]
+node|z12|place-village
 {font-size: 11;}
-node|z12[place=village]::int_name
+node|z12|place-village::int_name
 {font-size: 9;}
 
-node|z13-[place=village]
+node|z13-|place-village
 {font-size: 12;text-color: @label_medium;}
-node|z13-[place=village]::int_name
+node|z13-|place-village::int_name
 {font-size: 10;text-color: @label_medium;}
 
-node|z13-[place=hamlet]
+node|z13-|place-hamlet
 {font-size: 11;}
 
 /* 4.4 Districts & Small localities */
 
-node|z10-14[place=suburb],
-node|z13-[place=locality],
-node|z13-[place=neighbourhood],
-node|z14-[place=farm],
-node|z14-[place=isolated_dwelling],
-node|z17-[landuse=residential],
+node|z10-14|place-suburb,
+node|z13-|place-locality,
+node|z13-|place-neighbourhood,
+node|z14-|place-farm,
+node|z14-|place-isolated_dwelling,
+node|z17-|landuse-residential,
 {text: name;text-color: @district_label;}
-node|z13-14[place=suburb]::int_name,
-node|z13-[place=locality]::int_name,
-node|z13-[place=neighbourhood]::int_name,
-node|z14-[place=farm]::int_name,
-node|z14-[place=isolated_dwelling]::int_name,
-node|z17-[landuse=residential]::int_name,
+node|z13-14|place-suburb::int_name,
+node|z13-|place-locality::int_name,
+node|z13-|place-neighbourhood::int_name,
+node|z14-|place-farm::int_name,
+node|z14-|place-isolated_dwelling::int_name,
+node|z17-|landuse-residential::int_name,
 {text: int_name;text-color: @district_label;}
 
-node|z10[place=suburb]
+node|z10|place-suburb
 {font-size: 9;}
-node|z11[place=suburb]
+node|z11|place-suburb
 {font-size: 10;}
-node|z12[place=suburb]
+node|z12|place-suburb
 {font-size: 11;}
-node|z12[place=suburb]::int_name
+node|z12|place-suburb::int_name
 {font-size: 9;}
-node|z13-14[place=suburb]
+node|z13-14|place-suburb
 {font-size: 12;}
-node|z13-14[place=suburb]::int_name
+node|z13-14|place-suburb::int_name
 {font-size: 10;}
 
-node|z13-14[place=locality],
-node|z13-14[place=neighbourhood],
+node|z13-14|place-locality,
+node|z13-14|place-neighbourhood,
 {font-size: 10;}
-node|z13-14[place=locality]::int_name,
-node|z13-14[place=neighbourhood]::int_name,
+node|z13-14|place-locality::int_name,
+node|z13-14|place-neighbourhood::int_name,
 {font-size: 9;}
 
-node|z15-[place=locality],
-node|z15-[place=neighbourhood],
-node|z14-[place=farm],
-node|z14-[place=isolated_dwelling],
-node|z17-[landuse=residential],
+node|z15-|place-locality,
+node|z15-|place-neighbourhood,
+node|z14-|place-farm,
+node|z14-|place-isolated_dwelling,
+node|z17-|landuse-residential,
 {font-size: 12;}
-node|z15-[place=locality]::int_name,
-node|z15-[place=neighbourhood]::int_name,
-node|z14-[place=isolated_dwelling]::int_name,
-node|z14-[place=farm]::int_name,
-node|z17-[landuse=residential]::int_name,
+node|z15-|place-locality::int_name,
+node|z15-|place-neighbourhood::int_name,
+node|z14-|place-isolated_dwelling::int_name,
+node|z14-|place-farm::int_name,
+node|z17-|landuse-residential::int_name,
 {font-size: 10;}
 
 /* 5.VEGETATION, BEACH & GLACIER */
@@ -395,16 +395,16 @@ node|z17-[landuse=residential]::int_name,
    ToDo: Don't declare node rule here. Styles below will be broken otherwise?!
 node|z17-[leisure],
 */
-area|z17-[leisure],
+area|z17-|leisure,
 {text: name;text-color: @poi_label;text-offset: 1;font-size: 10;}
 
-area|z14-[leisure=park][name],
-area|z14-[landuse=forest][name],
-area|z16-[leisure=garden][garden:type!=residential][name]
+area|z14-|leisure-park[name],
+area|z14-|landuse-forest[name],
+area|z16-|[leisure=garden][garden:type!=residential] /*NO-TYPE-MATCH*/[name]
 {text: name;text-color: @park_label;text-halo-color: @halo_park_label;text-halo-radius: 0.5;text-halo-opacity: 0.8;icon-min-distance: 8;text-offset: 1;font-size: 10;}
-area|z16-[leisure=park][name]::int_name,
-area|z16-[landuse=forest][name]::int_name,
-area|z16-[leisure=garden][garden:type!=residential][name]::int_name
+area|z16-|leisure-park[name]::int_name,
+area|z16-|landuse-forest[name]::int_name,
+area|z16-|[leisure=garden][garden:type!=residential] /*NO-TYPE-MATCH*/[name]::int_name
 {text: int_name;text-color: @park_label;text-halo-color: @halo_park_label;text-halo-radius: 0.5;text-halo-opacity: 0.8;text-offset: 1;font-size: 10;}
 
 /*
@@ -412,161 +412,161 @@ area|z16-[leisure=garden][garden:type!=residential][name]::int_name
   ToDo: Looks strange, but needed for current styles generator.
   Specify text: none here, because we have generic z17-[leisure] declaration above.
 */
-area|z14-[leisure=park][!name],
-area|z14-[landuse=forest][!name],
-area|z16-[leisure=garden][garden:type!=residential][!name],
+area|z14-|leisure-park[!name],
+area|z14-|landuse-forest[!name],
+area|z16-|[leisure=garden][garden:type!=residential] /*NO-TYPE-MATCH*/[!name],
 {text: none}
-area|z16-[leisure=garden][garden:type=residential],
+area|z16-|leisure-garden-residential,
 {text: none}
 
-area|z14-[landuse=forest][name]
+area|z14-|landuse-forest[name]
 {icon-image: nparkf-outline-s.svg;}
-area|z14-[leisure=park][name]
+area|z14-|leisure-park[name]
 {icon-image: park-outline-s.svg;}
 
-area|z15-[landuse=forest][name]
+area|z15-|landuse-forest[name]
 {icon-image: nparkf-outline-m.svg;font-size: 11;}
-area|z15-[leisure=park][name]
+area|z15-|leisure-park[name]
 {icon-image: park-outline-m.svg;font-size: 11;}
-area|z16-[leisure=garden][garden:type!=residential][name]
+area|z16-|[leisure=garden][garden:type!=residential] /*NO-TYPE-MATCH*/[name]
 {icon-image: garden-outline-m.svg;text-offset: 1;font-size: 11;}
 
-area|z17[landuse=forest][name],
-area|z17[leisure=park][name],
-area|z17[leisure=garden][garden:type!=residential][name],
+area|z17|landuse-forest[name],
+area|z17|leisure-park[name],
+area|z17|[leisure=garden][garden:type!=residential] /*NO-TYPE-MATCH*/[name],
 {font-size: 12;}
 
-area|z18-[landuse=forest][name],
-area|z18-[leisure=park][name],
-area|z18-[leisure=garden][garden:type!=residential][name],
+area|z18-|landuse-forest[name],
+area|z18-|leisure-park[name],
+area|z18-|[leisure=garden][garden:type!=residential] /*NO-TYPE-MATCH*/[name],
 {font-size: 13;}
-area|z18-[leisure=park][name]::int_name,
-area|z18-[leisure=garden][garden:type!=residential][name]::int_name,
-area|z18-[landuse=forest][name]::int_name,
+area|z18-|leisure-park[name]::int_name,
+area|z18-|[leisure=garden][garden:type!=residential] /*NO-TYPE-MATCH*/[name]::int_name,
+area|z18-|landuse-forest[name]::int_name,
 {font-size: 11;}
 
-area|z18-[landuse=forest][!name]
+area|z18-|landuse-forest[!name]
 {text: none; icon-image: nparkf-m.svg;}
-area|z18-[leisure=park][!name]
+area|z18-|leisure-park[!name]
 {text: none; icon-image: park-m.svg;}
-area|z18-[leisure=garden][garden:type!=residential][!name]
+area|z18-|[leisure=garden][garden:type!=residential] /*NO-TYPE-MATCH*/[!name]
 {text: none; icon-image: garden-m.svg;}
 
 
-area|z15-[landuse=farmland],
-area|z15-[landuse=farmyard],
-area|z15-[landuse=allotments],
-area|z15-[landuse=recreation_ground],
-area|z15-[landuse=orchard],
-area|z15-[landuse=vineyard],
-node|z17-[landuse=farmland],
-node|z17-[landuse=farmyard],
-node|z17-[landuse=allotments],
-node|z17-[landuse=recreation_ground],
-node|z17-[landuse=orchard],
-node|z17-[landuse=vineyard],
+area|z15-|landuse-farmland,
+area|z15-|landuse-farmyard,
+area|z15-|landuse-allotments,
+area|z15-|landuse-recreation_ground,
+area|z15-|landuse-orchard,
+area|z15-|landuse-vineyard,
+node|z17-|landuse-farmland,
+node|z17-|landuse-farmyard,
+node|z17-|landuse-allotments,
+node|z17-|landuse-recreation_ground,
+node|z17-|landuse-orchard,
+node|z17-|landuse-vineyard,
 {text: name;font-size: 10;text-color: @poi_label;}
 
 /* 5.2 Beach, Glacier, Desert, etc. */
 
-area|z14-[natural=desert],
-area|z15-[natural=beach],
-node|z15-[natural=beach],
+area|z14-|natural-desert,
+area|z15-|natural-beach,
+node|z15-|natural-beach,
 {text: name;font-size: 10;text-color: @poi_label;}
 
-area|z16-[leisure=beach_resort],
+area|z16-|leisure-beach_resort,
 {text: name; font-size: 10; text-color: @poi_label; text-offset: 1;}
 
 /* 6.WATER */
 
-node|z1-[place=ocean],
-node|z4-[place=sea],
-area|z10-[landuse=reservoir][bbox_area>=4000000],
-area|z10-[natural=water][!tunnel][bbox_area>=4000000],
-line|z11-[waterway=river],
-line|z13-[waterway=stream],
-line|z13-[waterway=canal],
-line|z13-[waterway=fish_pass],
-line|z13-[natural=strait],
-node|z14-[natural=strait],
-node|z14-[natural=bay],
-node|z16-[natural=wetland],
-area|z16-[natural=wetland],
+node|z1-|place-ocean,
+node|z4-|place-sea,
+area|z10-|landuse-reservoir[bbox_area>=4000000],
+area|z10-|[natural=water][!tunnel] /*NO-TYPE-MATCH*/[bbox_area>=4000000],
+line|z11-|waterway-river,
+line|z13-|waterway-stream,
+line|z13-|waterway-canal,
+line|z13-|waterway-fish_pass,
+line|z13-|natural-strait,
+node|z14-|natural-strait,
+node|z14-|natural-bay,
+node|z16-|natural-wetland,
+area|z16-|natural-wetland,
 {text:name;text-color: @water_label;}
 
-area|z10-[natural=water][!tunnel][bbox_area<4000000],
+area|z10-|[natural=water][!tunnel] /*NO-TYPE-MATCH*/[bbox_area<4000000],
 {text:name;text-color: @water_label;}
 
-area|z12-[landuse=reservoir][bbox_area<4000000],
+area|z12-|landuse-reservoir[bbox_area<4000000],
 {text:name;text-color: @water_label;}
 
 /*6.1 Area water(ocean,sea,lake,pond etc.)*/
 
-node|z1-2[place=ocean]
+node|z1-2|place-ocean
 {font-size: 14;}
-node|z3[place=ocean]
+node|z3|place-ocean
 {font-size: 15;}
-node|z4[place=ocean]
+node|z4|place-ocean
 {font-size: 16;}
-node|z5-[place=ocean]
+node|z5-|place-ocean
 {font-size: 18;}
 
-node|z4-[place=sea]
+node|z4-|place-sea
 {font-size: 12;}
 
-area|z10-[landuse=reservoir][bbox_area>=4000000],
-area|z10-13[natural=water][!tunnel][bbox_area>=4000000],
+area|z10-|landuse-reservoir[bbox_area>=4000000],
+area|z10-13|[natural=water][!tunnel] /*NO-TYPE-MATCH*/[bbox_area>=4000000],
 {font-size: 9;}
-area|z12-[landuse=reservoir][bbox_area<4000000],
-area|z10-13[natural=water][!tunnel][bbox_area<4000000],
+area|z12-|landuse-reservoir[bbox_area<4000000],
+area|z10-13|[natural=water][!tunnel] /*NO-TYPE-MATCH*/[bbox_area<4000000],
 {text: none;}
 
 /*only render caption z17-*/
-area|z10-16[natural=water][water=moat],
-area|z10-16[natural=water][water=ditch],
-area|z10-16[natural=water][water=drain],
-area|z10-16[natural=water][water=wastewater],
+area|z10-16|natural-water-moat,
+area|z10-16|natural-water-ditch,
+area|z10-16|natural-water-drain,
+area|z10-16|natural-water-wastewater,
 {text: none;}
 
-node|z14-15[natural=bay],
-node|z14-15[natural=strait],
-area|z14-15[natural=water][!tunnel][bbox_area>=4000000],
+node|z14-15|natural-bay,
+node|z14-15|natural-strait,
+area|z14-15|[natural=water][!tunnel] /*NO-TYPE-MATCH*/[bbox_area>=4000000],
 {font-size: 10;}
-area|z14-15[natural=water][!tunnel][bbox_area<4000000],
+area|z14-15|[natural=water][!tunnel] /*NO-TYPE-MATCH*/[bbox_area<4000000],
 {font-size: 10;}
 
-node|z16-[natural=bay],
-node|z16-[natural=strait],
-node|z16-[natural=wetland],
-area|z16-[natural=water][!tunnel][bbox_area>=4000000],
-area|z16-[natural=wetland],
+node|z16-|natural-bay,
+node|z16-|natural-strait,
+node|z16-|natural-wetland,
+area|z16-|[natural=water][!tunnel] /*NO-TYPE-MATCH*/[bbox_area>=4000000],
+area|z16-|natural-wetland,
 {font-size: 11;}
-area|z16-[natural=water][!tunnel][bbox_area<4000000],
+area|z16-|[natural=water][!tunnel] /*NO-TYPE-MATCH*/[bbox_area<4000000],
 {font-size: 11;}
 
 /* 6.2 Line water(river,canal etc.) Do not draw tunnel waterways */
 
-line|z11-14[waterway=river],
-line|z13-14[waterway=stream],
-line|z13-14[waterway=canal],
-line|z13-14[waterway=fish_pass],
-line|z13-14[natural=strait],
+line|z11-14|waterway-river,
+line|z13-14|waterway-stream,
+line|z13-14|waterway-canal,
+line|z13-14|waterway-fish_pass,
+line|z13-14|natural-strait,
 {font-size: 10;text:name;text-color: @water_label;}
-line|z15-17[waterway=stream],
-line|z15-17[waterway=canal],
-line|z15-17[waterway=fish_pass],
-line|z15-17[natural=strait],
+line|z15-17|waterway-stream,
+line|z15-17|waterway-canal,
+line|z15-17|waterway-fish_pass,
+line|z15-17|natural-strait,
 {font-size: 11;text:name;text-color: @water_label;}
-line|z15-[waterway=river],
-line|z18-[waterway=stream],
-line|z18-[waterway=canal],
-line|z18-[waterway=fish_pass],
-line|z18-[natural=strait],
+line|z15-|waterway-river,
+line|z18-|waterway-stream,
+line|z18-|waterway-canal,
+line|z18-|waterway-fish_pass,
+line|z18-|natural-strait,
 {font-size: 12;text:name;text-color: @water_label;}
 
-line[waterway]
+line|waterway
 {text-position: line;}
-line[waterway][tunnel]
+line|[waterway][tunnel] /*NO-TYPE-MATCH*/
 {text: none;}
 
 /* 7. LANDUSE */
@@ -575,68 +575,68 @@ line[waterway][tunnel]
 
 /* 	7.1 Industrial */
 
-area|z15-[landuse=industrial],
-area|z15-[landuse=construction],
-area|z15-[landuse=railway],
-area|z15-[landuse=quarry],
-node|z15-[landuse=industrial],
-node|z15-[landuse=construction],
-node|z15-[landuse=landfill],
-node|z15-[landuse=railway],
-node|z15-[landuse=quarry],
+area|z15-|landuse-industrial,
+area|z15-|landuse-construction,
+area|z15-|landuse-railway,
+area|z15-|landuse-quarry,
+node|z15-|landuse-industrial,
+node|z15-|landuse-construction,
+node|z15-|landuse-landfill,
+node|z15-|landuse-railway,
+node|z15-|landuse-quarry,
 {text: name;font-size: 10;text-color: @city_label;text-position: center;}
 
 /* 7.3 University & Sport */
 
-area|z15-[piste:type=snow_park],
+area|z15-|piste:type-snow_park,
 {font-size: 9; text-position: center; text: name; text-color: @label_dark; text-halo-radius: 1; text-halo-opacity: 0.7; text-halo-color: @label_halo_light;}
-area|z16-17[piste:type=snow_park],
+area|z16-17|piste:type-snow_park,
 {font-size: 10;}
-area|z18-[piste:type=snow_park],
+area|z18-|piste:type-snow_park,
 {font-size: 12;}
 
 /* 	7.4 Cemetery */
 
-area|z15-[landuse=cemetery],
-node|z17-[landuse=cemetery],
-area|z17-[amenity=grave_yard],
-node|z17-[amenity=grave_yard],
-node|z17-[cemetery=grave],
-area|z17-[cemetery=grave],
+area|z15-|landuse-cemetery,
+node|z17-|landuse-cemetery,
+area|z17-|amenity-grave_yard,
+node|z17-|amenity-grave_yard,
+node|z17-|cemetery-grave,
+area|z17-|cemetery-grave,
 {icon-image: cemetery-m.svg; text: name; text-offset: 1; font-size: 10; text-color: @poi_label;}
 
 /* 	7.5 Pedestrian areas */
 
-area|z15-[highway=pedestrian][area?],
-area|z15-[area:highway=pedestrian],
-area|z15-[highway=footway][area?],
-area|z15-[area:highway=footway],
+area|z15-|highway-pedestrian-area,
+area|z15-|area:highway-pedestrian,
+area|z15-|highway-footway-area,
+area|z15-|area:highway-footway,
 {text: name;font-size: 11;text-color: @city_label;text-position: center;}
 
-area|z16-[place=square],
+area|z16-|place-square,
 {text: name;font-size: 11;text-color: @city_label;text-position: center;text-halo-color: @halo_park_label;text-halo-radius: 0.5;text-halo-opacity: 0.8;}
 /* 	7.6 Military */
 
-area|z16[landuse=military],
-node|z16[landuse=military]
+area|z16|landuse-military,
+node|z16|landuse-military
 {icon-image: military-m.svg;icon-min-distance: 10;}
 
-area|z17-[landuse=military],
-node|z17-[landuse=military]
+area|z17-|landuse-military,
+node|z17-|landuse-military
 {icon-image: military-m.svg;text-offset: 1;text: name;font-size: 10;text-color: @poi_label;}
 
 /* 	7.7 Commercial */
 
-area|z17-[landuse=commercial]
+area|z17-|landuse-commercial
 {text: name;font-size: 10;text-color: @poi_label;text-position: center;}
 
 /* 8.BUILDINGS */
 
-area|z16-[building],
-node|z16-[building],
+area|z16-|building,
+node|z16-|building,
 {text: name;text-color: @building_label;text-position: center;}
-area|z16-[building]::int_name,
-node|z16-[building]::int_name,
+area|z16-|building::int_name,
+node|z16-|building::int_name,
 {text:int_name;text-color: @building_label;text-position: center;}
 
 /*
@@ -648,104 +648,104 @@ node|z16-[building]::int_name,
   Housenumbers and main captions are displaced independently (e.g. a housenumber will stay if a building name is displaced),
   but are bound to icons (e.g. a housenumber will disappear if a parent icon is displaced).
 */
-node|z16-[addr:housenumber][addr:street],
+node|z16-|building-address,
 {text: name; text-color: @housenumber; text-position: center;}
-node|z16-[addr:housenumber][addr:street]::int_name,
+node|z16-|building-address::int_name,
 {text: int_name; text-color: @housenumber; text-position: center;}
 
-node|z18-[entrance=main],
-node|z18-[emergency=emergency_ward_entrance],
-node|z19-[entrance],
-node|z19-[entrance=exit],
-node|z19-[amenity=loading_dock],
+node|z18-|entrance-main,
+node|z18-|emergency-emergency_ward_entrance,
+node|z19-|entrance,
+node|z19-|entrance-exit,
+node|z19-|amenity-loading_dock,
 {text: name; text-color: @building_label;}
-node|z18-[entrance=main]::flats,
-node|z19-[entrance]::flats,
-node|z19-[entrance=exit]::flats,
+node|z18-|entrance-main::flats,
+node|z19-|entrance::flats,
+node|z19-|entrance-exit::flats,
 {text: int_name; text-color: @building_label; font-size: 8; text-offset: 1;}
 
 /* 8.1 Pier */
-area|z15-[waterway=dam],
-line|z15-[waterway=dam],
-line|z15-[waterway=weir],
-node|z15-[waterway=weir],
-area|z17-[man_made=pier],
-area|z17-[man_made=breakwater],
-line|z17-[man_made=pier],
-line|z17-[man_made=breakwater],
-node|z17-[man_made=pier],
-node|z17-[man_made=breakwater]
+area|z15-|waterway-dam,
+line|z15-|waterway-dam,
+line|z15-|waterway-weir,
+node|z15-|waterway-weir,
+area|z17-|man_made-pier,
+area|z17-|man_made-breakwater,
+line|z17-|man_made-pier,
+line|z17-|man_made-breakwater,
+node|z17-|man_made-pier,
+node|z17-|man_made-breakwater
 {text: name;font-size: 10;text-color:@poi_label;fill-opacity: 1;}
 
 /*	8.2 Building */
 
-area|z16-17[building],
-node|z16-17[building],
+area|z16-17|building,
+node|z16-17|building,
 {font-size: 9;}
-area|z16-17[building]::int_name,
-node|z16-17[building]::int_name,
+area|z16-17|building::int_name,
+node|z16-17|building::int_name,
 {font-size: 8;}
-area|z18-[building],
-node|z18-[building],
+area|z18-|building,
+node|z18-|building,
 {font-size: 11;}
-area|z18-[building]::int_name,
-node|z18-[building]::int_name,
+area|z18-|building::int_name,
+node|z18-|building::int_name,
 {font-size: 10;}
 
-node|z16-17[addr:housenumber][addr:street],
+node|z16-17|building-address,
 {font-size: 8;}
-node|z18-[addr:housenumber][addr:street],
+node|z18-|building-address,
 {font-size: 10;}
-node|z16-[addr:housenumber][addr:street]::int_name,
+node|z16-|building-address::int_name,
 {font-size: 8;}
 
-node|z19-[entrance],
-node|z19-[amenity=loading_dock],
+node|z19-|entrance,
+node|z19-|amenity-loading_dock,
 {icon-image: entrance-s.svg; font-size: 10; text-offset: 1;}
-node|z19-[entrance=exit],
+node|z19-|entrance-exit,
 {icon-image: entrance-exit-s.svg; font-size: 10; text-offset: 1;}
-node|z18-[entrance=main],
+node|z18-|entrance-main,
 {icon-image: entrance-main-s.svg; font-size: 10; text-offset: 1;}
-node|z18-[emergency=emergency_ward_entrance],
+node|z18-|emergency-emergency_ward_entrance,
 {icon-image: entrance-emergency-s.svg; font-size: 10; text-offset: 1;}
 
 /* 8.3 Airports */
-area|z14-[aeroway=terminal]
+area|z14-|aeroway-terminal
 {fill-color: @building0;}
 
-area|z14[aeroway=terminal]
+area|z14|aeroway-terminal
 {fill-opacity: 0.8;}
-area|z15[aeroway=terminal]
+area|z15|aeroway-terminal
 { text: name; font-size: 9; fill-opacity: 0.8; text-color: @building_label; text-position: center;}
-area|z16-[aeroway=terminal]
+area|z16-|aeroway-terminal
 {text: name; font-size: 9; fill-opacity: 1; text-color: @building_label; text-position: center;}
 
 /* 8.4 Platforms */
-area|z16-[railway=platform],
+area|z16-|railway-platform,
 /*
  Patch to avoid conflicts with highway=bus_stop icon on z16.
  Unfortunatelly, we can't disable text for nodes only.
 */
-area|z17-[public_transport=platform],
+area|z17-|public_transport-platform,
 {text: name; font-size: 9; fill-opacity: 1; text-color: @building_label; text-position: center;}
 
 /* 9. ISOLINES */
 
-line[isoline]
+line|isoline
 {text-position: line;}
 
-line|z11-[isoline=step_1000],
+line|z11-|isoline-step_1000,
 {text:name;font-size: 9;fill-opacity: 0.7;text-color: @label_isoline1000;}
 
-line|z12-[isoline=step_500],
+line|z12-|isoline-step_500,
 {text:name;font-size: 9;fill-opacity: 0.7;text-color: @label_isoline500;}
 
-line|z14-[isoline=step_100],
+line|z14-|isoline-step_100,
 {text:name;font-size: 9;fill-opacity: 0.7;text-color: @label_isoline100;}
 
-line|z16-[isoline=step_50],
-line|z17-[isoline=zero],
+line|z16-|isoline-step_50,
+line|z17-|isoline-zero,
 {text:name;font-size: 9;fill-opacity: 0.7;text-color: @label_isoline50;}
 
-line|z17-[isoline=step_10],
+line|z17-|isoline-step_10,
 {text:name;font-size: 9;fill-opacity: 0.7;text-color: @label_isoline10;}

--- a/data/styles/default/include/Icons.mapcss
+++ b/data/styles/default/include/Icons.mapcss
@@ -30,2721 +30,2721 @@ Generic POIs.
 Declare _before_ all concrete POIs to avoid styles overrides.
 */
 
-node|z18-[tourism],
-area|z18-[tourism],
-node|z18-[office],
-area|z18-[office],
-node|z18-[craft],
-area|z18-[craft],
-node|z19-[amenity],
-area|z19-[amenity],
+node|z18-|tourism,
+area|z18-|tourism,
+node|z18-|office,
+area|z18-|office,
+node|z18-|craft,
+area|z18-|craft,
+node|z19-|amenity,
+area|z19-|amenity,
 {text: name; text-color: @poi_label; text-offset: 1;}
 
-node|z19-[amenity],
-area|z19-[amenity],
+node|z19-|amenity,
+area|z19-|amenity,
 {font-size: 10;}
 
-node|z18-[office],
-area|z18-[office],
+node|z18-|office,
+area|z18-|office,
 {icon-image: office-m.svg;}
 
-node|z18-[craft],
-area|z18-[craft],
+node|z18-|craft,
+area|z18-|craft,
 {icon-image: craft-m.svg;}
 
-node|z16-[shop],
-area|z16-[shop],
+node|z16-|shop,
+area|z16-|shop,
 {icon-min-distance: 10;}
-node|z18-[shop],
-area|z18-[shop],
+node|z18-|shop,
+area|z18-|shop,
 {icon-image: shop-m.svg;}
 
 /* 2. NATURAL */
 
-node|z13-[natural=volcano],
-node|z14-[waterway=waterfall],
-node|z15-[natural=cave_entrance],
-node|z13-[natural=peak][name],
-node|z16-[natural=saddle],
-node|z15-[mountain_pass],
-node|z15-[natural=spring],
-node|z15-[natural=hot_spring],
-node|z14-[natural=geyser],
-node|z16-[natural=beach],
-area|z16-[natural=beach],
-area|z14-[natural=bare_rock],
-node|z17-[natural=rock],
+node|z13-|natural-volcano,
+node|z14-|waterway-waterfall,
+node|z15-|natural-cave_entrance,
+node|z13-|natural-peak[name],
+node|z16-|natural-saddle,
+node|z15-|mountain_pass,
+node|z15-|natural-spring,
+node|z15-|natural-hot_spring,
+node|z14-|natural-geyser,
+node|z16-|natural-beach,
+area|z16-|natural-beach,
+area|z14-|natural-bare_rock,
+node|z17-|natural-rock,
 {text: name;text-color: @poi_label;text-position: center;text-offset: 1;}
 
-node|z13-[natural=peak][!name],
+node|z13-|natural-peak[!name],
 {text: none;}
 
 
-node|z12-17[boundary=national_park],
-area|z12-17[boundary=national_park],
-node|z12-17[boundary=protected_area],
-area|z12-17[boundary=protected_area],
-node|z12-17[leisure=nature_reserve],
-area|z12-17[leisure=nature_reserve],
+node|z12-17|boundary-national_park,
+area|z12-17|boundary-national_park,
+node|z12-17|boundary-protected_area,
+area|z12-17|boundary-protected_area,
+node|z12-17|leisure-nature_reserve,
+area|z12-17|leisure-nature_reserve,
 {text: name;text-offset: 1;text-color: @park_label;text-halo-opacity: 0.8;text-halo-color: @label_halo_light;text-halo-radius:0.5;}
 
-area|z10-16[boundary=aboriginal_lands],
+area|z10-16|boundary-aboriginal_lands,
 {text: name;font-size: 10;text-color: @indigenous_label;text-halo-opacity: 0.8;text-halo-color: @label_halo_light;text-halo-radius:0.5;}
 
-node|z14[natural=cave_entrance],
+node|z14|natural-cave_entrance,
 {icon-image: cave-s.svg;}
-node|z15-[natural=cave_entrance],
+node|z15-|natural-cave_entrance,
 {icon-image: cave-m.svg; font-size: 10;}
-node|z17-[natural=cave_entrance],
+node|z17-|natural-cave_entrance,
 {font-size: 11;}
 
-node|z13-16[waterway=waterfall],
+node|z13-16|waterway-waterfall,
 {icon-image: waterfall-s.svg; font-size: 10;}
-node|z17-[waterway=waterfall],
+node|z17-|waterway-waterfall,
 {icon-image: waterfall-m.svg; font-size: 11;}
 
-node|z12-14[natural=volcano],
+node|z12-14|natural-volcano,
 {icon-image: volcano-s.svg; font-size: 10;}
-node|z15-[natural=volcano],
+node|z15-|natural-volcano,
 {icon-image: volcano-m.svg;}
-node|z17-[natural=volcano],
+node|z17-|natural-volcano,
 {font-size: 11;}
 
-node|z13[natural=peak][name],
+node|z13|natural-peak[name],
 {icon-image: peakt-s.svg; font-size: 9;}
-node|z14[natural=peak][name],
+node|z14|natural-peak[name],
 {icon-image: peakt-s.svg; font-size: 10;}
-node|z15-[natural=peak][name],
+node|z15-|natural-peak[name],
 {icon-image: peakt-m.svg; font-size: 10;}
-node|z17-[natural=peak][name],
+node|z17-|natural-peak[name],
 {font-size: 11;}
 
-node|z15-[natural=peak][!name],
+node|z15-|natural-peak[!name],
 {icon-image: peakt-m.svg;font-size: 10;}
 
-node|z17-[natural=rock],
+node|z17-|natural-rock,
 {icon-image: peakt-s.svg; font-size: 10;}
 
-node|z14[mountain_pass],
+node|z14|mountain_pass,
 {icon-image: mountain-pass-s.svg;}
-node|z15-[mountain_pass],
-node|z15-[natural=saddle],
+node|z15-|mountain_pass,
+node|z15-|natural-saddle,
 {icon-image: mountain-pass-m.svg; font-size: 10;}
-node|z17-[mountain_pass],
-node|z17-[natural=saddle],
+node|z17-|mountain_pass,
+node|z17-|natural-saddle,
 {font-size: 11;}
 
-node|z16[leisure=beach_resort],
+node|z16|leisure-beach_resort,
 {icon-image: beach-m.svg;}
-node|z17-[leisure=beach_resort],
+node|z17-|leisure-beach_resort,
 {icon-image: beach-m.svg;font-size: 11;}
 
-node|z11[boundary=national_park],
-area|z11[boundary=national_park],
-node|z11[boundary=protected_area],
-area|z11[boundary=protected_area],
-node|z11[leisure=nature_reserve],
-area|z11[leisure=nature_reserve]
+node|z11|boundary-national_park,
+area|z11|boundary-national_park,
+node|z11|boundary-protected_area,
+area|z11|boundary-protected_area,
+node|z11|leisure-nature_reserve,
+area|z11|leisure-nature_reserve
 {icon-image: nparkf-outline-s.svg; icon-min-distance: 20;}
-node|z12-14[boundary=national_park],
-area|z12-14[boundary=national_park],
-node|z12-14[boundary=protected_area],
-area|z12-14[boundary=protected_area],
-node|z12-14[leisure=nature_reserve],
-area|z12-14[leisure=nature_reserve],
+node|z12-14|boundary-national_park,
+area|z12-14|boundary-national_park,
+node|z12-14|boundary-protected_area,
+area|z12-14|boundary-protected_area,
+node|z12-14|leisure-nature_reserve,
+area|z12-14|leisure-nature_reserve,
 {icon-image: nparkf-outline-s.svg; font-size: 10; icon-min-distance: 12;}
-node|z15-17[boundary=national_park],
-area|z15-17[boundary=national_park],
-node|z15-17[boundary=protected_area],
-area|z15-17[boundary=protected_area],
-node|z15-17[leisure=nature_reserve],
-area|z15-17[leisure=nature_reserve],
+node|z15-17|boundary-national_park,
+area|z15-17|boundary-national_park,
+node|z15-17|boundary-protected_area,
+area|z15-17|boundary-protected_area,
+node|z15-17|leisure-nature_reserve,
+area|z15-17|leisure-nature_reserve,
 {icon-image: nparkf-outline-m.svg; font-size: 11; text-halo-opacity: 0.9;}
 
-area|z13[landuse=forest][name],
+area|z13|landuse-forest[name],
 {icon-image: nparkf-outline-s.svg;}
-area|z14-[landuse=forest][name],
+area|z14-|landuse-forest[name],
 {icon-image: nparkf-outline-s.svg; text: name; font-size: 10; text-offset: 1; text-color: @park_label; text-halo-opacity: 0.8; text-halo-color: @label_halo_light; text-halo-radius:0.5;}
-area|z15-[landuse=forest][name],
+area|z15-|landuse-forest[name],
 {icon-image: nparkf-outline-m.svg; font-size: 11; text-halo-opacity: 0.9;}
 
-area|z13-[landuse=forest][!name],
+area|z13-|landuse-forest[!name],
 {}
 
-node|z14-[natural=spring],
-node|z14-[natural=hot_spring],
+node|z14-|natural-spring,
+node|z14-|natural-hot_spring,
 {icon-image: drinking-water-s.svg; font-size: 10;}
-node|z17-[natural=spring],
-node|z17-[natural=hot_spring],
+node|z17-|natural-spring,
+node|z17-|natural-hot_spring,
 {icon-image: drinking-water-m.svg; font-size: 11;}
 
-node|z14-[natural=spring][drinking_water=not],
+node|z14-|natural-spring-drinking_water_no,
 {icon-image: drinking-water-no-s.svg; font-size: 10;}
-node|z17-[natural=spring][drinking_water=not],
+node|z17-|natural-spring-drinking_water_no,
 {icon-image: drinking-water-no-m.svg; font-size: 11;}
 
-node|z14[natural=geyser],
+node|z14|natural-geyser,
 {icon-image: geyser-s.svg;}
-node|z15-[natural=geyser],
+node|z15-|natural-geyser,
 {icon-image: geyser-m.svg;}
-node|z17-[natural=geyser],
+node|z17-|natural-geyser,
 {font-size: 11;}
 
-node|z16-[amenity=water_point],
-node|z16-[amenity=drinking_water],
-node|z16-[man_made=water_tap],
-node|z16-[man_made=water_well],
+node|z16-|amenity-water_point,
+node|z16-|amenity-drinking_water,
+node|z16-|man_made-water_tap,
+node|z16-|man_made-water_well,
 {icon-image: drinking-water-s.svg;}
-node|z18-[amenity=water_point],
-node|z18-[amenity=drinking_water],
-node|z18-[man_made=water_tap],
-node|z18-[man_made=water_well],
+node|z18-|amenity-water_point,
+node|z18-|amenity-drinking_water,
+node|z18-|man_made-water_tap,
+node|z18-|man_made-water_well,
 {text: name; text-color: @poi_label; text-offset: 1; font-size: 10;}
-node|z19-[amenity=water_point],
-node|z19-[amenity=drinking_water],
-node|z19-[man_made=water_tap],
-node|z19-[man_made=water_well],
+node|z19-|amenity-water_point,
+node|z19-|amenity-drinking_water,
+node|z19-|man_made-water_tap,
+node|z19-|man_made-water_well,
 {icon-image: drinking-water-m.svg;}
 
-node|z16-[man_made=water_tap][drinking_water=not],
-node|z16-[man_made=water_well][drinking_water=not],
-node|z16-[amenity=water_point][drinking_water=not],
+node|z16-|man_made-water_tap-drinking_water_no,
+node|z16-|man_made-water_well-drinking_water_no,
+node|z16-|amenity-water_point-drinking_water_no,
 {icon-image: none;}
-node|z18-[man_made=water_tap][drinking_water=not],
-node|z18-[man_made=water_well][drinking_water=not],
-node|z18-[amenity=water_point][drinking_water=not],
+node|z18-|man_made-water_tap-drinking_water_no,
+node|z18-|man_made-water_well-drinking_water_no,
+node|z18-|amenity-water_point-drinking_water_no,
 {icon-image: drinking-water-no-s.svg;}
-node|z19-[man_made=water_tap][drinking_water=not],
-node|z19-[man_made=water_well][drinking_water=not],
-node|z19-[amenity=water_point][drinking_water=not],
+node|z19-|man_made-water_tap-drinking_water_no,
+node|z19-|man_made-water_well-drinking_water_no,
+node|z19-|amenity-water_point-drinking_water_no,
 {icon-image: drinking-water-no-m.svg;}
 
 /* 3. TRANSPORT */
 
-node|z12-[railway=station],
-node|z13-[railway=halt],
+node|z12-|railway-station,
+node|z13-|railway-halt,
 {text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 0.6;text-halo-color: @label_halo_light;}
-node|z12-[railway=station]::int_name,
-node|z13-[railway=halt]::int_name,
+node|z12-|railway-station::int_name,
+node|z13-|railway-halt::int_name,
 {text: int_name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 0.6;text-halo-color: @label_halo_light;}
 
-node|z17-[railway=tram_stop],
-area|z17-[railway=tram_stop]
+node|z17-|railway-tram_stop,
+area|z17-|railway-tram_stop
 {text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 1;text-halo-color: @label_halo_light;}
-node|z17-[railway=tram_stop]::int_name,
-area|z17-[railway=tram_stop]::int_name
+node|z17-|railway-tram_stop::int_name,
+area|z17-|railway-tram_stop::int_name
 {text: int_name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 1;text-halo-color: @label_halo_light;}
-node|z17-[highway=bus_stop],
-area|z17-[highway=bus_stop],
-node|z14-[amenity=bus_station],
-area|z14-[amenity=bus_station]
+node|z17-|highway-bus_stop,
+area|z17-|highway-bus_stop,
+node|z14-|amenity-bus_station,
+area|z14-|amenity-bus_station
 {text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 0.9;text-halo-color: @label_halo_light;text-position: center;}
-node|z17-[highway=bus_stop]::int_name,
-area|z17-[highway=bus_stop]::int_name,
-node|z14-[amenity=bus_station]::int_name,
-area|z14-[amenity=bus_station]::int_name
+node|z17-|highway-bus_stop::int_name,
+area|z17-|highway-bus_stop::int_name,
+node|z14-|amenity-bus_station::int_name,
+area|z14-|amenity-bus_station::int_name
 {text: int_name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 0.9;text-halo-color: @label_halo_light;text-position: center;}
 
-area|z10-[aeroway=aerodrome][aerodrome=international],
-node|z10-[aeroway=aerodrome][aerodrome=international],
-area|z14-[aeroway=aerodrome],
-node|z14-[aeroway=aerodrome],
-node|z15-[aerialway=station],
-node|z16-[amenity=ferry_terminal]
+area|z10-|aeroway-aerodrome-international,
+node|z10-|aeroway-aerodrome-international,
+area|z14-|aeroway-aerodrome,
+node|z14-|aeroway-aerodrome,
+node|z15-|aerialway-station,
+node|z16-|amenity-ferry_terminal
 {text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 0.7;text-halo-color: @label_halo_light;text-position: center;}
-area|z12-[aeroway=aerodrome][aerodrome=international]::int_name,
-node|z12-[aeroway=aerodrome][aerodrome=international]::int_name,
-area|z14-[aeroway=aerodrome]::int_name,
-node|z14-[aeroway=aerodrome]::int_name,
+area|z12-|aeroway-aerodrome-international::int_name,
+node|z12-|aeroway-aerodrome-international::int_name,
+area|z14-|aeroway-aerodrome::int_name,
+node|z14-|aeroway-aerodrome::int_name,
 {text: int_name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 0.7;text-halo-color: @label_halo_light;text-position: center;}
 
 /* 3.1 Train Station */
 
 /* ToDo: check offset int_name */
 
-node|z12[railway=station],
+node|z12|railway-station,
 {icon-image: train-s.svg;text-offset: 1;font-size: 9;}
-node|z12[railway=station]::int_name,
+node|z12|railway-station::int_name,
 {text-offset: 1;font-size: 8;}
-node|z13[railway=station],
-node|z13[railway=halt],
+node|z13|railway-station,
+node|z13|railway-halt,
 {icon-image: train-s.svg;text-offset: 1;font-size: 10;}
-node|z13[railway=station]::int_name,
-node|z13[railway=halt]::int_name,
+node|z13|railway-station::int_name,
+node|z13|railway-halt::int_name,
 {text-offset: 1;font-size: 9;}
-node|z14[railway=station],
-node|z14[railway=halt],
+node|z14|railway-station,
+node|z14|railway-halt,
 {icon-image: train-s.svg;text-offset: 1;font-size: 11;text-halo-opacity: 0.7;}
-node|z14[railway=station]::int_name,
-node|z14[railway=halt]::int_name,
+node|z14|railway-station::int_name,
+node|z14|railway-halt::int_name,
 {text-offset: 1;font-size: 10;text-halo-opacity: 0.7;}
-node|z15[railway=station],
-node|z15[railway=halt],
+node|z15|railway-station,
+node|z15|railway-halt,
 {icon-image: train-m.svg;text-offset: 1;font-size: 12;text-halo-opacity: 0.8;}
-node|z15[railway=station]::int_name,
-node|z15[railway=halt]::int_name,
+node|z15|railway-station::int_name,
+node|z15|railway-halt::int_name,
 {text-offset: 1;font-size: 10;text-halo-opacity: 0.8;}
-node|z16[railway=station],
-node|z16[railway=halt],
+node|z16|railway-station,
+node|z16|railway-halt,
 {icon-image: train-m.svg;text-offset: 1;font-size: 13;text-halo-opacity: 0.8;}
-node|z16[railway=station]::int_name,
-node|z16[railway=halt]::int_name,
+node|z16|railway-station::int_name,
+node|z16|railway-halt::int_name,
 {text-offset: 1;font-size: 11;text-halo-opacity: 0.8;}
-node|z17-[railway=station],
-node|z17-[railway=halt],
+node|z17-|railway-station,
+node|z17-|railway-halt,
 {icon-image: train-m.svg;text-offset: 1;font-size: 13;text-halo-opacity: 0.9;}
-node|z17-[railway=station]::int_name,
-node|z17-[railway=halt]::int_name,
+node|z17-|railway-station::int_name,
+node|z17-|railway-halt::int_name,
 {text-offset: 1;font-size: 12;text-halo-opacity: 0.9;}
 
 /* 3.2 Road Icons */
 
-node|z19-[highway=traffic_signals],
+node|z19-|highway-traffic_signals,
 {icon-image: traffic_signals.svg}
 
-node|z17-[highway=elevator],
-area|z17-[highway=elevator],
+node|z17-|highway-elevator,
+area|z17-|highway-elevator,
 {icon-image: elevator-s.svg;}
 
 /* 3.3 Tram Station */
 
-node|z14[railway=tram_stop]
+node|z14|railway-tram_stop
 {icon-image: tram-s.svg;}
-node|z15-16[railway=tram_stop],
-area|z15-16[railway=tram_stop]
+node|z15-16|railway-tram_stop,
+area|z15-16|railway-tram_stop
 {icon-image: tram-m.svg;}
-node|z17[railway=tram_stop],
-area|z17[railway=tram_stop]
+node|z17|railway-tram_stop,
+area|z17|railway-tram_stop
 {icon-image: tram-m.svg;text-offset: 1;font-size: 11;text-halo-opacity: 0.9;}
-node|z17-[railway=tram_stop]::int_name,
-area|z17-[railway=tram_stop]::int_name
+node|z17-|railway-tram_stop::int_name,
+area|z17-|railway-tram_stop::int_name
 {text-offset: 1;font-size: 10;text-halo-opacity: 0.9;} /*check*/
-node|z18-[railway=tram_stop],
-area|z18-[railway=tram_stop]
+node|z18-|railway-tram_stop,
+area|z18-|railway-tram_stop
 {icon-image: tram-m.svg;text-offset: 1;font-size: 12;text-halo-opacity: 0.9;}
 
 /* 3.4 Bus Station */
 
-node|z13[amenity=bus_station],
-area|z13[amenity=bus_station]
+node|z13|amenity-bus_station,
+area|z13|amenity-bus_station
 {icon-image: bus-s.svg;icon-min-distance: 1;}
-node|z14[amenity=bus_station],
-area|z14[amenity=bus_station]
+node|z14|amenity-bus_station,
+area|z14|amenity-bus_station
 {icon-image: bus-s.svg;text-offset: 1;font-size: 10;text-halo-opacity: 0.8;}
-node|z15-16[amenity=bus_station],
-area|z15-16[amenity=bus_station]
+node|z15-16|amenity-bus_station,
+area|z15-16|amenity-bus_station
 {icon-image: bus-m.svg;text-offset: 1;font-size: 11;text-halo-opacity: 0.8;}
-node|z15-16[amenity=bus_station]::int_name,
-area|z15-16[amenity=bus_station]::int_name
+node|z15-16|amenity-bus_station::int_name,
+area|z15-16|amenity-bus_station::int_name
 {text-offset: 1;font-size: 9;text-halo-opacity: 0.8;}
-node|z17[amenity=bus_station],
-area|z17[amenity=bus_station]
+node|z17|amenity-bus_station,
+area|z17|amenity-bus_station
 {icon-image: bus-m.svg;text-offset: 1;font-size: 11;}
-node|z17[amenity=bus_station]::int_name,
-area|z17[amenity=bus_station]::int_name
+node|z17|amenity-bus_station::int_name,
+area|z17|amenity-bus_station::int_name
 {text-offset: 1;font-size: 9;}
-node|z18[amenity=bus_station],
-area|z18[amenity=bus_station]
+node|z18|amenity-bus_station,
+area|z18|amenity-bus_station
 {icon-image: bus-m.svg;text-offset: 1;font-size: 12;}
-node|z18[amenity=bus_station]::int_name,
-area|z18[amenity=bus_station]::int_name
+node|z18|amenity-bus_station::int_name,
+area|z18|amenity-bus_station::int_name
 {text-offset: 1;font-size: 10;}
-node|z19-[amenity=bus_station],
-area|z19-[amenity=bus_station]
+node|z19-|amenity-bus_station,
+area|z19-|amenity-bus_station
 {icon-image: bus-m.svg;text-offset: 1;font-size: 12;}
-node|z19-[amenity=bus_station]::int_name,
-area|z19-[amenity=bus_station]::int_name
+node|z19-|amenity-bus_station::int_name,
+area|z19-|amenity-bus_station::int_name
 {text-offset: 1;font-size: 10;}
 
-node|z16[highway=bus_stop],
-area|z16[highway=bus_stop]
+node|z16|highway-bus_stop,
+area|z16|highway-bus_stop
 {icon-image: bus-m.svg;}
-node|z17-[highway=bus_stop],
-area|z17-[highway=bus_stop],
+node|z17-|highway-bus_stop,
+area|z17-|highway-bus_stop,
 {icon-image: bus-m.svg;text-offset: 1;font-size: 11;}
-node|z18-19[highway=bus_stop]::int_name,
-area|z18-19[highway=bus_stop]::int_name,
+node|z18-19|highway-bus_stop::int_name,
+area|z18-19|highway-bus_stop::int_name,
 {icon-image: bus-m.svg;text-offset: 1;font-size: 9;}
 
 /* 3.5 Ferry terminal */
 
-node|z11-12[amenity=ferry_terminal]
+node|z11-12|amenity-ferry_terminal
 {icon-image: ship-s.svg;icon-min-distance: 12;}
-node|z13-14[amenity=ferry_terminal]
+node|z13-14|amenity-ferry_terminal
 {icon-image: ship-s.svg;}
-node|z15[amenity=ferry_terminal]
+node|z15|amenity-ferry_terminal
 {icon-image: ship-m.svg;}
-node|z16[amenity=ferry_terminal]
+node|z16|amenity-ferry_terminal
 {icon-image: ship-m.svg;text-offset: 1;font-size: 11;text-halo-opacity: 0.8;}
-node|z17-[amenity=ferry_terminal]
+node|z17-|amenity-ferry_terminal
 {icon-image: ship-m.svg;text-offset: 1;font-size: 12;}
 
 /* 3.6 Airport */
 
-area|z7-9[aeroway=aerodrome][aerodrome=international],
-node|z7-9[aeroway=aerodrome][aerodrome=international],
+area|z7-9|aeroway-aerodrome-international,
+node|z7-9|aeroway-aerodrome-international,
 {icon-image: airport-s.svg;}
 
-area|z10[aeroway=aerodrome][aerodrome=international],
-node|z10[aeroway=aerodrome][aerodrome=international],
+area|z10|aeroway-aerodrome-international,
+node|z10|aeroway-aerodrome-international,
 {icon-image: airport-s.svg;text-offset: 1;font-size: 10;}
-area|z11-13[aeroway=aerodrome][aerodrome=international],
-node|z11-13[aeroway=aerodrome][aerodrome=international],
+area|z11-13|aeroway-aerodrome-international,
+node|z11-13|aeroway-aerodrome-international,
 {icon-image: airport-m.svg; text-offset: 1; font-size: 11;}
-area|z14-[aeroway=aerodrome],
-node|z14-[aeroway=aerodrome]
+area|z14-|aeroway-aerodrome,
+node|z14-|aeroway-aerodrome
 {icon-image: airport-m.svg;text-offset: 1;font-size: 12;}
-area|z14-[aeroway=aerodrome]::int_name,
-node|z14-[aeroway=aerodrome]::int_name,
+area|z14-|aeroway-aerodrome::int_name,
+node|z14-|aeroway-aerodrome::int_name,
 {font-size: 11;}
 
-area|z16-[aeroway=helipad],
-node|z16-[aeroway=helipad]
+area|z16-|aeroway-helipad,
+node|z16-|aeroway-helipad
 {icon-image: helipad-m.svg;text-offset: 1;font-size: 10;text: name;text-color: @poi_label;}
 
 /* 3.7 Aerialway */
 
-node|z12-13[aerialway=station],
+node|z12-13|aerialway-station,
 {icon-image: cable-car-s.svg;icon-min-distance: 10;}
-node|z14[aerialway=station],
+node|z14|aerialway-station,
 {icon-image: cable-car-s.svg;}
-node|z15-[aerialway=station],
+node|z15-|aerialway-station,
 {icon-image: cable-car-m.svg;text-offset: 1;font-size: 10;}
-node|z17-[aerialway=station],
+node|z17-|aerialway-station,
 {font-size: 12;}
 
-node|z17-[railway=level_crossing]
+node|z17-|railway-level_crossing
 {icon-image: railway-crossing-m.svg;}
 
-node|z15-[railway=station][station=funicular],
+node|z15-|railway-station-funicular,
 {icon-image: funicular-m.svg;text-offset: 1;font-size: 10;}
-node|z17-[aerialway=station],
+node|z17-|aerialway-station,
 {font-size: 12;}
 
 /* 4.TOURISM */
 
 /* 4.1 Main POI */
 
-node|z12-[historic=fort],
-area|z12-[historic=fort],
-node|z12-[historic=castle],
-area|z12-[historic=castle],
-node|z13-[historic=city_gate],
-area|z13-[historic=city_gate],
-node|z13-[historic=monument],
-area|z13-[historic=monument],
-node|z13-[tourism=museum],
-area|z13-[tourism=museum],
-node|z13-[tourism=zoo],
-area|z13-[tourism=zoo],
-node|z14-[amenity=theatre],
-area|z14-[amenity=theatre],
-node|z14-[tourism=attraction],
-area|z14-[tourism=attraction],
-node|z14-[tourism=theme_park],
-area|z14-[tourism=theme_park],
-node|z14-[tourism=viewpoint],
-node|z15-[tourism=zoo][zoo=petting_zoo],
-area|z15-[tourism=zoo][zoo=petting_zoo],
-node|z15-[amenity=community_centre],
-area|z15-[amenity=community_centre],
-node|z15-[historic=memorial],
-area|z15-[historic=memorial],
-node|z15-[historic=mine],
-node|z15-[historic=battlefield],
-area|z15-[historic=battlefield],
-node|z15-[tourism=gallery],
-area|z15-[tourism=gallery],
-node|z15-[tourism=artwork],
-node|z15-[historic=ship],
-node|z16-[tourism=information],
-node|z15-[tourism=information][information=office],
-node|z15-[tourism=information][information=visitor_centre],
-node|z16-[historic=aircraft],
-node|z16-[historic=tank],
-node|z16-[historic=wreck],
-node|z16-[historic=locomotive],
-node|z16-[historic=boundary_stone],
-area|z16-[historic=boundary_stone],
-node|z16-[historic=wayside_cross],
-area|z16-[historic=wayside_cross],
-node|z16-[historic=tomb],
-area|z16-[historic=tomb],
-node|z16-[tourism=aquarium],
-area|z16-[tourism=aquarium],
-node|z17-[attraction=animal],
-node|z17-[attraction=amusement_ride],
-node|z17-[attraction=carousel],
-node|z17-[attraction=roller_coaster],
-node|z17-[attraction=maze],
-node|z17-[attraction=historic],
-node|z17-[attraction=big_wheel],
-node|z17-[attraction=bumper_car],
-node|z17-[historic=ruins],
-area|z17-[historic=ruins],
-node|z17-[historic=wayside_shrine],
-area|z17-[historic=wayside_shrine],
-node|z17-[historic=archaeological_site],
-area|z17-[historic=archaeological_site],
-node|z17-[historic=gallows],
-area|z17-[historic=gallows],
-node|z17-[historic=pillory],
-area|z17-[historic=pillory],
-node|z17-[amenity=arts_centre],
-area|z17-[amenity=arts_centre],
-node|z18-[historic=anchor],
-node|z18-[historic=cannon],
-node|z18-[historic=stone],
+node|z12-|historic-fort,
+area|z12-|historic-fort,
+node|z12-|historic-castle,
+area|z12-|historic-castle,
+node|z13-|historic-city_gate,
+area|z13-|historic-city_gate,
+node|z13-|historic-monument,
+area|z13-|historic-monument,
+node|z13-|tourism-museum,
+area|z13-|tourism-museum,
+node|z13-|tourism-zoo,
+area|z13-|tourism-zoo,
+node|z14-|amenity-theatre,
+area|z14-|amenity-theatre,
+node|z14-|tourism-attraction,
+area|z14-|tourism-attraction,
+node|z14-|tourism-theme_park,
+area|z14-|tourism-theme_park,
+node|z14-|tourism-viewpoint,
+node|z15-|tourism-zoo-petting,
+area|z15-|tourism-zoo-petting,
+node|z15-|amenity-community_centre,
+area|z15-|amenity-community_centre,
+node|z15-|historic-memorial,
+area|z15-|historic-memorial,
+node|z15-|historic-mine,
+node|z15-|historic-battlefield,
+area|z15-|historic-battlefield,
+node|z15-|tourism-gallery,
+area|z15-|tourism-gallery,
+node|z15-|tourism-artwork,
+node|z15-|historic-ship,
+node|z16-|tourism-information,
+node|z15-|tourism-information-office,
+node|z15-|tourism-information-visitor_centre,
+node|z16-|historic-aircraft,
+node|z16-|historic-tank,
+node|z16-|historic-wreck,
+node|z16-|historic-locomotive,
+node|z16-|historic-boundary_stone,
+area|z16-|historic-boundary_stone,
+node|z16-|historic-wayside_cross,
+area|z16-|historic-wayside_cross,
+node|z16-|historic-tomb,
+area|z16-|historic-tomb,
+node|z16-|tourism-aquarium,
+area|z16-|tourism-aquarium,
+node|z17-|attraction-animal,
+node|z17-|attraction-amusement_ride,
+node|z17-|attraction-carousel,
+node|z17-|attraction-roller_coaster,
+node|z17-|attraction-maze,
+node|z17-|attraction-historic,
+node|z17-|attraction-big_wheel,
+node|z17-|attraction-bumper_car,
+node|z17-|historic-ruins,
+area|z17-|historic-ruins,
+node|z17-|historic-wayside_shrine,
+area|z17-|historic-wayside_shrine,
+node|z17-|historic-archaeological_site,
+area|z17-|historic-archaeological_site,
+node|z17-|historic-gallows,
+area|z17-|historic-gallows,
+node|z17-|historic-pillory,
+area|z17-|historic-pillory,
+node|z17-|amenity-arts_centre,
+area|z17-|amenity-arts_centre,
+node|z18-|historic-anchor,
+node|z18-|historic-cannon,
+node|z18-|historic-stone,
 {text: name;text-offset: 1;font-size: 10;text-color: @poi_label;}
 
-node|z12-14[historic=fort],
-area|z12-14[historic=fort],
-node|z12-14[historic=castle],
-area|z12-14[historic=castle]
+node|z12-14|historic-fort,
+area|z12-14|historic-fort,
+node|z12-14|historic-castle,
+area|z12-14|historic-castle
 {icon-image: remains-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z15[historic=fort],
-area|z15[historic=fort],
-node|z15[historic=castle],
-area|z15[historic=castle]
+node|z15|historic-fort,
+area|z15|historic-fort,
+node|z15|historic-castle,
+area|z15|historic-castle
 {icon-image: remains-m.svg;icon-min-distance: 5;}
-node|z16[historic=fort],
-area|z16[historic=fort],
-node|z16[historic=castle],
-area|z16[historic=castle]
+node|z16|historic-fort,
+area|z16|historic-fort,
+node|z16|historic-castle,
+area|z16|historic-castle
 {icon-image: remains-m.svg;text-offset: 1;}
-node|z17-[historic=ruins][name],
-area|z17-[historic=ruins][name],
-node|z17-[historic=fort],
-area|z17-[historic=fort],
-node|z17-[historic=castle],
-area|z17-[historic=castle]
+node|z17-|historic-ruins[name],
+area|z17-|historic-ruins[name],
+node|z17-|historic-fort,
+area|z17-|historic-fort,
+node|z17-|historic-castle,
+area|z17-|historic-castle
 {icon-image: remains-m.svg;}
 
-node|z17-[historic=archaeological_site],
-area|z17-[historic=archaeological_site]
+node|z17-|historic-archaeological_site,
+area|z17-|historic-archaeological_site
 {icon-image: archaeological-site-m.svg;}
 
-node|z19-[historic=ruins][!name],
-area|z19-[historic=ruins][!name],
+node|z19-|historic-ruins[!name],
+area|z19-|historic-ruins[!name],
 {icon-image: remains-m.svg;}
 
-node|z15-[historic=mine],
+node|z15-|historic-mine,
 {icon-image: mine-m.svg;}
 
-node|z16-[historic=aircraft],
+node|z16-|historic-aircraft,
 {icon-image: aircraft-m.svg;}
 
-node|z16-[historic=tank],
+node|z16-|historic-tank,
 {icon-image: tank-m.svg;}
 
-node|z16-[historic=wreck],
+node|z16-|historic-wreck,
 {icon-image: wreck-m.svg;}
 
-node|z16-[historic=locomotive],
+node|z16-|historic-locomotive,
 {icon-image: locomotive-m.svg;}
 
-node|z18-[historic=cannon],
+node|z18-|historic-cannon,
 {icon-image: cannon-m.svg;}
 
-node|z18-[historic=anchor],
+node|z18-|historic-anchor,
 {icon-image: anchor-m.svg;}
 
-node|z18-[historic=stone],
+node|z18-|historic-stone,
 {icon-image: stone-m.svg;}
 
-node|z13-14[historic=monument],
-area|z13-14[historic=monument]
+node|z13-14|historic-monument,
+area|z13-14|historic-monument
 {icon-image: monument-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z15[historic=monument],
-area|z15[historic=monument],
-node|z15[historic=memorial],
-area|z15[historic=memorial],
-node|z15[historic=battlefield],
-area|z15[historic=battlefield],
+node|z15|historic-monument,
+area|z15|historic-monument,
+node|z15|historic-memorial,
+area|z15|historic-memorial,
+node|z15|historic-battlefield,
+area|z15|historic-battlefield,
 {icon-image: monument-m.svg;icon-min-distance: 24;}
-node|z16-[historic=monument],
-area|z16-[historic=monument],
-node|z16-[historic=memorial],
-area|z16-[historic=memorial],
-node|z16-[historic=battlefield],
-area|z16-[historic=battlefield],
+node|z16-|historic-monument,
+area|z16-|historic-monument,
+node|z16-|historic-memorial,
+area|z16-|historic-memorial,
+node|z16-|historic-battlefield,
+area|z16-|historic-battlefield,
 {icon-image: monument-m.svg;icon-min-distance: 12;}
 
 /* Do not display following features on lower zoom levels */
-node|z15-17[historic=memorial][memorial=plaque],
-area|z15-17[historic=memorial][memorial=plaque],
-node|z15-18[historic=memorial][memorial=stolperstein],
-area|z15-18[historic=memorial][memorial=stolperstein],
-node|z15-16[historic=memorial][memorial=cross],
-area|z15-16[historic=memorial][memorial=cross],
+node|z15-17|historic-memorial-plaque,
+area|z15-17|historic-memorial-plaque,
+node|z15-18|historic-memorial-stolperstein,
+area|z15-18|historic-memorial-stolperstein,
+node|z15-16|historic-memorial-cross,
+area|z15-16|historic-memorial-cross,
 {icon-image: none; text: none;}
 
-node|z18-[historic=memorial][memorial=plaque],
-area|z18-[historic=memorial][memorial=plaque],
-node|z19-[historic=memorial][memorial=stolperstein],
-area|z19-[historic=memorial][memorial=stolperstein],
+node|z18-|historic-memorial-plaque,
+area|z18-|historic-memorial-plaque,
+node|z19-|historic-memorial-stolperstein,
+area|z19-|historic-memorial-stolperstein,
 {icon-image: plaque.svg;}
-node|z17-[historic=memorial][memorial=cross],
-area|z17-[historic=memorial][memorial=cross],
+node|z17-|historic-memorial-cross,
+area|z17-|historic-memorial-cross,
 {icon-image: cross-m.svg;icon-min-distance: 12;}
 
-node|z13-14[historic=city_gate],
-area|z13-14[historic=city_gate]
+node|z13-14|historic-city_gate,
+area|z13-14|historic-city_gate
 {icon-image: remains-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z15[historic=city_gate],
-area|z15[historic=city_gate],
+node|z15|historic-city_gate,
+area|z15|historic-city_gate,
 {icon-image: remains-m.svg;icon-min-distance: 24;}
-node|z16-[historic=city_gate],
-area|z16-[historic=city_gate],
+node|z16-|historic-city_gate,
+area|z16-|historic-city_gate,
 {icon-image: remains-m.svg;icon-min-distance: 12;}
 
-node|z13-14[tourism=museum],
-area|z13-14[tourism=museum]
+node|z13-14|tourism-museum,
+area|z13-14|tourism-museum
 {icon-image: museum-s.svg;icon-min-distance: 16;}
-node|z15[tourism=museum],
-area|z15[tourism=museum]
+node|z15|tourism-museum,
+area|z15|tourism-museum
 {icon-image: museum-m.svg;icon-min-distance: 24;}
-node|z16-[tourism=museum],
-area|z16-[tourism=museum],
+node|z16-|tourism-museum,
+area|z16-|tourism-museum,
 {icon-image: museum-m.svg;text-offset: 1;icon-min-distance: 12;}
 
-node|z15[tourism=gallery]
+node|z15|tourism-gallery
 {icon-image: gallery-m.svg;icon-min-distance: 8;} /* <-- <-- не показывается, непонятно почему, позже разобраться */
-node|z16-[tourism=gallery],
-area|z16-[tourism=gallery],
-node|z17-[amenity=arts_centre],
-area|z17-[amenity=arts_centre]
+node|z16-|tourism-gallery,
+area|z16-|tourism-gallery,
+node|z17-|amenity-arts_centre,
+area|z17-|amenity-arts_centre
 {icon-image: gallery-m.svg;text-offset: 1;icon-min-distance: 12;}
 
-node|z14[amenity=theatre],
-area|z14[amenity=theatre]
+node|z14|amenity-theatre,
+area|z14|amenity-theatre
 {icon-image: theatre-s.svg;text-offset: 1;icon-min-distance: 8;}
-node|z15-[amenity=theatre],
-area|z15-[amenity=theatre]
+node|z15-|amenity-theatre,
+area|z15-|amenity-theatre
 {icon-image: theatre-m.svg;icon-min-distance: 10;}
 
-node|z13-14[tourism=zoo],
-area|z13-14[tourism=zoo]
+node|z13-14|tourism-zoo,
+area|z13-14|tourism-zoo
 {icon-image: zoo-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z15[tourism=zoo],
-area|z15[tourism=zoo]
+node|z15|tourism-zoo,
+area|z15|tourism-zoo
 {icon-image: zoo-m.svg;icon-min-distance: 8;}
-node|z16-[tourism=zoo],
-area|z16-[tourism=zoo]
+node|z16-|tourism-zoo,
+area|z16-|tourism-zoo
 {icon-image: zoo-m.svg;text-offset: 1;icon-min-distance: 8;}
-node|z16-[tourism=aquarium],
-area|z16-[tourism=aquarium]
+node|z16-|tourism-aquarium,
+area|z16-|tourism-aquarium
 {icon-image: aquarium-m.svg;text-offset: 1;icon-min-distance: 8;}
 
 
-node|z13-[tourism=zoo][zoo=petting_zoo],
-area|z13-[tourism=zoo][zoo=petting_zoo],
+node|z13-|tourism-zoo-petting,
+area|z13-|tourism-zoo-petting,
 {icon-image: none;text: none;} /*needed to override base type styles*/
 
-node|z15-[tourism=zoo][zoo=petting_zoo],
-area|z15-[tourism=zoo][zoo=petting_zoo],
+node|z15-|tourism-zoo-petting,
+area|z15-|tourism-zoo-petting,
 {icon-image: petting_zoo-m.svg;text: name;text-offset: 1;icon-min-distance: 8;}
 
-node|z14[tourism=viewpoint]
+node|z14|tourism-viewpoint
 {icon-image: viewpoint-s.svg;text-offset: 1;icon-min-distance: 8;}
-node|z15-[tourism=viewpoint]
+node|z15-|tourism-viewpoint
 {icon-image: viewpoint-m.svg;icon-min-distance: 8;}
 
-node|z16-[tourism=information]
+node|z16-|tourism-information
 {icon-image: information-m.svg;text-offset: 1;icon-min-distance: 10;}
-node|z15-[tourism=information][information=office],
-node|z15-[tourism=information][information=visitor_centre],
+node|z15-|tourism-information-office,
+node|z15-|tourism-information-visitor_centre,
 {icon-image: information-office-m.svg;text-offset: 1;icon-min-distance: 10;}
-node|z16-[tourism=information][information=board]
+node|z16-|tourism-information-board
 {icon-image: board.svg;text-offset: 1;icon-min-distance: 10;}
-node|z16-[tourism=information][information=guidepost]
+node|z16-|tourism-information-guidepost
 {icon-image: guidepost.svg;text-offset: 1;icon-min-distance: 10;}
-node|z16-[tourism=information][information=map]
+node|z16-|tourism-information-map
 {icon-image: map.svg;text-offset: 1;icon-min-distance: 10;}
 
-node|z16-[historic=boundary_stone],
-area|z16-[historic=boundary_stone],
-node|z16-[historic=gallows],
-area|z16-[historic=gallows],
-node|z16-[historic=pillory],
-area|z16-[historic=pillory],
+node|z16-|historic-boundary_stone,
+area|z16-|historic-boundary_stone,
+node|z16-|historic-gallows,
+area|z16-|historic-gallows,
+node|z16-|historic-pillory,
+area|z16-|historic-pillory,
 {icon-image: monument-m.svg;font-size: 11;icon-min-distance: 8;}
-node|z16-[historic=wayside_cross],
-area|z16-[historic=wayside_cross],
+node|z16-|historic-wayside_cross,
+area|z16-|historic-wayside_cross,
 {icon-image: cross-m.svg;font-size: 11;icon-min-distance: 8;}
-node|z15-[historic=ship],
+node|z15-|historic-ship,
 {icon-image: historic-ship-m.svg;font-size: 11;icon-min-distance: 8;}
-node|z16-[historic=tomb],
-area|z16-[historic=tomb],
+node|z16-|historic-tomb,
+area|z16-|historic-tomb,
 {icon-image: tomb-m.svg;font-size: 11;icon-min-distance: 8;}
-node|z16-[historic=wayside_shrine],
-area|z16-[historic=wayside_shrine],
+node|z16-|historic-wayside_shrine,
+area|z16-|historic-wayside_shrine,
 {icon-image: wayside_shrine-m.svg;font-size: 11;icon-min-distance: 8;}
 
-node|z15[tourism=artwork],
-area|z15[tourism=artwork],
+node|z15|tourism-artwork,
+area|z15|tourism-artwork,
 {icon-image: artwork-m.svg;icon-min-distance: 8;}
-node|z16-[tourism=artwork],
-area|z16-[tourism=artwork],
+node|z16-|tourism-artwork,
+area|z16-|tourism-artwork,
 {icon-image: artwork-m.svg;icon-min-distance: 24;}
 
-node|z15[tourism=artwork][artwork_type=statue],
-area|z15[tourism=artwork][artwork_type=statue],
+node|z15|tourism-artwork-statue,
+area|z15|tourism-artwork-statue,
 {icon-image: statue-m.svg;icon-min-distance: 8;}
-node|z16-[tourism=artwork][artwork_type=statue],
-area|z16-[tourism=artwork][artwork_type=statue],
+node|z16-|tourism-artwork-statue,
+area|z16-|tourism-artwork-statue,
 {icon-image: statue-m.svg;icon-min-distance: 24;}
 
-node|z14[tourism=attraction],
-area|z14[tourism=attraction],
+node|z14|tourism-attraction,
+area|z14|tourism-attraction,
 {icon-image: tourism-s.svg;icon-min-distance: 12;}
-node|z15[tourism=attraction],
-area|z15[tourism=attraction],
+node|z15|tourism-attraction,
+area|z15|tourism-attraction,
 {icon-image: tourism-m.svg;icon-min-distance: 36;}
-node|z16-[tourism=attraction],
-area|z16-[tourism=attraction],
+node|z16-|tourism-attraction,
+area|z16-|tourism-attraction,
 {icon-image: tourism-m.svg;icon-min-distance: 24;}
 
-node|z14[tourism=theme_park],
-area|z14[tourism=theme_park]
+node|z14|tourism-theme_park,
+area|z14|tourism-theme_park
 {icon-image: theme_park-s.svg;icon-min-distance: 12;}
-node|z15[tourism=theme_park],
-area|z15[tourism=theme_park]
+node|z15|tourism-theme_park,
+area|z15|tourism-theme_park
 {icon-image: theme_park-m.svg;icon-min-distance: 36;}
-node|z16-[tourism=theme_park],
-area|z16-[tourism=theme_park]
+node|z16-|tourism-theme_park,
+area|z16-|tourism-theme_park
 {icon-image: theme_park-m.svg;icon-min-distance: 24;}
 
-node|z17-[attraction=animal],
+node|z17-|attraction-animal,
 {icon-image: animal-m.svg;icon-min-distance: 24;}
 
-node|z17-[attraction=amusement_ride],
-node|z17-[attraction=carousel],
-node|z17-[attraction=roller_coaster],
-node|z17-[attraction=maze],
-node|z17-[attraction=historic],
-node|z17-[attraction=big_wheel],
-node|z17-[attraction=bumper_car],
+node|z17-|attraction-amusement_ride,
+node|z17-|attraction-carousel,
+node|z17-|attraction-roller_coaster,
+node|z17-|attraction-maze,
+node|z17-|attraction-historic,
+node|z17-|attraction-big_wheel,
+node|z17-|attraction-bumper_car,
 {icon-image: playground-m.svg;icon-min-distance: 24;}
 
-node|z15-[amenity=community_centre],
-area|z15-[amenity=community_centre],
-node|z16-[amenity=conference_centre],
-area|z16-[amenity=conference_centre],
-node|z16-[amenity=events_venue],
-area|z16-[amenity=events_venue],
-node|z16-[amenity=exhibition_centre],
-area|z16-[amenity=exhibition_centre],
+node|z15-|amenity-community_centre,
+area|z15-|amenity-community_centre,
+node|z16-|amenity-conference_centre,
+area|z16-|amenity-conference_centre,
+node|z16-|amenity-events_venue,
+area|z16-|amenity-events_venue,
+node|z16-|amenity-exhibition_centre,
+area|z16-|amenity-exhibition_centre,
 {icon-image: community-m.svg;icon-min-distance: 24;}
 
 /* 4.2 Apartment */
 
-node|z16-[tourism=hotel],
-node|z16-[tourism=hostel],
-node|z16-[tourism=guest_house],
-area|z16-[tourism=guest_house],
-node|z13-[tourism=alpine_hut],
-node|z16-[tourism=wilderness_hut],
-node|z16-[tourism=chalet],
-node|z16-[leisure=resort],
-area|z16-[leisure=resort],
-node|z16-[tourism=motel],
-area|z16-[tourism=motel],
-node|z16-[tourism=apartment],
-area|z16-[tourism=apartment]
+node|z16-|tourism-hotel,
+node|z16-|tourism-hostel,
+node|z16-|tourism-guest_house,
+area|z16-|tourism-guest_house,
+node|z13-|tourism-alpine_hut,
+node|z16-|tourism-wilderness_hut,
+node|z16-|tourism-chalet,
+node|z16-|leisure-resort,
+area|z16-|leisure-resort,
+node|z16-|tourism-motel,
+area|z16-|tourism-motel,
+node|z16-|tourism-apartment,
+area|z16-|tourism-apartment
 {text: name;text-offset: 1;font-size: 10;text-color: @poi_label;}
-node|z16-[tourism=camp_site],
-node|z16-[tourism=picnic_site],
-node|z18-[leisure=picnic_table],
-node|z17-[amenity=shelter],
-node|z16-[amenity=shelter][shelter_type=basic_hut],
-node|z16-[amenity=shelter][shelter_type=lean_to],
-node|z16-[tourism=caravan_site],
+node|z16-|tourism-camp_site,
+node|z16-|tourism-picnic_site,
+node|z18-|leisure-picnic_table,
+node|z17-|amenity-shelter,
+node|z16-|amenity-shelter-basic_hut,
+node|z16-|amenity-shelter-lean_to,
+node|z16-|tourism-caravan_site,
 {text: name;text-color: @poi_label;text-offset: 1;font-size: 10;}
 
 
-node|z16[tourism=hotel],
-node|z16[leisure=resort],
-area|z16[leisure=resort],
-node|z16[tourism=motel],
-area|z16[tourism=motel]
+node|z16|tourism-hotel,
+node|z16|leisure-resort,
+area|z16|leisure-resort,
+node|z16|tourism-motel,
+area|z16|tourism-motel
 {icon-image: hotel-m.svg;icon-min-distance: 24;}
-node|z16[tourism=hostel]
+node|z16|tourism-hostel
 {icon-image: hostel-m.svg;icon-min-distance: 24;}
-node|z16[tourism=guest_house],
-area|z16[tourism=guest_house],
-node|z16[tourism=apartment],
-area|z16[tourism=apartment]
+node|z16|tourism-guest_house,
+area|z16|tourism-guest_house,
+node|z16|tourism-apartment,
+area|z16|tourism-apartment
 {icon-image: apartment-m.svg;icon-min-distance: 24;text-halo-radius: 0;}
-node|z13-14[tourism=alpine_hut],
+node|z13-14|tourism-alpine_hut,
 {icon-image: alpine_hut-s.svg;}
-node|z15-16[tourism=alpine_hut],
-node|z16[tourism=wilderness_hut],
-node|z16[tourism=chalet],
+node|z15-16|tourism-alpine_hut,
+node|z16|tourism-wilderness_hut,
+node|z16|tourism-chalet,
 {icon-image: alpine_hut-m.svg;}
 
-node|z17-[tourism=hotel],
-node|z17-[tourism=motel],
-area|z17-[tourism=motel],
-node|z17-[leisure=resort],
-area|z17-[leisure=resort]
+node|z17-|tourism-hotel,
+node|z17-|tourism-motel,
+area|z17-|tourism-motel,
+node|z17-|leisure-resort,
+area|z17-|leisure-resort
 {icon-image: hotel-m.svg;icon-min-distance: 16;}
-node|z17-[tourism=hostel]
+node|z17-|tourism-hostel
 {icon-image: hostel-m.svg;icon-min-distance: 16;}
-node|z17[tourism=guest_house],
-area|z17[tourism=guest_house],
-node|z17[tourism=apartment],
-area|z17[tourism=apartment]
+node|z17|tourism-guest_house,
+area|z17|tourism-guest_house,
+node|z17|tourism-apartment,
+area|z17|tourism-apartment
 {icon-image: apartment-m.svg;text-halo-radius: 0;}
-node|z17-[tourism=alpine_hut],
-node|z17-[tourism=wilderness_hut],
-node|z17-[tourism=chalet],
+node|z17-|tourism-alpine_hut,
+node|z17-|tourism-wilderness_hut,
+node|z17-|tourism-chalet,
 {icon-image: alpine_hut-m.svg;}
 
-node|z18-[tourism=guest_house],
-area|z18-[tourism=guest_house],
-node|z18-[tourism=apartment],
-area|z18-[tourism=apartment]
+node|z18-|tourism-guest_house,
+area|z18-|tourism-guest_house,
+node|z18-|tourism-apartment,
+area|z18-|tourism-apartment
 {icon-image: apartment-m.svg;icon-min-distance: 16;}
 
-node|z16-[tourism=camp_site],
+node|z16-|tourism-camp_site,
 {icon-image: campsite-m.svg;}
 
-node|z16-[tourism=picnic_site],
+node|z16-|tourism-picnic_site,
 {icon-image: picnic-m.svg;}
-node|z17-[leisure=picnic_table],
+node|z17-|leisure-picnic_table,
 {icon-image: picnic_table-m.svg;}
-node|z17-[leisure=outdoor_seating],
+node|z17-|leisure-outdoor_seating,
 {text: none;}
-node|z18-[leisure=outdoor_seating],
+node|z18-|leisure-outdoor_seating,
 {icon-image: outdoor_seating-m.svg;}
 
-node|z17-[amenity=shelter],
-node|z16-[amenity=shelter][shelter_type=lean_to],
+node|z17-|amenity-shelter,
+node|z16-|amenity-shelter-lean_to,
 {icon-image: shelter-m.svg;}
-node|z16-[amenity=shelter][shelter_type=basic_hut],
+node|z16-|amenity-shelter-basic_hut,
 {icon-image: alpine_hut-m.svg;}
-node|z17-[amenity=shelter][shelter_type=public_transport],
+node|z17-|amenity-shelter-public_transport,
 {icon-image: shelter-public_transport-m.svg;}
 
-node|z16-[tourism=caravan_site],
+node|z16-|tourism-caravan_site,
 {icon-image: caravan_site-m.svg; font-size: 11;}
 
 /* 4.3 Food */
-node|z15-[amenity=cafe],
-area|z15-[amenity=cafe],
-node|z15-[amenity=restaurant],
-area|z15-[amenity=restaurant],
-node|z15-[amenity=fast_food],
-area|z15-[amenity=fast_food],
-node|z15-[amenity=food_court],
-area|z15-[amenity=food_court],
-node|z15-[amenity=bar],
-area|z15-[amenity=bar],
-node|z15-[amenity=pub],
-area|z15-[amenity=pub],
-node|z15-[amenity=biergarten],
-area|z15-[amenity=biergarten]
+node|z15-|amenity-cafe,
+area|z15-|amenity-cafe,
+node|z15-|amenity-restaurant,
+area|z15-|amenity-restaurant,
+node|z15-|amenity-fast_food,
+area|z15-|amenity-fast_food,
+node|z15-|amenity-food_court,
+area|z15-|amenity-food_court,
+node|z15-|amenity-bar,
+area|z15-|amenity-bar,
+node|z15-|amenity-pub,
+area|z15-|amenity-pub,
+node|z15-|amenity-biergarten,
+area|z15-|amenity-biergarten
 {text: name;text-color: @poi_label;text-offset: 1;font-size: 10;}
 
-node|z15[amenity=cafe],
-area|z15[amenity=cafe]
+node|z15|amenity-cafe,
+area|z15|amenity-cafe
 {icon-image: cafe-m.svg;icon-min-distance: 12;}
-node|z15[amenity=restaurant],
-area|z15[amenity=restaurant]
+node|z15|amenity-restaurant,
+area|z15|amenity-restaurant
 {icon-image: restaurant-m.svg;icon-min-distance: 28;}
-node|z15[amenity=fast_food],
-area|z15[amenity=fast_food],
-node|z15[amenity=food_court],
-area|z15[amenity=food_court]
+node|z15|amenity-fast_food,
+area|z15|amenity-fast_food,
+node|z15|amenity-food_court,
+area|z15|amenity-food_court
 {icon-image: fastfood-m.svg;icon-min-distance: 28;}
-node|z15[amenity=bar],
-area|z15[amenity=bar]
+node|z15|amenity-bar,
+area|z15|amenity-bar
 {icon-image: bar-m.svg;icon-min-distance: 28;}
-node|z15[amenity=pub],
-area|z15[amenity=pub],
-node|z15[amenity=biergarten],
-area|z15[amenity=biergarten]
+node|z15|amenity-pub,
+area|z15|amenity-pub,
+node|z15|amenity-biergarten,
+area|z15|amenity-biergarten
 {icon-image: pub-m.svg;icon-min-distance: 28;}
 
-node|z16-[amenity=cafe],
-area|z16-[amenity=cafe]
+node|z16-|amenity-cafe,
+area|z16-|amenity-cafe
 {icon-image: cafe-m.svg;icon-min-distance: 12;}
-node|z16-[amenity=restaurant],
-area|z16-[amenity=restaurant]
+node|z16-|amenity-restaurant,
+area|z16-|amenity-restaurant
 {icon-image: restaurant-m.svg;icon-min-distance: 12;}
-node|z16-[amenity=fast_food],
-area|z16-[amenity=fast_food],
-node|z16-[amenity=food_court],
-area|z16-[amenity=food_court]
+node|z16-|amenity-fast_food,
+area|z16-|amenity-fast_food,
+node|z16-|amenity-food_court,
+area|z16-|amenity-food_court
 {icon-image: fastfood-m.svg;icon-min-distance: 12;}
-node|z16-[amenity=bar],
-area|z16-[amenity=bar]
+node|z16-|amenity-bar,
+area|z16-|amenity-bar
 {icon-image: bar-m.svg;icon-min-distance: 12;}
-node|z16-[amenity=pub],
-area|z16-[amenity=pub],
-node|z16-[amenity=biergarten],
-area|z16-[amenity=biergarten]
+node|z16-|amenity-pub,
+area|z16-|amenity-pub,
+node|z16-|amenity-biergarten,
+area|z16-|amenity-biergarten
 {icon-image: pub-m.svg;icon-min-distance: 12;}
 
 
 /* 5.AMENITY (infrastructure) */
 
-node|z13-[leisure=stadium],
-area|z13-[leisure=stadium],
-node|z14-[barrier=toll_booth],
-area|z14-[barrier=toll_booth],
-node|z14-[amenity=university],
-area|z14-[amenity=university],
-node|z14-[amenity=place_of_worship],
-area|z14-[amenity=place_of_worship],
-node|z14-[man_made=lighthouse],
-area|z14-[man_made=lighthouse],
-node|z15-[amenity=hospital],
-node|z15-[landuse=landfill],
-area|z15-[landuse=landfill],
-node|z15-[landuse=quarry],
-area|z15-[landuse=quarry],
-node|z15-[landuse=industrial][industrial=mine],
-area|z15-[landuse=industrial][industrial=mine],
-node|z14-[barrier=border_control],
-node|z16-[amenity=veterinary],
-area|z16-[amenity=veterinary],
-node|z16-[amenity=fountain],
-area|z16-[amenity=fountain],
-node|z16-[leisure=marina],
-area|z16-[leisure=marina],
-node|z16-[leisure=water_park],
-area|z16-[leisure=water_park],
-node|z16-[barrier=block],
-node|z16-[barrier=bollard],
-node|z16-[barrier=chain],
-node|z16-[barrier=entrance],
-node|z16-[barrier=gate],
-node|z16-[barrier=kissing_gate],
-node|z16-[barrier=lift_gate],
-node|z16-[barrier=swing_gate],
-node|z16-[barrier=stile],
-node|z16-[barrier=turnstile],
-node|z16-[barrier=cycle_barrier],
-node|z16-[amenity=nightclub],
-area|z16-[amenity=nightclub],
-node|z16-[amenity=townhall],
-node|z16-[amenity=bank],
-area|z16-[amenity=bank],
-node|z16-[amenity=taxi],
-area|z16-[amenity=taxi],
-node|z16-[leisure=dog_park],
-area|z16-[leisure=dog_park],
-node|z16-[man_made=windmill],
-area|z16-[man_made=windmill],
-node|z16-[amenity=college],
-area|z16-[amenity=college],
-node|z16-[amenity=conference_centre],
-area|z16-[amenity=conference_centre],
-node|z16-[amenity=events_venue],
-area|z16-[amenity=events_venue],
-node|z16-[amenity=exhibition_centre],
-area|z16-[amenity=exhibition_centre],
-node|z17-[amenity=pharmacy],
-area|z17-[amenity=pharmacy],
-node|z17-[amenity=clinic],
-area|z17-[amenity=clinic],
-node|z17-[amenity=doctors],
-area|z17-[amenity=doctors],
-node|z17-[healthcare=laboratory],
-area|z17-[healthcare=laboratory],
-node|z17-[healthcare=physiotherapist],
-area|z17-[healthcare=physiotherapist],
-node|z17-[healthcare=alternative],
-area|z17-[healthcare=alternative],
-node|z17-[healthcare=audiologist],
-area|z17-[healthcare=audiologist],
-node|z17-[healthcare=blood_donation],
-area|z17-[healthcare=blood_donation],
-node|z17-[healthcare=optometrist],
-area|z17-[healthcare=optometrist],
-node|z17-[healthcare=podiatrist],
-area|z17-[healthcare=podiatrist],
-node|z17-[healthcare=psychotherapist],
-area|z17-[healthcare=psychotherapist],
-node|z17-[healthcare=sample_collection],
-area|z17-[healthcare=sample_collection],
-node|z17-[healthcare=speech_therapist],
-area|z17-[healthcare=speech_therapist],
-node|z17-[amenity=dentist],
-area|z17-[amenity=dentist],
-node|z17-[amenity=casino],
-area|z17-[amenity=casino],
-node|z17-[amenity=gambling],
-area|z17-[amenity=gambling],
-node|z17-[leisure=adult_gaming_centre],
-area|z17-[leisure=adult_gaming_centre],
-node|z17-[leisure=amusement_arcade],
-area|z17-[leisure=amusement_arcade],
-node|z17-[amenity=courthouse],
-area|z17-[amenity=courthouse],
-node|z17-[amenity=nursing_home],
-area|z17-[amenity=nursing_home],
-node|z17-[amenity=social_facility],
-area|z17-[amenity=social_facility],
-node|z17-[amenity=kindergarten],
-area|z17-[amenity=kindergarten],
-node|z17-[amenity=childcare],
-area|z17-[amenity=childcare],
-node|z17-[amenity=school],
-area|z17-[amenity=school],
-node|z17-[amenity=cinema],
-area|z17-[amenity=cinema],
-node|z17-[amenity=ice_cream],
-area|z17-[amenity=ice_cream],
-node|z17-[leisure=bowling_alley],
-area|z17-[leisure=bowling_alley],
-node|z17-[amenity=police],
-area|z17-[amenity=police],
-node|z17-[amenity=prison],
-area|z17-[amenity=prison],
-node|z17-[office=diplomatic],
-area|z17-[office=diplomatic],
-node|z17-[office=lawyer],
-area|z17-[office=lawyer],
-node|z17-[amenity=vending_machine][vending=parking_tickets],
-area|z17-[amenity=vending_machine][vending=parking_tickets],
-node|z17-[amenity=vending_machine][vending=public_transport_tickets],
-area|z17-[amenity=vending_machine][vending=public_transport_tickets],
-node|z17-[amenity=payment_terminal],
-area|z17-[amenity=payment_terminal],
-node|z17-[amenity=shower],
-area|z17-[amenity=shower],
-node|z17-[amenity=bicycle_rental],
-area|z17-[amenity=bicycle_rental],
-node|z17-[amenity=bicycle_repair_station],
-area|z17-[amenity=bicycle_repair_station],
-node|z17-[amenity=post_office],
-area|z17-[amenity=post_office],
-node|z17-[power=station],
-area|z17-[power=station],
-node|z17-[man_made=works],
-area|z17-[man_made=works],
-node|z17-[amenity=parcel_locker],
-area|z17-[amenity=parcel_locker],
-node|z17-[amenity=public_bath],
-area|z17-[amenity=public_bath],
-node|z17-[aeroway=gate],
-area|z17-[aeroway=gate],
-node|z17-[sport],
-area|z17-[sport],
-node|z18-[amenity=dojo],
-area|z18-[amenity=dojo],
-node|z18-[amenity=vending_machine],
-area|z18-[amenity=vending_machine],
-node|z18-[amenity=post_box],
-area|z18-[amenity=post_box],
-node|z18-[amenity=fire_station],
-area|z18-[amenity=fire_station],
-node|z18-[emergency=defibrillator],
-area|z18-[emergency=defibrillator],
-node|z18-[emergency=assembly_point],
-area|z18-[emergency=assembly_point],
-node|z18-[amenity=toilets],
-area|z18-[amenity=toilets],
-node|z18-[amenity=atm],
-area|z18-[amenity=atm],
-node|z18-[amenity=bureau_de_change],
-area|z18-[amenity=bureau_de_change],
-node|z18-[amenity=money_transfer],
-area|z18-[amenity=money_transfer],
-node|z18-[amenity=library],
-area|z18-[amenity=library],
-node|z18-[amenity=waste_disposal],
-area|z18-[amenity=waste_disposal],
-node|z18-[amenity=hunting_stand],
-area|z18-[amenity=hunting_stand],
-node|z18-[shop=lottery],
-area|z18-[shop=lottery],
-node|z18-[man_made=chimney],
-area|z18-[man_made=chimney],
-node|z18-[man_made=silo],
-area|z18-[man_made=silo],
-node|z18-[man_made=storage_tank],
-area|z18-[man_made=storage_tank],
-node|z18-[man_made=water_tower],
-node|z18-[amenity=bbq],
-area|z18-[amenity=bbq],
-node|z18-[amenity=brothel],
-area|z18-[amenity=brothel],
-node|z18-[amenity=stripclub],
-area|z18-[amenity=stripclub],
-node|z18-[amenity=public_bookcase],
-area|z18-[amenity=public_bookcase],
-node|z19-[power=substation],
-area|z19-[power=substation],
-node|z18-[man_made=survey_point],
-node|z19-[emergency=fire_hydrant],
-node|z19-[man_made=cairn],
+node|z13-|leisure-stadium,
+area|z13-|leisure-stadium,
+node|z14-|barrier-toll_booth,
+area|z14-|barrier-toll_booth,
+node|z14-|amenity-university,
+area|z14-|amenity-university,
+node|z14-|amenity-place_of_worship,
+area|z14-|amenity-place_of_worship,
+node|z14-|man_made-lighthouse,
+area|z14-|man_made-lighthouse,
+node|z15-|amenity-hospital,
+node|z15-|landuse-landfill,
+area|z15-|landuse-landfill,
+node|z15-|landuse-quarry,
+area|z15-|landuse-quarry,
+node|z15-|landuse-industrial-mine,
+area|z15-|landuse-industrial-mine,
+node|z14-|barrier-border_control,
+node|z16-|amenity-veterinary,
+area|z16-|amenity-veterinary,
+node|z16-|amenity-fountain,
+area|z16-|amenity-fountain,
+node|z16-|leisure-marina,
+area|z16-|leisure-marina,
+node|z16-|leisure-water_park,
+area|z16-|leisure-water_park,
+node|z16-|barrier-block,
+node|z16-|barrier-bollard,
+node|z16-|barrier-chain,
+node|z16-|barrier-entrance,
+node|z16-|barrier-gate,
+node|z16-|barrier-kissing_gate,
+node|z16-|barrier-lift_gate,
+node|z16-|barrier-swing_gate,
+node|z16-|barrier-stile,
+node|z16-|barrier-turnstile,
+node|z16-|barrier-cycle_barrier,
+node|z16-|amenity-nightclub,
+area|z16-|amenity-nightclub,
+node|z16-|amenity-townhall,
+node|z16-|amenity-bank,
+area|z16-|amenity-bank,
+node|z16-|amenity-taxi,
+area|z16-|amenity-taxi,
+node|z16-|leisure-dog_park,
+area|z16-|leisure-dog_park,
+node|z16-|man_made-windmill,
+area|z16-|man_made-windmill,
+node|z16-|amenity-college,
+area|z16-|amenity-college,
+node|z16-|amenity-conference_centre,
+area|z16-|amenity-conference_centre,
+node|z16-|amenity-events_venue,
+area|z16-|amenity-events_venue,
+node|z16-|amenity-exhibition_centre,
+area|z16-|amenity-exhibition_centre,
+node|z17-|amenity-pharmacy,
+area|z17-|amenity-pharmacy,
+node|z17-|amenity-clinic,
+area|z17-|amenity-clinic,
+node|z17-|amenity-doctors,
+area|z17-|amenity-doctors,
+node|z17-|healthcare-laboratory,
+area|z17-|healthcare-laboratory,
+node|z17-|healthcare-physiotherapist,
+area|z17-|healthcare-physiotherapist,
+node|z17-|healthcare-alternative,
+area|z17-|healthcare-alternative,
+node|z17-|healthcare-audiologist,
+area|z17-|healthcare-audiologist,
+node|z17-|healthcare-blood_donation,
+area|z17-|healthcare-blood_donation,
+node|z17-|healthcare-optometrist,
+area|z17-|healthcare-optometrist,
+node|z17-|healthcare-podiatrist,
+area|z17-|healthcare-podiatrist,
+node|z17-|healthcare-psychotherapist,
+area|z17-|healthcare-psychotherapist,
+node|z17-|healthcare-sample_collection,
+area|z17-|healthcare-sample_collection,
+node|z17-|healthcare-speech_therapist,
+area|z17-|healthcare-speech_therapist,
+node|z17-|amenity-dentist,
+area|z17-|amenity-dentist,
+node|z17-|amenity-casino,
+area|z17-|amenity-casino,
+node|z17-|amenity-gambling,
+area|z17-|amenity-gambling,
+node|z17-|leisure-adult_gaming_centre,
+area|z17-|leisure-adult_gaming_centre,
+node|z17-|leisure-amusement_arcade,
+area|z17-|leisure-amusement_arcade,
+node|z17-|amenity-courthouse,
+area|z17-|amenity-courthouse,
+node|z17-|amenity-nursing_home,
+area|z17-|amenity-nursing_home,
+node|z17-|amenity-social_facility,
+area|z17-|amenity-social_facility,
+node|z17-|amenity-kindergarten,
+area|z17-|amenity-kindergarten,
+node|z17-|amenity-childcare,
+area|z17-|amenity-childcare,
+node|z17-|amenity-school,
+area|z17-|amenity-school,
+node|z17-|amenity-cinema,
+area|z17-|amenity-cinema,
+node|z17-|amenity-ice_cream,
+area|z17-|amenity-ice_cream,
+node|z17-|leisure-bowling_alley,
+area|z17-|leisure-bowling_alley,
+node|z17-|amenity-police,
+area|z17-|amenity-police,
+node|z17-|amenity-prison,
+area|z17-|amenity-prison,
+node|z17-|office-diplomatic,
+area|z17-|office-diplomatic,
+node|z17-|office-lawyer,
+area|z17-|office-lawyer,
+node|z17-|amenity-vending_machine-parking_tickets,
+area|z17-|amenity-vending_machine-parking_tickets,
+node|z17-|amenity-vending_machine-public_transport_tickets,
+area|z17-|amenity-vending_machine-public_transport_tickets,
+node|z17-|amenity-payment_terminal,
+area|z17-|amenity-payment_terminal,
+node|z17-|amenity-shower,
+area|z17-|amenity-shower,
+node|z17-|amenity-bicycle_rental,
+area|z17-|amenity-bicycle_rental,
+node|z17-|amenity-bicycle_repair_station,
+area|z17-|amenity-bicycle_repair_station,
+node|z17-|amenity-post_office,
+area|z17-|amenity-post_office,
+node|z17-|power-station,
+area|z17-|power-station,
+node|z17-|man_made-works,
+area|z17-|man_made-works,
+node|z17-|amenity-parcel_locker,
+area|z17-|amenity-parcel_locker,
+node|z17-|amenity-public_bath,
+area|z17-|amenity-public_bath,
+node|z17-|aeroway-gate,
+area|z17-|aeroway-gate,
+node|z17-|sport,
+area|z17-|sport,
+node|z18-|amenity-dojo,
+area|z18-|amenity-dojo,
+node|z18-|amenity-vending_machine,
+area|z18-|amenity-vending_machine,
+node|z18-|amenity-post_box,
+area|z18-|amenity-post_box,
+node|z18-|amenity-fire_station,
+area|z18-|amenity-fire_station,
+node|z18-|emergency-defibrillator,
+area|z18-|emergency-defibrillator,
+node|z18-|emergency-assembly_point,
+area|z18-|emergency-assembly_point,
+node|z18-|amenity-toilets,
+area|z18-|amenity-toilets,
+node|z18-|amenity-atm,
+area|z18-|amenity-atm,
+node|z18-|amenity-bureau_de_change,
+area|z18-|amenity-bureau_de_change,
+node|z18-|amenity-money_transfer,
+area|z18-|amenity-money_transfer,
+node|z18-|amenity-library,
+area|z18-|amenity-library,
+node|z18-|amenity-waste_disposal,
+area|z18-|amenity-waste_disposal,
+node|z18-|amenity-hunting_stand,
+area|z18-|amenity-hunting_stand,
+node|z18-|shop-lottery,
+area|z18-|shop-lottery,
+node|z18-|man_made-chimney,
+area|z18-|man_made-chimney,
+node|z18-|man_made-silo,
+area|z18-|man_made-silo,
+node|z18-|man_made-storage_tank,
+area|z18-|man_made-storage_tank,
+node|z18-|man_made-water_tower,
+node|z18-|amenity-bbq,
+area|z18-|amenity-bbq,
+node|z18-|amenity-brothel,
+area|z18-|amenity-brothel,
+node|z18-|amenity-stripclub,
+area|z18-|amenity-stripclub,
+node|z18-|amenity-public_bookcase,
+area|z18-|amenity-public_bookcase,
+node|z19-|power-substation,
+area|z19-|power-substation,
+node|z18-|man_made-survey_point,
+node|z19-|emergency-fire_hydrant,
+node|z19-|man_made-cairn,
 {text: name;text-color: @poi_label;text-offset: 1;font-size: 10;}
 
 /* TODO: all specific tourism/office/craft feature definitions atm rely on this to increase font size on z18- */
-node|z18-[tourism],
-area|z18-[tourism],
-node|z18-[office],
-area|z18-[office],
-node|z18-[craft],
-area|z18-[craft],
+node|z18-|tourism,
+area|z18-|tourism,
+node|z18-|office,
+area|z18-|office,
+node|z18-|craft,
+area|z18-|craft,
 {font-size: 11;}
 
 /* 5.1 Hospital */
 
-area|z14[amenity=hospital]
+area|z14|amenity-hospital
 {icon-image: hospital-s.svg;icon-min-distance: 8;}
-node|z15[amenity=hospital]
+node|z15|amenity-hospital
 {icon-image: hospital-m.svg;icon-min-distance: 6;}
-node|z16-[amenity=hospital],
+node|z16-|amenity-hospital,
 {icon-image: hospital-m.svg;icon-min-distance: 4;}
-node|z17[amenity=clinic],
-area|z17[amenity=clinic],
-node|z17[amenity=doctors],
-area|z17[amenity=doctors],
+node|z17|amenity-clinic,
+area|z17|amenity-clinic,
+node|z17|amenity-doctors,
+area|z17|amenity-doctors,
 {icon-image: clinic-m.svg;icon-min-distance: 4;}
-node|z18-[amenity=hospital],
+node|z18-|amenity-hospital,
 {icon-image: hospital-m.svg;font-size: 11;}
-node|z18-[amenity=clinic],
-area|z18-[amenity=clinic],
-node|z18-[amenity=doctors],
-area|z18-[amenity=doctors],
+node|z18-|amenity-clinic,
+area|z18-|amenity-clinic,
+node|z18-|amenity-doctors,
+area|z18-|amenity-doctors,
 {icon-image: clinic-m.svg;font-size: 11;}
-node|z17[healthcare=laboratory],
-area|z17[healthcare=laboratory],
+node|z17|healthcare-laboratory,
+area|z17|healthcare-laboratory,
 {icon-image: sample_collection-m.svg;}
-node|z18-[healthcare=laboratory],
-area|z18-[healthcare=laboratory],
+node|z18-|healthcare-laboratory,
+area|z18-|healthcare-laboratory,
 {icon-image: sample_collection-m.svg;font-size: 11;}
-node|z17[amenity=dentist],
-area|z17[amenity=dentist]
+node|z17|amenity-dentist,
+area|z17|amenity-dentist
 {icon-image: dentist-m.svg;}
-node|z18-[amenity=dentist],
-area|z18-[amenity=dentist]
+node|z18-|amenity-dentist,
+area|z18-|amenity-dentist
 {icon-image: dentist-m.svg;font-size: 11;}
-node|z17[healthcare=physiotherapist],
-area|z17[healthcare=physiotherapist]
+node|z17|healthcare-physiotherapist,
+area|z17|healthcare-physiotherapist
 {icon-image: physiotherapist-m.svg;}
-node|z18-[healthcare=physiotherapist],
-area|z18-[healthcare=physiotherapist]
+node|z18-|healthcare-physiotherapist,
+area|z18-|healthcare-physiotherapist
 {icon-image: physiotherapist-m.svg;font-size: 11;}
-node|z17[healthcare=alternative],
-area|z17[healthcare=alternative]
+node|z17|healthcare-alternative,
+area|z17|healthcare-alternative
 {icon-image: alternative-m.svg;}
-node|z18-[healthcare=alternative],
-area|z18-[healthcare=alternative]
+node|z18-|healthcare-alternative,
+area|z18-|healthcare-alternative
 {icon-image: alternative-m.svg;font-size: 11;}
-node|z17[healthcare=audiologist],
-area|z17[healthcare=audiologist]
+node|z17|healthcare-audiologist,
+area|z17|healthcare-audiologist
 {icon-image: audiologist-m.svg;}
-node|z18-[healthcare=audiologist],
-area|z18-[healthcare=audiologist]
+node|z18-|healthcare-audiologist,
+area|z18-|healthcare-audiologist
 {icon-image: audiologist-m.svg;font-size: 11;}
-node|z17[healthcare=blood_donation],
-area|z17[healthcare=blood_donation]
+node|z17|healthcare-blood_donation,
+area|z17|healthcare-blood_donation
 {icon-image: blood_donation-m.svg;}
-node|z18-[healthcare=blood_donation],
-area|z18-[healthcare=blood_donation]
+node|z18-|healthcare-blood_donation,
+area|z18-|healthcare-blood_donation
 {icon-image: blood_donation-m.svg;font-size: 11;}
-node|z17[healthcare=optometrist],
-area|z17[healthcare=optometrist]
+node|z17|healthcare-optometrist,
+area|z17|healthcare-optometrist
 {icon-image: optometrist-m.svg;}
-node|z18-[healthcare=optometrist],
-area|z18-[healthcare=optometrist]
+node|z18-|healthcare-optometrist,
+area|z18-|healthcare-optometrist
 {icon-image: optometrist-m.svg;font-size: 11;}
-node|z17[healthcare=podiatrist],
-area|z17[healthcare=podiatrist]
+node|z17|healthcare-podiatrist,
+area|z17|healthcare-podiatrist
 {icon-image: podiatrist-m.svg;}
-node|z18-[healthcare=podiatrist],
-area|z18-[healthcare=podiatrist]
+node|z18-|healthcare-podiatrist,
+area|z18-|healthcare-podiatrist
 {icon-image: podiatrist-m.svg;font-size: 11;}
-node|z17[healthcare=psychotherapist],
-area|z17[healthcare=psychotherapist]
+node|z17|healthcare-psychotherapist,
+area|z17|healthcare-psychotherapist
 {icon-image: psychotherapist-m.svg;}
-node|z18-[healthcare=psychotherapist],
-area|z18-[healthcare=psychotherapist]
+node|z18-|healthcare-psychotherapist,
+area|z18-|healthcare-psychotherapist
 {icon-image: psychotherapist-m.svg;font-size: 11;}
-node|z17[healthcare=sample_collection],
-area|z17[healthcare=sample_collection]
+node|z17|healthcare-sample_collection,
+area|z17|healthcare-sample_collection
 {icon-image: sample_collection-m.svg;}
-node|z18-[healthcare=sample_collection],
-area|z18-[healthcare=sample_collection]
+node|z18-|healthcare-sample_collection,
+area|z18-|healthcare-sample_collection
 {icon-image: sample_collection-m.svg;font-size: 11;}
-node|z17[healthcare=speech_therapist],
-area|z17[healthcare=speech_therapist]
+node|z17|healthcare-speech_therapist,
+area|z17|healthcare-speech_therapist
 {icon-image: speech_therapist-m.svg;}
-node|z18-[healthcare=speech_therapist],
-area|z18-[healthcare=speech_therapist]
+node|z18-|healthcare-speech_therapist,
+area|z18-|healthcare-speech_therapist
 {icon-image: speech_therapist-m.svg;font-size: 11;}
 
-node|z16-[amenity=veterinary],
-area|z16-[amenity=veterinary]
+node|z16-|amenity-veterinary,
+area|z16-|amenity-veterinary
 {icon-image: veterinary-m.svg;}
-node|z18-[amenity=veterinary],
-area|z18-[amenity=veterinary]
+node|z18-|amenity-veterinary,
+area|z18-|amenity-veterinary
 {font-size: 11;}
 
-node|z16-[amenity=pharmacy],
-area|z16-[amenity=pharmacy]
+node|z16-|amenity-pharmacy,
+area|z16-|amenity-pharmacy
 {icon-image: pharmacy-m.svg;icon-min-distance: 20;}
-node|z17-[amenity=pharmacy],
-area|z17-[amenity=pharmacy]
+node|z17-|amenity-pharmacy,
+area|z17-|amenity-pharmacy
 {text-offset: 1;font-size: 11;icon-min-distance: 20;}
 
 /* 5.2 Education */
 
-area|z14[amenity=university][name]
+area|z14|amenity-university[name]
 {icon-image: college-s.svg;icon-min-distance: 12;}
-area|z15-[amenity=university][name],
-node|z15-[amenity=university][name]
+area|z15-|amenity-university[name],
+node|z15-|amenity-university[name]
 {icon-image: college-m.svg;icon-min-distance: 12;}
-node|z16[amenity=university][name],
-area|z16[amenity=university][name]
+node|z16|amenity-university[name],
+area|z16|amenity-university[name]
 {icon-min-distance: 11;}
-node|z17[amenity=university][name],
-area|z17[amenity=university][name]
+node|z17|amenity-university[name],
+area|z17|amenity-university[name]
 {icon-min-distance: 10;}
-node|z18-[amenity=university][name],
-area|z18-[amenity=university][name]
+node|z18-|amenity-university[name],
+area|z18-|amenity-university[name]
 {icon-min-distance: 0; font-size: 11;}
 
-node|z15-[amenity=university][!name]
+node|z15-|amenity-university[!name]
 {text: none}
 
-node|z16-[amenity=college],
-area|z16-[amenity=college]
+node|z16-|amenity-college,
+area|z16-|amenity-college
 {icon-image: college-m.svg;}
-node|z18-[amenity=college],
-area|z18-[amenity=college]
+node|z18-|amenity-college,
+area|z18-|amenity-college
 {font-size: 11;}
-node|z17-[amenity=kindergarten],
-area|z17-[amenity=kindergarten]
+node|z17-|amenity-kindergarten,
+area|z17-|amenity-kindergarten
 {icon-image: kindergarten-m.svg;}
-node|z18-[amenity=kindergarten],
-area|z18-[amenity=kindergarten]
+node|z18-|amenity-kindergarten,
+area|z18-|amenity-kindergarten
 {font-size: 11;}
-node|z17-[amenity=childcare],
-area|z17-[amenity=childcare]
+node|z17-|amenity-childcare,
+area|z17-|amenity-childcare
 {icon-image: kindergarten-m.svg;}
-node|z18-[amenity=childcare],
-area|z18-[amenity=childcare]
+node|z18-|amenity-childcare,
+area|z18-|amenity-childcare
 {font-size: 11;}
-node|z17-[amenity=school],
-area|z17-[amenity=school]
+node|z17-|amenity-school,
+area|z17-|amenity-school
 {icon-image: school-m.svg;}
-node|z18-[amenity=school],
-area|z18-[amenity=school]
+node|z18-|amenity-school,
+area|z18-|amenity-school
 {font-size: 11;}
 
-node|z17-[amenity=music_school],
-area|z17-[amenity=music_school]
+node|z17-|amenity-music_school,
+area|z17-|amenity-music_school
 {icon-image: music_school-m.svg;}
-node|z17-[amenity=driving_school],
-area|z17-[amenity=driving_school]
+node|z17-|amenity-driving_school,
+area|z17-|amenity-driving_school
 {icon-image: driving_school-m.svg;}
-node|z17-[amenity=language_school],
-area|z17-[amenity=language_school]
+node|z17-|amenity-language_school,
+area|z17-|amenity-language_school
 {icon-image: language_school-m.svg;}
-node|z17-[leisure=hackerspace],
-area|z17-[leisure=hackerspace]
+node|z17-|leisure-hackerspace,
+area|z17-|leisure-hackerspace
 {icon-image: hackerspace-m.svg;}
 
 /* 5.3 Sport */
 
-node|z13-14[leisure=stadium]
+node|z13-14|leisure-stadium
 {icon-image: stadium-s.svg;icon-min-distance: 16;}
-node|z15-[leisure=stadium]
+node|z15-|leisure-stadium
 {icon-image: stadium-m.svg;icon-min-distance: 8;}
 
-node|z17-[leisure=pitch],
-node|z17-[leisure=ice_rink]
+node|z17-|leisure-pitch,
+node|z17-|leisure-ice_rink
 {icon-image: pitch-m.svg;icon-min-distance: 10;}
-node|z17-[leisure=fitness_station]
+node|z17-|leisure-fitness_station
 {icon-image: fitness_station-m.svg;icon-min-distance: 10;}
-node|z17-[leisure=sports_centre]
-node|z17-[leisure=sports_hall]
+node|z17-|leisure-sports_centre,
+node|z17-|leisure-sports_hall
 {icon-image: pitch-m.svg;icon-min-distance: 10;}
-node|z17-[leisure=fitness_centre]
+node|z17-|leisure-fitness_centre
 {icon-image: fitness_centre-m.svg;icon-min-distance: 10;}
-node|z17-[leisure=sauna]
+node|z17-|leisure-sauna
 {icon-image: public_bath-m.svg;icon-min-distance: 10;}
-node|z17-[leisure=playground],
-area|z17-[leisure=playground],
+node|z17-|leisure-playground,
+area|z17-|leisure-playground,
 {icon-image: playground-m.svg;font-size: 11;icon-min-distance: 10;}
-node|z17-[leisure=swimming_pool],
-area|z17-[leisure=swimming_pool]
+node|z17-|leisure-swimming_pool,
+area|z17-|leisure-swimming_pool
 {icon-image: swimming-m.svg;icon-min-distance: 10;}
-node|z17-[leisure=swimming_pool][access=private],
-area|z17-[leisure=swimming_pool][access=private]
+node|z17-|leisure-swimming_pool-private,
+area|z17-|leisure-swimming_pool-private
 {icon-image: zero-icon.svg;}
-node|z15-[leisure=golf_course],
-area|z15-[leisure=golf_course],
-node|z17-[leisure=miniature_golf],
-area|z17-[leisure=miniature_golf],
+node|z15-|leisure-golf_course,
+area|z15-|leisure-golf_course,
+node|z17-|leisure-miniature_golf,
+area|z17-|leisure-miniature_golf,
 {icon-image: golf-m.svg;icon-min-distance: 10;}
 
-node|z17-[amenity=dojo]
+node|z17-|amenity-dojo
 {icon-image: martial-arts-m.svg;}
 
-node|z17-[sport],
-area|z17-[sport],
+node|z17-|sport,
+area|z17-|sport,
 {icon-image: pitch-m.svg; icon-min-distance: 10; }
 
-node|z17-[sport=american_football],
-area|z17-[sport=american_football]
+node|z17-|sport-american_football,
+area|z17-|sport-american_football
 {icon-image: america-football-m.svg;}
-node|z17-[sport=basketball],
-area|z17-[sport=basketball]
+node|z17-|sport-basketball,
+area|z17-|sport-basketball
 {icon-image: basketball-m.svg;}
-node|z17-[sport=baseball],
-area|z17-[sport=baseball]
+node|z17-|sport-baseball,
+area|z17-|sport-baseball
 {icon-image: baseball-m.svg;}
-node|z17-[sport=equestrian],
-area|z17-[sport=equestrian]
+node|z17-|sport-equestrian,
+area|z17-|sport-equestrian
 {icon-image: equestrian-m.svg;}
-node|z17-[sport=soccer],
-area|z17-[sport=soccer]
+node|z17-|sport-soccer,
+area|z17-|sport-soccer
 {icon-image: soccer-m.svg;}
-node|z17-[sport=tennis],
-area|z17-[sport=tennis]
+node|z17-|sport-tennis,
+area|z17-|sport-tennis
 {icon-image: tennis-m.svg;}
-node|z17-[sport=skiing],
-area|z17-[sport=skiing]
+node|z17-|sport-skiing,
+area|z17-|sport-skiing
 {icon-image: skiing-m.svg;}
-node|z17-[sport=archery],
-area|z17-[sport=archery]
+node|z17-|sport-archery,
+area|z17-|sport-archery
 {icon-image: archery-m.svg;}
-node|z17-[sport=shooting],
-area|z17-[sport=shooting]
+node|z17-|sport-shooting,
+area|z17-|sport-shooting
 {icon-image: archery-m.svg;}
-node|z17-[sport=australian_football],
-area|z17-[sport=australian_football]
+node|z17-|sport-australian_football,
+area|z17-|sport-australian_football
 {icon-image: australian-football-m.svg;}
-node|z17-[sport=cricket],
-area|z17-[sport=cricket]
+node|z17-|sport-cricket,
+area|z17-|sport-cricket
 {icon-image: cricket-m.svg;}
-node|z17-[sport=curling],
-area|z17-[sport=curling]
+node|z17-|sport-curling,
+area|z17-|sport-curling
 {icon-image: curling-m.svg;}
-node|z17-[sport=diving],
-area|z17-[sport=diving]
+node|z17-|sport-diving,
+area|z17-|sport-diving
 {icon-image: diving-m.svg;}
-node|z17-[sport=scuba_diving],
-area|z17-[sport=scuba_diving]
+node|z17-|sport-scuba_diving,
+area|z17-|sport-scuba_diving
 {icon-image: diving-m.svg;}
-node|z17-[sport=9pin],
-area|z17-[sport=9pin]
+node|z17-|sport-9pin,
+area|z17-|sport-9pin
 {icon-image: bowling-m.svg;}
-node|z17-[sport=10pin],
-area|z17-[sport=10pin]
+node|z17-|sport-10pin,
+area|z17-|sport-10pin
 {icon-image: bowling-m.svg;}
-node|z17-[sport=chess],
-area|z17-[sport=chess]
+node|z17-|sport-chess,
+area|z17-|sport-chess
 {icon-image: chess-m.svg;}
-node|z17-[sport=climbing],
-area|z17-[sport=climbing]
+node|z17-|sport-climbing,
+area|z17-|sport-climbing
 {icon-image: climbing-m.svg;}
-node|z17-[sport=golf],
-area|z17-[sport=golf]
+node|z17-|sport-golf,
+area|z17-|sport-golf
 {icon-image: golf-m.svg;}
-node|z17-[sport=skateboard],
-area|z17-[sport=skateboard]
+node|z17-|sport-skateboard,
+area|z17-|sport-skateboard
 {icon-image: skateboard-m.svg;}
-node|z17-[sport=swimming],
-area|z17-[sport=swimming]
+node|z17-|sport-swimming,
+area|z17-|sport-swimming
 {icon-image: swimming-m.svg;}
-node|z17-[sport=table_tennis],
-area|z17-[sport=table_tennis]
+node|z17-|sport-table_tennis,
+area|z17-|sport-table_tennis
 {icon-image: table-tennis-m.svg;}
-node|z17-[sport=volleyball],
-area|z17-[sport=volleyball],
-node|z17-[sport=beachvolleyball],
-area|z17-[sport=beachvolleyball],
+node|z17-|sport-volleyball,
+area|z17-|sport-volleyball,
+node|z17-|sport-beachvolleyball,
+area|z17-|sport-beachvolleyball,
 {icon-image: volleyball-m.svg;}
-node|z17-[sport=yoga],
-area|z17-[sport=yoga]
+node|z17-|sport-yoga,
+area|z17-|sport-yoga
 {icon-image: yoga-m.svg;}
-node|z17-[sport=padel],
-area|z17-[sport=padel]
+node|z17-|sport-padel,
+area|z17-|sport-padel
 {icon-image: padel-m.svg;}
-node|z17-[sport=handball],
-area|z17-[sport=handball]
+node|z17-|sport-handball,
+area|z17-|sport-handball
 {icon-image: handball-m.svg;}
-node|z17-[sport=futsal],
-area|z17-[sport=futsal]
+node|z17-|sport-futsal,
+area|z17-|sport-futsal
 {icon-image: soccer-m.svg;}
-node|z17-[sport=ice_hockey],
-area|z17-[sport=ice_hockey]
+node|z17-|sport-ice_hockey,
+area|z17-|sport-ice_hockey
 {icon-image: hockey-m.svg;}
-node|z17-[sport=field_hockey],
-area|z17-[sport=field_hockey]
+node|z17-|sport-field_hockey,
+area|z17-|sport-field_hockey
 {icon-image: hockey-m.svg;}
-node|z17-[sport=badminton],
-area|z17-[sport=badminton]
+node|z17-|sport-badminton,
+area|z17-|sport-badminton
 {icon-image: badminton-m.svg;}
-node|z17-[sport=pelota],
-area|z17-[sport=pelota]
+node|z17-|sport-pelota,
+area|z17-|sport-pelota
 {icon-image: pelota-m.svg;}
 
-node|z18-[sport],
-area|z18-[sport],
+node|z18-|sport,
+area|z18-|sport,
 {font-size: 11; }
 
 /* 5.4 Religion */
 
-node|z14[amenity=place_of_worship],
-area|z14[amenity=place_of_worship]
+node|z14|amenity-place_of_worship,
+area|z14|amenity-place_of_worship
 {icon-image: place-of-worship-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z14[amenity=place_of_worship][religion=christian],
-area|z14[amenity=place_of_worship][religion=christian]
+node|z14|amenity-place_of_worship-christian,
+area|z14|amenity-place_of_worship-christian
 {icon-image: christian-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z14[amenity=place_of_worship][religion=muslim],
-area|z14[amenity=place_of_worship][religion=muslim]
+node|z14|amenity-place_of_worship-muslim,
+area|z14|amenity-place_of_worship-muslim
 {icon-image: muslim-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z14[amenity=place_of_worship][religion=buddhist],
-area|z14[amenity=place_of_worship][religion=buddhist]
+node|z14|amenity-place_of_worship-buddhist,
+area|z14|amenity-place_of_worship-buddhist
 {icon-image: buddhist-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z14[amenity=place_of_worship][religion=hindu],
-area|z14[amenity=place_of_worship][religion=hindu]
+node|z14|amenity-place_of_worship-hindu,
+area|z14|amenity-place_of_worship-hindu
 {icon-image: hindu-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z14[amenity=place_of_worship][religion=shinto],
-area|z14[amenity=place_of_worship][religion=shinto]
+node|z14|amenity-place_of_worship-shinto,
+area|z14|amenity-place_of_worship-shinto
 {icon-image: shinto-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z14[amenity=place_of_worship][religion=jewish],
-area|z14[amenity=place_of_worship][religion=jewish]
+node|z14|amenity-place_of_worship-jewish,
+area|z14|amenity-place_of_worship-jewish
 {icon-image: jewish-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z14[amenity=place_of_worship][religion=taoist],
-area|z14[amenity=place_of_worship][religion=taoist]
+node|z14|amenity-place_of_worship-taoist,
+area|z14|amenity-place_of_worship-taoist
 {icon-image: taoist-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z14-[amenity=place_of_worship][religion=christian][denomination=mormon],
-area|z14-[amenity=place_of_worship][religion=christian][denomination=mormon],
+node|z14-|amenity-place_of_worship-christian-mormon,
+area|z14-|amenity-place_of_worship-christian-mormon,
 {icon-image: mormon-s.svg;text-offset: 1;icon-min-distance: 12;}
-node|z14-[amenity=place_of_worship][religion=christian][denomination=jehovahs_witness],
-area|z14-[amenity=place_of_worship][religion=christian][denomination=jehovahs_witness],
+node|z14-|amenity-place_of_worship-christian-jehovahs_witness,
+area|z14-|amenity-place_of_worship-christian-jehovahs_witness,
 {icon-image: place-of-worship-s.svg;text-offset: 1;icon-min-distance: 12;}
 
-node|z15-[amenity=place_of_worship],
-area|z15-[amenity=place_of_worship]
+node|z15-|amenity-place_of_worship,
+area|z15-|amenity-place_of_worship
 {icon-image: place-of-worship-m.svg;icon-min-distance: 10;}
-node|z15-[amenity=place_of_worship][religion=christian],
-area|z15-[amenity=place_of_worship][religion=christian]
+node|z15-|amenity-place_of_worship-christian,
+area|z15-|amenity-place_of_worship-christian
 {icon-image: christian-m.svg;}
-node|z15-[amenity=place_of_worship][religion=muslim],
-area|z15-[amenity=place_of_worship][religion=muslim]
+node|z15-|amenity-place_of_worship-muslim,
+area|z15-|amenity-place_of_worship-muslim
 {icon-image: muslim-m.svg;}
-node|z15-[amenity=place_of_worship][religion=buddhist],
-area|z15-[amenity=place_of_worship][religion=buddhist]
+node|z15-|amenity-place_of_worship-buddhist,
+area|z15-|amenity-place_of_worship-buddhist
 {icon-image: buddhist-m.svg;}
-node|z15-[amenity=place_of_worship][religion=hindu],
-area|z15-[amenity=place_of_worship][religion=hindu]
+node|z15-|amenity-place_of_worship-hindu,
+area|z15-|amenity-place_of_worship-hindu
 {icon-image: hindu-m.svg;}
-node|z15-[amenity=place_of_worship][religion=shinto],
-area|z15-[amenity=place_of_worship][religion=shinto]
+node|z15-|amenity-place_of_worship-shinto,
+area|z15-|amenity-place_of_worship-shinto
 {icon-image: shinto-m.svg;}
-node|z15-[amenity=place_of_worship][religion=jewish],
-area|z15-[amenity=place_of_worship][religion=jewish]
+node|z15-|amenity-place_of_worship-jewish,
+area|z15-|amenity-place_of_worship-jewish
 {icon-image: jewish-m.svg;}
-node|z15-[amenity=place_of_worship][religion=taoist],
-area|z15-[amenity=place_of_worship][religion=taoist]
+node|z15-|amenity-place_of_worship-taoist,
+area|z15-|amenity-place_of_worship-taoist
 {icon-image: taoist-m.svg;}
-node|z15-[amenity=place_of_worship][religion=christian][denomination=mormon],
-area|z15-[amenity=place_of_worship][religion=christian][denomination=mormon],
+node|z15-|amenity-place_of_worship-christian-mormon,
+area|z15-|amenity-place_of_worship-christian-mormon,
 {icon-image: mormon-m.svg;}
-node|z15-[amenity=place_of_worship][religion=christian][denomination=jehovahs_witness],
-area|z15-[amenity=place_of_worship][religion=christian][denomination=jehovahs_witness],
+node|z15-|amenity-place_of_worship-christian-jehovahs_witness,
+area|z15-|amenity-place_of_worship-christian-jehovahs_witness,
 {icon-image: place-of-worship-m.svg;}
 
 /* 5.5 Others */
 
-node|z16-[amenity=nightclub],
-area|z16-[amenity=nightclub]
+node|z16-|amenity-nightclub,
+area|z16-|amenity-nightclub
 {icon-image: nightclub-m.svg;font-size: 11;}
 
-node|z18-[amenity=brothel],
-area|z18-[amenity=brothel],
-node|z18-[amenity=stripclub],
-area|z18-[amenity=stripclub]
+node|z18-|amenity-brothel,
+area|z18-|amenity-brothel,
+node|z18-|amenity-stripclub,
+area|z18-|amenity-stripclub
 {icon-image: stripclub-m.svg;font-size: 11;}
 
-node|z16[amenity=bank],
-area|z16[amenity=bank]
+node|z16|amenity-bank,
+area|z16|amenity-bank
 {icon-image: bank-m.svg;text-offset: 1;font-size: 11;}
-node|z17-[amenity=bank],
-area|z17-[amenity=bank]
+node|z17-|amenity-bank,
+area|z17-|amenity-bank
 {icon-image: bank-m.svg;}
 
-node|z15-[landuse=landfill],
-area|z15-[landuse=landfill]
+node|z15-|landuse-landfill,
+area|z15-|landuse-landfill
 {icon-image: waste-basket-m.svg;text-offset: 1;font-size: 10;}
 
-node|z15-[landuse=quarry],
-area|z15-[landuse=quarry],
-node|z15-[landuse=industrial][industrial=mine],
-area|z15-[landuse=industrial][industrial=mine]
+node|z15-|landuse-quarry,
+area|z15-|landuse-quarry,
+node|z15-|landuse-industrial-mine,
+area|z15-|landuse-industrial-mine
 {icon-image: mine-m.svg;text-offset: 1;font-size: 10;}
 
-node|z16-[leisure=water_park],
-area|z16-[leisure=water_park]
+node|z16-|leisure-water_park,
+area|z16-|leisure-water_park
 {icon-image: swimming-m.svg;icon-min-distance: 30;}
-node|z17-[leisure=water_park],
-area|z17-[leisure=water_park]
+node|z17-|leisure-water_park,
+area|z17-|leisure-water_park
 {icon-min-distance: 20;}
 
-node|z16-[leisure=marina],
-area|z16-[leisure=marina]
+node|z16-|leisure-marina,
+area|z16-|leisure-marina
 {icon-image: marina-m.svg;icon-min-distance: 30;}
-node|z17-[leisure=marina],
-area|z17-[leisure=marina]
+node|z17-|leisure-marina,
+area|z17-|leisure-marina
 {icon-min-distance: 20;}
 
-node|z16-[amenity=fountain],
-area|z16-[amenity=fountain]
+node|z16-|amenity-fountain,
+area|z16-|amenity-fountain
 {icon-image: fountain-s.svg;icon-min-distance: 20;}
-node|z19-[amenity=fountain],
-area|z19-[amenity=fountain]
+node|z19-|amenity-fountain,
+area|z19-|amenity-fountain
 {icon-image: fountain-m.svg;icon-min-distance: 20;}
 
-node|z14[man_made=lighthouse],
-area|z14[man_made=lighthouse]
+node|z14|man_made-lighthouse,
+area|z14|man_made-lighthouse
 {icon-image: lighthouse-s.svg;text-offset: 1;icon-min-distance: 5;}
-node|z15-[man_made=lighthouse],
-area|z15-[man_made=lighthouse]
+node|z15-|man_made-lighthouse,
+area|z15-|man_made-lighthouse
 {icon-image: lighthouse-m.svg;}
 
-node|z12-14[barrier=toll_booth],
-area|z12-14[barrier=toll_booth],
+node|z12-14|barrier-toll_booth,
+area|z12-14|barrier-toll_booth,
 {icon-image: toll_booth-s.svg;}
-node|z15-[barrier=toll_booth],
-area|z15-[barrier=toll_booth],
+node|z15-|barrier-toll_booth,
+area|z15-|barrier-toll_booth,
 {icon-image: toll_booth-m.svg;}
 
-node|z14[barrier=border_control],
+node|z14|barrier-border_control,
 {icon-image: bcontrol-s.svg;}
-node|z15-[barrier=border_control],
+node|z15-|barrier-border_control,
 {icon-image: bcontrol-m.svg;}
 
-node|z16-[barrier=block],
-node|z16-[barrier=bollard],
-node|z16-[barrier=chain],
-node|z16-[barrier=stile],
-node|z16-[barrier=turnstile],
+node|z16-|barrier-block,
+node|z16-|barrier-bollard,
+node|z16-|barrier-chain,
+node|z16-|barrier-stile,
+node|z16-|barrier-turnstile,
 {icon-image: dot-m.svg;font-size: 11;}
 
-node|z16-[barrier=entrance],
+node|z16-|barrier-entrance,
 {icon-image: entrance-barrier-s.svg; font-size: 11;}
 
-node|z16-[barrier=gate],
-node|z16-[barrier=kissing_gate],
+node|z16-|barrier-gate,
+node|z16-|barrier-kissing_gate,
 {icon-image: gate-s.svg;font-size: 11;}
 
-node|z16-[barrier=cycle_barrier],
+node|z16-|barrier-cycle_barrier,
 {icon-image: cycle_barrier-s.svg;font-size: 11;}
 
-node|z16-[highway=ford],
+node|z16-|highway-ford,
 {icon-image: ford-m.svg;}
 
-node|z19-[power=tower],
-node|z15-[man_made=flagpole],
-node|z16-[man_made=mast],
-node|z17-[man_made=tower][tower:type=communication],
+node|z19-|power-tower,
+node|z15-|man_made-flagpole,
+node|z16-|man_made-mast,
+node|z17-|man_made-tower-communication,
 {icon-image: dot-m.svg;}
 
-node|z16-[amenity=taxi],
-area|z16-[amenity=taxi]
+node|z16-|amenity-taxi,
+area|z16-|amenity-taxi
 {icon-image: taxi-m.svg;icon-min-distance: 30;}
-node|z17-[amenity=taxi],
-area|z17-[amenity=taxi]
+node|z17-|amenity-taxi,
+area|z17-|amenity-taxi
 {icon-min-distance: 20;}
 
-line|z16-[barrier=lift_gate],
-line|z16-[barrier=swing_gate],
+line|z16-|barrier-lift_gate,
+line|z16-|barrier-swing_gate,
 {icon-image: lift_gate-m.svg;icon-min-distance: 30;}
-line|z17-[barrier=lift_gate],
-line|z17-[barrier=swing_gate],
+line|z17-|barrier-lift_gate,
+line|z17-|barrier-swing_gate,
 {icon-min-distance: 20;}
 
-node|z16-[leisure=dog_park],
-area|z16-[leisure=dog_park]
+node|z16-|leisure-dog_park,
+area|z16-|leisure-dog_park
 {icon-image: dog_park-m.svg;icon-min-distance: 30;}
-node|z17-[leisure=dog_park],
-area|z17-[leisure=dog_park]
+node|z17-|leisure-dog_park,
+area|z17-|leisure-dog_park
 {icon-min-distance: 20;}
 
-node|z16-[man_made=windmill],
-area|z16-[man_made=windmill]
+node|z16-|man_made-windmill,
+area|z16-|man_made-windmill
 {icon-image: windmill-m.svg;icon-min-distance: 30;}
-node|z17-[man_made=windmill],
-area|z17-[man_made=windmill]
+node|z17-|man_made-windmill,
+area|z17-|man_made-windmill
 {icon-min-distance: 20;}
 
-node|z17-[amenity=casino],
-area|z17-[amenity=casino]
+node|z17-|amenity-casino,
+area|z17-|amenity-casino
 {icon-image: casino-m.svg;icon-min-distance: 20;}
-node|z17-[amenity=gambling],
-area|z17-[amenity=gambling],
+node|z17-|amenity-gambling,
+area|z17-|amenity-gambling,
 {icon-image: gambling-m.svg;icon-min-distance: 20;}
-node|z17-[leisure=adult_gaming_centre],
-area|z17-[leisure=adult_gaming_centre],
+node|z17-|leisure-adult_gaming_centre,
+area|z17-|leisure-adult_gaming_centre,
 {icon-image: slots-m.svg;icon-min-distance: 20;}
-node|z17-[leisure=amusement_arcade],
-area|z17-[leisure=amusement_arcade],
+node|z17-|leisure-amusement_arcade,
+area|z17-|leisure-amusement_arcade,
 {icon-image: arcade-m.svg;icon-min-distance: 20;}
-node|z18-[shop=lottery],
-area|z18-[shop=lottery],
+node|z18-|shop-lottery,
+area|z18-|shop-lottery,
 {icon-image: lottery-m.svg;icon-min-distance: 20;}
 
-node|z17-[amenity=courthouse],
-area|z17-[amenity=courthouse]
+node|z17-|amenity-courthouse,
+area|z17-|amenity-courthouse
 {icon-image: public-building-m.svg;}
 
-node|z17-[amenity=nursing_home],
-area|z17-[amenity=nursing_home]
+node|z17-|amenity-nursing_home,
+area|z17-|amenity-nursing_home
 {icon-image: home-m.svg;}
 
-node|z17-[amenity=social_facility],
-area|z17-[amenity=social_facility]
+node|z17-|amenity-social_facility,
+area|z17-|amenity-social_facility
 {icon-image: social_facility-m.svg;}
 
-node|z17-[amenity=cinema],
-area|z17-[amenity=cinema]
+node|z17-|amenity-cinema,
+area|z17-|amenity-cinema
 {icon-image: cinema-m.svg;}
-node|z18-[amenity=cinema],
-area|z18-[amenity=cinema]
+node|z18-|amenity-cinema,
+area|z18-|amenity-cinema
 {font-size: 11;}
 
-node|z17-[leisure=bowling_alley],
-area|z17-[leisure=bowling_alley],
+node|z17-|leisure-bowling_alley,
+area|z17-|leisure-bowling_alley,
 {icon-image: bowling_alley-m.svg;}
-node|z18-[leisure=bowling_alley],
-area|z18-[leisure=bowling_alley],
+node|z18-|leisure-bowling_alley,
+area|z18-|leisure-bowling_alley,
 {font-size: 11;}
 
-node|z17-[amenity=police],
-area|z17-[amenity=police]
+node|z17-|amenity-police,
+area|z17-|amenity-police
 {icon-image: police-m.svg;}
-node|z18-[amenity=police],
-area|z18-[amenity=police]
+node|z18-|amenity-police,
+area|z18-|amenity-police
 {font-size: 11;}
 
-node|z17-[amenity=prison],
-area|z17-[amenity=prison]
+node|z17-|amenity-prison,
+area|z17-|amenity-prison
 {icon-image: prison-m.svg;}
-node|z18-[amenity=prison],
-area|z18-[amenity=prison]
+node|z18-|amenity-prison,
+area|z18-|amenity-prison
 {font-size: 11;}
 
-node|z16-[amenity=townhall],
-node|z17-[office=diplomatic],
-area|z17-[office=diplomatic],
+node|z16-|amenity-townhall,
+node|z17-|office-diplomatic,
+area|z17-|office-diplomatic,
 {icon-image: embassy-m.svg;}
-node|z17-[amenity=townhall],
-node|z18-[office=diplomatic],
-area|z18-[office=diplomatic],
+node|z17-|amenity-townhall,
+node|z18-|office-diplomatic,
+area|z18-|office-diplomatic,
 {font-size: 11;}
 
-node|z17-[amenity=bicycle_rental],
-area|z17-[amenity=bicycle_rental]
+node|z17-|amenity-bicycle_rental,
+area|z17-|amenity-bicycle_rental
 {icon-image: bicycle-rental.svg;}
-node|z18-[amenity=bicycle_rental],
-area|z18-[amenity=bicycle_rental]
+node|z18-|amenity-bicycle_rental,
+area|z18-|amenity-bicycle_rental
 {font-size: 11;}
 
-node|z17-[amenity=bicycle_repair_station],
-area|z17-[amenity=bicycle_repair_station]
+node|z17-|amenity-bicycle_repair_station,
+area|z17-|amenity-bicycle_repair_station
 {icon-image: bicycle-repair-station.svg;}
-node|z18-[amenity=bicycle_repair_station],
-area|z18-[amenity=bicycle_repair_station]
+node|z18-|amenity-bicycle_repair_station,
+area|z18-|amenity-bicycle_repair_station
 {font-size: 11;}
 
-node|z17-[amenity=post_office],
-area|z17-[amenity=post_office],
+node|z17-|amenity-post_office,
+area|z17-|amenity-post_office,
 {icon-image: mail-m.svg;}
-node|z18-[amenity=post_office],
-area|z18-[amenity=post_office],
+node|z18-|amenity-post_office,
+area|z18-|amenity-post_office,
 {font-size: 11;}
-node|z18-[amenity=post_box],
-area|z18-[amenity=post_box],
+node|z18-|amenity-post_box,
+area|z18-|amenity-post_box,
 {icon-image: postbox-m.svg;font-size: 11;}
-node|z19-[emergency=fire_hydrant],
+node|z19-|emergency-fire_hydrant,
 {icon-image: firehydrant-m.svg;font-size: 11;}
 
-node|z18-[emergency=defibrillator],
-area|z18-[emergency=defibrillator]
+node|z18-|emergency-defibrillator,
+area|z18-|emergency-defibrillator
 {icon-image: defibrillator-m.svg;font-size: 11;}
 
-node|z18-[emergency=assembly_point],
-area|z18-[emergency=assembly_point]
+node|z18-|emergency-assembly_point,
+area|z18-|emergency-assembly_point
 {icon-image: assembly_point-m.svg;font-size: 11;}
 
-node|z17-[office=lawyer],
-area|z17-[office=lawyer]
+node|z17-|office-lawyer,
+area|z17-|office-lawyer
 {icon-image: lawyer-m.svg;}
 
-node|z17-[amenity=telephone]
+node|z17-|amenity-telephone
 {icon-image: phone-m.svg;}
 
-node|z17-[emergency=phone]
+node|z17-|emergency-phone
 {icon-image: emergency-phone-m.svg;}
 
-node|z17-[amenity=recycling],
-area|z17-[amenity=recycling],
-node|z17-[amenity=waste_transfer_station],
-area|z17-[amenity=waste_transfer_station],
+node|z17-|amenity-recycling,
+area|z17-|amenity-recycling,
+node|z17-|amenity-waste_transfer_station,
+area|z17-|amenity-waste_transfer_station,
 {icon-image: recycling-m.svg;}
 
-node|z17-[power=station],
-area|z17-[power=station],
-node|z17-[power=plant],
-area|z17-[power=plant],
+node|z17-|power-station,
+area|z17-|power-station,
+node|z17-|power-plant,
+area|z17-|power-plant,
 /* Skip individual solar generators, because there are a lot of mapped panels */
-node|z17-[power=generator][generator:source!=solar],
-area|z17-[power=generator][generator:source!=solar],
-node|z19-[power=substation],
-area|z19-[power=substation],
+node|z17-|[power=generator][generator:source!=solar] /*NO-TYPE-MATCH*/,
+area|z17-|[power=generator][generator:source!=solar] /*NO-TYPE-MATCH*/,
+node|z19-|power-substation,
+area|z19-|power-substation,
 {icon-image: power-m.svg;font-size: 11;}
 
 
-node|z15-[power=generator][generator:source=wind],
-area|z15-[power=generator][generator:source=wind],
+node|z15-|power-generator-wind,
+area|z15-|power-generator-wind,
 {icon-image: dot-m.svg;}
-node|z18-[power=generator][generator:source=wind],
-area|z18-[power=generator][generator:source=wind],
+node|z18-|power-generator-wind,
+area|z18-|power-generator-wind,
 {icon-image: wind_turbine-m.svg;text: name;text-color: @poi_label; text-offset: 1; font-size: 10;}
 
-node|z15-[power=plant][plant:source=wind],
-area|z15-[power=plant][plant:source=wind],
+node|z15-|power-plant-wind,
+area|z15-|power-plant-wind,
 {icon-image: power_plant_wind-m.svg;}
-node|z16-[power=plant][plant:source=wind],
-area|z16-[power=plant][plant:source=wind],
+node|z16-|power-plant-wind,
+area|z16-|power-plant-wind,
 {text: name;text-color: @poi_label; text-offset: 1; font-size: 10;}
 
-node|z17-[amenity=shower],
-area|z17-[amenity=shower]
+node|z17-|amenity-shower,
+area|z17-|amenity-shower
 {icon-image: shower-m.svg;}
 
-node|z17-[amenity=payment_terminal],
-area|z17-[amenity=payment_terminal]
+node|z17-|amenity-payment_terminal,
+area|z17-|amenity-payment_terminal
 {icon-image: vending-m.svg;}
-node|z18-[amenity=vending_machine],
-area|z18-[amenity=vending_machine],
+node|z18-|amenity-vending_machine,
+area|z18-|amenity-vending_machine,
 {icon-image: vending-m.svg;}
-node|z17-[amenity=vending_machine][vending=parking_tickets],
-area|z17-[amenity=vending_machine][vending=parking_tickets],
+node|z17-|amenity-vending_machine-parking_tickets,
+area|z17-|amenity-vending_machine-parking_tickets,
 {icon-image: parking-meter-m.svg;font-size: 11;}
-node|z17-[amenity=vending_machine][vending=public_transport_tickets],
-area|z17-[amenity=vending_machine][vending=public_transport_tickets],
+node|z17-|amenity-vending_machine-public_transport_tickets,
+area|z17-|amenity-vending_machine-public_transport_tickets,
 {icon-image: vending-m.svg;}
-node|z18-[amenity=vending_machine][vending=excrement_bags],
-area|z18-[amenity=vending_machine][vending=excrement_bags],
+node|z18-|amenity-vending_machine-excrement_bags,
+area|z18-|amenity-vending_machine-excrement_bags,
 {icon-image: excrement_bags-m.svg;}
-node|z17-[amenity=parcel_locker],
-area|z17-[amenity=parcel_locker],
+node|z17-|amenity-parcel_locker,
+area|z17-|amenity-parcel_locker,
 {icon-image: parcel_locker-m.svg;}
 
-node|z18-[amenity=vending_machine][vending=fuel],
-area|z18-[amenity=vending_machine][vending=fuel],
+node|z18-|amenity-vending_machine-fuel,
+area|z18-|amenity-vending_machine-fuel,
 {icon-image: fuel-dispenser-m.svg;}
 
-node|z17-[aeroway=gate],
-area|z17-[aeroway=gate]
+node|z17-|aeroway-gate,
+area|z17-|aeroway-gate
 {icon-image: airport_gate-m.svg;font-size: 11;}
 
-area|z17-[amenity=bureau_de_change],
-node|z17-[amenity=bureau_de_change],
-area|z17-[amenity=money_transfer],
-node|z17-[amenity=money_transfer],
+area|z17-|amenity-bureau_de_change,
+node|z17-|amenity-bureau_de_change,
+area|z17-|amenity-money_transfer,
+node|z17-|amenity-money_transfer,
 {icon-image: banknote-m.svg;font-size: 11;}
 
-node|z18-[amenity=fire_station],
-area|z18-[amenity=fire_station]
+node|z18-|amenity-fire_station,
+area|z18-|amenity-fire_station
 {icon-image: fire_station-m.svg;font-size: 11;}
-node|z18-[amenity=toilets],
-area|z18-[amenity=toilets]
+node|z18-|amenity-toilets,
+area|z18-|amenity-toilets
 {icon-image: toilets-m.svg;font-size: 11;}
-node|z18-[amenity=atm],
-area|z18-[amenity=atm]
+node|z18-|amenity-atm,
+area|z18-|amenity-atm
 {icon-image: atm-m.svg;font-size: 11;}
 
-node|z18-[amenity=bench]
+node|z18-|amenity-bench
 {icon-image: bench.svg;}
-node|z18-[amenity=waste_basket]
+node|z18-|amenity-waste_basket
 {icon-image: waste-basket-s.svg;}
 
-node|z18-[amenity=library]
+node|z18-|amenity-library
 {icon-image: library-m.svg;font-size: 11;}
-node|z18-[amenity=waste_disposal],
-area|z18-[amenity=waste_disposal]
+node|z18-|amenity-waste_disposal,
+area|z18-|amenity-waste_disposal
 {icon-image: waste-basket-m.svg;font-size: 11;}
 
-node|z18-[amenity=internet_cafe]
+node|z18-|amenity-internet_cafe
 {icon-image: internet_cafe-m.svg;}
 
-node|z18-[amenity=hunting_stand],
-area|z18-[amenity=hunting_stand]
+node|z18-|amenity-hunting_stand,
+area|z18-|amenity-hunting_stand
 {icon-image: hunting-tower-m.svg;font-size: 11;}
 
-node|z16-[man_made=chimney],
-area|z16-[man_made=chimney],
+node|z16-|man_made-chimney,
+area|z16-|man_made-chimney,
 {icon-image: chimney-m.svg;font-size: 11;}
 
-node|z16-[man_made=works],
-area|z16-[man_made=works]
+node|z16-|man_made-works,
+area|z16-|man_made-works
 {icon-image: factory-m.svg;font-size: 11;}
 
-node|z16-[man_made=silo],
-area|z16-[man_made=silo],
-node|z16-[man_made=storage_tank],
-area|z16-[man_made=storage_tank],
-node|z16-[man_made=water_tower],
+node|z16-|man_made-silo,
+area|z16-|man_made-silo,
+node|z16-|man_made-storage_tank,
+area|z16-|man_made-storage_tank,
+node|z16-|man_made-water_tower,
 {icon-image: storage-tank.svg;font-size: 11;}
 
-node|z18-[amenity=bbq],
-area|z18-[amenity=bbq]
+node|z18-|amenity-bbq,
+area|z18-|amenity-bbq
 {icon-image: bbq-m.svg;font-size: 11;}
 
-node|z18-[man_made=survey_point],
+node|z18-|man_made-survey_point,
 {icon-image: survey_point-m.svg;font-size: 11;}
 
-node|z19-[man_made=cairn]
+node|z19-|man_made-cairn
 {icon-image: cairn-m.svg;font-size: 11;}
 
-node|z18-[amenity=public_bookcase],
-area|z18-[amenity=public_bookcase]
+node|z18-|amenity-public_bookcase,
+area|z18-|amenity-public_bookcase
 {icon-image: bookcase-m.svg;font-size: 11;}
 
-node|z17-[amenity=public_bath],
-area|z17-[amenity=public_bath],
+node|z17-|amenity-public_bath,
+area|z17-|amenity-public_bath,
 {icon-image: public_bath-m.svg;font-size: 11;}
 
 /* 6. SHOP */
 
-node|z16-[amenity=marketplace],
-area|z16-[amenity=marketplace],
+node|z16-|amenity-marketplace,
+area|z16-|amenity-marketplace,
 {text: name; text-color: @poi_label; text-offset: 1; font-size: 10;}
 
-node|z16[amenity=marketplace],
-area|z16[amenity=marketplace]
+node|z16|amenity-marketplace,
+area|z16|amenity-marketplace
 {icon-image: marketplace-m.svg; text-offset: 1; font-size: 11; icon-min-distance: 24;}
-node|z17-[amenity=marketplace],
-area|z17-[amenity=marketplace]
+node|z17-|amenity-marketplace,
+area|z17-|amenity-marketplace
 {icon-image: marketplace-m.svg; font-size: 11; icon-min-distance: 8;}
 
-node|z18-[shop],
-area|z18-[shop],
-node|z14-[shop=mall],
-area|z14-[shop=mall],
-node|z15-[shop=car_repair][service=tyres],
-area|z15-[shop=car_repair][service=tyres],
-node|z16-[shop=supermarket],
-area|z16-[shop=supermarket],
-node|z16-[shop=cheese],
-area|z16-[shop=cheese],
-node|z16-[shop=alcohol],
-area|z16-[shop=alcohol],
-node|z16-[shop=art],
-area|z16-[shop=art],
-node|z16-[shop=wine],
-area|z16-[shop=wine],
-node|z16-[shop=books],
-area|z16-[shop=books],
-node|z16-[shop=charity],
-area|z16-[shop=charity],
-node|z16-[shop=second_hand],
-area|z16-[shop=second_hand],
-node|z16-[shop=antiques],
-area|z16-[shop=antiques],
-node|z16-[shop=auction],
-area|z16-[shop=auction],
-node|z16-[shop=bookmaker],
-area|z16-[shop=bookmaker],
-node|z16-[shop=bakery],
-area|z16-[shop=bakery],
-node|z16-[shop=pastry],
-area|z16-[shop=pastry],
-node|z16-[shop=pasta],
-area|z16-[shop=pasta],
-node|z16-[shop=beauty],
-area|z16-[shop=beauty],
-node|z16-[shop=cosmetics],
-area|z16-[shop=cosmetics],
-node|z16-[shop=beverages],
-area|z16-[shop=beverages],
-node|z16-[shop=bicycle],
-area|z16-[shop=bicycle],
-node|z16-[shop=butcher],
-area|z16-[shop=butcher],
-node|z16-[shop=car],
-area|z16-[shop=car],
-node|z16-[shop=caravan],
-area|z16-[shop=caravan],
-node|z16-[shop=motorcycle],
-area|z16-[shop=motorcycle],
-node|z16-[shop=car_parts],
-area|z16-[shop=car_parts],
-node|z16-[shop=car_repair],
-area|z16-[shop=car_repair],
-node|z16-[amenity=vehicle_inspection],
-area|z16-[amenity=vehicle_inspection],
-node|z16-[shop=tyres],
-area|z16-[shop=tyres],
-node|z16-[shop=chemist],
-area|z16-[shop=chemist],
-node|z16-[shop=clothes],
-area|z16-[shop=clothes],
-node|z16-[shop=computer],
-area|z16-[shop=computer],
-node|z16-[shop=video_games],
-area|z16-[shop=video_games],
-node|z16-[shop=tattoo],
-area|z16-[shop=tattoo],
-node|z16-[shop=erotic],
-area|z16-[shop=erotic],
-node|z16-[shop=funeral_directors],
-area|z16-[shop=funeral_directors],
-node|z16-[shop=confectionery],
-area|z16-[shop=confectionery],
-node|z16-[shop=chocolate],
-area|z16-[shop=chocolate],
-node|z16-[shop=convenience],
-area|z16-[shop=convenience],
-node|z16-[shop=deli],
-area|z16-[shop=deli],
-node|z16-[shop=farm],
-area|z16-[shop=farm],
-node|z16-[shop=grocery],
-area|z16-[shop=grocery],
-node|z16-[shop=health_food],
-area|z16-[shop=health_food],
-node|z16-[shop=copyshop],
-area|z16-[shop=copyshop],
-node|z16-[shop=photo],
-area|z16-[shop=photo],
-node|z16-[shop=camera],
-area|z16-[shop=camera],
-node|z16-[shop=pet],
-area|z16-[shop=pet],
-node|z16-[shop=department_store],
-area|z16-[shop=department_store],
-node|z16-[shop=interior_decoration],
-area|z16-[shop=interior_decoration],
-node|z16-[shop=doityourself],
-area|z16-[shop=doityourself],
-node|z16-[shop=electronics],
-area|z16-[shop=electronics],
-node|z16-[shop=florist],
-area|z16-[shop=florist],
-node|z16-[shop=furniture],
-area|z16-[shop=furniture],
-node|z16-[shop=kitchen],
-area|z16-[shop=kitchen],
-node|z16-[shop=garden_centre],
-area|z16-[shop=garden_centre],
-node|z16-[shop=gift],
-area|z16-[shop=gift],
-node|z16-[shop=music],
-area|z16-[shop=music],
-node|z16-[shop=video],
-area|z16-[shop=video],
-node|z16-[shop=musical_instrument],
-area|z16-[shop=musical_instrument],
-node|z16-[shop=greengrocer],
-area|z16-[shop=greengrocer],
-node|z16-[shop=hairdresser],
-area|z16-[shop=hairdresser],
-node|z16-[shop=sewing],
-area|z16-[shop=sewing],
-node|z16-[shop=hardware],
-area|z16-[shop=hardware],
-node|z16-[shop=houseware],
-area|z16-[shop=houseware],
-node|z16-[shop=jewelry],
-area|z16-[shop=jewelry],
-node|z16-[shop=kiosk],
-area|z16-[shop=kiosk],
-node|z16-[shop=laundry],
-area|z16-[shop=laundry],
-node|z16-[shop=dry_cleaning],
-area|z16-[shop=dry_cleaning],
-node|z16-[shop=mobile_phone],
-area|z16-[shop=mobile_phone],
-node|z16-[shop=optician],
-area|z16-[shop=optician],
-node|z16-[shop=outdoor],
-area|z16-[shop=outdoor],
-node|z16-[shop=rental],
-area|z16-[shop=rental],
-node|z16-[shop=rental][rental=bike],
-area|z16-[shop=rental][rental=bike],
-node|z16-[shop=seafood],
-area|z16-[shop=seafood],
-node|z16-[shop=shoes],
-area|z16-[shop=shoes],
-node|z16-[shop=sports],
-area|z16-[shop=sports],
-node|z16-[shop=ticket],
-area|z16-[shop=ticket],
-node|z16-[shop=toys],
-area|z16-[shop=toys],
-node|z16-[shop=fabric],
-area|z16-[shop=fabric],
-node|z16-[shop=stationery],
-area|z16-[shop=stationery],
-node|z17-[shop=variety_store],
-area|z17-[shop=variety_store],
-node|z17-[shop=money_lender],
-area|z17-[shop=money_lender],
-node|z17-[shop=pawnbroker],
-area|z17-[shop=pawnbroker],
-node|z17-[shop=wholesale],
-node|z18-[shop=tobacco],
-area|z18-[shop=tobacco],
+node|z18-|shop,
+area|z18-|shop,
+node|z14-|shop-mall,
+area|z14-|shop-mall,
+node|z15-|shop-car_repair-tyres,
+area|z15-|shop-car_repair-tyres,
+node|z16-|shop-supermarket,
+area|z16-|shop-supermarket,
+node|z16-|shop-cheese,
+area|z16-|shop-cheese,
+node|z16-|shop-alcohol,
+area|z16-|shop-alcohol,
+node|z16-|shop-art,
+area|z16-|shop-art,
+node|z16-|shop-wine,
+area|z16-|shop-wine,
+node|z16-|shop-books,
+area|z16-|shop-books,
+node|z16-|shop-charity,
+area|z16-|shop-charity,
+node|z16-|shop-second_hand,
+area|z16-|shop-second_hand,
+node|z16-|shop-antiques,
+area|z16-|shop-antiques,
+node|z16-|shop-auction,
+area|z16-|shop-auction,
+node|z16-|shop-bookmaker,
+area|z16-|shop-bookmaker,
+node|z16-|shop-bakery,
+area|z16-|shop-bakery,
+node|z16-|shop-pastry,
+area|z16-|shop-pastry,
+node|z16-|shop-pasta,
+area|z16-|shop-pasta,
+node|z16-|shop-beauty,
+area|z16-|shop-beauty,
+node|z16-|shop-cosmetics,
+area|z16-|shop-cosmetics,
+node|z16-|shop-beverages,
+area|z16-|shop-beverages,
+node|z16-|shop-bicycle,
+area|z16-|shop-bicycle,
+node|z16-|shop-butcher,
+area|z16-|shop-butcher,
+node|z16-|shop-car,
+area|z16-|shop-car,
+node|z16-|shop-caravan,
+area|z16-|shop-caravan,
+node|z16-|shop-motorcycle,
+area|z16-|shop-motorcycle,
+node|z16-|shop-car_parts,
+area|z16-|shop-car_parts,
+node|z16-|shop-car_repair,
+area|z16-|shop-car_repair,
+node|z16-|amenity-vehicle_inspection,
+area|z16-|amenity-vehicle_inspection,
+node|z16-|shop-tyres,
+area|z16-|shop-tyres,
+node|z16-|shop-chemist,
+area|z16-|shop-chemist,
+node|z16-|shop-clothes,
+area|z16-|shop-clothes,
+node|z16-|shop-computer,
+area|z16-|shop-computer,
+node|z16-|shop-video_games,
+area|z16-|shop-video_games,
+node|z16-|shop-tattoo,
+area|z16-|shop-tattoo,
+node|z16-|shop-erotic,
+area|z16-|shop-erotic,
+node|z16-|shop-funeral_directors,
+area|z16-|shop-funeral_directors,
+node|z16-|shop-confectionery,
+area|z16-|shop-confectionery,
+node|z16-|shop-chocolate,
+area|z16-|shop-chocolate,
+node|z16-|shop-convenience,
+area|z16-|shop-convenience,
+node|z16-|shop-deli,
+area|z16-|shop-deli,
+node|z16-|shop-farm,
+area|z16-|shop-farm,
+node|z16-|shop-grocery,
+area|z16-|shop-grocery,
+node|z16-|shop-health_food,
+area|z16-|shop-health_food,
+node|z16-|shop-copyshop,
+area|z16-|shop-copyshop,
+node|z16-|shop-photo,
+area|z16-|shop-photo,
+node|z16-|shop-camera,
+area|z16-|shop-camera,
+node|z16-|shop-pet,
+area|z16-|shop-pet,
+node|z16-|shop-department_store,
+area|z16-|shop-department_store,
+node|z16-|shop-interior_decoration,
+area|z16-|shop-interior_decoration,
+node|z16-|shop-doityourself,
+area|z16-|shop-doityourself,
+node|z16-|shop-electronics,
+area|z16-|shop-electronics,
+node|z16-|shop-florist,
+area|z16-|shop-florist,
+node|z16-|shop-furniture,
+area|z16-|shop-furniture,
+node|z16-|shop-kitchen,
+area|z16-|shop-kitchen,
+node|z16-|shop-garden_centre,
+area|z16-|shop-garden_centre,
+node|z16-|shop-gift,
+area|z16-|shop-gift,
+node|z16-|shop-music,
+area|z16-|shop-music,
+node|z16-|shop-video,
+area|z16-|shop-video,
+node|z16-|shop-musical_instrument,
+area|z16-|shop-musical_instrument,
+node|z16-|shop-greengrocer,
+area|z16-|shop-greengrocer,
+node|z16-|shop-hairdresser,
+area|z16-|shop-hairdresser,
+node|z16-|shop-sewing,
+area|z16-|shop-sewing,
+node|z16-|shop-hardware,
+area|z16-|shop-hardware,
+node|z16-|shop-houseware,
+area|z16-|shop-houseware,
+node|z16-|shop-jewelry,
+area|z16-|shop-jewelry,
+node|z16-|shop-kiosk,
+area|z16-|shop-kiosk,
+node|z16-|shop-laundry,
+area|z16-|shop-laundry,
+node|z16-|shop-dry_cleaning,
+area|z16-|shop-dry_cleaning,
+node|z16-|shop-mobile_phone,
+area|z16-|shop-mobile_phone,
+node|z16-|shop-optician,
+area|z16-|shop-optician,
+node|z16-|shop-outdoor,
+area|z16-|shop-outdoor,
+node|z16-|shop-rental,
+area|z16-|shop-rental,
+node|z16-|shop-rental-bike,
+area|z16-|shop-rental-bike,
+node|z16-|shop-seafood,
+area|z16-|shop-seafood,
+node|z16-|shop-shoes,
+area|z16-|shop-shoes,
+node|z16-|shop-sports,
+area|z16-|shop-sports,
+node|z16-|shop-ticket,
+area|z16-|shop-ticket,
+node|z16-|shop-toys,
+area|z16-|shop-toys,
+node|z16-|shop-fabric,
+area|z16-|shop-fabric,
+node|z16-|shop-stationery,
+area|z16-|shop-stationery,
+node|z17-|shop-variety_store,
+area|z17-|shop-variety_store,
+node|z17-|shop-money_lender,
+area|z17-|shop-money_lender,
+node|z17-|shop-pawnbroker,
+area|z17-|shop-pawnbroker,
+node|z17-|shop-wholesale,
+node|z18-|shop-tobacco,
+area|z18-|shop-tobacco,
 {text: name; text-color: @poi_label; text-offset: 1; font-size: 10;}
 
-node|z14[shop=mall],
-area|z14[shop=mall],
+node|z14|shop-mall,
+area|z14|shop-mall,
 {icon-image: shop-s.svg;icon-min-distance: 16;}
-node|z15-[shop=mall],
-area|z15-[shop=mall],
+node|z15-|shop-mall,
+area|z15-|shop-mall,
 {icon-image: shop-m.svg;font-size: 11;icon-min-distance: 16;}
-node|z15[shop=car_repair][service=tyres],
-area|z15[shop=car_repair][service=tyres],
+node|z15|shop-car_repair-tyres,
+area|z15|shop-car_repair-tyres,
 {icon-image: car-repair-s.svg; text-offset: 1; icon-min-distance: 20;}
-node|z16-[shop=car_repair][service=tyres],
-area|z16-[shop=car_repair][service=tyres],
+node|z16-|shop-car_repair-tyres,
+area|z16-|shop-car_repair-tyres,
 {icon-image: car-repair-m.svg;}
-node|z17-[shop=mall],
-area|z17-[shop=mall],
+node|z17-|shop-mall,
+area|z17-|shop-mall,
 {font-size: 11;icon-min-distance: 8;}
 
-node|z16[shop=supermarket],
-area|z16[shop=supermarket],
+node|z16|shop-supermarket,
+area|z16|shop-supermarket,
 {icon-image: supermarket-m.svg;font-size: 11;icon-min-distance: 16;}
-node|z17-[shop=supermarket],
-area|z17-[shop=supermarket],
+node|z17-|shop-supermarket,
+area|z17-|shop-supermarket,
 {icon-image: supermarket-m.svg;font-size: 11;icon-min-distance: 8;}
 
-node|z16[shop=cheese],
-area|z16[shop=cheese]
+node|z16|shop-cheese,
+area|z16|shop-cheese
 {icon-image: cheese-m.svg;}
-node|z16[shop=alcohol],
-area|z16[shop=alcohol]
+node|z16|shop-alcohol,
+area|z16|shop-alcohol
 {icon-image: alcohol-m.svg;}
-node|z16[shop=art],
-area|z16[shop=art]
+node|z16|shop-art,
+area|z16|shop-art
 {icon-image: art-m.svg;}
-node|z16[shop=wine],
-area|z16[shop=wine]
+node|z16|shop-wine,
+area|z16|shop-wine
 {icon-image: alcohol-m.svg;}
-node|z16[shop=books],
-area|z16[shop=books]
+node|z16|shop-books,
+area|z16|shop-books
 {icon-image: book-shop-m.svg;}
-node|z16[shop=charity],
-area|z16[shop=charity]
+node|z16|shop-charity,
+area|z16|shop-charity
 {icon-image: charity_shop-m.svg;}
-node|z16[shop=second_hand],
-area|z16[shop=second_hand]
+node|z16|shop-second_hand,
+area|z16|shop-second_hand
 {icon-image: second_hand_shop-m.svg;}
-node|z16[shop=antiques],
-area|z16[shop=antiques]
+node|z16|shop-antiques,
+area|z16|shop-antiques
 {icon-image: antiques-m.svg;}
-node|z16[shop=auction],
-area|z16[shop=auction]
+node|z16|shop-auction,
+area|z16|shop-auction
 {icon-image: auction-m.svg;}
-node|z16[shop=bookmaker],
-area|z16[shop=bookmaker],
+node|z16|shop-bookmaker,
+area|z16|shop-bookmaker,
 {icon-image: lottery-m.svg;}
-node|z16[shop=bakery],
-area|z16[shop=bakery],
-node|z16[shop=pastry],
-area|z16[shop=pastry],
+node|z16|shop-bakery,
+area|z16|shop-bakery,
+node|z16|shop-pastry,
+area|z16|shop-pastry,
 {icon-image: bakery-m.svg;}
-node|z16[shop=beauty],
-area|z16[shop=beauty]
+node|z16|shop-beauty,
+area|z16|shop-beauty
 {icon-image: beauty-m.svg;}
-node|z16[shop=cosmetics],
-area|z16[shop=cosmetics]
+node|z16|shop-cosmetics,
+area|z16|shop-cosmetics
 {icon-image: beauty-m.svg;}
-node|z16[shop=beverages],
-area|z16[shop=beverages]
+node|z16|shop-beverages,
+area|z16|shop-beverages
 {icon-image: alcohol-m.svg;}
-node|z16[shop=bicycle],
-area|z16[shop=bicycle]
+node|z16|shop-bicycle,
+area|z16|shop-bicycle
 {icon-image: shop-bicycle-m.svg;}
-node|z16[shop=butcher],
-area|z16[shop=butcher]
+node|z16|shop-butcher,
+area|z16|shop-butcher
 {icon-image: butcher-m.svg;}
-node|z16[shop=car],
-area|z16[shop=car]
+node|z16|shop-car,
+area|z16|shop-car
 {icon-image: car_shop-m.svg;}
-node|z16[shop=caravan],
-area|z16[shop=caravan]
+node|z16|shop-caravan,
+area|z16|shop-caravan
 {icon-image: caravan-shop-m.svg;}
-node|z16[shop=motorcycle],
-area|z16[shop=motorcycle]
+node|z16|shop-motorcycle,
+area|z16|shop-motorcycle
 {icon-image: motorcycle_shop-m.svg;}
-node|z16[shop=car_parts],
-area|z16[shop=car_parts]
+node|z16|shop-car_parts,
+area|z16|shop-car_parts
 {icon-image: car-part-m.svg;}
-node|z16[shop=car_repair],
-area|z16[shop=car_repair]
+node|z16|shop-car_repair,
+area|z16|shop-car_repair
 {icon-image: car-repair-m.svg;}
-node|z16[shop=motorcycle_repair],
-area|z16[shop=motorcycle_repair]
+node|z16|shop-motorcycle_repair,
+area|z16|shop-motorcycle_repair
 {icon-image: motorcycle_repair-m.svg;}
-node|z16[shop=tyres],
-area|z16[shop=tyres]
+node|z16|shop-tyres,
+area|z16|shop-tyres
 {icon-image: car-repair-m.svg;}
-node|z16-[amenity=vehicle_inspection],
-area|z16-[amenity=vehicle_inspection],
+node|z16-|amenity-vehicle_inspection,
+area|z16-|amenity-vehicle_inspection,
 {icon-image: vehicle_inspection-m.svg;}
-node|z16[shop=chemist],
-area|z16[shop=chemist]
+node|z16|shop-chemist,
+area|z16|shop-chemist
 {icon-image: chemist-m.svg;}
-node|z16[shop=clothes],
-area|z16[shop=clothes]
+node|z16|shop-clothes,
+area|z16|shop-clothes
 {icon-image: clothes-m.svg;}
-node|z16[shop=computer],
-area|z16[shop=computer]
+node|z16|shop-computer,
+area|z16|shop-computer
 {icon-image: computer-m.svg;}
-node|z16[shop=video_games],
-area|z16[shop=video_games]
+node|z16|shop-video_games,
+area|z16|shop-video_games
 {icon-image: video-games-m.svg;}
-node|z16[shop=tattoo],
-area|z16[shop=tattoo]
+node|z16|shop-tattoo,
+area|z16|shop-tattoo
 {icon-image: craft-m.svg;}
-node|z16[shop=erotic],
-area|z16[shop=erotic]
+node|z16|shop-erotic,
+area|z16|shop-erotic
 {icon-image: erotic-m.svg;}
-node|z16[shop=funeral_directors],
-area|z16[shop=funeral_directors]
+node|z16|shop-funeral_directors,
+area|z16|shop-funeral_directors
 {icon-image: funeral_directors-m.svg;}
-node|z16[shop=confectionery],
-area|z16[shop=confectionery],
-node|z16[shop=chocolate],
-area|z16[shop=chocolate]
+node|z16|shop-confectionery,
+area|z16|shop-confectionery,
+node|z16|shop-chocolate,
+area|z16|shop-chocolate
 {icon-image: confectionery-m.svg;}
-node|z16[amenity=ice_cream],
-area|z16[amenity=ice_cream]
+node|z16|amenity-ice_cream,
+area|z16|amenity-ice_cream
 {icon-image: ice_cream-m.svg;}
-node|z16[shop=convenience],
-area|z16[shop=convenience],
-node|z16[shop=deli],
-area|z16[shop=deli],
-node|z16[shop=farm],
-area|z16[shop=farm],
-node|z16[shop=grocery],
-area|z16[shop=grocery],
-node|z16[shop=health_food],
-area|z16[shop=health_food],
+node|z16|shop-convenience,
+area|z16|shop-convenience,
+node|z16|shop-deli,
+area|z16|shop-deli,
+node|z16|shop-farm,
+area|z16|shop-farm,
+node|z16|shop-grocery,
+area|z16|shop-grocery,
+node|z16|shop-health_food,
+area|z16|shop-health_food,
 {icon-image: convenience-m.svg;}
-node|z16[shop=collector],
-area|z16[shop=collector]
+node|z16|shop-collector,
+area|z16|shop-collector
 {icon-image: shop-m.svg;}
-node|z16[shop=copyshop],
-area|z16[shop=copyshop]
+node|z16|shop-copyshop,
+area|z16|shop-copyshop
 {icon-image: copyshop-m.svg;}
-node|z16[shop=camera],
-area|z16[shop=camera]
+node|z16|shop-camera,
+area|z16|shop-camera
 {icon-image: photo-shop-m.svg;}
-node|z16[shop=photo],
-area|z16[shop=photo]
+node|z16|shop-photo,
+area|z16|shop-photo
 {icon-image: photo-shop-m.svg;}
-node|z16[shop=pet],
-area|z16[shop=pet]
+node|z16|shop-pet,
+area|z16|shop-pet
 {icon-image: petshop-m.svg;}
-node|z16[shop=department_store],
-area|z16[shop=department_store]
+node|z16|shop-department_store,
+area|z16|shop-department_store
 {icon-image: department_store-m.svg;}
-node|z16[shop=interior_decoration],
-area|z16[shop=interior_decoration]
+node|z16|shop-interior_decoration,
+area|z16|shop-interior_decoration
 {icon-image: interior_decoration-m.svg;}
-node|z16[shop=doityourself],
-area|z16[shop=doityourself]
+node|z16|shop-doityourself,
+area|z16|shop-doityourself
 {icon-image: doityourself-m.svg;}
-node|z16[shop=electronics],
-area|z16[shop=electronics]
+node|z16|shop-electronics,
+area|z16|shop-electronics
 {icon-image: electronics-m.svg;}
-node|z16[shop=florist],
-area|z16[shop=florist]
+node|z16|shop-florist,
+area|z16|shop-florist
 {icon-image: florist-m.svg;}
-node|z16[shop=furniture],
-area|z16[shop=furniture],
-node|z16[shop=kitchen],
-area|z16[shop=kitchen],
+node|z16|shop-furniture,
+area|z16|shop-furniture,
+node|z16|shop-kitchen,
+area|z16|shop-kitchen,
 {icon-image: furniture-m.svg;}
-node|z16[shop=garden_centre],
-area|z16[shop=garden_centre]
+node|z16|shop-garden_centre,
+area|z16|shop-garden_centre
 {icon-image: garden_center-m.svg;}
-node|z16[shop=gift],
-area|z16[shop=gift]
+node|z16|shop-gift,
+area|z16|shop-gift
 {icon-image: gift-m.svg;}
-node|z16[shop=music],
-area|z16[shop=music],
+node|z16|shop-music,
+area|z16|shop-music,
 {icon-image: music-m.svg;}
-node|z16[shop=video],
-area|z16[shop=video]
+node|z16|shop-video,
+area|z16|shop-video
 {icon-image: media-m.svg;}
-node|z16[shop=musical_instrument],
-area|z16[shop=musical_instrument]
+node|z16|shop-musical_instrument,
+area|z16|shop-musical_instrument
 {icon-image: musical-instrument-m.svg;}
-node|z16[shop=greengrocer],
-area|z16[shop=greengrocer]
+node|z16|shop-greengrocer,
+area|z16|shop-greengrocer
 {icon-image: greengrocer-m.svg;}
-node|z16[shop=hairdresser],
-area|z16[shop=hairdresser]
+node|z16|shop-hairdresser,
+area|z16|shop-hairdresser
 {icon-image: hairdresser-m.svg;}
-node|z16-[shop=sewing],
-area|z16-[shop=sewing]
+node|z16-|shop-sewing,
+area|z16-|shop-sewing
 {icon-image: needle_and_thread-m.svg;}
-node|z16[shop=hardware],
-area|z16[shop=hardware],
-node|z16[shop=houseware],
-area|z16[shop=houseware],
+node|z16|shop-hardware,
+area|z16|shop-hardware,
+node|z16|shop-houseware,
+area|z16|shop-houseware,
 {icon-image: doityourself-m.svg;}
-node|z16[shop=jewelry],
-area|z16[shop=jewelry]
+node|z16|shop-jewelry,
+area|z16|shop-jewelry
 {icon-image: jewelry-m.svg;}
-node|z16[shop=kiosk],
-area|z16[shop=kiosk]
+node|z16|shop-kiosk,
+area|z16|shop-kiosk
 {icon-image: kiosk-m.svg;}
-node|z16[shop=laundry],
-area|z16[shop=laundry]
+node|z16|shop-laundry,
+area|z16|shop-laundry
 {icon-image:laundry-m.svg;}
-node|z16[shop=dry_cleaning],
-area|z16[shop=dry_cleaning]
+node|z16|shop-dry_cleaning,
+area|z16|shop-dry_cleaning
 {icon-image:dry_cleaning-m.svg;}
-node|z16[shop=mobile_phone],
-area|z16[shop=mobile_phone]
+node|z16|shop-mobile_phone,
+area|z16|shop-mobile_phone
 {icon-image: mobile_phone-m.svg;}
-node|z16[shop=optician],
-area|z16[shop=optician]
+node|z16|shop-optician,
+area|z16|shop-optician
 {icon-image: optician-m.svg;}
-node|z16[shop=outdoor],
-area|z16[shop=outdoor]
+node|z16|shop-outdoor,
+area|z16|shop-outdoor
 {icon-image: outdoor-shop-m.svg;}
-node|z16[shop=seafood],
-area|z16[shop=seafood]
+node|z16|shop-seafood,
+area|z16|shop-seafood
 {icon-image: seafood-shop-m.svg;}
-node|z16[shop=shoes],
-area|z16[shop=shoes]
+node|z16|shop-shoes,
+area|z16|shop-shoes
 {icon-image: shoes-m.svg;}
-node|z16[shop=sports],
-area|z16[shop=sports]
+node|z16|shop-sports,
+area|z16|shop-sports
 {icon-image: sports-m.svg;}
-node|z16[shop=ticket],
-area|z16[shop=ticket]
+node|z16|shop-ticket,
+area|z16|shop-ticket
 {icon-image: ticket-shop-m.svg;}
-node|z16[shop=toys],
-area|z16[shop=toys]
+node|z16|shop-toys,
+area|z16|shop-toys
 {icon-image: toys-m.svg;}
-node|z16[shop=stationery],
-area|z16[shop=stationery]
+node|z16|shop-stationery,
+area|z16|shop-stationery
 {icon-image: stationery_shop-m.svg;}
-node|z16[shop=fabric],
-area|z16[shop=fabric]
+node|z16|shop-fabric,
+area|z16|shop-fabric
 {icon-image: shop-m.svg;}
-node|z16[shop=rental],
-area|z16[shop=rental]
+node|z16|shop-rental,
+area|z16|shop-rental
 {icon-image: rental-m.svg;}
-node|z16[shop=rental][rental=bike],
-area|z16[shop=rental][rental=bike],
+node|z16|shop-rental-bike,
+area|z16|shop-rental-bike,
 {icon-image: shop-rental-bicycle-m.svg;}
 
-node|z17-[shop=cheese],
-area|z17-[shop=cheese]
+node|z17-|shop-cheese,
+area|z17-|shop-cheese
 {icon-image: cheese-m.svg;icon-min-distance: 24;}
-node|z17-[shop=alcohol],
-area|z17-[shop=alcohol]
+node|z17-|shop-alcohol,
+area|z17-|shop-alcohol
 {icon-image: alcohol-m.svg;icon-min-distance: 24;}
-node|z17-[shop=art],
-area|z17-[shop=art]
+node|z17-|shop-art,
+area|z17-|shop-art
 {icon-image: art-m.svg;icon-min-distance: 24;}
-node|z17-[shop=wine],
-area|z17-[shop=wine]
+node|z17-|shop-wine,
+area|z17-|shop-wine
 {icon-image: alcohol-m.svg;icon-min-distance: 24;}
-node|z17-[shop=books],
-area|z17-[shop=books]
+node|z17-|shop-books,
+area|z17-|shop-books
 {icon-image: book-shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=charity],
-area|z17-[shop=charity]
+node|z17-|shop-charity,
+area|z17-|shop-charity
 {icon-image: charity_shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=second_hand],
-area|z17-[shop=second_hand]
+node|z17-|shop-second_hand,
+area|z17-|shop-second_hand
 {icon-image: second_hand_shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=antiques],
-area|z17-[shop=antiques]
+node|z17-|shop-antiques,
+area|z17-|shop-antiques
 {icon-image: antiques-m.svg;icon-min-distance: 24;}
-node|z17-[shop=auction],
-area|z17-[shop=auction]
+node|z17-|shop-auction,
+area|z17-|shop-auction
 {icon-image: auction-m.svg;icon-min-distance: 24;}
-node|z17-[shop=bookmaker],
-area|z17-[shop=bookmaker]
+node|z17-|shop-bookmaker,
+area|z17-|shop-bookmaker
 {icon-image: lottery-m.svg;icon-min-distance: 24;}
-node|z17-[shop=bakery],
-area|z17-[shop=bakery],
-node|z17-[shop=pastry],
-area|z17-[shop=pastry],
+node|z17-|shop-bakery,
+area|z17-|shop-bakery,
+node|z17-|shop-pastry,
+area|z17-|shop-pastry,
 {icon-image: bakery-m.svg;icon-min-distance: 24;}
-node|z17-[shop=beauty],
-area|z17-[shop=beauty]
+node|z17-|shop-beauty,
+area|z17-|shop-beauty
 {icon-image: beauty-m.svg;icon-min-distance: 24;}
-node|z17-[shop=cosmetics],
-area|z17-[shop=cosmetics]
+node|z17-|shop-cosmetics,
+area|z17-|shop-cosmetics
 {icon-image: beauty-m.svg;icon-min-distance: 24;}
-node|z17-[shop=beverages],
-area|z17-[shop=beverages]
+node|z17-|shop-beverages,
+area|z17-|shop-beverages
 {icon-image: alcohol-m.svg;icon-min-distance: 24;}
-node|z17-[shop=bicycle],
-area|z17-[shop=bicycle]
+node|z17-|shop-bicycle,
+area|z17-|shop-bicycle
 {icon-image: shop-bicycle-m.svg;icon-min-distance: 24;}
-node|z17-[shop=butcher],
-area|z17-[shop=butcher]
+node|z17-|shop-butcher,
+area|z17-|shop-butcher
 {icon-image: butcher-m.svg;icon-min-distance: 24;}
-node|z17-[shop=car],
-area|z17-[shop=car]
+node|z17-|shop-car,
+area|z17-|shop-car
 {icon-image: car_shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=caravan],
-area|z17-[shop=caravan]
+node|z17-|shop-caravan,
+area|z17-|shop-caravan
 {icon-image: caravan-shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=motorcycle],
-area|z17-[shop=motorcycle]
+node|z17-|shop-motorcycle,
+area|z17-|shop-motorcycle
 {icon-image: motorcycle_shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=car_parts],
-area|z17-[shop=car_parts]
+node|z17-|shop-car_parts,
+area|z17-|shop-car_parts
 {icon-image: car-part-m.svg;icon-min-distance: 24;}
-node|z17-[shop=car_repair],
-area|z17-[shop=car_repair]
+node|z17-|shop-car_repair,
+area|z17-|shop-car_repair
 {icon-image: car-repair-m.svg;icon-min-distance: 24;}
-node|z17-[shop=motorcycle_repair],
-area|z17-[shop=motorcycle_repair]
+node|z17-|shop-motorcycle_repair,
+area|z17-|shop-motorcycle_repair
 {icon-image: motorcycle_repair-m.svg;icon-min-distance: 24;}
-node|z17-[shop=tyres],
-area|z17-[shop=tyres]
+node|z17-|shop-tyres,
+area|z17-|shop-tyres
 {icon-image: car-repair-m.svg;icon-min-distance: 24;}
-node|z17-[amenity=vehicle_inspection],
-area|z17-[amenity=vehicle_inspection],
+node|z17-|amenity-vehicle_inspection,
+area|z17-|amenity-vehicle_inspection,
 {icon-image: vehicle_inspection-m.svg;icon-min-distance: 24;}
-node|z17-[shop=chemist],
-area|z17-[shop=chemist]
+node|z17-|shop-chemist,
+area|z17-|shop-chemist
 {icon-image: chemist-m.svg;icon-min-distance: 24;}
-node|z17-[shop=clothes],
-area|z17-[shop=clothes]
+node|z17-|shop-clothes,
+area|z17-|shop-clothes
 {icon-image: clothes-m.svg;icon-min-distance: 24;}
-node|z17-[shop=computer],
-area|z17-[shop=computer]
+node|z17-|shop-computer,
+area|z17-|shop-computer
 {icon-image: computer-m.svg;icon-min-distance: 24;}
-node|z17-[shop=video_games],
-area|z17-[shop=video_games]
+node|z17-|shop-video_games,
+area|z17-|shop-video_games
 {icon-image: video-games-m.svg;icon-min-distance: 24;}
-node|z17-[shop=tattoo],
-area|z17-[shop=tattoo]
+node|z17-|shop-tattoo,
+area|z17-|shop-tattoo
 {icon-image: craft-m.svg;icon-min-distance: 24;}
-node|z17-[shop=erotic],
-area|z17-[shop=erotic]
+node|z17-|shop-erotic,
+area|z17-|shop-erotic
 {icon-image: erotic-m.svg;icon-min-distance: 24;}
-node|z17-[shop=funeral_directors],
-area|z17-[shop=funeral_directors]
+node|z17-|shop-funeral_directors,
+area|z17-|shop-funeral_directors
 {icon-image: funeral_directors-m.svg;icon-min-distance: 24;}
-node|z17-[shop=confectionery],
-area|z17-[shop=confectionery],
-node|z17-[shop=chocolate],
-area|z17-[shop=chocolate]
+node|z17-|shop-confectionery,
+area|z17-|shop-confectionery,
+node|z17-|shop-chocolate,
+area|z17-|shop-chocolate
 {icon-image: confectionery-m.svg;icon-min-distance: 24;}
-node|z17-[amenity=ice_cream],
-area|z17-[amenity=ice_cream]
+node|z17-|amenity-ice_cream,
+area|z17-|amenity-ice_cream
 {icon-image: ice_cream-m.svg;icon-min-distance: 24;}
-node|z17-[shop=convenience],
-area|z17-[shop=convenience],
-node|z17-[shop=deli],
-area|z17-[shop=deli],
-node|z17-[shop=farm],
-area|z17-[shop=farm],
-node|z17-[shop=grocery],
-area|z17-[shop=grocery],
-node|z17-[shop=health_food],
-area|z17-[shop=health_food],
+node|z17-|shop-convenience,
+area|z17-|shop-convenience,
+node|z17-|shop-deli,
+area|z17-|shop-deli,
+node|z17-|shop-farm,
+area|z17-|shop-farm,
+node|z17-|shop-grocery,
+area|z17-|shop-grocery,
+node|z17-|shop-health_food,
+area|z17-|shop-health_food,
 {icon-image: convenience-m.svg;icon-min-distance: 24;}
-node|z17-[shop=collector],
-area|z17-[shop=collector]
+node|z17-|shop-collector,
+area|z17-|shop-collector
 {icon-image: shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=copyshop],
-area|z17-[shop=copyshop]
+node|z17-|shop-copyshop,
+area|z17-|shop-copyshop
 {icon-image: copyshop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=camera],
-area|z17-[shop=camera]
+node|z17-|shop-camera,
+area|z17-|shop-camera
 {icon-image: photo-shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=photo],
-area|z17-[shop=photo]
+node|z17-|shop-photo,
+area|z17-|shop-photo
 {icon-image: photo-shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=pet],
-area|z17-[shop=pet]
+node|z17-|shop-pet,
+area|z17-|shop-pet
 {icon-image: petshop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=department_store],
-area|z17-[shop=department_store]
+node|z17-|shop-department_store,
+area|z17-|shop-department_store
 {icon-image: department_store-m.svg;icon-min-distance: 24;}
-node|z17-[shop=interior_decoration],
-area|z17-[shop=interior_decoration]
+node|z17-|shop-interior_decoration,
+area|z17-|shop-interior_decoration
 {icon-image: interior_decoration-m.svg;icon-min-distance: 24;}
-node|z17-[shop=doityourself],
-area|z17-[shop=doityourself]
+node|z17-|shop-doityourself,
+area|z17-|shop-doityourself
 {icon-image: doityourself-m.svg;icon-min-distance: 24;}
-node|z17-[shop=electronics],
-area|z17-[shop=electronics]
+node|z17-|shop-electronics,
+area|z17-|shop-electronics
 {icon-image: electronics-m.svg;icon-min-distance: 24;}
-node|z17-[shop=florist],
-area|z17-[shop=florist]
+node|z17-|shop-florist,
+area|z17-|shop-florist
 {icon-image: florist-m.svg;icon-min-distance: 24;}
-node|z17-[shop=furniture],
-area|z17-[shop=furniture],
-node|z17-[shop=kitchen],
-area|z17-[shop=kitchen],
+node|z17-|shop-furniture,
+area|z17-|shop-furniture,
+node|z17-|shop-kitchen,
+area|z17-|shop-kitchen,
 {icon-image: furniture-m.svg;icon-min-distance: 24;}
-node|z17-[shop=garden_centre],
-area|z17-[shop=garden_centre]
+node|z17-|shop-garden_centre,
+area|z17-|shop-garden_centre
 {icon-image: garden_center-m.svg;icon-min-distance: 24;}
-node|z17-[shop=gift],
-area|z17-[shop=gift]
+node|z17-|shop-gift,
+area|z17-|shop-gift
 {icon-image: gift-m.svg;icon-min-distance: 24;}
-node|z17-[shop=music],
-area|z17-[shop=music],
+node|z17-|shop-music,
+area|z17-|shop-music,
 {icon-image: music-m.svg;icon-min-distance: 24;}
-node|z17-[shop=video],
-area|z17-[shop=video]
+node|z17-|shop-video,
+area|z17-|shop-video
 {icon-image: media-m.svg;icon-min-distance: 24;}
-node|z17-[shop=musical_instrument],
-area|z17-[shop=musical_instrument]
+node|z17-|shop-musical_instrument,
+area|z17-|shop-musical_instrument
 {icon-image: musical-instrument-m.svg;icon-min-distance: 24;}
-node|z17-[shop=greengrocer],
-area|z17-[shop=greengrocer]
+node|z17-|shop-greengrocer,
+area|z17-|shop-greengrocer
 {icon-image: greengrocer-m.svg;icon-min-distance: 24;}
-node|z17-[shop=hairdresser],
-area|z17-[shop=hairdresser]
+node|z17-|shop-hairdresser,
+area|z17-|shop-hairdresser
 {icon-image: hairdresser-m.svg;icon-min-distance: 24;}
-node|z17-[shop=sewing],
-area|z17-[shop=sewing]
+node|z17-|shop-sewing,
+area|z17-|shop-sewing
 {icon-image: needle_and_thread-m.svg;icon-min-distance 24;}
-node|z17-[shop=hardware],
-area|z17-[shop=hardware],
-node|z17-[shop=houseware],
-area|z17-[shop=houseware],
+node|z17-|shop-hardware,
+area|z17-|shop-hardware,
+node|z17-|shop-houseware,
+area|z17-|shop-houseware,
 {icon-image: doityourself-m.svg;icon-min-distance: 24;}
-node|z17-[shop=jewelry],
-area|z17-[shop=jewelry]
+node|z17-|shop-jewelry,
+area|z17-|shop-jewelry
 {icon-image: jewelry-m.svg;icon-min-distance: 24;}
-node|z17-[shop=kiosk],
-area|z17-[shop=kiosk]
+node|z17-|shop-kiosk,
+area|z17-|shop-kiosk
 {icon-image: kiosk-m.svg;icon-min-distance: 24;}
-node|z17-[shop=laundry],
-area|z17-[shop=laundry]
+node|z17-|shop-laundry,
+area|z17-|shop-laundry
 {icon-image:laundry-m.svg;icon-min-distance: 24;}
-node|z17-[shop=dry_cleaning],
-area|z17-[shop=dry_cleaning]
+node|z17-|shop-dry_cleaning,
+area|z17-|shop-dry_cleaning
 {icon-image:dry_cleaning-m.svg;icon-min-distance: 24;}
-node|z17-[shop=mobile_phone],
-area|z17-[shop=mobile_phone]
+node|z17-|shop-mobile_phone,
+area|z17-|shop-mobile_phone
 {icon-image: mobile_phone-m.svg;icon-min-distance: 24;}
-node|z17-[shop=optician],
-area|z17-[shop=optician]
+node|z17-|shop-optician,
+area|z17-|shop-optician
 {icon-image: optician-m.svg;icon-min-distance: 24;}
-node|z17-[shop=outdoor],
-area|z17-[shop=outdoor]
+node|z17-|shop-outdoor,
+area|z17-|shop-outdoor
 {icon-image: outdoor-shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=seafood],
-area|z17-[shop=seafood]
+node|z17-|shop-seafood,
+area|z17-|shop-seafood
 {icon-image: seafood-shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=shoes],
-area|z17-[shop=shoes]
+node|z17-|shop-shoes,
+area|z17-|shop-shoes
 {icon-image: shoes-m.svg;icon-min-distance: 24;}
-node|z17-[shop=sports],
-area|z17-[shop=sports]
+node|z17-|shop-sports,
+area|z17-|shop-sports
 {icon-image: sports-m.svg;icon-min-distance: 24;}
-node|z17-[shop=ticket],
-area|z17-[shop=ticket]
+node|z17-|shop-ticket,
+area|z17-|shop-ticket
 {icon-image: ticket-shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=toys],
-area|z17-[shop=toys]
+node|z17-|shop-toys,
+area|z17-|shop-toys
 {icon-image: toys-m.svg;icon-min-distance: 24;}
-node|z17-[shop=stationery],
-area|z17-[shop=stationery]
+node|z17-|shop-stationery,
+area|z17-|shop-stationery
 {icon-image: stationery_shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=newsagent],
-area|z17-[shop=newsagent]
+node|z17-|shop-newsagent,
+area|z17-|shop-newsagent
 {icon-image: newsagent_shop-m.svg;icon-min-distance: 24;}
-node|z17-[shop=fabric],
-area|z17-[shop=fabric],
-node|z17-[shop=variety_store],
-area|z17-[shop=variety_store],
+node|z17-|shop-fabric,
+area|z17-|shop-fabric,
+node|z17-|shop-variety_store,
+area|z17-|shop-variety_store,
 {icon-image: shop-m.svg;}
-node|z17-[shop=massage],
-area|z17-[shop=massage],
+node|z17-|shop-massage,
+area|z17-|shop-massage,
 {icon-image: public_bath-m.svg;icon-min-distance: 24;}
-node|z17-[shop=money_lender],
-area|z17-[shop=money_lender],
+node|z17-|shop-money_lender,
+area|z17-|shop-money_lender,
 {icon-image: bank-m.svg;icon-min-distance: 24;}
-area|z17-[shop=pawnbroker],
-node|z17-[shop=pawnbroker],
+area|z17-|shop-pawnbroker,
+node|z17-|shop-pawnbroker,
 {icon-image: bookmaker-m.svg;icon-min-distance: 24;}
-node|z17-[shop=wholesale],
+node|z17-|shop-wholesale,
 {icon-image: wholesale-m.svg;icon-min-distance: 24;}
-node|z17-[shop=rental],
-area|z17-[shop=rental]
+node|z17-|shop-rental,
+area|z17-|shop-rental
 {icon-image: rental-m.svg;icon-min-distance: 24;}
-node|z17-[shop=rental][rental=bike],
-area|z17-[shop=rental][rental=bike],
+node|z17-|shop-rental-bike,
+area|z17-|shop-rental-bike,
 {icon-image: shop-rental-bicycle-m.svg;icon-min-distance: 24;}
-node|z18-[shop=tobacco],
-area|z18-[shop=tobacco],
+node|z18-|shop-tobacco,
+area|z18-|shop-tobacco,
 {icon-image: tobacco-m.svg;icon-min-distance: 24;}
 
 /* 6.1 Craft */
 
-node|z17-[craft=beekeeper],
-area|z17-[craft=beekeeper]
+node|z17-|craft-beekeeper,
+area|z17-|craft-beekeeper
 {icon-image:beekeeper-m.svg;}
-node|z17-[craft=blacksmith],
-area|z17-[craft=blacksmith]
+node|z17-|craft-blacksmith,
+area|z17-|craft-blacksmith
 {icon-image:blacksmith-m.svg;}
-node|z17-[craft=brewery],
-area|z17-[craft=brewery]
+node|z17-|craft-brewery,
+area|z17-|craft-brewery
 {icon-image:brewery-m.svg;}
-node|z17-[craft=carpenter],
-area|z17-[craft=carpenter]
+node|z17-|craft-carpenter,
+area|z17-|craft-carpenter
 {icon-image:carpenter-m.svg;}
-node|z17-[craft=caterer],
+node|z17-|craft-caterer,
 {icon-image:caterer-m.svg;}
-node|z17-[craft=confectionery],
-area|z17-[craft=confectionery]
+node|z17-|craft-confectionery,
+area|z17-|craft-confectionery
 {icon-image:confectionery-m.svg;}
-node|z17-[craft=electrician],
-area|z17-[craft=electrician]
+node|z17-|craft-electrician,
+area|z17-|craft-electrician
 {icon-image:electrician-m.svg;}
-node|z17-[craft=electronics_repair],
-area|z17-[craft=electronics_repair]
+node|z17-|craft-electronics_repair,
+area|z17-|craft-electronics_repair
 {icon-image:electrician-m.svg;}
-node|z17-[craft=gardener],
-area|z17-[craft=gardener]
+node|z17-|craft-gardener,
+area|z17-|craft-gardener
 {icon-image:florist-m.svg;}
-node|z17-[craft=grinding_mill],
+node|z17-|craft-grinding_mill,
 {icon-image:grinding_mill-m.svg;}
-node|z17-[craft=handicraft],
+node|z17-|craft-handicraft,
 {icon-image:handicraft-m.svg;}
-node|z17-[craft=hvac],
+node|z17-|craft-hvac,
 {icon-image:plumber-m.svg;}
-node|z17-[craft=key_cutter],
+node|z17-|craft-key_cutter,
 {icon-image:key_cutter-m.svg;}
-node|z17-[craft=locksmith],
+node|z17-|craft-locksmith,
 {icon-image:key_cutter-m.svg;}
-node|z17-[craft=painter],
-area|z17-[craft=painter]
+node|z17-|craft-painter,
+area|z17-|craft-painter
 {icon-image:painter-m.svg;}
-node|z17-[craft=photographer],
-area|z17-[craft=photographer]
+node|z17-|craft-photographer,
+area|z17-|craft-photographer
 {icon-image:photo-shop-m.svg;}
-node|z17-[craft=plumber],
-area|z17-[craft=plumber]
+node|z17-|craft-plumber,
+area|z17-|craft-plumber
 {icon-image:plumber-m.svg;}
-node|z17-[craft=sawmill],
-area|z17-[craft=sawmill]
+node|z17-|craft-sawmill,
+area|z17-|craft-sawmill
 {icon-image:sawmill-m.svg;}
-node|z17-[craft=shoemaker],
-area|z17-[craft=shoemaker]
+node|z17-|craft-shoemaker,
+area|z17-|craft-shoemaker
 {icon-image:shoes-m.svg;}
-node|z17-[craft=tailor],
-area|z17-[craft=tailor]
+node|z17-|craft-tailor,
+area|z17-|craft-tailor
 {icon-image:clothes-m.svg;}
-node|z17-[craft=metal_construction],
-area|z17-[craft=metal_construction]
+node|z17-|craft-metal_construction,
+area|z17-|craft-metal_construction
 {icon-image:metal_construction-m.svg;}
-node|z17-[craft=winery],
-area|z17-[craft=winery],
+node|z17-|craft-winery,
+area|z17-|craft-winery,
 {icon-image:winery-m.svg;}
 
 /* 7. CAR */
 
-area|z14-[highway=services],
-area|z15-[highway=rest_area],
+area|z14-|highway-services,
+area|z15-|highway-rest_area,
 {text-position: center;}
 
-node|z14-[amenity=fuel],
-area|z14-[amenity=fuel],
-node|z14-[amenity=charging_station][motorcar?],
-area|z14-[amenity=charging_station][motorcar?],
-area|z14-[highway=services],
-area|z15-[highway=rest_area],
-node|z15-[amenity=sanitary_dump_station],
-area|z15-[amenity=sanitary_dump_station],
-node|z16-[amenity=charging_station],
-area|z16-[amenity=charging_station],
-node|z17-[amenity=bicycle_parking],
-area|z17-[amenity=bicycle_parking],
-node|z17-[amenity=motorcycle_parking],
-area|z17-[amenity=motorcycle_parking],
-node|z17-[amenity=car_wash],
-area|z17-[amenity=car_wash],
-node|z18-[amenity=parking],
-area|z18-[amenity=parking],
-node|z18-[amenity=car_rental],
-area|z18-[amenity=car_rental],
-node|z18-[amenity=car_sharing],
-area|z18-[amenity=car_sharing]
+node|z14-|amenity-fuel,
+area|z14-|amenity-fuel,
+node|z14-|amenity-charging_station-motorcar,
+area|z14-|amenity-charging_station-motorcar,
+area|z14-|highway-services,
+area|z15-|highway-rest_area,
+node|z15-|amenity-sanitary_dump_station,
+area|z15-|amenity-sanitary_dump_station,
+node|z16-|amenity-charging_station,
+area|z16-|amenity-charging_station,
+node|z17-|amenity-bicycle_parking,
+area|z17-|amenity-bicycle_parking,
+node|z17-|amenity-motorcycle_parking,
+area|z17-|amenity-motorcycle_parking,
+node|z17-|amenity-car_wash,
+area|z17-|amenity-car_wash,
+node|z18-|amenity-parking,
+area|z18-|amenity-parking,
+node|z18-|amenity-car_rental,
+area|z18-|amenity-car_rental,
+node|z18-|amenity-car_sharing,
+area|z18-|amenity-car_sharing
 {text: name;text-color: @poi_label;text-offset: 1;font-size: 10;}
 
-node|z14[amenity=fuel],
-area|z14[amenity=fuel]
+node|z14|amenity-fuel,
+area|z14|amenity-fuel
 {icon-image: fuel-s.svg; text-offset: 1; icon-min-distance: 20;}
-node|z15[amenity=fuel],
-area|z15[amenity=fuel]
+node|z15|amenity-fuel,
+area|z15|amenity-fuel
 {icon-image: fuel-m.svg; icon-min-distance: 20;}
-node|z16[amenity=fuel],
-area|z16[amenity=fuel]
+node|z16|amenity-fuel,
+area|z16|amenity-fuel
 {icon-image: fuel-m.svg; icon-min-distance: 10;}
-node|z17-[amenity=fuel],
-area|z17-[amenity=fuel]
+node|z17-|amenity-fuel,
+area|z17-|amenity-fuel
 {icon-image: fuel-m.svg;}
-node|z18-[amenity=fuel],
-area|z18-[amenity=fuel]
+node|z18-|amenity-fuel,
+area|z18-|amenity-fuel
 {font-size: 11;}
 
-node|z14[amenity=charging_station][motorcar?],
-area|z14[amenity=charging_station][motorcar?],
+node|z14|amenity-charging_station-motorcar,
+area|z14|amenity-charging_station-motorcar,
 {icon-image: charging-station-s.svg;text-offset: 1;font-size: 10;icon-min-distance: 20;}
-node|z15[amenity=charging_station][motorcar?],
-area|z15[amenity=charging_station][motorcar?],
+node|z15|amenity-charging_station-motorcar,
+area|z15|amenity-charging_station-motorcar,
 {icon-image: charging-station-m.svg;icon-min-distance: 20;}
-node|z16[amenity=charging_station],
-area|z16[amenity=charging_station]
+node|z16|amenity-charging_station,
+area|z16|amenity-charging_station
 {icon-image: charging-station-m.svg;icon-min-distance: 10;}
-node|z17-[amenity=charging_station],
-area|z17-[amenity=charging_station]
+node|z17-|amenity-charging_station,
+area|z17-|amenity-charging_station
 {icon-image: charging-station-m.svg;}
-node|z18-[amenity=charging_station],
-area|z18-[amenity=charging_station]
+node|z18-|amenity-charging_station,
+area|z18-|amenity-charging_station
 {font-size: 11;}
 
-area|z14[highway=services],
+area|z14|highway-services,
 {icon-image: car-repair-s.svg; icon-min-distance: 20;}
-area|z15[highway=services],
+area|z15|highway-services,
 {icon-image: car-repair-m.svg; icon-min-distance: 10;}
-area|z15[highway=rest_area]
+area|z15|highway-rest_area
 {icon-image: picnic-m.svg; icon-min-distance: 10;}
-area|z16-[highway=services],
+area|z16-|highway-services,
 {icon-image: car-repair-m.svg;}
-area|z16-[highway=rest_area],
+area|z16-|highway-rest_area,
 {icon-image: picnic-m.svg;}
-area|z18-[highway=services],
-area|z18-[highway=rest_area],
+area|z18-|highway-services,
+area|z18-|highway-rest_area,
 {font-size: 11;}
 
-node|z17-[amenity=car_wash],
-area|z17-[amenity=car_wash]
+node|z17-|amenity-car_wash,
+area|z17-|amenity-car_wash
 {icon-image: car-wash-m.svg;font-size: 11;icon-min-distance: 24;}
 
-node|z18-[amenity=car_rental],
-area|z18-[amenity=car_rental]
+node|z18-|amenity-car_rental,
+area|z18-|amenity-car_rental
 {icon-image: car_sharing-m.svg;text-offset: 1;font-size: 11;}
 
-node|z18-[amenity=car_sharing],
-area|z18-[amenity=car_sharing]
+node|z18-|amenity-car_sharing,
+area|z18-|amenity-car_sharing
 {icon-image: car_sharing-m.svg;text-offset: 1;font-size: 11;}
 
-node|z15-[amenity=sanitary_dump_station],
-area|z15-[amenity=sanitary_dump_station]
+node|z15-|amenity-sanitary_dump_station,
+area|z15-|amenity-sanitary_dump_station
 {icon-image: dump-station-m.svg; icon-min-distance: 20;}
 
-node|z18-[amenity=compressed_air],
-area|z18-[amenity=compressed_air],
+node|z18-|amenity-compressed_air,
+area|z18-|amenity-compressed_air,
 {icon-image: compressed_air-m.svg;}
 
 /* 7.1 Parking */
 
-node|z16-[amenity=parking],
-area|z16-[amenity=parking],
+node|z16-|amenity-parking,
+area|z16-|amenity-parking,
 {icon-image: parking-s.svg;icon-min-distance: 5;}
-node|z17-[amenity=parking],
-area|z17-[amenity=parking],
+node|z17-|amenity-parking,
+area|z17-|amenity-parking,
 {icon-image: parking-m.svg;font-size: 11;icon-min-distance: 10}
 
-node|z16-[amenity=parking][location=underground],
-area|z16-[amenity=parking][location=underground],
+node|z16-|amenity-parking-underground,
+area|z16-|amenity-parking-underground,
 {icon-image:parking_underground-m.svg;}
 
-node|z16-[amenity=parking][fee?],
-area|z16-[amenity=parking][fee?],
+node|z16-|[amenity=parking][fee?] /*NO-TYPE-MATCH*/,
+area|z16-|[amenity=parking][fee?] /*NO-TYPE-MATCH*/,
 {icon-image: parking_pay-s.svg;}
-node|z17-[amenity=parking][fee?],
-area|z17-[amenity=parking][fee?],
+node|z17-|[amenity=parking][fee?] /*NO-TYPE-MATCH*/,
+area|z17-|[amenity=parking][fee?] /*NO-TYPE-MATCH*/,
 {icon-image: parking_pay-m.svg;}
-node|z16-[amenity=parking][location=underground][fee?],
-area|z16-[amenity=parking][location=underground][fee?],
+node|z16-|[amenity=parking][location=underground][fee?] /*NO-TYPE-MATCH*/,
+area|z16-|[amenity=parking][location=underground][fee?] /*NO-TYPE-MATCH*/,
 {icon-image:parking_underground_pay-m.svg;}
 
 /* no icon as these subtypes should display later */
-node|z16-[amenity=parking][access=private],
-area|z16-[amenity=parking][access=private],
-node|z16-[amenity=parking][parking=street_side],
-area|z16-[amenity=parking][parking=street_side],
-node|z16-[amenity=parking][parking=lane],
-area|z16-[amenity=parking][parking=lane],
+node|z16-|amenity-parking-private,
+area|z16-|amenity-parking-private,
+node|z16-|amenity-parking-street_side,
+area|z16-|amenity-parking-street_side,
+node|z16-|amenity-parking-lane,
+area|z16-|amenity-parking-lane,
 /* =no doesn't work in kothic */
 /* node|z16-[amenity=parking][access=no], */
 /* area|z16-[amenity=parking][access=no], */
-node|z16-[amenity=parking][parking=street_side][fee?],
-area|z16-[amenity=parking][parking=street_side][fee?],
-node|z16-[amenity=parking][parking=lane][fee?],
-area|z16-[amenity=parking][parking=lane][fee?],
+node|z16-|[amenity=parking][parking=street_side][fee?] /*NO-TYPE-MATCH*/,
+area|z16-|[amenity=parking][parking=street_side][fee?] /*NO-TYPE-MATCH*/,
+node|z16-|[amenity=parking][parking=lane][fee?] /*NO-TYPE-MATCH*/,
+area|z16-|[amenity=parking][parking=lane][fee?] /*NO-TYPE-MATCH*/,
 {icon-image: none; icon-min-distance: 0;}
 
-node|z18-[amenity=parking][parking=street_side],
-area|z18-[amenity=parking][parking=street_side],
-node|z18-[amenity=parking][parking=lane],
-area|z18-[amenity=parking][parking=lane],
+node|z18-|amenity-parking-street_side,
+area|z18-|amenity-parking-street_side,
+node|z18-|amenity-parking-lane,
+area|z18-|amenity-parking-lane,
 {icon-image: parking-s.svg;}
 
-node|z18-[amenity=parking][parking=street_side][fee?],
-area|z18-[amenity=parking][parking=street_side][fee?],
-node|z18-[amenity=parking][parking=lane][fee?],
-area|z18-[amenity=parking][parking=lane][fee?],
+node|z18-|[amenity=parking][parking=street_side][fee?] /*NO-TYPE-MATCH*/,
+area|z18-|[amenity=parking][parking=street_side][fee?] /*NO-TYPE-MATCH*/,
+node|z18-|[amenity=parking][parking=lane][fee?] /*NO-TYPE-MATCH*/,
+area|z18-|[amenity=parking][parking=lane][fee?] /*NO-TYPE-MATCH*/,
 {icon-image: parking_pay-s.svg;}
 
-node|z17-[amenity=parking_entrance],
-area|z17-[amenity=parking_entrance],
+node|z17-|amenity-parking_entrance,
+area|z17-|amenity-parking_entrance,
 {icon-image: parking_entrance-m.svg;}
-node|z17-[amenity=parking_entrance][access=private],
-area|z17-[amenity=parking_entrance][access=private],
+node|z17-|amenity-parking_entrance-private,
+area|z17-|amenity-parking_entrance-private,
 {icon-image: none; text: none;}
-node|z19-[amenity=parking_entrance][access=private],
-area|z19-[amenity=parking_entrance][access=private],
+node|z19-|amenity-parking_entrance-private,
+area|z19-|amenity-parking_entrance-private,
 {icon-image: parking_entrance_private-m.svg; text: name;}
 
-node|z18-[amenity=parking][access=private],
-area|z18-[amenity=parking][access=private],
+node|z18-|amenity-parking-private,
+area|z18-|amenity-parking-private,
 /* node|z18-[amenity=parking][access=no], */
 /* area|z18-[amenity=parking][access=no], */
 {icon-image:parking_private-m.svg;}
-node|z18-[amenity=parking][location=underground][access=private],
-area|z18-[amenity=parking][location=underground][access=private],
+node|z18-|amenity-parking-underground-private,
+area|z18-|amenity-parking-underground-private,
 {icon-image:parking_underground_private-m.svg;}
-node|z18-[amenity=parking][parking=street_side][access=private],
-area|z18-[amenity=parking][parking=street_side][access=private],
+node|z18-|amenity-parking-street_side-private,
+area|z18-|amenity-parking-street_side-private,
 {icon-image: parking_private-s.svg;}
-node|z18-[amenity=parking][parking=lane][access=private],
-area|z18-[amenity=parking][parking=lane][access=private],
+node|z18-|amenity-parking-lane-private,
+area|z18-|amenity-parking-lane-private,
 {icon-image: none; text: none;}
-node|z19-[amenity=parking][parking=lane][access=private],
-area|z19-[amenity=parking][parking=lane][access=private],
+node|z19-|amenity-parking-lane-private,
+area|z19-|amenity-parking-lane-private,
 {icon-image: parking_private-s.svg; text: name;}
 
-node|z17-[amenity=bicycle_parking],
-area|z17-[amenity=bicycle_parking],
+node|z17-|amenity-bicycle_parking,
+area|z17-|amenity-bicycle_parking,
 {icon-image: bicycle-parking-m.svg;}
 
-node|z17-[amenity=motorcycle_parking],
-area|z17-[amenity=motorcycle_parking],
+node|z17-|amenity-motorcycle_parking,
+area|z17-|amenity-motorcycle_parking,
 {icon-image: motorcycle-parking-m.svg;}
 
-node|z18-[amenity=parking_space][parking_space=disabled],
-area|z18-[amenity=parking_space][parking_space=disabled],
+node|z18-|amenity-parking_space-disabled,
+area|z18-|amenity-parking_space-disabled,
 {icon-image: parking-disabled-m.svg;}

--- a/data/styles/default/include/Roads.mapcss
+++ b/data/styles/default/include/Roads.mapcss
@@ -51,656 +51,656 @@
 
 /* 2.WORLD LEVEL ROAD 4-9 ZOOM */
 
-line|z6-9[highway=world_towns_level],
-line|z4-9[highway=world_level],
+line|z6-9|highway-world_towns_level,
+line|z4-9|highway-world_level,
 {color: @trunk1;opacity: 1;}
 
-line|z4[highway=world_level]
+line|z4|highway-world_level
 {width: 0.5;}
-line|z5-6[highway=world_level],
+line|z5-6|highway-world_level,
 {width: 0.7;}
-line|z6[highway=world_towns_level],
+line|z6|highway-world_towns_level,
 {width: 0.9;}
-line|z7[highway=world_towns_level],
-line|z7[highway=world_level]
+line|z7|highway-world_towns_level,
+line|z7|highway-world_level
 {width: 0.7;}
-line|z8[highway=world_towns_level],
-line|z8[highway=world_level]
+line|z8|highway-world_towns_level,
+line|z8|highway-world_level
 {width: 0.9;}
-line|z9[highway=world_towns_level],
-line|z9[highway=world_level]
+line|z9|highway-world_towns_level,
+line|z9|highway-world_level
 {width: 0.8;}
 
 /* 3.TRUNK & MOTORWAY 6-22 ZOOM */
 
-line|z6[highway=trunk],
-line|z6[highway=motorway],
+line|z6|highway-trunk,
+line|z6|highway-motorway,
 {color: @trunk0; opacity: 0.3;}
-line|z7-9[highway=trunk],
-line|z7-9[highway=motorway],
+line|z7-9|highway-trunk,
+line|z7-9|highway-motorway,
 {color: @trunk0; opacity: 0.7;}
 
-line|z10-[highway=trunk],
-line|z10-[highway=motorway],
+line|z10-|highway-trunk,
+line|z10-|highway-motorway,
 {color: @trunk1; opacity: 0.7;}
-line|z10-[highway=motorway_link],
-line|z10-[highway=trunk_link],
+line|z10-|highway-motorway_link,
+line|z10-|highway-trunk_link,
 {color: @primary0; opacity: 0.7;}
-line|z13-14[highway=trunk],
-line|z13-14[highway=motorway],
-line|z14-15[highway=motorway_link],
-line|z14-15[highway=trunk_link],
+line|z13-14|highway-trunk,
+line|z13-14|highway-motorway,
+line|z14-15|highway-motorway_link,
+line|z14-15|highway-trunk_link,
 {opacity: 0.85;}
-line|z15-[highway=trunk],
-line|z15-[highway=motorway],
-line|z16-[highway=motorway_link],
-line|z16-[highway=trunk_link],
+line|z15-|highway-trunk,
+line|z15-|highway-motorway,
+line|z16-|highway-motorway_link,
+line|z16-|highway-trunk_link,
 {opacity: 1;}
 
-line|z13-[highway=motorway][bridge?]::bridgewhite,
-line|z13-[highway=trunk][bridge?]::bridgewhite,
-line|z14-[highway=motorway_link][bridge?]::bridgewhite,
-line|z14-[highway=trunk_link][bridge?]::bridgewhite,
+line|z13-|highway-motorway-bridge::bridgewhite,
+line|z13-|highway-trunk-bridge::bridgewhite,
+line|z14-|highway-motorway_link-bridge::bridgewhite,
+line|z14-|highway-trunk_link-bridge::bridgewhite,
 {casing-linecap: butt; casing-color: @bridge_background; casing-opacity: 0.8;}
-line|z13-[highway=motorway][bridge?]::bridgeblack,
-line|z13-[highway=trunk][bridge?]::bridgeblack,
-line|z14-[highway=motorway_link][bridge?]::bridgeblack,
-line|z14-[highway=trunk_link][bridge?]::bridgeblack,
+line|z13-|highway-motorway-bridge::bridgeblack,
+line|z13-|highway-trunk-bridge::bridgeblack,
+line|z14-|highway-motorway_link-bridge::bridgeblack,
+line|z14-|highway-trunk_link-bridge::bridgeblack,
 {casing-linecap: butt; casing-color: @bridge_casing; casing-opacity: 0.7;}
 
 /* 3.1 Trunk & Motorway 6-22 ZOOM */
 
-line|z6[highway=trunk],
-line|z6[highway=motorway],
+line|z6|highway-trunk,
+line|z6|highway-motorway,
 {width: 0.8;}
-line|z7[highway=trunk],
-line|z7[highway=motorway]
+line|z7|highway-trunk,
+line|z7|highway-motorway
 {width: 0.9;}
-line|z8[highway=trunk],
-line|z8[highway=motorway]
+line|z8|highway-trunk,
+line|z8|highway-motorway
 {width: 1.1;}
-line|z9[highway=trunk],
-line|z9[highway=motorway]
+line|z9|highway-trunk,
+line|z9|highway-motorway
 {width: 1.2;}
-line|z10[highway=trunk],
-line|z10[highway=motorway]
+line|z10|highway-trunk,
+line|z10|highway-motorway
 {width: 1.5;}
-line|z11[highway=trunk],
-line|z11[highway=motorway]
+line|z11|highway-trunk,
+line|z11|highway-motorway
 {width: 1.7;}
-line|z12[highway=trunk],
-line|z12[highway=motorway]
+line|z12|highway-trunk,
+line|z12|highway-motorway
 {width: 1.9;}
-line|z13[highway=trunk],
-line|z13[highway=motorway],
+line|z13|highway-trunk,
+line|z13|highway-motorway,
 {width: 2.8;}
-line|z14[highway=trunk],
-line|z14[highway=motorway],
+line|z14|highway-trunk,
+line|z14|highway-motorway,
 {width: 3.8;}
-line|z15[highway=trunk],
-line|z15[highway=motorway],
+line|z15|highway-trunk,
+line|z15|highway-motorway,
 {width: 4.4;}
-line|z16[highway=trunk],
-line|z16[highway=motorway],
+line|z16|highway-trunk,
+line|z16|highway-motorway,
 {width: 6;}
-line|z17[highway=trunk],
-line|z17[highway=motorway],
+line|z17|highway-trunk,
+line|z17|highway-motorway,
 {width: 8.2;}
-line|z18[highway=trunk],
-line|z18[highway=motorway],
+line|z18|highway-trunk,
+line|z18|highway-motorway,
 {width: 11;}
-line|z19-[highway=trunk],
-line|z19-[highway=motorway],
+line|z19-|highway-trunk,
+line|z19-|highway-motorway,
 {width: 13.5;}
 
-line|z10[highway=motorway_link],
-line|z10[highway=trunk_link]
+line|z10|highway-motorway_link,
+line|z10|highway-trunk_link
 {width: 0.8;}
-line|z11[highway=motorway_link],
-line|z11[highway=trunk_link]
+line|z11|highway-motorway_link,
+line|z11|highway-trunk_link
 {width: 1.0;}
-line|z12[highway=motorway_link],
-line|z12[highway=trunk_link]
+line|z12|highway-motorway_link,
+line|z12|highway-trunk_link
 {width: 1.3;}
-line|z13[highway=motorway_link],
-line|z13[highway=trunk_link]
+line|z13|highway-motorway_link,
+line|z13|highway-trunk_link
 {width: 1.8;}
-line|z14[highway=motorway_link],
-line|z14[highway=trunk_link]
+line|z14|highway-motorway_link,
+line|z14|highway-trunk_link
 {width: 2.6;}
-line|z15[highway=motorway_link],
-line|z15[highway=trunk_link]
+line|z15|highway-motorway_link,
+line|z15|highway-trunk_link
 {width: 3.6;}
-line|z16[highway=motorway_link],
-line|z16[highway=trunk_link]
+line|z16|highway-motorway_link,
+line|z16|highway-trunk_link
 {width: 5;}
-line|z17[highway=motorway_link],
-line|z17[highway=trunk_link]
+line|z17|highway-motorway_link,
+line|z17|highway-trunk_link
 {width: 6.6;}
-line|z18[highway=motorway_link],
-line|z18[highway=trunk_link]
+line|z18|highway-motorway_link,
+line|z18|highway-trunk_link
 {width: 9.4;}
-line|z19-[highway=motorway_link],
-line|z19-[highway=trunk_link]
+line|z19-|highway-motorway_link,
+line|z19-|highway-trunk_link
 {width: 11.6;}
 
 /* 3.2 Trunk & Motorway tunnel 12-22 ZOOM */
 
-line|z12-[highway=motorway][tunnel?],
-line|z12-[highway=trunk][tunnel?],
-line|z13-[highway=motorway_link][tunnel?],
-line|z13-[highway=trunk_link][tunnel?],
+line|z12-|highway-motorway-tunnel,
+line|z12-|highway-trunk-tunnel,
+line|z13-|highway-motorway_link-tunnel,
+line|z13-|highway-trunk_link-tunnel,
 {color: @trunk_tunnel; casing-linecap: butt; casing-color: @trunk_tunnel_casing; casing-opacity: 0.7;}
 
-line|z12[highway=motorway][tunnel?],
-line|z12[highway=trunk][tunnel?],
+line|z12|highway-motorway-tunnel,
+line|z12|highway-trunk-tunnel,
 {opacity: 0.9; casing-width: 0.5; casing-dashes: 2,2;}
-line|z13-14[highway=motorway][tunnel?],
-line|z13-14[highway=trunk][tunnel?],
-line|z13-14[highway=motorway_link][tunnel?],
-line|z13-14[highway=trunk_link][tunnel?],
+line|z13-14|highway-motorway-tunnel,
+line|z13-14|highway-trunk-tunnel,
+line|z13-14|highway-motorway_link-tunnel,
+line|z13-14|highway-trunk_link-tunnel,
 {opacity: 0.8; casing-width: 0.8; casing-dashes: 4,4;}
-line|z15-[highway=motorway][tunnel?],
-line|z15-[highway=trunk][tunnel?],
-line|z15-[highway=motorway_link][tunnel?],
-line|z15-[highway=trunk_link][tunnel?],
+line|z15-|highway-motorway-tunnel,
+line|z15-|highway-trunk-tunnel,
+line|z15-|highway-motorway_link-tunnel,
+line|z15-|highway-trunk_link-tunnel,
 {opacity: 0.7; casing-width: 1; casing-dashes: 5,5;}
 
 /* 3.3 Trunk & Motorway bridge 13-22 ZOOM */
 
-line|z13[highway=motorway][bridge?]::bridgewhite,
-line|z13[highway=trunk][bridge?]::bridgewhite
+line|z13|highway-motorway-bridge::bridgewhite,
+line|z13|highway-trunk-bridge::bridgewhite
 {casing-width-add: 0.2;}
-line|z14-16[highway=motorway][bridge?]::bridgewhite,
-line|z14-16[highway=trunk][bridge?]::bridgewhite,
-line|z14-16[highway=motorway_link][bridge?]::bridgewhite,
-line|z14-16[highway=trunk_link][bridge?]::bridgewhite,
+line|z14-16|highway-motorway-bridge::bridgewhite,
+line|z14-16|highway-trunk-bridge::bridgewhite,
+line|z14-16|highway-motorway_link-bridge::bridgewhite,
+line|z14-16|highway-trunk_link-bridge::bridgewhite,
 {casing-width-add: 0;}
-line|z17[highway=motorway][bridge?]::bridgewhite,
-line|z17[highway=trunk][bridge?]::bridgewhite,
-line|z17[highway=motorway_link][bridge?]::bridgewhite,
-line|z17[highway=trunk_link][bridge?]::bridgewhite,
+line|z17|highway-motorway-bridge::bridgewhite,
+line|z17|highway-trunk-bridge::bridgewhite,
+line|z17|highway-motorway_link-bridge::bridgewhite,
+line|z17|highway-trunk_link-bridge::bridgewhite,
 {casing-width-add: 0.8;}
-line|z18-[highway=motorway][bridge?]::bridgewhite,
-line|z18-[highway=trunk][bridge?]::bridgewhite,
-line|z18-[highway=motorway_link][bridge?]::bridgewhite,
-line|z18-[highway=trunk_link][bridge?]::bridgewhite,
+line|z18-|highway-motorway-bridge::bridgewhite,
+line|z18-|highway-trunk-bridge::bridgewhite,
+line|z18-|highway-motorway_link-bridge::bridgewhite,
+line|z18-|highway-trunk_link-bridge::bridgewhite,
 {casing-width-add: 1;}
 
-line|z13-16[highway=motorway][bridge?]::bridgeblack,
-line|z13-16[highway=trunk][bridge?]::bridgeblack,
-line|z14-16[highway=motorway_link][bridge?]::bridgeblack,
-line|z14-16[highway=trunk_link][bridge?]::bridgeblack
+line|z13-16|highway-motorway-bridge::bridgeblack,
+line|z13-16|highway-trunk-bridge::bridgeblack,
+line|z14-16|highway-motorway_link-bridge::bridgeblack,
+line|z14-16|highway-trunk_link-bridge::bridgeblack
 {casing-width-add: 0.4;}
-line|z17[highway=motorway][bridge?]::bridgeblack,
-line|z17[highway=trunk][bridge?]::bridgeblack,
-line|z17[highway=motorway_link][bridge?]::bridgeblack,
-line|z17[highway=trunk_link][bridge?]::bridgeblack
+line|z17|highway-motorway-bridge::bridgeblack,
+line|z17|highway-trunk-bridge::bridgeblack,
+line|z17|highway-motorway_link-bridge::bridgeblack,
+line|z17|highway-trunk_link-bridge::bridgeblack
 {casing-width-add: 1.6;}
-line|z18-[highway=motorway][bridge?]::bridgeblack,
-line|z18-[highway=trunk][bridge?]::bridgeblack,
-line|z18-[highway=motorway_link][bridge?]::bridgeblack,
-line|z18-[highway=trunk_link][bridge?]::bridgeblack
+line|z18-|highway-motorway-bridge::bridgeblack,
+line|z18-|highway-trunk-bridge::bridgeblack,
+line|z18-|highway-motorway_link-bridge::bridgeblack,
+line|z18-|highway-trunk_link-bridge::bridgeblack
 {casing-width-add: 2;}
 
 /* 4.PRIMARY 8-22 ZOOM */
 
-line|z8-10[highway=primary],
+line|z8-10|highway-primary,
 {color: @primary0; opacity: 0.7;}
 
-line|z11-12[highway=primary],
-line|z11-12[highway=primary_link]
+line|z11-12|highway-primary,
+line|z11-12|highway-primary_link
 {color: @primary1; opacity: 0.7;}
-line|z13-14[highway=primary],
-line|z13-14[highway=primary_link],
+line|z13-14|highway-primary,
+line|z13-14|highway-primary_link,
 {color: @primary1; opacity: 0.85;}
-line|z15-[highway=primary],
-line|z15-[highway=primary_link],
+line|z15-|highway-primary,
+line|z15-|highway-primary_link,
 {color: @primary2; opacity: 1;}
 
-line|z14-[highway=primary][bridge?]::bridgewhite,
-line|z14-[highway=primary_link][bridge?]::bridgewhite,
+line|z14-|highway-primary-bridge::bridgewhite,
+line|z14-|highway-primary_link-bridge::bridgewhite,
 {casing-linecap: butt;casing-color:@bridge_background;casing-opacity: 0.8;}
-line|z14-[highway=primary][bridge?]::bridgeblack,
-line|z14-[highway=primary_link][bridge?]::bridgeblack,
+line|z14-|highway-primary-bridge::bridgeblack,
+line|z14-|highway-primary_link-bridge::bridgeblack,
 {casing-linecap: butt;casing-color:@bridge_casing;casing-opacity: 0.7;}
 
 /* 4.1 Primary 8-22 ZOOM */
 
-line|z8[highway=primary],
+line|z8|highway-primary,
 {width: 0.7;}
-line|z9[highway=primary],
+line|z9|highway-primary,
 {width: 0.8;}
-line|z10[highway=primary],
+line|z10|highway-primary,
 {width: 1.2;}
-line|z11[highway=primary],
+line|z11|highway-primary,
 {width: 1.5;}
-line|z12[highway=primary],
+line|z12|highway-primary,
 {width: 1.7;}
-line|z13[highway=primary],
+line|z13|highway-primary,
 {width: 2.3;}
-line|z14[highway=primary],
+line|z14|highway-primary,
 {width: 3.2;}
-line|z15[highway=primary],
+line|z15|highway-primary,
 {width: 3.8;}
-line|z16[highway=primary],
+line|z16|highway-primary,
 {width: 5;}
-line|z17[highway=primary],
+line|z17|highway-primary,
 {width: 6.6;}
-line|z18[highway=primary],
+line|z18|highway-primary,
 {width: 9.4;}
-line|z19-[highway=primary],
+line|z19-|highway-primary,
 {width: 11.6;}
 
-line|z11[highway=primary_link],
+line|z11|highway-primary_link,
 {width: 0.8;}
-line|z12[highway=primary_link],
+line|z12|highway-primary_link,
 {width: 1.0;}
-line|z13[highway=primary_link],
+line|z13|highway-primary_link,
 {width: 1.3;}
-line|z14[highway=primary_link],
+line|z14|highway-primary_link,
 {width: 1.8;}
-line|z15[highway=primary_link],
+line|z15|highway-primary_link,
 {width: 2.5;}
-line|z16[highway=primary_link],
+line|z16|highway-primary_link,
 {width: 3.2;}
-line|z17[highway=primary_link],
+line|z17|highway-primary_link,
 {width: 4.7;}
-line|z18[highway=primary_link],
+line|z18|highway-primary_link,
 {width: 6.4;}
-line|z19-[highway=primary_link],
+line|z19-|highway-primary_link,
 {width: 8.2;}
 
 /* 4.2 Primary tunnel 14-22 ZOOM */
 
-line|z14-[highway=primary][tunnel?],
-line|z14-[highway=primary_link][tunnel?],
+line|z14-|highway-primary-tunnel,
+line|z14-|highway-primary_link-tunnel,
 {color: @primary_tunnel; casing-linecap: butt; casing-color: @primary_tunnel_casing; casing-opacity: 0.7;}
 
-line|z14[highway=primary][tunnel?],
-line|z14[highway=primary_link][tunnel?],
+line|z14|highway-primary-tunnel,
+line|z14|highway-primary_link-tunnel,
 {opacity: 0.8; casing-width: 0.8; casing-dashes: 4,4;}
-line|z15-[highway=primary][tunnel?],
-line|z15-[highway=primary_link][tunnel?],
+line|z15-|highway-primary-tunnel,
+line|z15-|highway-primary_link-tunnel,
 {opacity: 0.7; casing-width: 1; casing-dashes: 5,5;}
 
 /* 4.3 Primary bridge 14-22 ZOOM */
 
-line|z14-16[highway=primary][bridge?]::bridgewhite,
-line|z14-16[highway=primary_link][bridge?]::bridgewhite,
+line|z14-16|highway-primary-bridge::bridgewhite,
+line|z14-16|highway-primary_link-bridge::bridgewhite,
 {casing-width-add: 0;}
-line|z17[highway=primary][bridge?]::bridgewhite,
-line|z17[highway=primary_link][bridge?]::bridgewhite,
+line|z17|highway-primary-bridge::bridgewhite,
+line|z17|highway-primary_link-bridge::bridgewhite,
 {casing-width-add: 0.8;}
-line|z18-[highway=primary][bridge?]::bridgewhite,
-line|z18-[highway=primary_link][bridge?]::bridgewhite,
+line|z18-|highway-primary-bridge::bridgewhite,
+line|z18-|highway-primary_link-bridge::bridgewhite,
 {casing-width-add: 1;}
 
-line|z14-16[highway=primary][bridge?]::bridgeblack,
-line|z14-16[highway=primary_link][bridge?]::bridgeblack,
+line|z14-16|highway-primary-bridge::bridgeblack,
+line|z14-16|highway-primary_link-bridge::bridgeblack,
 {casing-width-add: 0.4;}
-line|z17[highway=primary][bridge?]::bridgeblack,
-line|z17[highway=primary_link][bridge?]::bridgeblack,
+line|z17|highway-primary-bridge::bridgeblack,
+line|z17|highway-primary_link-bridge::bridgeblack,
 {casing-width-add: 1.6;}
-line|z18-[highway=primary][bridge?]::bridgeblack,
-line|z18-[highway=primary_link][bridge?]::bridgeblack,
+line|z18-|highway-primary-bridge::bridgeblack,
+line|z18-|highway-primary_link-bridge::bridgeblack,
 {casing-width-add: 2;}
 
 /* 5.SECONDARY 10-22 ZOOM */
 
-line|z10-12[highway=secondary],
+line|z10-12|highway-secondary,
 {color: @secondary0; opacity: 0.8;}
-line|z13-14[highway=secondary],
-line|z13-14[highway=secondary_link],
+line|z13-14|highway-secondary,
+line|z13-14|highway-secondary_link,
 {color: @secondary1; opacity: 0.9;}
-line|z15-[highway=secondary],
-line|z15-[highway=secondary_link],
+line|z15-|highway-secondary,
+line|z15-|highway-secondary_link,
 {color: @secondary1; opacity: 1;}
 
-line|z14-[highway=secondary][bridge?]::bridgewhite,
-line|z14-[highway=secondary_link][bridge?]::bridgewhite,
+line|z14-|highway-secondary-bridge::bridgewhite,
+line|z14-|highway-secondary_link-bridge::bridgewhite,
 {casing-linecap: butt;casing-color:@bridge_background;casing-opacity: 0.8;}
-line|z14-[highway=secondary][bridge?]::bridgeblack,
-line|z14-[highway=secondary_link][bridge?]::bridgeblack,
+line|z14-|highway-secondary-bridge::bridgeblack,
+line|z14-|highway-secondary_link-bridge::bridgeblack,
 {casing-linecap: butt;casing-color:@bridge_casing;casing-opacity: 0.7;}
 
 /* 5.1 Secondary 10-22 ZOOM */
 
-line|z10[highway=secondary],
+line|z10|highway-secondary,
 {width: 1.2;}
-line|z11[highway=secondary],
+line|z11|highway-secondary,
 {width: 1.5;}
-line|z12[highway=secondary],
+line|z12|highway-secondary,
 {width: 1.7;}
-line|z13[highway=secondary],
+line|z13|highway-secondary,
 {width: 2.3;}
-line|z14[highway=secondary],
+line|z14|highway-secondary,
 {width: 3.2;}
-line|z15[highway=secondary],
+line|z15|highway-secondary,
 {width: 3.8;}
-line|z16[highway=secondary],
+line|z16|highway-secondary,
 {width: 5;}
-line|z17[highway=secondary],
+line|z17|highway-secondary,
 {width: 6.6;}
-line|z18[highway=secondary],
+line|z18|highway-secondary,
 {width: 9.4;}
-line|z19-[highway=secondary],
+line|z19-|highway-secondary,
 {width: 11.6;}
 
-line|z13[highway=secondary_link],
+line|z13|highway-secondary_link,
 {width: 1.3;}
-line|z14[highway=secondary_link],
+line|z14|highway-secondary_link,
 {width: 1.8;}
-line|z15[highway=secondary_link],
+line|z15|highway-secondary_link,
 {width: 2.5;}
-line|z16[highway=secondary_link],
+line|z16|highway-secondary_link,
 {width: 3.2;}
-line|z17[highway=secondary_link],
+line|z17|highway-secondary_link,
 {width: 4.7;}
-line|z18[highway=secondary_link],
+line|z18|highway-secondary_link,
 {width: 6.4;}
-line|z19-[highway=secondary_link],
+line|z19-|highway-secondary_link,
 {width: 8.2;}
 
 /* 5.2 Secondary tunnel 16-22 ZOOM */
 
-line|z16-[highway=secondary][tunnel?],
-line|z16-[highway=secondary_link][tunnel?],
+line|z16-|highway-secondary-tunnel,
+line|z16-|highway-secondary_link-tunnel,
 {opacity: 0.7; casing-width: 1; casing-dashes: 5,5; color: @secondary_tunnel; casing-linecap: butt; casing-color: @secondary_tunnel_casing; casing-opacity: 0.7;}
 
 /* 5.3 Secondary bridge 14-22 ZOOM */
 
-line|z14-16[highway=secondary][bridge?]::bridgewhite,
-line|z14-16[highway=secondary_link][bridge?]::bridgewhite,
+line|z14-16|highway-secondary-bridge::bridgewhite,
+line|z14-16|highway-secondary_link-bridge::bridgewhite,
 {casing-width-add: 0;}
-line|z17[highway=secondary][bridge?]::bridgewhite,
-line|z17[highway=secondary_link][bridge?]::bridgewhite,
+line|z17|highway-secondary-bridge::bridgewhite,
+line|z17|highway-secondary_link-bridge::bridgewhite,
 {casing-width-add: 0.8;}
-line|z18-[highway=secondary][bridge?]::bridgewhite,
-line|z18-[highway=secondary_link][bridge?]::bridgewhite,
+line|z18-|highway-secondary-bridge::bridgewhite,
+line|z18-|highway-secondary_link-bridge::bridgewhite,
 {casing-width-add: 1;}
 
-line|z14-16[highway=secondary][bridge?]::bridgeblack,
-line|z14-16[highway=secondary_link][bridge?]::bridgeblack,
+line|z14-16|highway-secondary-bridge::bridgeblack,
+line|z14-16|highway-secondary_link-bridge::bridgeblack,
 {casing-width-add: 0.4;}
-line|z17[highway=secondary][bridge?]::bridgeblack,
-line|z17[highway=secondary_link][bridge?]::bridgeblack,
+line|z17|highway-secondary-bridge::bridgeblack,
+line|z17|highway-secondary_link-bridge::bridgeblack,
 {casing-width-add: 1.6;}
-line|z18-[highway=secondary][bridge?]::bridgeblack,
-line|z18-[highway=secondary_link][bridge?]::bridgeblack
+line|z18-|highway-secondary-bridge::bridgeblack,
+line|z18-|highway-secondary_link-bridge::bridgeblack
 {casing-width-add: 2;}
 
 /* 6.TERTIARY & UNCLASSIFIED 11-22 ZOOM */
 
-line|z11-[highway=tertiary],
-line|z11-[highway=unclassified],
-line|z14-[highway=tertiary_link],
+line|z11-|highway-tertiary,
+line|z11-|highway-unclassified,
+line|z14-|highway-tertiary_link,
 {color: @tertiary; opacity: 0.7;}
-line|z14-15[highway=tertiary],
-line|z14-15[highway=unclassified],
-line|z15-16[highway=tertiary_link],
+line|z14-15|highway-tertiary,
+line|z14-15|highway-unclassified,
+line|z15-16|highway-tertiary_link,
 {opacity: 0.85;}
-line|z16-[highway=tertiary],
-line|z16-[highway=unclassified],
-line|z17-[highway=tertiary_link],
+line|z16-|highway-tertiary,
+line|z16-|highway-unclassified,
+line|z17-|highway-tertiary_link,
 {opacity: 1;}
 
-line|z14-[highway=tertiary][bridge?]::bridgewhite,
-line|z14-[highway=tertiary_link][bridge?]::bridgewhite
-line|z14-[highway=unclassified][bridge?]::bridgewhite,
+line|z14-|highway-tertiary-bridge::bridgewhite,
+line|z14-|highway-tertiary_link-bridge::bridgewhite
+line|z14-|highway-unclassified-bridge::bridgewhite,
 {casing-linecap: butt;casing-color:@bridge_background;casing-opacity: 0.8;}
-line|z14-[highway=tertiary][bridge?]::bridgeblack,
-line|z14-[highway=tertiary_link][bridge?]::bridgeblack
-line|z14-[highway=unclassified][bridge?]::bridgeblack,
+line|z14-|highway-tertiary-bridge::bridgeblack,
+line|z14-|highway-tertiary_link-bridge::bridgeblack
+line|z14-|highway-unclassified-bridge::bridgeblack,
 {casing-linecap: butt;casing-color:@bridge_casing;casing-opacity: 0.7;}
 
 /* 6.1 Tertiary & Unclassified 11-22 ZOOM */
 
-line|z11[highway=tertiary],
-line|z11[highway=unclassified],
+line|z11|highway-tertiary,
+line|z11|highway-unclassified,
 {width: 0.8;}
-line|z12[highway=tertiary],
-line|z12[highway=unclassified],
+line|z12|highway-tertiary,
+line|z12|highway-unclassified,
 {width: 1.3;}
-line|z13[highway=tertiary],
-line|z13[highway=unclassified],
+line|z13|highway-tertiary,
+line|z13|highway-unclassified,
 {width: 1.8;}
-line|z14[highway=tertiary],
-line|z14[highway=unclassified],
+line|z14|highway-tertiary,
+line|z14|highway-unclassified,
 {width: 2.7;}
-line|z15[highway=tertiary],
-line|z15[highway=unclassified],
+line|z15|highway-tertiary,
+line|z15|highway-unclassified,
 {width: 3.8;}
-line|z16[highway=tertiary],
-line|z16[highway=unclassified],
+line|z16|highway-tertiary,
+line|z16|highway-unclassified,
 {width: 5;}
-line|z17[highway=tertiary],
-line|z17[highway=unclassified],
+line|z17|highway-tertiary,
+line|z17|highway-unclassified,
 {width: 6.6;}
-line|z18[highway=tertiary],
-line|z18[highway=unclassified],
+line|z18|highway-tertiary,
+line|z18|highway-unclassified,
 {width: 9.4;}
-line|z19-[highway=tertiary],
-line|z19-[highway=unclassified],
+line|z19-|highway-tertiary,
+line|z19-|highway-unclassified,
 {width: 11.6;}
 
-line|z14[highway=tertiary_link],
+line|z14|highway-tertiary_link,
 {width: 1.8;}
-line|z15[highway=tertiary_link],
+line|z15|highway-tertiary_link,
 {width: 2.5;}
-line|z16[highway=tertiary_link],
+line|z16|highway-tertiary_link,
 {width: 3.2;}
-line|z17[highway=tertiary_link],
+line|z17|highway-tertiary_link,
 {width: 4.7;}
-line|z18[highway=tertiary_link],
+line|z18|highway-tertiary_link,
 {width: 6.4;}
-line|z19-[highway=tertiary_link],
+line|z19-|highway-tertiary_link,
 {width: 8.2;}
 
 /* 6.2 Tertiary & Unclassified tunnel 16-22 ZOOM */
 
-line|z16-[highway=tertiary][tunnel?],
-line|z16-[highway=tertiary_link][tunnel?],
-line|z16-[highway=unclassified][tunnel?],
+line|z16-|highway-tertiary-tunnel,
+line|z16-|highway-tertiary_link-tunnel,
+line|z16-|highway-unclassified-tunnel,
 {opacity: 0.7; casing-width: 1; casing-dashes: 5,5; color: @tertiary_tunnel; casing-linecap: butt; casing-color: @tertiary_tunnel_casing; casing-opacity: 0.7;}
 
 /* 6.3 Tertiary & Unclassified bridge 14-22 ZOOM */
 
-line|z14-16[highway=tertiary][bridge?]::bridgewhite,
-line|z14-16[highway=tertiary_link][bridge?]::bridgewhite,
-line|z14-16[highway=unclassified][bridge?]::bridgewhite,
+line|z14-16|highway-tertiary-bridge::bridgewhite,
+line|z14-16|highway-tertiary_link-bridge::bridgewhite,
+line|z14-16|highway-unclassified-bridge::bridgewhite,
 {casing-width-add: 0;}
-line|z17[highway=tertiary][bridge?]::bridgewhite,
-line|z17[highway=tertiary_link][bridge?]::bridgewhite,
-line|z17[highway=unclassified][bridge?]::bridgewhite,
+line|z17|highway-tertiary-bridge::bridgewhite,
+line|z17|highway-tertiary_link-bridge::bridgewhite,
+line|z17|highway-unclassified-bridge::bridgewhite,
 {casing-width-add: 0.8;}
-line|z18-[highway=tertiary][bridge?]::bridgewhite,
-line|z18-[highway=tertiary_link][bridge?]::bridgewhite,
-line|z18-[highway=unclassified][bridge?]::bridgewhite,
+line|z18-|highway-tertiary-bridge::bridgewhite,
+line|z18-|highway-tertiary_link-bridge::bridgewhite,
+line|z18-|highway-unclassified-bridge::bridgewhite,
 {casing-width-add: 1;}
 
-line|z14-16[highway=tertiary][bridge?]::bridgeblack,
-line|z14-16[highway=tertiary_link][bridge?]::bridgeblack,
-line|z14-16[highway=unclassified][bridge?]::bridgeblack,
+line|z14-16|highway-tertiary-bridge::bridgeblack,
+line|z14-16|highway-tertiary_link-bridge::bridgeblack,
+line|z14-16|highway-unclassified-bridge::bridgeblack,
 {casing-width-add: 0.4;}
-line|z17[highway=tertiary][bridge?]::bridgeblack,
-line|z17[highway=tertiary_link][bridge?]::bridgeblack,
-line|z17[highway=unclassified][bridge?]::bridgeblack,
+line|z17|highway-tertiary-bridge::bridgeblack,
+line|z17|highway-tertiary_link-bridge::bridgeblack,
+line|z17|highway-unclassified-bridge::bridgeblack,
 {casing-width-add: 1.6;}
-line|z18-[highway=tertiary][bridge?]::bridgeblack,
-line|z18-[highway=tertiary_link][bridge?]::bridgeblack,
-line|z18-[highway=unclassified][bridge?]::bridgeblack,
+line|z18-|highway-tertiary-bridge::bridgeblack,
+line|z18-|highway-tertiary_link-bridge::bridgeblack,
+line|z18-|highway-unclassified-bridge::bridgeblack,
 {casing-width-add: 2;}
 
 /* 7.RESIDENTIAL, ROAD, STREETS & SERVICE 12-22 ZOOM */
 
-line|z12-[highway=residential],
-line|z12-[highway=road],
-line|z12-[highway=living_street],
+line|z12-|highway-residential,
+line|z12-|highway-road,
+line|z12-|highway-living_street,
 {color: @residential; opacity: 0.7;}
-line|z14-16[highway=residential],
-line|z14-16[highway=road],
-line|z14-16[highway=living_street],
+line|z14-16|highway-residential,
+line|z14-16|highway-road,
+line|z14-16|highway-living_street,
 {opacity: 0.85;}
-line|z17-[highway=residential],
-line|z17-[highway=road],
-line|z17-[highway=living_street],
+line|z17-|highway-residential,
+line|z17-|highway-road,
+line|z17-|highway-living_street,
 {opacity: 1;}
 
-line|z14-[highway=residential][bridge?]::bridgewhite,
+line|z14-|highway-residential-bridge::bridgewhite,
 {casing-linecap: butt;casing-color:@bridge_background;casing-opacity: 0.8;}
-line|z14-[highway=residential][bridge?]::bridgeblack,
+line|z14-|highway-residential-bridge::bridgeblack,
 {casing-linecap: butt;casing-color:@bridge_casing;casing-opacity: 0.7;}
 
 /* 7.1 Residential, Road, Street 12-22 ZOOM */
 
-line|z12[highway=residential],
-line|z12[highway=road],
-line|z12[highway=living_street]
+line|z12|highway-residential,
+line|z12|highway-road,
+line|z12|highway-living_street
 {width: 0.7;}
-line|z13[highway=residential],
-line|z13[highway=road],
-line|z13[highway=living_street]
+line|z13|highway-residential,
+line|z13|highway-road,
+line|z13|highway-living_street
 {width: 1;}
-line|z14[highway=residential],
-line|z14[highway=road],
-line|z14[highway=living_street]
+line|z14|highway-residential,
+line|z14|highway-road,
+line|z14|highway-living_street
 {width: 1.6;}
-line|z15[highway=residential],
-line|z15[highway=road],
-line|z15[highway=living_street]
+line|z15|highway-residential,
+line|z15|highway-road,
+line|z15|highway-living_street
 {width: 2.4;}
-line|z16[highway=residential],
-line|z16[highway=road],
-line|z16[highway=living_street]
+line|z16|highway-residential,
+line|z16|highway-road,
+line|z16|highway-living_street
 {width: 3.2;}
-line|z17[highway=residential],
-line|z17[highway=road],
-line|z17[highway=living_street]
+line|z17|highway-residential,
+line|z17|highway-road,
+line|z17|highway-living_street
 {width: 4.7;}
-line|z18[highway=residential],
-line|z18[highway=road],
-line|z18[highway=living_street]
+line|z18|highway-residential,
+line|z18|highway-road,
+line|z18|highway-living_street
 {width: 6.4;}
-line|z19-[highway=residential],
-line|z19-[highway=road],
-line|z19-[highway=living_street]
+line|z19-|highway-residential,
+line|z19-|highway-road,
+line|z19-|highway-living_street
 {width: 8.2;}
 
 /* 7.2 Residential, Road, Street tunnel 16-22 ZOOM */
 
-line|z16-[highway=residential][tunnel?],
-line|z16-[highway=living_street][tunnel?],
+line|z16-|highway-residential-tunnel,
+line|z16-|highway-living_street-tunnel,
 {opacity: 0.7; casing-width: 1; casing-dashes: 5,5; color: @residential_tunnel; casing-linecap: butt; casing-color: @residential_tunnel_casing; casing-opacity: 0.7;}
 
 /* 7.3 Residential, Road, Street bridge 14-22 ZOOM */
 
-line|z14-16[highway=residential][bridge?]::bridgewhite,
+line|z14-16|highway-residential-bridge::bridgewhite,
 {casing-width-add: 0;}
-line|z17[highway=residential][bridge?]::bridgewhite,
+line|z17|highway-residential-bridge::bridgewhite,
 {casing-width-add: 0.8;}
-line|z18-[highway=residential][bridge?]::bridgewhite,
+line|z18-|highway-residential-bridge::bridgewhite,
 {casing-width-add: 1;}
 
-line|z14-16[highway=residential][bridge?]::bridgeblack,
+line|z14-16|highway-residential-bridge::bridgeblack,
 {casing-width-add: 0.4;}
-line|z17[highway=residential][bridge?]::bridgeblack,
+line|z17|highway-residential-bridge::bridgeblack,
 {casing-width-add: 1.6;}
-line|z18-[highway=residential][bridge?]::bridgeblack,
+line|z18-|highway-residential-bridge::bridgeblack,
 {casing-width-add: 2;}
 
 /* 7.4 Service 15-22 ZOOM */
 
-line|z15-[highway=service],
-line|z15-[highway=service][service=busway],
-line|z15-[highway=busway],
+line|z15-|highway-service,
+line|z15-|[highway=service][service=busway] /*NO-TYPE-MATCH*/,
+line|z15-|highway-busway,
 {color: @residential; opacity: 0.8;}
 
-line|z15[highway=service],
-line|z15[highway=service][service=busway],
-line|z15[highway=busway],
+line|z15|highway-service,
+line|z15|[highway=service][service=busway] /*NO-TYPE-MATCH*/,
+line|z15|highway-busway,
 {width: 1.2;}
-line|z15[highway=service][service=driveway]
+line|z15|highway-service-driveway
 {width: 0;}
-line|z16[highway=service],
-line|z16[highway=service][service=busway],
-line|z16[highway=busway],
+line|z16|highway-service,
+line|z16|[highway=service][service=busway] /*NO-TYPE-MATCH*/,
+line|z16|highway-busway,
 {width: 1.6;}
-line|z17[highway=service],
-line|z17[highway=service][service=busway],
-line|z17[highway=busway],
+line|z17|highway-service,
+line|z17|[highway=service][service=busway] /*NO-TYPE-MATCH*/,
+line|z17|highway-busway,
 {width: 2;}
-line|z18[highway=service],
-line|z18[highway=service][service=busway],
-line|z18[highway=busway],
+line|z18|highway-service,
+line|z18|[highway=service][service=busway] /*NO-TYPE-MATCH*/,
+line|z18|highway-busway,
 {width: 3;}
-line|z19-[highway=service],
-line|z19-[highway=service][service=busway],
-line|z19-[highway=busway],
+line|z19-|highway-service,
+line|z19-|[highway=service][service=busway] /*NO-TYPE-MATCH*/,
+line|z19-|highway-busway,
 {width: 4;}
 
 /* 8.OTHERS ROADS 13-22 ZOOM */
 
-line|z13-[highway=pedestrian],
-line|z13-[highway=ford]
+line|z13-|highway-pedestrian,
+line|z13-|highway-ford
 {color: @pedestrian;opacity: 0.85;}
-line|z13-[highway=cycleway],
-line|z14-[highway=path][bicycle=designated]::cycleline,
-line|z15-[highway=footway][bicycle=designated]::cycleline,
+line|z13-|highway-cycleway,
+line|z14-|highway-path-bicycle::cycleline,
+line|z15-|highway-footway-bicycle::cycleline,
 {color: @cycleway;}
-line|z13-[highway=construction],
+line|z13-|highway-construction,
 {color: @construction;opacity: 0.7;}
-line|z13-[highway=pedestrian][bridge?]::bridgewhite,
-line|z15-[highway=footway][bridge?]::bridgewhite,
-line|z15-[highway=cycleway][bridge?]::bridgewhite,
-line|z15-[highway=path][bridge?]::bridgewhite,
-line|z15-[highway=track][bridge?]::bridgewhite,
-line|z15-[highway=bridleway][bridge?]::bridgewhite,
-line|z15-[highway=steps][bridge?]::bridgewhite,
-line|z16-[highway=road][bridge?]::bridgewhite,
-line|z16-[highway=service][bridge?]::bridgewhite
+line|z13-|highway-pedestrian-bridge::bridgewhite,
+line|z15-|highway-footway-bridge::bridgewhite,
+line|z15-|highway-cycleway-bridge::bridgewhite,
+line|z15-|highway-path-bridge::bridgewhite,
+line|z15-|highway-track-bridge::bridgewhite,
+line|z15-|highway-bridleway-bridge::bridgewhite,
+line|z15-|highway-steps-bridge::bridgewhite,
+line|z16-|highway-road-bridge::bridgewhite,
+line|z16-|highway-service-bridge::bridgewhite
 {casing-linecap: butt;casing-color:@bridge_background;casing-opacity: 0.8;}
-line|z13-[highway=pedestrian][bridge?]::bridgeblack,
-line|z17-[highway=footway][bridge?]::bridgeblack,
-line|z17-[highway=cycleway][bridge?]::bridgeblack,
-line|z17-[highway=path][bridge?]::bridgeblack,
-line|z17-[highway=track][bridge?]::bridgeblack,
-line|z17-[highway=bridleway][bridge?]::bridgeblack,
-line|z17-[highway=steps][bridge?]::bridgeblack,
-line|z16-[highway=road][bridge?]::bridgeblack,
-line|z16-[highway=service][bridge?]::bridgeblack
+line|z13-|highway-pedestrian-bridge::bridgeblack,
+line|z17-|highway-footway-bridge::bridgeblack,
+line|z17-|highway-cycleway-bridge::bridgeblack,
+line|z17-|highway-path-bridge::bridgeblack,
+line|z17-|highway-track-bridge::bridgeblack,
+line|z17-|highway-bridleway-bridge::bridgeblack,
+line|z17-|highway-steps-bridge::bridgeblack,
+line|z16-|highway-road-bridge::bridgeblack,
+line|z16-|highway-service-bridge::bridgeblack
 {casing-linecap: butt;casing-color:@bridge_casing;casing-opacity: 0.7;}
-line|z14-[highway=track],
+line|z14-|highway-track,
 {color: @track;opacity: 0.6;}
-line|z14-[highway=raceway],
+line|z14-|highway-raceway,
 {color: @track;opacity: 0.7;}
-line|z15-[leisure=track][!area],
+line|z15-|[leisure=track][!area] /*NO-TYPE-MATCH*/,
 {color: @sport2;opacity: 0.7;}
-line|z14-[highway=bridleway]
+line|z14-|highway-bridleway
 {color: @bridleway;opacity: 0.6;}
-line|z15-[highway=footway],
+line|z15-|highway-footway,
 {color: @footway;opacity: 0.75;}
-line|z15-[highway=steps],
+line|z15-|highway-steps,
 {color: @footway;opacity: 0.85;}
-line|z14-[highway=path],
+line|z14-|highway-path,
 {color: @path;opacity: 0.6;}
-line|z14-[highway=path][_path_grade=expert],
+line|z14-|highway-path-expert,
 {color: @path_expert; opacity: 0.6;}
-line|z14-[piste:type=hike],
+line|z14-|piste:type-hike,
 {color: @piste; opacity: 0.4;}
-line|z17-[highway=footway][tunnel?]::tunnelBackground,
-line|z17-[highway=cycleway][tunnel?]::tunnelBackground,
-line|z17-[highway=path][tunnel?]::tunnelBackground,
-line|z17-[highway=track][tunnel?]::tunnelBackground,
-line|z17-[highway=bridleway][tunnel?]::tunnelBackground,
-line|z17-[highway=steps][tunnel?]::tunnelBackground,
+line|z17-|highway-footway-tunnel::tunnelBackground,
+line|z17-|highway-cycleway-tunnel::tunnelBackground,
+line|z17-|highway-path-tunnel::tunnelBackground,
+line|z17-|highway-track-tunnel::tunnelBackground,
+line|z17-|highway-bridleway-tunnel::tunnelBackground,
+line|z17-|highway-steps-tunnel::tunnelBackground,
 {casing-color: @bridge_background;casing-opacity: 0.7;}
-line|z17-[highway=footway][tunnel?]::tunnelCasing,
-line|z17-[highway=cycleway][tunnel?]::tunnelCasing,
-line|z17-[highway=path][tunnel?]::tunnelCasing,
-line|z17-[highway=track][tunnel?]::tunnelCasing,
-line|z17-[highway=bridleway][tunnel?]::tunnelCasing,
-line|z17-[highway=steps][tunnel?]::tunnelCasing,
+line|z17-|highway-footway-tunnel::tunnelCasing,
+line|z17-|highway-cycleway-tunnel::tunnelCasing,
+line|z17-|highway-path-tunnel::tunnelCasing,
+line|z17-|highway-track-tunnel::tunnelCasing,
+line|z17-|highway-bridleway-tunnel::tunnelCasing,
+line|z17-|highway-steps-tunnel::tunnelCasing,
 {
   casing-color: @bridge_casing;
   casing-dashes: 2,2;
@@ -709,589 +709,589 @@ line|z17-[highway=steps][tunnel?]::tunnelCasing,
 
 /* 8.1 Pedestrian & ford 13-22 ZOOM */
 
-line|z13[highway=pedestrian],
-line|z13[highway=ford]
+line|z13|highway-pedestrian,
+line|z13|highway-ford
 {width: 1;dashes: 2,1;}
-line|z14[highway=pedestrian],
-line|z14[highway=ford]
+line|z14|highway-pedestrian,
+line|z14|highway-ford
 {width: 1.6;dashes: 3.6,1.6;}
-line|z15[highway=pedestrian],
-line|z15[highway=ford]
+line|z15|highway-pedestrian,
+line|z15|highway-ford
 {width: 2;dashes: 5,2.2;}
-line|z16[highway=pedestrian],
-line|z16[highway=ford]
+line|z16|highway-pedestrian,
+line|z16|highway-ford
 {width: 2.4;dashes: 5.4,2.7;}
-line|z17[highway=pedestrian],
-line|z17[highway=ford]
+line|z17|highway-pedestrian,
+line|z17|highway-ford
 {width: 3;dashes: 5,2;}
-line|z18[highway=pedestrian],
-line|z18[highway=ford]
+line|z18|highway-pedestrian,
+line|z18|highway-ford
 {width: 4;dashes: 7,3;opacity: 1;}
-line|z19-[highway=pedestrian],
-line|z19-[highway=ford]
+line|z19-|highway-pedestrian,
+line|z19-|highway-ford
 {width: 5;dashes: 16.2,8.1;opacity: 1;}
 
 /* 8.2 Pedestrian & ford tunnel 16-22 ZOOM */
 
-line|z16-[highway=pedestrian][tunnel?],
+line|z16-|highway-pedestrian-tunnel,
 {opacity: 0.7; casing-width: 1; casing-dashes: 5,5; color: @residential_tunnel; casing-linecap: butt; casing-color: @residential_tunnel_casing; casing-opacity: 0.7;}
 
 /* 8.3 Pedestrian & other brige 13-22 ZOOM */
 
-line|z13[highway=pedestrian][bridge?]::bridgewhite,
+line|z13|highway-pedestrian-bridge::bridgewhite,
 {casing-width-add: -0.2;}
-line|z14-[highway=pedestrian][bridge?]::bridgewhite,
-line|z16-[highway=road][bridge?]::bridgewhite,
-line|z16-[highway=service][bridge?]::bridgewhite
+line|z14-|highway-pedestrian-bridge::bridgewhite,
+line|z16-|highway-road-bridge::bridgewhite,
+line|z16-|highway-service-bridge::bridgewhite
 {casing-width-add: 0;}
-line|z16-[highway=pedestrian][bridge?]::bridgewhite,
+line|z16-|highway-pedestrian-bridge::bridgewhite,
 {casing-width-add: 0.2;}
 
-line|z14-[highway=pedestrian][bridge?]::bridgeblack,
-line|z16-[highway=road][bridge?]::bridgeblack,
-line|z16-[highway=service][bridge?]::bridgeblack
+line|z14-|highway-pedestrian-bridge::bridgeblack,
+line|z16-|highway-road-bridge::bridgeblack,
+line|z16-|highway-service-bridge::bridgeblack
 {casing-width-add: 0.2;}
-line|z16-[highway=pedestrian][bridge?]::bridgeblack,
+line|z16-|highway-pedestrian-bridge::bridgeblack,
 {casing-width-add: 0.6;}
 
 /* 8.4 Cycleway 13-22 ZOOM */
 
-line|z13[highway=cycleway],
+line|z13|highway-cycleway,
 {opacity: 0.3;}
-line|z14[highway=cycleway],
-line|z14[highway=path][bicycle=designated]::cycleline,
+line|z14|highway-cycleway,
+line|z14|highway-path-bicycle::cycleline,
 {opacity: 0.4;}
-line|z15[highway=cycleway],
-line|z15[highway=path][bicycle=designated]::cycleline,
+line|z15|highway-cycleway,
+line|z15|highway-path-bicycle::cycleline,
 {opacity: 0.5;}
-line|z16-17[highway=cycleway],
-line|z16-17[highway=path][bicycle=designated]::cycleline,
+line|z16-17|highway-cycleway,
+line|z16-17|highway-path-bicycle::cycleline,
 {opacity: 0.6;}
-line|z18-[highway=cycleway],
-line|z18-[highway=path][bicycle=designated]::cycleline,
+line|z18-|highway-cycleway,
+line|z18-|highway-path-bicycle::cycleline,
 {opacity: 0.8;}
 
-line|z15-16[highway=footway][bicycle=designated]::cycleline,
+line|z15-16|highway-footway-bicycle::cycleline,
 {opacity: 0.4;}
-line|z17-[highway=footway][bicycle=designated]::cycleline,
+line|z17-|highway-footway-bicycle::cycleline,
 {opacity: 0.5;}
 
-line|z13[highway=cycleway]
+line|z13|highway-cycleway
 {width: 0.9;}
-line|z14[highway=cycleway],
-line|z14[highway=path][bicycle=designated]::cycleline,
+line|z14|highway-cycleway,
+line|z14|highway-path-bicycle::cycleline,
 {width: 1.1;}
-line|z15[highway=cycleway]
-line|z15[highway=footway][bicycle=designated]::cycleline,
-line|z15[highway=path][bicycle=designated]::cycleline,
+line|z15|highway-cycleway,
+line|z15|highway-footway-bicycle::cycleline,
+line|z15|highway-path-bicycle::cycleline,
 {width: 1.2;}
-line|z16[highway=cycleway],
-line|z16[highway=footway][bicycle=designated]::cycleline,
-line|z16[highway=path][bicycle=designated]::cycleline,
+line|z16|highway-cycleway,
+line|z16|highway-footway-bicycle::cycleline,
+line|z16|highway-path-bicycle::cycleline,
 {width: 1.3;}
-line|z17[highway=cycleway],
-line|z17[highway=footway][bicycle=designated]::cycleline,
-line|z17[highway=path][bicycle=designated]::cycleline,
+line|z17|highway-cycleway,
+line|z17|highway-footway-bicycle::cycleline,
+line|z17|highway-path-bicycle::cycleline,
 {width: 1.4;}
-line|z18[highway=cycleway],
-line|z18[highway=footway][bicycle=designated]::cycleline,
-line|z18[highway=path][bicycle=designated]::cycleline,
+line|z18|highway-cycleway,
+line|z18|highway-footway-bicycle::cycleline,
+line|z18|highway-path-bicycle::cycleline,
 {width: 1.6;}
-line|z19-[highway=cycleway],
-line|z19-[highway=footway][bicycle=designated]::cycleline,
-line|z19-[highway=path][bicycle=designated]::cycleline,
+line|z19-|highway-cycleway,
+line|z19-|highway-footway-bicycle::cycleline,
+line|z19-|highway-path-bicycle::cycleline,
 {width: 1.8;}
 
-line|z17[highway=cycleway][tunnel?]::tunnelBackground
+line|z17|highway-cycleway-tunnel::tunnelBackground
 {casing-width-add: 1;}
-line|z18[highway=cycleway][tunnel?]::tunnelBackground
+line|z18|highway-cycleway-tunnel::tunnelBackground
 {casing-width-add: 2;}
-line|z19-[highway=cycleway][tunnel?]::tunnelBackground
+line|z19-|highway-cycleway-tunnel::tunnelBackground
 {casing-width-add: 2.5;}
-line|z17[highway=cycleway][tunnel?]::tunnelCasing
+line|z17|highway-cycleway-tunnel::tunnelCasing
 {casing-width-add: 1.5;}
-line|z18[highway=cycleway][tunnel?]::tunnelCasing
+line|z18|highway-cycleway-tunnel::tunnelCasing
 {casing-width-add: 2.5;}
-line|z19-[highway=cycleway][tunnel?]::tunnelCasing
+line|z19-|highway-cycleway-tunnel::tunnelCasing
 {casing-width-add: 3;}
 
-line|z15-16[highway=cycleway][bridge?]::bridgewhite
+line|z15-16|highway-cycleway-bridge::bridgewhite
 {casing-width-add: 0.5;}
-line|z17[highway=cycleway][bridge?]::bridgewhite
+line|z17|highway-cycleway-bridge::bridgewhite
 {casing-width-add: 1;}
-line|z18[highway=cycleway][bridge?]::bridgewhite
+line|z18|highway-cycleway-bridge::bridgewhite
 {casing-width-add: 2;}
-line|z19-[highway=cycleway][bridge?]::bridgewhite
+line|z19-|highway-cycleway-bridge::bridgewhite
 {casing-width-add: 2.5;}
-line|z17[highway=cycleway][bridge?]::bridgeblack
+line|z17|highway-cycleway-bridge::bridgeblack
 {casing-width-add: 1.5;}
-line|z18[highway=cycleway][bridge?]::bridgeblack
+line|z18|highway-cycleway-bridge::bridgeblack
 {casing-width-add: 2.5;}
-line|z19-[highway=cycleway][bridge?]::bridgeblack
+line|z19-|highway-cycleway-bridge::bridgeblack
 {casing-width-add: 3;}
 
 /* 8.5 Construction 13-22 ZOOM */
 
-line|z13[highway=construction],
+line|z13|highway-construction,
 {width: 1.2;dashes: 3.6,1.8;}
-line|z14[highway=construction],
+line|z14|highway-construction,
 {width: 1.4;dashes: 4.5,1.8;}
-line|z15[highway=construction],
+line|z15|highway-construction,
 {width: 2;dashes: 7.2,2.7;}
-line|z16[highway=construction],
+line|z16|highway-construction,
 {width: 2.6;dashes: 9,3.6;}
-line|z17[highway=construction],
+line|z17|highway-construction,
 {width: 3;dashes: 10.8,4.5;}
-line|z18[highway=construction],
+line|z18|highway-construction,
 {width: 4;dashes: 13.5,5.4;}
-line|z19-[highway=construction],
+line|z19-|highway-construction,
 {width: 6;dashes: 18,6.2;}
 
 /* 8.6 Track & Path 14-22 ZOOM */
 
-line|z14[highway=raceway],
+line|z14|highway-raceway,
 {width: 1;}
-line|z15[highway=raceway],
-line|z15[leisure=track][!area]
+line|z15|highway-raceway,
+line|z15|[leisure=track][!area] /*NO-TYPE-MATCH*/
 {width: 1.5;}
-line|z16[highway=raceway],
-line|z16[leisure=track][!area]
+line|z16|highway-raceway,
+line|z16|[leisure=track][!area] /*NO-TYPE-MATCH*/
 {width: 1.8;}
-line|z17-18[highway=raceway],
-line|z17-18[leisure=track][!area]
+line|z17-18|highway-raceway,
+line|z17-18|[leisure=track][!area] /*NO-TYPE-MATCH*/
 {width:3; opacity: 0.8;}
-line|z19-[highway=raceway],
-line|z19-[leisure=track][!area]
+line|z19-|highway-raceway,
+line|z19-|[leisure=track][!area] /*NO-TYPE-MATCH*/
 {width:4; opacity: 0.8;}
 
-line|z14[highway=track],
+line|z14|highway-track,
 {width: 1.1; dashes: 6,2.5;}
-line|z15[highway=track],
+line|z15|highway-track,
 {width: 1.4; dashes: 6,2.5;}
-line|z16[highway=track],
+line|z16|highway-track,
 {width: 1.9; dashes: 7,3;}
-line|z17[highway=track],
+line|z17|highway-track,
 {width: 2.5; dashes: 7,3;}
-line|z18[highway=track],
+line|z18|highway-track,
 {width: 3.3; dashes: 9,3.5; opacity: 0.8;}
-line|z19-[highway=track],
+line|z19-|highway-track,
 {width: 4.2; dashes: 12,3.5; opacity: 0.8;}
 
-line|z14[highway=path],
-line|z14[piste:type=hike],
+line|z14|highway-path,
+line|z14|piste:type-hike,
 {width: 0.9; dashes: 3.5,2;}
-line|z15[highway=path],
-line|z15[piste:type=hike],
+line|z15|highway-path,
+line|z15|piste:type-hike,
 {width: 1.1; dashes: 3.5,2;}
-line|z16[highway=path],
-line|z16[piste:type=hike],
+line|z16|highway-path,
+line|z16|piste:type-hike,
 {width: 1.5; dashes: 4,2.5;}
-line|z17[highway=path],
-line|z17-[piste:type=hike],
+line|z17|highway-path,
+line|z17-|piste:type-hike,
 {width: 2; dashes: 4,2.5;}
-line|z18[highway=path],
+line|z18|highway-path,
 {width: 2.8; dashes: 6,3.5; opacity: 0.8;}
-line|z19-[highway=path],
+line|z19-|highway-path,
 {width: 3.7; dashes: 8,4.5; opacity: 0.8;}
 
-line|z14[highway=path][bicycle=designated],
+line|z14|highway-path-bicycle,
 {width: 0.9; dashes: 3.5,2.7;}
-line|z15[highway=path][bicycle=designated],
+line|z15|highway-path-bicycle,
 {width: 1.1; dashes: 3.5,2.7;}
-line|z16[highway=path][bicycle=designated],
+line|z16|highway-path-bicycle,
 {width: 1.5; dashes: 4,3.2;}
-line|z17[highway=path][bicycle=designated],
+line|z17|highway-path-bicycle,
 {width: 2; dashes: 4,3.2;}
-line|z18[highway=path][bicycle=designated],
+line|z18|highway-path-bicycle,
 {width: 2.8; dashes: 6,4.7; opacity: 0.8;}
-line|z19-[highway=path][bicycle=designated],
+line|z19-|highway-path-bicycle,
 {width: 3.7; dashes: 8,6.2; opacity: 0.8;}
 
-line|z14[highway=path][_path_grade=difficult],
+line|z14|highway-path-difficult,
 {width: 0.9; dashes: 1,2;}
-line|z15[highway=path][_path_grade=difficult],
+line|z15|highway-path-difficult,
 {width: 1.1; dashes: 1,2;}
-line|z16[highway=path][_path_grade=difficult],
+line|z16|highway-path-difficult,
 {width: 1.5; dashes: 1.8,2.5;}
-line|z17[highway=path][_path_grade=difficult],
+line|z17|highway-path-difficult,
 {width: 2; dashes: 1.8,2.5;}
-line|z18-[highway=path][_path_grade=difficult],
+line|z18-|highway-path-difficult,
 {width: 2.8; dashes: 2.8,3.5;}
 
-line|z14[highway=path][_path_grade=expert],
+line|z14|highway-path-expert,
 {width: 0.9; dashes: 1,4;}
-line|z15[highway=path][_path_grade=expert],
+line|z15|highway-path-expert,
 {width: 1.1; dashes: 1,4;}
-line|z16[highway=path][_path_grade=expert],
+line|z16|highway-path-expert,
 {width: 1.5; dashes: 1.6,6;}
-line|z17[highway=path][_path_grade=expert],
+line|z17|highway-path-expert,
 {width: 2; dashes: 1.6,6;}
-line|z18-[highway=path][_path_grade=expert],
+line|z18-|highway-path-expert,
 {width: 2.8; dashes: 2.8,8;}
 
-line|z17-[highway=path][tunnel?]::tunnelBackground
+line|z17-|highway-path-tunnel::tunnelBackground
 {casing-width-add: 0.5;}
-line|z17-[highway=path][tunnel?]::tunnelCasing
+line|z17-|highway-path-tunnel::tunnelCasing
 {casing-width-add: 1;}
 
-line|z17-[highway=track][tunnel?]::tunnelBackground
+line|z17-|highway-track-tunnel::tunnelBackground
 {casing-width-add: 0.5;}
-line|z17-[highway=track][tunnel?]::tunnelCasing
+line|z17-|highway-track-tunnel::tunnelCasing
 {casing-width-add: 1;}
 
-line|z15-[highway=path][bridge?]::bridgewhite
+line|z15-|highway-path-bridge::bridgewhite
 {casing-width-add: 0.5;}
-line|z17-[highway=path][bridge?]::bridgeblack
+line|z17-|highway-path-bridge::bridgeblack
 {casing-width-add: 1;}
 
-line|z15-[highway=track][bridge?]::bridgewhite
+line|z15-|highway-track-bridge::bridgewhite
 {casing-width-add: 0.5;}
-line|z17-[highway=track][bridge?]::bridgeblack
+line|z17-|highway-track-bridge::bridgeblack
 {casing-width-add: 1;}
 
 
 /* 8.7 Footway 15-22 ZOOM */
 
-line|z15[highway=footway]
+line|z15|highway-footway
 {width: 1.5; dashes: 5,2;}
-line|z16[highway=footway]
+line|z16|highway-footway
 {width: 2; dashes: 5,2;}
-line|z17[highway=footway]
+line|z17|highway-footway
 {width: 2.4; dashes: 6,2.5;}
-line|z18[highway=footway]
+line|z18|highway-footway
 {width: 3.2; dashes: 8,3; opacity: 1;}
-line|z19-[highway=footway],
+line|z19-|highway-footway,
 {width: 4.2; dashes: 10,3.5; opacity: 1;}
 
-line|z15[highway=footway][bicycle=designated],
+line|z15|highway-footway-bicycle,
 {width: 1.5; dashes: 5,3;}
-line|z16[highway=footway][bicycle=designated],
+line|z16|highway-footway-bicycle,
 {width: 2; dashes: 5,3;}
-line|z17[highway=footway][bicycle=designated],
+line|z17|highway-footway-bicycle,
 {width: 2.4; dashes: 6,4.2; opacity: 0.9;}
-line|z18[highway=footway][bicycle=designated],
+line|z18|highway-footway-bicycle,
 {width: 3.2; dashes: 8,5.5; opacity: 1;}
-line|z19-[highway=footway][bicycle=designated],
+line|z19-|highway-footway-bicycle,
 {width: 4.2; dashes: 10,6.7; opacity: 1;}
 
 /* Don't display sidewalks and pedestrian crossings on z15. */
-line|z15[highway=footway][footway=sidewalk],
-line|z15[highway=footway][footway=crossing],
+line|z15|highway-footway-sidewalk,
+line|z15|highway-footway-crossing,
 {width: 0;}
 
-line|z17-[highway=footway][tunnel?]::tunnelBackground
+line|z17-|highway-footway-tunnel::tunnelBackground
 {casing-width-add: 0.5;}
-line|z17-[highway=footway][tunnel?]::tunnelCasing
+line|z17-|highway-footway-tunnel::tunnelCasing
 {casing-width-add: 1;}
 
-line|z15-[highway=footway][bridge?]::bridgewhite
+line|z15-|highway-footway-bridge::bridgewhite
 {casing-width-add: 0.5;}
-line|z17-[highway=footway][bridge?]::bridgeblack
+line|z17-|highway-footway-bridge::bridgeblack
 {casing-width-add: 1;}
 
 /* 8.8 Steps 15-22 ZOOM */
 
-line|z15[highway=steps]
+line|z15|highway-steps
 {width: 2.4; dashes: 1.5,1.3;}
-line|z16[highway=steps]
+line|z16|highway-steps
 {width: 4; dashes: 1.8,1.6;}
-line|z17-[highway=steps]
+line|z17-|highway-steps
 {width: 6; dashes: 2.5,2.2; opacity: 1;}
-line|z18[highway=steps]
+line|z18|highway-steps
 {width: 8; dashes: 3.2,2.8;}
-line|z19-[highway=steps]
+line|z19-|highway-steps
 {width: 10; dashes: 4,3.5;}
 
-line|z17-[highway=steps][tunnel?]::tunnelBackground
+line|z17-|highway-steps-tunnel::tunnelBackground
 {casing-width: 0.5;}
-line|z17-[highway=steps][tunnel?]::tunnelCasing
+line|z17-|highway-steps-tunnel::tunnelCasing
 {casing-width: 1;}
 
-line|z15-16[highway=steps][bridge?]::bridgewhite
+line|z15-16|highway-steps-bridge::bridgewhite
 {casing-width-add: -2;}
-line|z17[highway=steps][bridge?]::bridgewhite
+line|z17|highway-steps-bridge::bridgewhite
 {casing-width-add: -2.5;}
-line|z18[highway=steps][bridge?]::bridgewhite
+line|z18|highway-steps-bridge::bridgewhite
 {casing-width-add: -3;}
-line|z19-[highway=steps][bridge?]::bridgewhite
+line|z19-|highway-steps-bridge::bridgewhite
 {casing-width-add: -3.5;}
 /*
 line|z16[highway=steps][bridge?]::bridgeblack
 {casing-width-add: -1.5;}
 */
-line|z17[highway=steps][bridge?]::bridgeblack
+line|z17|highway-steps-bridge::bridgeblack
 {casing-width-add: -2;}
-line|z18[highway=steps][bridge?]::bridgeblack
+line|z18|highway-steps-bridge::bridgeblack
 {casing-width-add: -2.5;}
-line|z19-[highway=steps][bridge?]::bridgeblack
+line|z19-|highway-steps-bridge::bridgeblack
 {casing-width-add: -3;}
 
 /* 8.9 Bridleway 14-22 ZOOM */
 
-line|z14[highway=bridleway]
+line|z14|highway-bridleway
 {width: 0.9;dashes: 2.7,1.26;}
-line|z15[highway=bridleway]
+line|z15|highway-bridleway
 {width: 1.4;dashes: 2.7,1.26;}
-line|z16[highway=bridleway]
+line|z16|highway-bridleway
 {width: 1.8;dashes: 3.6,1.8;}
-line|z17[highway=bridleway]
+line|z17|highway-bridleway
 {width: 2;dashes: 4.5,1.8;}
-line|z18[highway=bridleway]
+line|z18|highway-bridleway
 {width: 3;dashes: 7.2,2.7;}
-line|z19-[highway=bridleway]
+line|z19-|highway-bridleway
 {width: 4;dashes: 9,3.6;}
 
-line|z17-[highway=bridleway][tunnel?]::tunnelBackground
+line|z17-|highway-bridleway-tunnel::tunnelBackground
 {casing-width-add: 0.5;}
-line|z17-[highway=bridleway][tunnel?]::tunnelCasing
+line|z17-|highway-bridleway-tunnel::tunnelCasing
 {casing-width-add: 1;}
 
-line|z15-[highway=bridleway][bridge?]::bridgewhite
+line|z15-|highway-bridleway-bridge::bridgewhite
 {casing-width-add: 0.5;}
-line|z17-[highway=bridleway][bridge?]::bridgeblack
+line|z17-|highway-bridleway-bridge::bridgeblack
 {casing-width-add: 1;}
 
 /* 8.11 Runway 12-22 ZOOM */
 
-line|z12-[aeroway=runway],
-line|z14-[aeroway=taxiway],
+line|z12-|aeroway-runway,
+line|z14-|aeroway-taxiway,
 {color: @residential; opacity: 0.8;}
 
-line|z12[aeroway=runway]
+line|z12|aeroway-runway
 {width: 1; opacity: 0.4;}
-line|z13[aeroway=runway]
+line|z13|aeroway-runway
 {width: 1.5; opacity: 0.5;}
-line|z14-15[aeroway=runway]
+line|z14-15|aeroway-runway
 {width: 2.4; opacity: 0.7;}
-line|z16-[aeroway=runway]
+line|z16-|aeroway-runway
 {width: 3.5;}
 
-line|z14[aeroway=taxiway]
+line|z14|aeroway-taxiway
 {width: 0.6; opacity: 0.4;}
-line|z15-[aeroway=taxiway]
+line|z15-|aeroway-taxiway
 {width: 1.2; opacity: 0.5;}
 
 /* 9.RAIL 11-22 ZOOM */
 
-line|z11-[railway=rail],
+line|z11-|railway-rail,
 {color: @railway_light; opacity: 0.7;}
-line|z16-[railway=rail]::dash,
+line|z16-|railway-rail::dash,
 {color: @railway_dash; opacity: 1;}
 
 
-line|z10-[railway=rail][highspeed?],
-line|z10-[railway=rail][usage=main],
-line|z11-[railway=rail][usage=branch],
+line|z10-|railway-rail-highspeed,
+line|z10-|railway-rail-main,
+line|z11-|railway-rail-branch,
 {color: @railway; opacity: 0.7;}
-line|z10-[railway=rail][usage=tourism],
+line|z10-|railway-rail-tourism,
 {color: @railway_tourism; opacity: 0.7;}
 
-line|z16-[railway=rail][highspeed?]::dash,
-line|z16-[railway=rail][usage=main]::dash,
-line|z16-[railway=rail][usage=tourism]::dash,
-line|z16-[railway=rail][usage=branch]::dash,
+line|z16-|railway-rail-highspeed::dash,
+line|z16-|railway-rail-main::dash,
+line|z16-|railway-rail-tourism::dash,
+line|z16-|railway-rail-branch::dash,
 {color: @railway_dash; opacity: 1;}
 
-line|z13-[railway=rail][usage=utility],
-line|z15-[railway=rail][service=spur],
-line|z16-[railway=rail][service=service],
+line|z13-|railway-rail-utility,
+line|z15-|railway-rail-spur,
+line|z16-|railway-rail-service,
 {color: @railway_light; opacity: 0.7;}
-line|z17-[railway=rail][usage=utility]::dash,
-line|z17-[railway=rail][service=spur]::dash,
-line|z17-[railway=rail][service=service]::dash,
+line|z17-|railway-rail-utility::dash,
+line|z17-|railway-rail-spur::dash,
+line|z17-|railway-rail-service::dash,
 {color: @industrial; opacity: 1;}
 
 
-line|z12-[railway=funicular],
-line|z14-[railway=monorail],
-line|z15-[railway=narrow_gauge],
-line|z15-[railway=construction],
-line|z15-[railway=preserved],
-line|z16-[railway=disused],
-line|z16-[railway=abandoned],
+line|z12-|railway-funicular,
+line|z14-|railway-monorail,
+line|z15-|railway-narrow_gauge,
+line|z15-|railway-construction,
+line|z15-|railway-preserved,
+line|z16-|railway-disused,
+line|z16-|railway-abandoned,
 {color: @railway; opacity: 0.7;}
 
-line|z13-[railway=light_rail][!tunnel],
-line|z13-[railway=subway][!tunnel],
+line|z13-|[railway=light_rail][!tunnel] /*NO-TYPE-MATCH*/,
+line|z13-|[railway=subway][!tunnel] /*NO-TYPE-MATCH*/,
 {color: @railway_light; opacity: 0.7;}
 
-line|z13-[railway=tram]
+line|z13-|railway-tram
 {color: @tram;}
 
-line|z16-[railway=subway][!tunnel]::dash,
-line|z16-[railway=light_rail][!tunnel]::dash,
+line|z16-|[railway=subway][!tunnel] /*NO-TYPE-MATCH*/::dash,
+line|z16-|[railway=light_rail][!tunnel] /*NO-TYPE-MATCH*/::dash,
 {color: @railway_dash; opacity: 1;}
 
-line|z13-[railway=rail][bridge?]::bridgewhite,
-line|z13-[railway=subway][bridge?]::bridgewhite,
-line|z13-[railway=light_rail][bridge?]::bridgewhite,
-line|z15-[railway=preserved][bridge?]::bridgewhite,
-line|z16-[railway=abandoned][bridge?]::bridgewhite,
+line|z13-|railway-rail-bridge::bridgewhite,
+line|z13-|railway-subway-bridge::bridgewhite,
+line|z13-|railway-light_rail-bridge::bridgewhite,
+line|z15-|railway-preserved-bridge::bridgewhite,
+line|z16-|railway-abandoned-bridge::bridgewhite,
 {casing-linecap: butt;casing-color:@bridge_background;casing-opacity: 0.8;}
-line|z16-[railway=rail][bridge?]::bridgeblack,
-line|z16-[railway=subway][bridge?]::bridgeblack,
-line|z16-[railway=light_rail][bridge?]::bridgeblack,
-line|z16-[railway=preserved][bridge?]::bridgeblack,
-line|z16-[railway=abandoned][bridge?]::bridgeblack,
+line|z16-|railway-rail-bridge::bridgeblack,
+line|z16-|railway-subway-bridge::bridgeblack,
+line|z16-|railway-light_rail-bridge::bridgeblack,
+line|z16-|railway-preserved-bridge::bridgeblack,
+line|z16-|railway-abandoned-bridge::bridgeblack,
 {casing-linecap: butt;casing-color:@bridge_casing;casing-opacity: 0.7;}
 
 /* 9.1 RAIL 11-22 ZOOM */
 
-line|z11-12[railway=rail],
+line|z11-12|railway-rail,
 {width: 0.6;}
-line|z13[railway=rail],
+line|z13|railway-rail,
 {width: 0.8;}
-line|z14[railway=rail],
+line|z14|railway-rail,
 {width: 1;}
-line|z15[railway=rail],
+line|z15|railway-rail,
 {width: 1.2;}
-line|z16[railway=rail],
+line|z16|railway-rail,
 {width: 2.6;}
-line|z17-[railway=rail],
+line|z17-|railway-rail,
 {width: 3; opacity: 1;}
 
-line|z16[railway=rail]::dash,
+line|z16|railway-rail::dash,
 {width: 1.3; dashes: 4.5,4.5;}
-line|z17[railway=rail]::dash,
+line|z17|railway-rail::dash,
 {width: 2; dashes: 6.3,6.3;}
-line|z18-[railway=rail]::dash,
+line|z18-|railway-rail::dash,
 {width: 2; dashes: 8.1,8.1;}
 
 /* Reset styling inherited from railway=rail. */
-line|z11-12[railway=rail][usage=utility],
-line|z11-14[railway=rail][service=spur],
-line|z11-15[railway=rail][service=service],
+line|z11-12|railway-rail-utility,
+line|z11-14|railway-rail-spur,
+line|z11-15|railway-rail-service,
 {width: 0;}
-line|z16[railway=rail][usage=utility]::dash,
-line|z16[railway=rail][service=spur]::dash,
-line|z16[railway=rail][service=service]::dash,
+line|z16|railway-rail-utility::dash,
+line|z16|railway-rail-spur::dash,
+line|z16|railway-rail-service::dash,
 {width: 0;}
 
 
-line|z10-11[railway=rail][usage=main],
-line|z10-11[railway=rail][usage=tourism],
-line|z11[railway=rail][usage=branch],
-line|z13[railway=rail][usage=utility],
+line|z10-11|railway-rail-main,
+line|z10-11|railway-rail-tourism,
+line|z11|railway-rail-branch,
+line|z13|railway-rail-utility,
 {width: 1;}
-line|z12[railway=rail][usage=main],
-line|z12[railway=rail][usage=tourism],
-line|z12[railway=rail][usage=branch],
-line|z14[railway=rail][usage=utility],
+line|z12|railway-rail-main,
+line|z12|railway-rail-tourism,
+line|z12|railway-rail-branch,
+line|z14|railway-rail-utility,
 {width: 1.1;}
-line|z10[railway=rail][highspeed?],
-line|z13[railway=rail][usage=main],
-line|z13[railway=rail][usage=tourism],
-line|z13[railway=rail][usage=branch],
-line|z15[railway=rail][usage=utility],
-line|z15[railway=rail][service=spur],
+line|z10|railway-rail-highspeed,
+line|z13|railway-rail-main,
+line|z13|railway-rail-tourism,
+line|z13|railway-rail-branch,
+line|z15|railway-rail-utility,
+line|z15|railway-rail-spur,
 {width: 1.2;}
-line|z11[railway=rail][highspeed?],
-line|z14[railway=rail][usage=main],
-line|z14[railway=rail][usage=tourism],
-line|z14[railway=rail][usage=branch],
-line|z16[railway=rail][usage=utility],
-line|z16[railway=rail][service=spur],
-line|z16[railway=rail][service=service],
+line|z11|railway-rail-highspeed,
+line|z14|railway-rail-main,
+line|z14|railway-rail-tourism,
+line|z14|railway-rail-branch,
+line|z16|railway-rail-utility,
+line|z16|railway-rail-spur,
+line|z16|railway-rail-service,
 {width: 1.3;}
-line|z12[railway=rail][highspeed?],
-line|z15[railway=rail][usage=main],
-line|z15[railway=rail][usage=tourism],
-line|z15[railway=rail][usage=branch],
+line|z12|railway-rail-highspeed,
+line|z15|railway-rail-main,
+line|z15|railway-rail-tourism,
+line|z15|railway-rail-branch,
 {width: 1.4;}
-line|z13[railway=rail][highspeed?],
+line|z13|railway-rail-highspeed,
 {width: 1.6;}
-line|z14[railway=rail][highspeed?],
+line|z14|railway-rail-highspeed,
 {width: 1.8;}
-line|z15[railway=rail][highspeed?],
+line|z15|railway-rail-highspeed,
 {width: 2;}
-line|z16[railway=rail][highspeed?],
-line|z16[railway=rail][usage=main],
-line|z16[railway=rail][usage=tourism],
-line|z16[railway=rail][usage=branch],
+line|z16|railway-rail-highspeed,
+line|z16|railway-rail-main,
+line|z16|railway-rail-tourism,
+line|z16|railway-rail-branch,
 {width: 2.6;}
-line|z17[railway=rail][highspeed?],
-line|z17[railway=rail][usage=main],
-line|z17[railway=rail][usage=tourism],
-line|z17[railway=rail][usage=branch],
-line|z17[railway=rail][usage=utility],
-line|z17[railway=rail][service=spur],
-line|z17[railway=rail][service=service],
+line|z17|railway-rail-highspeed,
+line|z17|railway-rail-main,
+line|z17|railway-rail-tourism,
+line|z17|railway-rail-branch,
+line|z17|railway-rail-utility,
+line|z17|railway-rail-spur,
+line|z17|railway-rail-service,
 {width: 2.9; opacity: 1;}
-line|z18-[railway=rail][highspeed?],
-line|z18-[railway=rail][usage=main],
-line|z18-[railway=rail][usage=tourism],
-line|z18-[railway=rail][usage=branch],
-line|z18-[railway=rail][usage=utility],
-line|z18-[railway=rail][service=spur],
-line|z18-[railway=rail][service=service],
+line|z18-|railway-rail-highspeed,
+line|z18-|railway-rail-main,
+line|z18-|railway-rail-tourism,
+line|z18-|railway-rail-branch,
+line|z18-|railway-rail-utility,
+line|z18-|railway-rail-spur,
+line|z18-|railway-rail-service,
 {width: 3.4; opacity: 1;}
 
 
-line|z16[railway=rail][highspeed?]::dash,
+line|z16|railway-rail-highspeed::dash,
 {width: 1.1; dashes: 10,10;}
-line|z17[railway=rail][highspeed?]::dash,
+line|z17|railway-rail-highspeed::dash,
 {width: 1.5; dashes: 13,13;}
-line|z18-[railway=rail][highspeed?]::dash,
+line|z18-|railway-rail-highspeed::dash,
 {width: 1.7; dashes: 16,16;}
 
-line|z16[railway=rail][usage=main]::dash,
-line|z16[railway=rail][usage=tourism]::dash,
-line|z16[railway=rail][usage=branch]::dash,
+line|z16|railway-rail-main::dash,
+line|z16|railway-rail-tourism::dash,
+line|z16|railway-rail-branch::dash,
 {width: 1.4; dashes: 4.5,4.5;}
-line|z17[railway=rail][usage=main]::dash,
-line|z17[railway=rail][usage=tourism]::dash,
-line|z17[railway=rail][usage=branch]::dash,
-line|z17[railway=rail][usage=utility]::dash,
-line|z17[railway=rail][service=spur]::dash,
-line|z17[railway=rail][service=service]::dash,
+line|z17|railway-rail-main::dash,
+line|z17|railway-rail-tourism::dash,
+line|z17|railway-rail-branch::dash,
+line|z17|railway-rail-utility::dash,
+line|z17|railway-rail-spur::dash,
+line|z17|railway-rail-service::dash,
 {width: 1.8; dashes: 6.3,6.3;}
-line|z18-[railway=rail][usage=main]::dash,
-line|z18-[railway=rail][usage=tourism]::dash,
-line|z18-[railway=rail][usage=branch]::dash,
-line|z18-[railway=rail][usage=utility]::dash,
-line|z18-[railway=rail][service=spur]::dash,
-line|z18-[railway=rail][service=service]::dash,
+line|z18-|railway-rail-main::dash,
+line|z18-|railway-rail-tourism::dash,
+line|z18-|railway-rail-branch::dash,
+line|z18-|railway-rail-utility::dash,
+line|z18-|railway-rail-spur::dash,
+line|z18-|railway-rail-service::dash,
 {width: 2; dashes: 8.1,8.1;}
 
 
-line|z13-[railway=subway][!tunnel],
-line|z13-[railway=light_rail][!tunnel],
+line|z13-|[railway=subway][!tunnel] /*NO-TYPE-MATCH*/,
+line|z13-|[railway=light_rail][!tunnel] /*NO-TYPE-MATCH*/,
 {width: 0.8;}
-line|z14[railway=subway][!tunnel],
-line|z14[railway=light_rail][!tunnel],
+line|z14|[railway=subway][!tunnel] /*NO-TYPE-MATCH*/,
+line|z14|[railway=light_rail][!tunnel] /*NO-TYPE-MATCH*/,
 {width: 1;}
-line|z15[railway=subway][!tunnel],
-line|z15[railway=light_rail][!tunnel],
+line|z15|[railway=subway][!tunnel] /*NO-TYPE-MATCH*/,
+line|z15|[railway=light_rail][!tunnel] /*NO-TYPE-MATCH*/,
 {width: 1.2;}
-line|z16[railway=subway][!tunnel],
-line|z16[railway=light_rail][!tunnel],
+line|z16|[railway=subway][!tunnel] /*NO-TYPE-MATCH*/,
+line|z16|[railway=light_rail][!tunnel] /*NO-TYPE-MATCH*/,
 {width: 2.6;}
-line|z17-[railway=subway][!tunnel],
-line|z17-[railway=light_rail][!tunnel],
+line|z17-|[railway=subway][!tunnel] /*NO-TYPE-MATCH*/,
+line|z17-|[railway=light_rail][!tunnel] /*NO-TYPE-MATCH*/,
 {width: 2.9; opacity: 1;}
 
-line|z16[railway=subway][!tunnel]::dash,
-line|z16[railway=light_rail][!tunnel]::dash,
+line|z16|[railway=subway][!tunnel] /*NO-TYPE-MATCH*/::dash,
+line|z16|[railway=light_rail][!tunnel] /*NO-TYPE-MATCH*/::dash,
 {width: 1.3;dashes: 4.5,4.5;}
-line|z17[railway=subway][!tunnel]::dash,
-line|z17[railway=light_rail][!tunnel]::dash,
+line|z17|[railway=subway][!tunnel] /*NO-TYPE-MATCH*/::dash,
+line|z17|[railway=light_rail][!tunnel] /*NO-TYPE-MATCH*/::dash,
 {width: 2;dashes: 6.3,6.3;}
-line|z18-[railway=subway][!tunnel]::dash,
-line|z18-[railway=light_rail][!tunnel]::dash,
+line|z18-|[railway=subway][!tunnel] /*NO-TYPE-MATCH*/::dash,
+line|z18-|[railway=light_rail][!tunnel] /*NO-TYPE-MATCH*/::dash,
 {width: 2;dashes: 8.1,8.1;}
 
 
-line|z15-[railway=preserved],
-line|z16-[railway=abandoned],
+line|z15-|railway-preserved,
+line|z16-|railway-abandoned,
 {width: 1.6;dashes: 6.3,6.3;}
 
-line|z15-[railway=construction],
-line|z16-[railway=disused],
+line|z15-|railway-construction,
+line|z16-|railway-disused,
 {width: 1;dashes: 1.8,5.4;}
 
 /* 9.2 Rail tunnel 14-22 ZOOM */
 
-line|z14-[railway=rail][tunnel?],
+line|z14-|railway-rail-tunnel,
 {casing-width: 1;casing-linecap: butt;casing-color: @railway_tunnel;casing-dashes: 5,5;casing-opacity: 0.7;}
 
 /* 9.3 Rail bridge 14-22 ZOOM */
@@ -1306,242 +1306,242 @@ This definition is just a plug to keep these styles "disabled" for now, because 
  - add casing-color and z-index definitions to new bridges
  - test visually
 */
-line|z14-[railway=tram][bridge?]::bridgewhite,
-line|z14-[railway=monorail][bridge?]::bridgewhite,
-line|z14-[railway=funicular][bridge?]::bridgewhite,
-line|z14-[railway=narrow_gauge][bridge?]::bridgewhite,
-line|z14-[railway=tram][bridge?]::bridgeblack,
-line|z14-[railway=monorail][bridge?]::bridgeblack,
-line|z14-[railway=funicular][bridge?]::bridgeblack,
-line|z14-[railway=narrow_gauge][bridge?]::bridgeblack,
+line|z14-|railway-tram-bridge::bridgewhite,
+line|z14-|railway-monorail-bridge::bridgewhite,
+line|z14-|railway-funicular-bridge::bridgewhite,
+line|z14-|railway-narrow_gauge-bridge::bridgewhite,
+line|z14-|railway-tram-bridge::bridgeblack,
+line|z14-|railway-monorail-bridge::bridgeblack,
+line|z14-|railway-funicular-bridge::bridgeblack,
+line|z14-|railway-narrow_gauge-bridge::bridgeblack,
 {casing-linecap: round;}
 
 
-line|z13-15[railway=rail][bridge?]::bridgewhite,
-line|z13-15[railway=subway][bridge?]::bridgewhite,
-line|z13-15[railway=light_rail][bridge?]::bridgewhite,
-line|z15[railway=preserved][bridge?]::bridgewhite,
+line|z13-15|railway-rail-bridge::bridgewhite,
+line|z13-15|railway-subway-bridge::bridgewhite,
+line|z13-15|railway-light_rail-bridge::bridgewhite,
+line|z15|railway-preserved-bridge::bridgewhite,
 {casing-width-add: 1.2;}
-line|z16[railway=rail][bridge?]::bridgewhite,
-line|z16[railway=subway][bridge?]::bridgewhite,
-line|z16[railway=light_rail][bridge?]::bridgewhite,
-line|z16[railway=preserved][bridge?]::bridgewhite,
-line|z16[railway=abandoned][bridge?]::bridgewhite,
+line|z16|railway-rail-bridge::bridgewhite,
+line|z16|railway-subway-bridge::bridgewhite,
+line|z16|railway-light_rail-bridge::bridgewhite,
+line|z16|railway-preserved-bridge::bridgewhite,
+line|z16|railway-abandoned-bridge::bridgewhite,
 {casing-width-add: 1.6;}
-line|z17[railway=rail][bridge?]::bridgewhite,
-line|z17[railway=subway][bridge?]::bridgewhite,
-line|z17[railway=light_rail][bridge?]::bridgewhite,
-line|z17[railway=preserved][bridge?]::bridgewhite,
-line|z17[railway=abandoned][bridge?]::bridgewhite,
+line|z17|railway-rail-bridge::bridgewhite,
+line|z17|railway-subway-bridge::bridgewhite,
+line|z17|railway-light_rail-bridge::bridgewhite,
+line|z17|railway-preserved-bridge::bridgewhite,
+line|z17|railway-abandoned-bridge::bridgewhite,
 {casing-width-add: 2.3;}
-line|z18-[railway=rail][bridge?]::bridgewhite,
-line|z18-[railway=subway][bridge?]::bridgewhite,
-line|z18-[railway=light_rail][bridge?]::bridgewhite,
-line|z18-[railway=preserved][bridge?]::bridgewhite,
-line|z18-[railway=abandoned][bridge?]::bridgewhite,
+line|z18-|railway-rail-bridge::bridgewhite,
+line|z18-|railway-subway-bridge::bridgewhite,
+line|z18-|railway-light_rail-bridge::bridgewhite,
+line|z18-|railway-preserved-bridge::bridgewhite,
+line|z18-|railway-abandoned-bridge::bridgewhite,
 {casing-width-add: 3.5;}
 
-line|z16[railway=rail][bridge?]::bridgeblack,
-line|z16[railway=subway][bridge?]::bridgeblack,
-line|z16[railway=light_rail][bridge?]::bridgeblack,
-line|z16[railway=preserved][bridge?]::bridgeblack,
-line|z16[railway=abandoned][bridge?]::bridgeblack,
+line|z16|railway-rail-bridge::bridgeblack,
+line|z16|railway-subway-bridge::bridgeblack,
+line|z16|railway-light_rail-bridge::bridgeblack,
+line|z16|railway-preserved-bridge::bridgeblack,
+line|z16|railway-abandoned-bridge::bridgeblack,
 {casing-width-add: 2.2;}
-line|z17[railway=rail][bridge?]::bridgeblack,
-line|z17[railway=subway][bridge?]::bridgeblack,
-line|z17[railway=light_rail][bridge?]::bridgeblack,
-line|z17[railway=preserved][bridge?]::bridgeblack,
-line|z17[railway=abandoned][bridge?]::bridgeblack,
+line|z17|railway-rail-bridge::bridgeblack,
+line|z17|railway-subway-bridge::bridgeblack,
+line|z17|railway-light_rail-bridge::bridgeblack,
+line|z17|railway-preserved-bridge::bridgeblack,
+line|z17|railway-abandoned-bridge::bridgeblack,
 {casing-width-add: 3;}
-line|z18-[railway=rail][bridge?]::bridgeblack,
-line|z18-[railway=subway][bridge?]::bridgeblack,
-line|z18-[railway=light_rail][bridge?]::bridgeblack,
-line|z18-[railway=preserved][bridge?]::bridgeblack,
-line|z18-[railway=abandoned][bridge?]::bridgeblack,
+line|z18-|railway-rail-bridge::bridgeblack,
+line|z18-|railway-subway-bridge::bridgeblack,
+line|z18-|railway-light_rail-bridge::bridgeblack,
+line|z18-|railway-preserved-bridge::bridgeblack,
+line|z18-|railway-abandoned-bridge::bridgeblack,
 {casing-width-add: 4.4;}
 
 /* 9.4 Monorail 14-22 ZOOM */
 
-line|z14[railway=monorail]
+line|z14|railway-monorail
 {color: @railway_light;width: 1;}
-line|z15-16[railway=monorail],
-line|z15-16[railway=narrow_gauge]
+line|z15-16|railway-monorail,
+line|z15-16|railway-narrow_gauge
 {width: 1.2;}
-line|z17-[railway=monorail],
-line|z17-[railway=narrow_gauge]
+line|z17-|railway-monorail,
+line|z17-|railway-narrow_gauge
 {width: 2; opacity: 1;}
 
 /* 9.5 Tram line 13-22 ZOOM */
 
-line|z13-14[railway=tram]
+line|z13-14|railway-tram
 {width: 0.6; opacity: 0.5;}
-line|z15[railway=tram]
+line|z15|railway-tram
 {width: 0.7; opacity: 0.7;}
-line|z16[railway=tram]
+line|z16|railway-tram
 {width: 0.8; opacity: 0.8;}
-line|z17-[railway=tram]
+line|z17-|railway-tram
 {width: 1; opacity: 1;}
 
 /* 9.6 Funicular 12-22 ZOOM */
 
-line|z12[railway=funicular],
+line|z12|railway-funicular,
 {width: 1.4;}
-line|z13-14[railway=funicular],
+line|z13-14|railway-funicular,
 {width: 2;}
-line|z15-[railway=funicular],
+line|z15-|railway-funicular,
 {width: 3;}
-line|z17-[railway=funicular],
+line|z17-|railway-funicular,
 {opacity: 1;}
 
 /* 10.PISTE 12-22 ZOOM */
 
-line|z12-[aerialway=cable_car],
-line|z12-[aerialway=gondola],
-line|z12-[aerialway=mixed_lift],
-line|z13-[aerialway=chair_lift],
-line|z13-[aerialway=drag_lift],
-line|z13-[aerialway=j-bar],
-line|z13-[aerialway=t-bar],
-line|z13-[aerialway=magic_carpet],
-line|z13-[aerialway=platter],
-line|z13-[aerialway=rope_tow],
+line|z12-|aerialway-cable_car,
+line|z12-|aerialway-gondola,
+line|z12-|aerialway-mixed_lift,
+line|z13-|aerialway-chair_lift,
+line|z13-|aerialway-drag_lift,
+line|z13-|aerialway-j-bar,
+line|z13-|aerialway-t-bar,
+line|z13-|aerialway-magic_carpet,
+line|z13-|aerialway-platter,
+line|z13-|aerialway-rope_tow,
 {color: @aerialway; opacity: 0.7;}
 
-line|z12-[aerialway=cable_car]::dash,
-line|z12-[aerialway=gondola]::dash,
-line|z12-[aerialway=mixed_lift]::dash,
-line|z13-[aerialway=chair_lift]::dash,
-line|z13-[aerialway=drag_lift]::dash,
-line|z13-[aerialway=j-bar]::dash,
-line|z13-[aerialway=t-bar]::dash,
-line|z13-[aerialway=magic_carpet]::dash,
-line|z13-[aerialway=platter]::dash,
-line|z13-[aerialway=rope_tow]::dash,
+line|z12-|aerialway-cable_car::dash,
+line|z12-|aerialway-gondola::dash,
+line|z12-|aerialway-mixed_lift::dash,
+line|z13-|aerialway-chair_lift::dash,
+line|z13-|aerialway-drag_lift::dash,
+line|z13-|aerialway-j-bar::dash,
+line|z13-|aerialway-t-bar::dash,
+line|z13-|aerialway-magic_carpet::dash,
+line|z13-|aerialway-platter::dash,
+line|z13-|aerialway-rope_tow::dash,
 {color: @aerialway; opacity: 0.7;}
 
 /* 10.2 Aerialway 12-22 ZOOM */
 
-line|z12-15[aerialway=cable_car],
-line|z12-15[aerialway=gondola],
-line|z12-15[aerialway=mixed_lift],
+line|z12-15|aerialway-cable_car,
+line|z12-15|aerialway-gondola,
+line|z12-15|aerialway-mixed_lift,
 {width: 0.5;}
-line|z16-[aerialway=cable_car],
-line|z16-[aerialway=gondola],
-line|z16-[aerialway=mixed_lift],
+line|z16-|aerialway-cable_car,
+line|z16-|aerialway-gondola,
+line|z16-|aerialway-mixed_lift,
 {width: 1;}
 
-line|z12-13[aerialway=cable_car]::dash,
-line|z12-13[aerialway=gondola]::dash,
-line|z12-13[aerialway=mixed_lift]::dash,
+line|z12-13|aerialway-cable_car::dash,
+line|z12-13|aerialway-gondola::dash,
+line|z12-13|aerialway-mixed_lift::dash,
 {width: 2.5; dashes: 2.5,15;}
-line|z14-15[aerialway=cable_car]::dash,
-line|z14-15[aerialway=gondola]::dash,
-line|z14-15[aerialway=mixed_lift]::dash,
+line|z14-15|aerialway-cable_car::dash,
+line|z14-15|aerialway-gondola::dash,
+line|z14-15|aerialway-mixed_lift::dash,
 {width: 3; dashes: 3,30;}
-line|z16-[aerialway=cable_car]::dash,
-line|z16-[aerialway=gondola]::dash,
-line|z16-[aerialway=mixed_lift]::dash,
+line|z16-|aerialway-cable_car::dash,
+line|z16-|aerialway-gondola::dash,
+line|z16-|aerialway-mixed_lift::dash,
 {width: 4; dashes: 4,45; opacity: 0.7;}
 
-line|z13-15[aerialway=chair_lift],
-line|z13-15[aerialway=drag_lift],
-line|z13-15[aerialway=j-bar],
-line|z13-15[aerialway=t-bar],
-line|z13-15[aerialway=magic_carpet],
-line|z13-15[aerialway=platter],
-line|z13-15[aerialway=rope_tow],
+line|z13-15|aerialway-chair_lift,
+line|z13-15|aerialway-drag_lift,
+line|z13-15|aerialway-j-bar,
+line|z13-15|aerialway-t-bar,
+line|z13-15|aerialway-magic_carpet,
+line|z13-15|aerialway-platter,
+line|z13-15|aerialway-rope_tow,
 {width: 0.5;}
-line|z16-[aerialway=chair_lift],
-line|z16-[aerialway=drag_lift],
-line|z16-[aerialway=j-bar],
-line|z16-[aerialway=t-bar],
-line|z16-[aerialway=magic_carpet],
-line|z16-[aerialway=platter],
-line|z16-[aerialway=rope_tow],
+line|z16-|aerialway-chair_lift,
+line|z16-|aerialway-drag_lift,
+line|z16-|aerialway-j-bar,
+line|z16-|aerialway-t-bar,
+line|z16-|aerialway-magic_carpet,
+line|z16-|aerialway-platter,
+line|z16-|aerialway-rope_tow,
 {width: 1;}
 
-line|z13-14[aerialway=chair_lift]::dash,
-line|z13-14[aerialway=drag_lift]::dash,
-line|z13-14[aerialway=j-bar]::dash,
-line|z13-14[aerialway=t-bar]::dash,
-line|z13-14[aerialway=magic_carpet]::dash,
-line|z13-14[aerialway=platter]::dash,
-line|z13-14[aerialway=rope_tow]::dash,
+line|z13-14|aerialway-chair_lift::dash,
+line|z13-14|aerialway-drag_lift::dash,
+line|z13-14|aerialway-j-bar::dash,
+line|z13-14|aerialway-t-bar::dash,
+line|z13-14|aerialway-magic_carpet::dash,
+line|z13-14|aerialway-platter::dash,
+line|z13-14|aerialway-rope_tow::dash,
 {width: 2.5; dashes: 1,10; opacity: 0.5;}
-line|z15-16[aerialway=chair_lift]::dash,
-line|z15-16[aerialway=drag_lift]::dash,
-line|z15-16[aerialway=j-bar]::dash,
-line|z15-16[aerialway=t-bar]::dash,
-line|z15-16[aerialway=magic_carpet]::dash,
-line|z15-16[aerialway=platter]::dash,
-line|z15-16[aerialway=rope_tow]::dash,
+line|z15-16|aerialway-chair_lift::dash,
+line|z15-16|aerialway-drag_lift::dash,
+line|z15-16|aerialway-j-bar::dash,
+line|z15-16|aerialway-t-bar::dash,
+line|z15-16|aerialway-magic_carpet::dash,
+line|z15-16|aerialway-platter::dash,
+line|z15-16|aerialway-rope_tow::dash,
 {width: 3; dashes: 1,15;}
-line|z17-[aerialway=chair_lift]::dash,
-line|z17-[aerialway=drag_lift]::dash,
-line|z17-[aerialway=j-bar]::dash,
-line|z17-[aerialway=t-bar]::dash,
-line|z17-[aerialway=magic_carpet]::dash,
-line|z17-[aerialway=platter]::dash,
-line|z17-[aerialway=rope_tow]::dash,
+line|z17-|aerialway-chair_lift::dash,
+line|z17-|aerialway-drag_lift::dash,
+line|z17-|aerialway-j-bar::dash,
+line|z17-|aerialway-t-bar::dash,
+line|z17-|aerialway-magic_carpet::dash,
+line|z17-|aerialway-platter::dash,
+line|z17-|aerialway-rope_tow::dash,
 {width: 4; dashes: 1,22; opacity: 1;}
 
-line|z19-[power=line],
+line|z19-|power-line,
 {color: @powerline; width: 1; opacity: 0.4;}
-line|z19-[power=line]::dash,
+line|z19-|power-line::dash,
 {color: @powerline; width: 4; opacity: 0.5; dashes: 1,80;}
 
 /* 10.3 Piste & Route 14-22 ZOOM */
 
-line|z14-[piste:type=nordic],
-line|z14-[piste:type=skitour],
-line|z15-[piste:type=connection],
+line|z14-|piste:type-nordic,
+line|z14-|piste:type-skitour,
+line|z15-|piste:type-connection,
 {color: @piste; opacity: 0.6;}
 
-line|z14[piste:type=nordic],
-line|z14[piste:type=skitour],
+line|z14|piste:type-nordic,
+line|z14|piste:type-skitour,
 {width: 0.8;}
-line|z15-[piste:type=nordic],
-line|z15-[piste:type=skitour],
-line|z15-[piste:type=connection],
+line|z15-|piste:type-nordic,
+line|z15-|piste:type-skitour,
+line|z15-|piste:type-connection,
 {width: 1.1;}
-line|z17-[piste:type=nordic],
-line|z17-[piste:type=skitour],
-line|z17-[piste:type=connection],
+line|z17-|piste:type-nordic,
+line|z17-|piste:type-skitour,
+line|z17-|piste:type-connection,
 {width: 1.5;}
 
-line|z14-[piste:type=downhill],
-line|z14-[piste:type=sled],
+line|z14-|piste:type-downhill,
+line|z14-|piste:type-sled,
 {color: @piste; opacity: 0.5;}
 
-line|z14-[piste:type=downhill][piste:difficulty=novice]
+line|z14-|piste:type-downhill-novice
 {color: @piste_novice; opacity: 0.7;}
-line|z14-[piste:type=downhill][piste:difficulty=easy]
+line|z14-|piste:type-downhill-easy
 {color: @piste_easy;}
-line|z14-[piste:type=downhill][piste:difficulty=intermediate]
+line|z14-|piste:type-downhill-intermediate
 {color: @piste_intermediate;}
-line|z14-[piste:type=downhill][piste:difficulty=advanced]
+line|z14-|piste:type-downhill-advanced
 {color: @piste_advanced;}
-line|z14-[piste:type=downhill][piste:difficulty=expert],
+line|z14-|piste:type-downhill-expert,
 {color: @piste_expert;}
-line|z14-[piste:type=downhill][piste:difficulty=freeride],
+line|z14-|piste:type-downhill-freeride,
 {color: @piste_freeride;}
 
 
-line|z14[piste:type=downhill],
-line|z14[piste:type=sled],
+line|z14|piste:type-downhill,
+line|z14|piste:type-sled,
 {width: 1; opacity: 0.4;}
-line|z15-[piste:type=downhill],
-line|z15-[piste:type=sled],
+line|z15-|piste:type-downhill,
+line|z15-|piste:type-sled,
 {width: 1.6;}
-line|z17-[piste:type=downhill],
-line|z17-[piste:type=sled],
+line|z17-|piste:type-downhill,
+line|z17-|piste:type-sled,
 {width: 1.8;}
 
-area|z14-[piste:type=downhill][area],
-area|z14-[piste:type=sled][area],
+area|z14-|[piste:type=downhill][area] /*NO-TYPE-MATCH*/,
+area|z14-|[piste:type=sled][area] /*NO-TYPE-MATCH*/,
 {width: 0;}
 
 /* 11. FERRY */
 
-line|z7-[route=ferry],
+line|z7-|route-ferry,
 {color: @ferry;width: 1;opacity: 0.6;dashes: 5.4,2.7;}

--- a/data/styles/default/include/Roads_label.mapcss
+++ b/data/styles/default/include/Roads_label.mapcss
@@ -22,362 +22,362 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-line[highway]
+line|highway
 {text-position: line;}
 
 /* 2.SHIELD 10-22 ZOOM */
 
-line|z10-[highway=motorway]::shield,
-line|z10-[highway=trunk]::shield,
-line|z10-[highway=motorway_link]::shield,
-line|z10-[highway=trunk_link]::shield,
-line|z10-[highway=primary]::shield,
-line|z11-[highway=primary_link]::shield,
-line|z12-[highway=secondary]::shield,
-line|z13-[highway=tertiary]::shield,
-line|z15-[highway=residential]::shield,
+line|z10-|highway-motorway::shield,
+line|z10-|highway-trunk::shield,
+line|z10-|highway-motorway_link::shield,
+line|z10-|highway-trunk_link::shield,
+line|z10-|highway-primary::shield,
+line|z11-|highway-primary_link::shield,
+line|z12-|highway-secondary::shield,
+line|z13-|highway-tertiary::shield,
+line|z15-|highway-residential::shield,
 {shield-font-size: 9;shield-text-color: @shield_text;shield-text-halo-radius: 0;shield-text-halo-color: @shield_text_halo;shield-color: @shield;shield-outline-radius: 1;shield-outline-color: @shield_outline;}
 
-line|z10[highway=motorway]::shield,
-line|z10[highway=trunk]::shield,
-line|z10[highway=motorway_link]::shield,
-line|z10[highway=trunk_link]::shield,
-line|z10[highway=primary]::shield,
+line|z10|highway-motorway::shield,
+line|z10|highway-trunk::shield,
+line|z10|highway-motorway_link::shield,
+line|z10|highway-trunk_link::shield,
+line|z10|highway-primary::shield,
 {shield-min-distance: 85;}
-line|z11-12[highway=motorway]::shield,
-line|z11-12[highway=trunk]::shield,
-line|z11-12[highway=motorway_link]::shield,
-line|z11-12[highway=trunk_link]::shield,
-line|z11-12[highway=primary]::shield,
-line|z11-12[highway=primary_link]::shield,
-line|z12[highway=secondary]::shield,
+line|z11-12|highway-motorway::shield,
+line|z11-12|highway-trunk::shield,
+line|z11-12|highway-motorway_link::shield,
+line|z11-12|highway-trunk_link::shield,
+line|z11-12|highway-primary::shield,
+line|z11-12|highway-primary_link::shield,
+line|z12|highway-secondary::shield,
 {shield-min-distance: 90;}
-line|z13[highway=motorway]::shield,
-line|z13[highway=trunk]::shield,
-line|z13[highway=motorway_link]::shield,
-line|z13[highway=trunk_link]::shield,
-line|z13[highway=primary]::shield,
-line|z13[highway=primary_link]::shield,
-line|z13[highway=secondary]::shield,
-line|z13[highway=tertiary]::shield,
+line|z13|highway-motorway::shield,
+line|z13|highway-trunk::shield,
+line|z13|highway-motorway_link::shield,
+line|z13|highway-trunk_link::shield,
+line|z13|highway-primary::shield,
+line|z13|highway-primary_link::shield,
+line|z13|highway-secondary::shield,
+line|z13|highway-tertiary::shield,
 {shield-min-distance: 120;}
-line|z14[highway=motorway]::shield,
-line|z14[highway=trunk]::shield,
-line|z14[highway=motorway_link]::shield,
-line|z14[highway=trunk_link]::shield,
-line|z14[highway=primary]::shield,
-line|z14[highway=primary_link]::shield,
-line|z14[highway=secondary]::shield,
-line|z14[highway=tertiary]::shield,
+line|z14|highway-motorway::shield,
+line|z14|highway-trunk::shield,
+line|z14|highway-motorway_link::shield,
+line|z14|highway-trunk_link::shield,
+line|z14|highway-primary::shield,
+line|z14|highway-primary_link::shield,
+line|z14|highway-secondary::shield,
+line|z14|highway-tertiary::shield,
 {shield-min-distance: 175;}
-line|z15[highway=motorway]::shield,
-line|z15[highway=trunk]::shield,
-line|z15[highway=motorway_link]::shield,
-line|z15[highway=trunk_link]::shield,
-line|z15[highway=primary]::shield,
-line|z15[highway=primary_link]::shield,
-line|z15[highway=secondary]::shield,
-line|z15[highway=tertiary]::shield,
-line|z15[highway=residential]::shield,
+line|z15|highway-motorway::shield,
+line|z15|highway-trunk::shield,
+line|z15|highway-motorway_link::shield,
+line|z15|highway-trunk_link::shield,
+line|z15|highway-primary::shield,
+line|z15|highway-primary_link::shield,
+line|z15|highway-secondary::shield,
+line|z15|highway-tertiary::shield,
+line|z15|highway-residential::shield,
 {shield-min-distance: 250;}
-line|z16[highway=motorway]::shield,
-line|z16[highway=trunk]::shield,
-line|z16[highway=motorway_link]::shield,
-line|z16[highway=trunk_link]::shield,
-line|z16[highway=primary]::shield,
-line|z16[highway=primary_link]::shield,
-line|z16[highway=secondary]::shield,
-line|z16[highway=tertiary]::shield,
-line|z16[highway=residential]::shield,
+line|z16|highway-motorway::shield,
+line|z16|highway-trunk::shield,
+line|z16|highway-motorway_link::shield,
+line|z16|highway-trunk_link::shield,
+line|z16|highway-primary::shield,
+line|z16|highway-primary_link::shield,
+line|z16|highway-secondary::shield,
+line|z16|highway-tertiary::shield,
+line|z16|highway-residential::shield,
 {shield-min-distance: 300;}
-line|z17[highway=motorway]::shield,
-line|z17[highway=trunk]::shield,
-line|z17[highway=motorway_link]::shield,
-line|z17[highway=trunk_link]::shield,
-line|z17[highway=primary]::shield,
-line|z17[highway=primary_link]::shield,
-line|z17[highway=secondary]::shield,
-line|z17[highway=tertiary]::shield,
-line|z17[highway=residential]::shield,
+line|z17|highway-motorway::shield,
+line|z17|highway-trunk::shield,
+line|z17|highway-motorway_link::shield,
+line|z17|highway-trunk_link::shield,
+line|z17|highway-primary::shield,
+line|z17|highway-primary_link::shield,
+line|z17|highway-secondary::shield,
+line|z17|highway-tertiary::shield,
+line|z17|highway-residential::shield,
 {shield-font-size: 10;shield-min-distance: 300;}
-line|z18[highway=motorway]::shield,
-line|z18[highway=trunk]::shield,
-line|z18[highway=motorway_link]::shield,
-line|z18[highway=trunk_link]::shield,
-line|z18[highway=primary]::shield,
-line|z18[highway=primary_link]::shield,
-line|z18[highway=secondary]::shield,
-line|z18[highway=residential]::shield,
-line|z18[highway=tertiary]::shield,
+line|z18|highway-motorway::shield,
+line|z18|highway-trunk::shield,
+line|z18|highway-motorway_link::shield,
+line|z18|highway-trunk_link::shield,
+line|z18|highway-primary::shield,
+line|z18|highway-primary_link::shield,
+line|z18|highway-secondary::shield,
+line|z18|highway-residential::shield,
+line|z18|highway-tertiary::shield,
 {shield-font-size: 10;shield-min-distance: 300;}
-line|z19-[highway=motorway]::shield,
-line|z19-[highway=trunk]::shield,
-line|z19-[highway=motorway_link]::shield,
-line|z19-[highway=trunk_link]::shield,
-line|z19-[highway=primary]::shield,
-line|z19-[highway=primary_link]::shield,
-line|z19-[highway=secondary]::shield,
-line|z19-[highway=residential]::shield,
-line|z19-[highway=tertiary]::shield,
+line|z19-|highway-motorway::shield,
+line|z19-|highway-trunk::shield,
+line|z19-|highway-motorway_link::shield,
+line|z19-|highway-trunk_link::shield,
+line|z19-|highway-primary::shield,
+line|z19-|highway-primary_link::shield,
+line|z19-|highway-secondary::shield,
+line|z19-|highway-residential::shield,
+line|z19-|highway-tertiary::shield,
 {shield-font-size: 11;shield-min-distance: 350;}
 
 /* 3.TRUNK & MOTORWAY 10-22 ZOOM */
 
-line|z10-[highway=trunk],
-line|z10-[highway=motorway],
-line|z10-[highway=motorway_link],
-line|z10-[highway=trunk_link],
+line|z10-|highway-trunk,
+line|z10-|highway-motorway,
+line|z10-|highway-motorway_link,
+line|z10-|highway-trunk_link,
 {text: name; text-halo-radius: 1; text-halo-color: @label_halo_medium;}
 
-line|z10-11[highway=motorway],
-line|z10-11[highway=trunk],
+line|z10-11|highway-motorway,
+line|z10-11|highway-trunk,
 {font-size: 11; text-color: @label_medium; text-halo-opacity: 0.9;}
-line|z12-13[highway=motorway],
-line|z12-13[highway=trunk],
+line|z12-13|highway-motorway,
+line|z12-13|highway-trunk,
 {font-size: 12; text-color: @label_medium; text-halo-opacity: 1;}
-line|z14-[highway=trunk],
-line|z14-[highway=motorway],
+line|z14-|highway-trunk,
+line|z14-|highway-motorway,
 {font-size: 14; text-color: @label_dark; text-halo-opacity: 1; text-halo-color: @label_halo_light;}
 
-line|z10-13[highway=motorway_link],
-line|z10-13[highway=trunk_link],
+line|z10-13|highway-motorway_link,
+line|z10-13|highway-trunk_link,
 {font-size: 10; text-color: @label_medium; text-halo-opacity: 0.7;}
-line|z14-15[highway=motorway_link],
-line|z14-15[highway=trunk_link],
+line|z14-15|highway-motorway_link,
+line|z14-15|highway-trunk_link,
 {font-size: 11; text-color: @label_medium; text-halo-opacity: 0.9;}
-line|z16-[highway=motorway_link],
-line|z16-[highway=trunk_link],
+line|z16-|highway-motorway_link,
+line|z16-|highway-trunk_link,
 {font-size: 12; text-color: @label_medium; text-halo-opacity: 1; text-halo-color: @label_halo_light;}
 
 /* 4.PRIMARY 10-22 ZOOM */
 
-line|z10-[highway=primary],
-line|z11-[highway=primary_link],
+line|z10-|highway-primary,
+line|z11-|highway-primary_link,
 {text: name; text-halo-radius: 1; text-halo-color: @label_halo_medium;}
 
-line|z10-13[highway=primary],
-line|z11-13[highway=primary_link],
+line|z10-13|highway-primary,
+line|z11-13|highway-primary_link,
 {font-size: 10; text-color: @label_medium; text-halo-opacity: 0.7;}
-line|z14-15[highway=primary],
+line|z14-15|highway-primary,
 {font-size: 13; text-color: @label_dark; text-halo-opacity: 0.9;}
-line|z16-[highway=primary],
+line|z16-|highway-primary,
 {font-size: 14; text-color: @label_dark; text-halo-opacity: 1; text-halo-color: @label_halo_light;}
 
-line|z14-15[highway=primary_link],
+line|z14-15|highway-primary_link,
 {font-size: 10; text-color: @label_medium; text-halo-opacity: 0.9;}
-line|z16-[highway=primary_link],
+line|z16-|highway-primary_link,
 {font-size: 12; text-color: @label_medium; text-halo-opacity: 1; text-halo-color: @label_halo_light;}
 
 /* 5.SECONDARY 10-22 ZOOM */
 
-line|z10-[highway=secondary],
-line|z16-[highway=secondary_link],
+line|z10-|highway-secondary,
+line|z16-|highway-secondary_link,
 {text: name; text-halo-radius: 1; text-halo-color: @label_halo_medium;}
 
-line|z10-13[highway=secondary],
+line|z10-13|highway-secondary,
 {font-size: 10; text-color: @label_light; text-halo-opacity: 0.7;}
-line|z14-15[highway=secondary],
+line|z14-15|highway-secondary,
 {font-size: 11; text-color: @label_medium; text-halo-opacity: 0.9;}
-line|z16-[highway=secondary],
+line|z16-|highway-secondary,
 {font-size: 14; text-color: @label_dark; text-halo-opacity: 1; text-halo-color: @label_halo_light;}
 
-line|z16-[highway=secondary_link],
+line|z16-|highway-secondary_link,
 {font-size: 12; text-color: @label_medium; text-halo-opacity: 1; text-halo-color: @label_halo_light;}
 
 /* 6.RESIDENTAL & TERTIARY 12-22 ZOOM */
 
-line|z14-[railway=rail][usage=tourism],
+line|z14-|railway-rail-tourism,
 {font-size: 10; text: name; text-position: line; text-color: @label_medium; text-halo-opacity: 0.8; text-halo-radius: 1; text-halo-color: @label_halo_medium;}
-line|z15[railway=rail][usage=tourism],
+line|z15|railway-rail-tourism,
 {font-size: 11;}
-line|z16-[railway=rail][usage=tourism],
+line|z16-|railway-rail-tourism,
 {font-size: 12; text-halo-color: @label_halo_light;}
 
 
-line|z12-[highway=tertiary],
-line|z13-[highway=unclassified],
-line|z13-[highway=residential],
-line|z14-[highway=road],
-line|z18-[highway=tertiary_link],
+line|z12-|highway-tertiary,
+line|z13-|highway-unclassified,
+line|z13-|highway-residential,
+line|z14-|highway-road,
+line|z18-|highway-tertiary_link,
 {text: name; text-halo-radius: 1; text-halo-color: @label_halo_medium;}
 
-line|z12-13[highway=tertiary],
-line|z13[highway=unclassified],
-line|z13[highway=residential],
+line|z12-13|highway-tertiary,
+line|z13|highway-unclassified,
+line|z13|highway-residential,
 {font-size: 10; text-color: @label_light; text-halo-opacity: 0.7;}
-line|z14-15[highway=tertiary],
-line|z14-15[highway=unclassified],
-line|z14-15[highway=residential],
-line|z14-15[highway=road],
+line|z14-15|highway-tertiary,
+line|z14-15|highway-unclassified,
+line|z14-15|highway-residential,
+line|z14-15|highway-road,
 {font-size: 10; text-color: @label_medium; text-halo-opacity: 0.9;}
-line|z16-[highway=tertiary],
-line|z16-[highway=unclassified],
-line|z16-[highway=residential],
-line|z16-[highway=road],
-line|z18-[highway=tertiary_link],
+line|z16-|highway-tertiary,
+line|z16-|highway-unclassified,
+line|z16-|highway-residential,
+line|z16-|highway-road,
+line|z18-|highway-tertiary_link,
 {font-size: 12; text-color: @label_medium; text-halo-opacity: 1; text-halo-color: @label_halo_light;}
 
 /* 7.STREETS & SERVICE 14-22 ZOOM */
 
-line|z14-[highway=living_street],
-line|z14-[highway=pedestrian],
-line|z16-[highway=service],
-line|z16-[highway=service][service=busway],
-line|z16-[highway=busway],
+line|z14-|highway-living_street,
+line|z14-|highway-pedestrian,
+line|z16-|highway-service,
+line|z16-|[highway=service][service=busway] /*NO-TYPE-MATCH*/,
+line|z16-|highway-busway,
 {text: name; text-halo-radius: 1; text-halo-color: @label_halo_medium;}
 
-line|z14-15[highway=living_street],
-line|z14-15[highway=pedestrian],
+line|z14-15|highway-living_street,
+line|z14-15|highway-pedestrian,
 {font-size: 10; text-color: @label_light; text-halo-opacity: 0.9;}
-line|z16-17[highway=living_street],
-line|z16-17[highway=pedestrian],
-line|z16-17[highway=service],
-line|z16-17[highway=service][service=busway],
-line|z16-17[highway=busway],
+line|z16-17|highway-living_street,
+line|z16-17|highway-pedestrian,
+line|z16-17|highway-service,
+line|z16-17|[highway=service][service=busway] /*NO-TYPE-MATCH*/,
+line|z16-17|highway-busway,
 {font-size: 10; text-color: @label_medium; text-halo-opacity: 1; text-halo-color: @label_halo_light;}
-line|z18-[highway=living_street],
-line|z18-[highway=pedestrian],
-line|z18-[highway=service],
-line|z18-[highway=service][service=busway],
-line|z18-[highway=busway],
+line|z18-|highway-living_street,
+line|z18-|highway-pedestrian,
+line|z18-|highway-service,
+line|z18-|[highway=service][service=busway] /*NO-TYPE-MATCH*/,
+line|z18-|highway-busway,
 {font-size: 12; text-color: @label_medium; text-halo-opacity: 1; text-halo-color: @label_halo_light;}
 
 /* 8.OTHERS ROADS 15-22 ZOOM */
 
-line|z15-[highway=cycleway],
-line|z15-[highway=construction],
-line|z15-[highway=track],
-line|z15-[highway=path],
-line|z15-[highway=bridleway],
-line|z15-[highway=footway],
-line|z16-[leisure=track],
-line|z16-[highway=steps],
-line|z16-[highway=ford],
-line|z16-[highway=raceway],
+line|z15-|highway-cycleway,
+line|z15-|highway-construction,
+line|z15-|highway-track,
+line|z15-|highway-path,
+line|z15-|highway-bridleway,
+line|z15-|highway-footway,
+line|z16-|leisure-track,
+line|z16-|highway-steps,
+line|z16-|highway-ford,
+line|z16-|highway-raceway,
 {text: name;text-color: @label_medium;text-halo-opacity: 0.8;text-halo-radius: 1;text-halo-color: @label_halo_light;}
 
 /* Don't display names of sidewalks and pedestrian crossings. */
-line|z15-[highway=footway][footway=sidewalk],
-line|z15-[highway=footway][footway=crossing],
+line|z15-|highway-footway-sidewalk,
+line|z15-|highway-footway-crossing,
 {text: none;}
 
-line|z15[highway=construction],
-line|z15[highway=bridleway],
-line|z15[highway=path],
-line|z15[highway=footway],
-line|z15[highway=cycleway],
-line|z15[highway=track]
+line|z15|highway-construction,
+line|z15|highway-bridleway,
+line|z15|highway-path,
+line|z15|highway-footway,
+line|z15|highway-cycleway,
+line|z15|highway-track
 {font-size: 8;}
-line|z16-17[highway=ford],
-line|z16-17[highway=cycleway],
-line|z16-17[highway=construction],
-line|z16-17[highway=track],
-line|z16-17[highway=raceway],
-line|z16-17[leisure=track],
-line|z16-17[highway=path],
-line|z16-17[highway=bridleway],
-line|z16-17[highway=footway],
+line|z16-17|highway-ford,
+line|z16-17|highway-cycleway,
+line|z16-17|highway-construction,
+line|z16-17|highway-track,
+line|z16-17|highway-raceway,
+line|z16-17|leisure-track,
+line|z16-17|highway-path,
+line|z16-17|highway-bridleway,
+line|z16-17|highway-footway,
 {font-size: 9;}
-line|z18-[highway=ford],
-line|z18-[highway=cycleway],
-line|z18-[highway=construction],
-line|z18-[highway=track],
-line|z18-[highway=raceway],
-line|z18-[leisure=track],
-line|z18-[highway=path],
-line|z18-[highway=bridleway],
-line|z18-[highway=footway],
+line|z18-|highway-ford,
+line|z18-|highway-cycleway,
+line|z18-|highway-construction,
+line|z18-|highway-track,
+line|z18-|highway-raceway,
+line|z18-|leisure-track,
+line|z18-|highway-path,
+line|z18-|highway-bridleway,
+line|z18-|highway-footway,
 {font-size: 10;}
 
 /* 10.PISTE 15-22 ZOOM */
 
-line|z15-[aerialway=cable_car],
-line|z15-[aerialway=gondola],
-line|z15-[aerialway=mixed_lift],
-line|z15-[aerialway=chair_lift],
-line|z15-[aerialway=drag_lift],
-line|z15-[aerialway=j-bar],
-line|z15-[aerialway=t-bar],
-line|z15-[aerialway=magic_carpet],
-line|z15-[aerialway=platter],
-line|z15-[aerialway=rope_tow],
-line|z15-[piste:type=downhill],
-line|z15-[piste:type=nordic],
-line|z15-[piste:type=sled],
-line|z15-[piste:type=hike],
-line|z15-[piste:type=skitour],
+line|z15-|aerialway-cable_car,
+line|z15-|aerialway-gondola,
+line|z15-|aerialway-mixed_lift,
+line|z15-|aerialway-chair_lift,
+line|z15-|aerialway-drag_lift,
+line|z15-|aerialway-j-bar,
+line|z15-|aerialway-t-bar,
+line|z15-|aerialway-magic_carpet,
+line|z15-|aerialway-platter,
+line|z15-|aerialway-rope_tow,
+line|z15-|piste:type-downhill,
+line|z15-|piste:type-nordic,
+line|z15-|piste:type-sled,
+line|z15-|piste:type-hike,
+line|z15-|piste:type-skitour,
 {font-size: 9; text: name; text-color: @label_dark; text-halo-radius: 1; text-halo-opacity: 0.7; text-halo-color: @label_halo_light; text-position: line;}
 
-line|z16-17[aerialway=cable_car],
-line|z16-17[aerialway=gondola],
-line|z16-17[aerialway=mixed_lift],
-line|z16-17[aerialway=chair_lift],
-line|z16-17[aerialway=drag_lift],
-line|z16-17[aerialway=j-bar],
-line|z16-17[aerialway=t-bar],
-line|z16-17[aerialway=magic_carpet],
-line|z16-17[aerialway=platter],
-line|z16-17[aerialway=rope_tow],
-line|z16-17[piste:type=downhill],
-line|z16-17[piste:type=nordic],
-line|z16-17[piste:type=sled],
-line|z16-17[piste:type=hike],
-line|z16-17[piste:type=skitour],
+line|z16-17|aerialway-cable_car,
+line|z16-17|aerialway-gondola,
+line|z16-17|aerialway-mixed_lift,
+line|z16-17|aerialway-chair_lift,
+line|z16-17|aerialway-drag_lift,
+line|z16-17|aerialway-j-bar,
+line|z16-17|aerialway-t-bar,
+line|z16-17|aerialway-magic_carpet,
+line|z16-17|aerialway-platter,
+line|z16-17|aerialway-rope_tow,
+line|z16-17|piste:type-downhill,
+line|z16-17|piste:type-nordic,
+line|z16-17|piste:type-sled,
+line|z16-17|piste:type-hike,
+line|z16-17|piste:type-skitour,
 {font-size: 10;}
 
-line|z18-[aerialway=cable_car],
-line|z18-[aerialway=gondola],
-line|z18-[aerialway=mixed_lift],
-line|z18-[aerialway=chair_lift],
-line|z18-[aerialway=drag_lift],
-line|z18-[aerialway=j-bar],
-line|z18-[aerialway=t-bar],
-line|z18-[aerialway=magic_carpet],
-line|z18-[aerialway=platter],
-line|z18-[aerialway=rope_tow],
-line|z18-[piste:type=downhill],
-line|z18-[piste:type=nordic],
-line|z18-[piste:type=sled],
-line|z18-[piste:type=hike],
-line|z18-[piste:type=skitour],
+line|z18-|aerialway-cable_car,
+line|z18-|aerialway-gondola,
+line|z18-|aerialway-mixed_lift,
+line|z18-|aerialway-chair_lift,
+line|z18-|aerialway-drag_lift,
+line|z18-|aerialway-j-bar,
+line|z18-|aerialway-t-bar,
+line|z18-|aerialway-magic_carpet,
+line|z18-|aerialway-platter,
+line|z18-|aerialway-rope_tow,
+line|z18-|piste:type-downhill,
+line|z18-|piste:type-nordic,
+line|z18-|piste:type-sled,
+line|z18-|piste:type-hike,
+line|z18-|piste:type-skitour,
 {font-size: 12;}
 
 /* No captions for areal ski runs as they're supposed to have a labelled centerline. */
-area|z15-[piste:type=downhill][area],
-area|z15-[piste:type=sled][area],
+area|z15-|[piste:type=downhill][area] /*NO-TYPE-MATCH*/,
+area|z15-|[piste:type=sled][area] /*NO-TYPE-MATCH*/,
 {text: none;}
 
 /* 11. FERRY */
 
-line|z10-[route=ferry],
+line|z10-|route-ferry,
 {text: name;text-color: @water_label;text-position: line;}
 
-line|z10-16[route=ferry],
+line|z10-16|route-ferry,
 {font-size: 9;}
-line|z17-[route=ferry],
+line|z17-|route-ferry,
 {font-size: 10;}
 
 /* 12. ONEWAY ARROWS  */
 
 /* line|z15-[highway=primary][hwtag=oneway]::arrows <-- не работает по типам магистралей */
 
-line|z15[hwtag=oneway]::arrows
+line|z15|hwtag-oneway::arrows
 {pattern-offset: 30;pattern-image: arrow-xs.svg;pattern-spacing: 60;}
-line|z16[hwtag=oneway]::arrows
+line|z16|hwtag-oneway::arrows
 {pattern-offset: 50;pattern-image: arrow-s.svg;pattern-spacing: 70;}
-line|z17[hwtag=oneway]::arrows
+line|z17|hwtag-oneway::arrows
 {pattern-offset: 70;pattern-image: arrow-s.svg;pattern-spacing: 80;}
-line|z18-[hwtag=oneway]::arrows
+line|z18-|hwtag-oneway::arrows
 {pattern-offset: 90;pattern-image: arrow-m.svg;pattern-spacing: 90;}
 
 /* 13.JUNCTION  */
 
-node|z15-[highway=motorway_junction],
-node|z17-[junction],
+node|z15-|highway-motorway_junction,
+node|z17-|junction,
 {text: name;text-color: @subway_label;text-position: center;}
 
-node|z15[highway=motorway_junction]
+node|z15|highway-motorway_junction
 {font-size: 9;}
-node|z16-[highway=motorway_junction],
-node|z17-[junction],
+node|z16-|highway-motorway_junction,
+node|z17-|junction,
 {font-size: 10;}

--- a/data/styles/default/include/Subways.mapcss
+++ b/data/styles/default/include/Subways.mapcss
@@ -10,787 +10,1183 @@ the bbox to MatchCity() in generator/osm2type.cpp
 /* 1. Generic Subway and light_rail Station */
 
 /* reset style for generic station because railway-station inherited from icons.mapcss */
-node|z0-[railway=station][transport=subway],
-node|z0-[railway=station][station=light_rail],
+node|z0-|railway-station-subway,
+node|z0-|railway-station-light_rail,
 {icon-image: none; text: none;}
 
-node|z0-[railway=station][transport=subway]::int_name,
-node|z0-[railway=station][station=light_rail]::int_name,
+node|z0-|railway-station-subway::int_name,
+node|z0-|railway-station-light_rail::int_name,
 {icon-image: none; text: none;}
 /*TODO: for some reason, int_name rules and normal rules have to be
 separate, otherwise generating drules fails with a priority error */
 
-node|z13-[railway=station][transport=subway],
+node|z13-|railway-station-subway,
 {icon-image: subway-s.svg;}
-node|z15-[railway=station][transport=subway],
+node|z15-|railway-station-subway,
 {icon-image: subway-m.svg;}
-node|z13-[railway=station][station=light_rail],
+node|z13-|railway-station-light_rail,
 {icon-image: train-s.svg;}
-node|z15-[railway=station][station=light_rail],
+node|z15-|railway-station-light_rail,
 {icon-image: train-m.svg;}
 
-node|z14-[railway=station][transport=subway],
-node|z14-[railway=station][station=light_rail],
+node|z14-|railway-station-subway,
+node|z14-|railway-station-light_rail,
 {text: name;text-offset: 1;font-size: 11;text-color: @label_dark;text-halo-radius: 1;text-halo-color: @label_halo_light;text-halo-opacity: 0.8;}
-node|z14-[railway=station][transport=subway]::int_name,
-node|z14-[railway=station][station=light_rail]::int_name,
+node|z14-|railway-station-subway::int_name,
+node|z14-|railway-station-light_rail::int_name,
 {text: int_name;text-offset: 1;font-size: 9;text-color: @label_dark;text-halo-radius: 1;text-halo-color: @label_halo_light;text-halo-opacity: 0.8;}
 
-node|z15-[railway=station][transport=subway],
-node|z15-[railway=station][station=light_rail],
+node|z15-|railway-station-subway,
+node|z15-|railway-station-light_rail,
 {font-size: 12;}
-node|z16-[railway=station][transport=subway],
-node|z16-[railway=station][station=light_rail],
+node|z16-|railway-station-subway,
+node|z16-|railway-station-light_rail,
 {font-size: 13;}
-node|z17-[railway=station][transport=subway],
-node|z17-[railway=station][station=light_rail],
+node|z17-|railway-station-subway,
+node|z17-|railway-station-light_rail,
 {text-halo-opacity: 0.9;}
 
-node|z15-[railway=station][transport=subway]::int_name,
-node|z15-[railway=station][station=light_rail]::int_name,
+node|z15-|railway-station-subway::int_name,
+node|z15-|railway-station-light_rail::int_name,
 {font-size: 10;}
-node|z16-[railway=station][transport=subway]::int_name,
-node|z16-[railway=station][station=light_rail]::int_name
+node|z16-|railway-station-subway::int_name,
+node|z16-|railway-station-light_rail::int_name
 {font-size: 11}
-node|z17-[railway=station][transport=subway]::int_name,
-node|z17-[railway=station][station=light_rail]::int_name,
+node|z17-|railway-station-subway::int_name,
+node|z17-|railway-station-light_rail::int_name,
 {text-halo-opacity: 0.9;}
 
-node|z16-[railway=subway_entrance],
+node|z16-|railway-subway_entrance,
 {icon-image: subway-entrance-m.svg;}
 
-node|z17-[railway=subway_entrance],
+node|z17-|railway-subway_entrance,
 {text: name;font-size: 13;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 0.9;text-halo-color: @label_halo_light;text-offset: 1;}
-node|z17-[railway=subway_entrance]::int_name,
+node|z17-|railway-subway_entrance::int_name,
 {text: int_name;font-size: 11;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 0.9;text-halo-color: @label_halo_light;text-offset: 1;}
 
 
 /* 2. Custom Subway Station*/
 
 /* reset for stations that should render below z13 because railway-station-subway|light_rail inherited from above */
-node|z0-13[railway=station][transport=subway][city=tokyo],
+node|z0-13|railway-station-subway-tokyo,
 {icon-image: none; text: none;}
 
 /* Adana Subway Station */
-node|z12-[railway=station][transport=subway][city=adana] {icon-image: subway-adana-s.svg;}
-node|z15-[railway=station][transport=subway][city=adana] {icon-image: subway-adana-m.svg;}
-node|z16-[railway=subway_entrance][city=adana] {icon-image: subway-adana-s.svg;}
-node|z18-[railway=subway_entrance][city=adana] {icon-image: subway-adana-m.svg;}
+node|z12-|railway-station-subway-adana
+{icon-image: subway-adana-s.svg;}
+node|z15-|railway-station-subway-adana
+{icon-image: subway-adana-m.svg;}
+node|z16-|railway-subway_entrance-adana
+{icon-image: subway-adana-s.svg;}
+node|z18-|railway-subway_entrance-adana
+{icon-image: subway-adana-m.svg;}
 
 /* Algiers Subway Station */
-node|z12-[railway=station][transport=subway][city=algiers] {icon-image: subway-algeria-s.svg;}
-node|z15-[railway=station][transport=subway][city=algiers] {icon-image: subway-algeria-m.svg;}
-node|z16-[railway=subway_entrance][city=algiers] {icon-image: subway-algeria-s.svg;}
-node|z18-[railway=subway_entrance][city=algiers] {icon-image: subway-algeria-m.svg;}
+node|z12-|railway-station-subway-algiers
+{icon-image: subway-algeria-s.svg;}
+node|z15-|railway-station-subway-algiers
+{icon-image: subway-algeria-m.svg;}
+node|z16-|railway-subway_entrance-algiers
+{icon-image: subway-algeria-s.svg;}
+node|z18-|railway-subway_entrance-algiers
+{icon-image: subway-algeria-m.svg;}
 
 /* Almaty Subway Station */
-node|z12-[railway=station][transport=subway][city=almaty] {icon-image: subway-almaty-s.svg;}
-node|z15-[railway=station][transport=subway][city=almaty] {icon-image: subway-almaty-m.svg;}
-node|z16-[railway=subway_entrance][city=almaty] {icon-image: subway-almaty-s.svg;}
-node|z18-[railway=subway_entrance][city=almaty] {icon-image: subway-almaty-m.svg;}
+node|z12-|railway-station-subway-almaty
+{icon-image: subway-almaty-s.svg;}
+node|z15-|railway-station-subway-almaty
+{icon-image: subway-almaty-m.svg;}
+node|z16-|railway-subway_entrance-almaty
+{icon-image: subway-almaty-s.svg;}
+node|z18-|railway-subway_entrance-almaty
+{icon-image: subway-almaty-m.svg;}
 
 /* Amsterdam Subway Station */
-node|z12-[railway=station][transport=subway][city=amsterdam] {icon-image: subway-amsterdam-s.svg;}
-node|z15-[railway=station][transport=subway][city=amsterdam] {icon-image: subway-amsterdam-m.svg;}
-node|z16-[railway=subway_entrance][city=amsterdam] {icon-image: subway-amsterdam-s.svg;}
-node|z18-[railway=subway_entrance][city=amsterdam] {icon-image: subway-amsterdam-m.svg;}
+node|z12-|railway-station-subway-amsterdam
+{icon-image: subway-amsterdam-s.svg;}
+node|z15-|railway-station-subway-amsterdam
+{icon-image: subway-amsterdam-m.svg;}
+node|z16-|railway-subway_entrance-amsterdam
+{icon-image: subway-amsterdam-s.svg;}
+node|z18-|railway-subway_entrance-amsterdam
+{icon-image: subway-amsterdam-m.svg;}
 
 /* Ankara Subway Station */
-node|z13-[railway=station][transport=subway][city=ankara] {icon-image: subway-ankara-s.svg;}
-node|z15-[railway=station][transport=subway][city=ankara] {icon-image: subway-ankara-m.svg;}
-node|z16-[railway=subway_entrance][city=ankara] {icon-image: subway-ankara-s.svg;}
-node|z18-[railway=subway_entrance][city=ankara] {icon-image: subway-ankara-m.svg;}
+node|z13-|railway-station-subway-ankara
+{icon-image: subway-ankara-s.svg;}
+node|z15-|railway-station-subway-ankara
+{icon-image: subway-ankara-m.svg;}
+node|z16-|railway-subway_entrance-ankara
+{icon-image: subway-ankara-s.svg;}
+node|z18-|railway-subway_entrance-ankara
+{icon-image: subway-ankara-m.svg;}
 
 /* Athens Subway Station */
-node|z13-[railway=station][transport=subway][city=athens] {icon-image: subway-athens-s.svg;}
-node|z15-[railway=station][transport=subway][city=athens] {icon-image: subway-athens-m.svg;}
-node|z16-[railway=subway_entrance][city=athens] {icon-image: subway-athens-s.svg;}
-node|z18-[railway=subway_entrance][city=athens] {icon-image: subway-athens-m.svg;}
+node|z13-|railway-station-subway-athens
+{icon-image: subway-athens-s.svg;}
+node|z15-|railway-station-subway-athens
+{icon-image: subway-athens-m.svg;}
+node|z16-|railway-subway_entrance-athens
+{icon-image: subway-athens-s.svg;}
+node|z18-|railway-subway_entrance-athens
+{icon-image: subway-athens-m.svg;}
 
 /* Baku Subway Station */
-node|z13-[railway=station][transport=subway][city=baku] {icon-image: subway-baku-s.svg;}
-node|z15-[railway=station][transport=subway][city=baku] {icon-image: subway-baku-m.svg;}
-node|z16-[railway=subway_entrance][city=baku] {icon-image: subway-baku-s.svg;}
-node|z18-[railway=subway_entrance][city=baku] {icon-image: subway-baku-m.svg;}
+node|z13-|railway-station-subway-baku
+{icon-image: subway-baku-s.svg;}
+node|z15-|railway-station-subway-baku
+{icon-image: subway-baku-m.svg;}
+node|z16-|railway-subway_entrance-baku
+{icon-image: subway-baku-s.svg;}
+node|z18-|railway-subway_entrance-baku
+{icon-image: subway-baku-m.svg;}
 
 /* Bangkok Subway Station */
-node|z13-[railway=station][transport=subway][city=bangkok] {icon-image: subway-bangkok-s.svg;}
-node|z15-[railway=station][transport=subway][city=bangkok] {icon-image: subway-bangkok-m.svg;}
-node|z16-[railway=subway_entrance][city=bangkok] {icon-image: subway-bangkok-s.svg;}
-node|z18-[railway=subway_entrance][city=bangkok] {icon-image: subway-bangkok-m.svg;}
+node|z13-|railway-station-subway-bangkok
+{icon-image: subway-bangkok-s.svg;}
+node|z15-|railway-station-subway-bangkok
+{icon-image: subway-bangkok-m.svg;}
+node|z16-|railway-subway_entrance-bangkok
+{icon-image: subway-bangkok-s.svg;}
+node|z18-|railway-subway_entrance-bangkok
+{icon-image: subway-bangkok-m.svg;}
 
 /* Barcelona Subway Station */
-node|z13-[railway=station][transport=subway][city=barcelona] {icon-image: subway-barcelona-s.svg;}
-node|z15-[railway=station][transport=subway][city=barcelona] {icon-image: subway-barcelona-m.svg;}
-node|z16-[railway=subway_entrance][city=barcelona] {icon-image: subway-barcelona-s.svg;}
-node|z18-[railway=subway_entrance][city=barcelona] {icon-image: subway-barcelona-m.svg;}
+node|z13-|railway-station-subway-barcelona
+{icon-image: subway-barcelona-s.svg;}
+node|z15-|railway-station-subway-barcelona
+{icon-image: subway-barcelona-m.svg;}
+node|z16-|railway-subway_entrance-barcelona
+{icon-image: subway-barcelona-s.svg;}
+node|z18-|railway-subway_entrance-barcelona
+{icon-image: subway-barcelona-m.svg;}
 
 /* Beijing Subway Station */
-node|z12-[railway=station][transport=subway][city=beijing] {icon-image: subway-beijing-s.svg;}
-node|z15-[railway=station][transport=subway][city=beijing] {icon-image: subway-beijing-m.svg;}
-node|z16-[railway=subway_entrance][city=beijing] {icon-image: subway-beijing-s.svg;}
-node|z18-[railway=subway_entrance][city=beijing] {icon-image: subway-beijing-m.svg;}
+node|z12-|railway-station-subway-beijing
+{icon-image: subway-beijing-s.svg;}
+node|z15-|railway-station-subway-beijing
+{icon-image: subway-beijing-m.svg;}
+node|z16-|railway-subway_entrance-beijing
+{icon-image: subway-beijing-s.svg;}
+node|z18-|railway-subway_entrance-beijing
+{icon-image: subway-beijing-m.svg;}
 
 /* Berlin Subway Station*/
-node|z12-[railway=station][transport=subway][city=berlin] {icon-image: subway-ubahn-s.svg;}
-node|z15-[railway=station][transport=subway][city=berlin] {icon-image: subway-ubahn-m.svg;}
-node|z16-[railway=subway_entrance][city=berlin] {icon-image: subway-ubahn-s.svg;}
+node|z12-|railway-station-subway-berlin
+{icon-image: subway-ubahn-s.svg;}
+node|z15-|railway-station-subway-berlin
+{icon-image: subway-ubahn-m.svg;}
+node|z16-|railway-subway_entrance-berlin
+{icon-image: subway-ubahn-s.svg;}
 
 /* Boston Subway Station*/
-node|z12-[railway=station][transport=subway][city=boston] {icon-image: subway-massachusetts-s.svg;}
-node|z15-[railway=station][transport=subway][city=boston] {icon-image: subway-massachusetts-m.svg;}
-node|z16-[railway=subway_entrance][city=boston] {icon-image: subway-massachusetts-m.svg;}
+node|z12-|railway-station-subway-boston
+{icon-image: subway-massachusetts-s.svg;}
+node|z15-|railway-station-subway-boston
+{icon-image: subway-massachusetts-m.svg;}
+node|z16-|railway-subway_entrance-boston
+{icon-image: subway-massachusetts-m.svg;}
 
 /* Bengaluru Subway Station*/
-node|z13-[railway=station][transport=subway][city=bengalore] {icon-image: subway-bengaluru-s.svg;}
-node|z15-[railway=station][transport=subway][city=bengalore] {icon-image: subway-bengaluru-m.svg;}
-node|z16-[railway=subway_entrance][city=bengalore] {icon-image: subway-bengaluru-s.svg;}
+node|z13-|railway-station-subway-bengalore
+{icon-image: subway-bengaluru-s.svg;}
+node|z15-|railway-station-subway-bengalore
+{icon-image: subway-bengaluru-m.svg;}
+node|z16-|railway-subway_entrance-bengalore
+{icon-image: subway-bengaluru-s.svg;}
 
 /* Bilbao Subway Station*/
-node|z13-[railway=station][transport=subway][city=bilbao] {icon-image: subway-bilbao-s.svg;}
-node|z15-[railway=station][transport=subway][city=bilbao] {icon-image: subway-bilbao-m.svg;}
-node|z16-[railway=subway_entrance][city=bilbao] {icon-image: subway-bilbao-s.svg;}
+node|z13-|railway-station-subway-bilbao
+{icon-image: subway-bilbao-s.svg;}
+node|z15-|railway-station-subway-bilbao
+{icon-image: subway-bilbao-m.svg;}
+node|z16-|railway-subway_entrance-bilbao
+{icon-image: subway-bilbao-s.svg;}
 
 /* Brasilia Subway Station*/
-node|z13-[railway=station][transport=subway][city=brasilia] {icon-image: subway-brasilia-s.svg;}
-node|z15-[railway=station][transport=subway][city=brasilia] {icon-image: subway-brasilia-m.svg;}
-node|z16-[railway=subway_entrance][city=brasilia] {icon-image: subway-brasilia-s.svg;}
+node|z13-|railway-station-subway-brasilia
+{icon-image: subway-brasilia-s.svg;}
+node|z15-|railway-station-subway-brasilia
+{icon-image: subway-brasilia-m.svg;}
+node|z16-|railway-subway_entrance-brasilia
+{icon-image: subway-brasilia-s.svg;}
 
 /* Brescia Subway Station*/
-node|z13-[railway=station][transport=subway][city=brescia] {icon-image: subway-brescia-s.svg;}
-node|z15-[railway=station][transport=subway][city=brescia] {icon-image: subway-brescia-m.svg;}
-node|z16-[railway=subway_entrance][city=brescia] {icon-image: subway-brescia-s.svg;}
+node|z13-|railway-station-subway-brescia
+{icon-image: subway-brescia-s.svg;}
+node|z15-|railway-station-subway-brescia
+{icon-image: subway-brescia-m.svg;}
+node|z16-|railway-subway_entrance-brescia
+{icon-image: subway-brescia-s.svg;}
 
 /* Brussels Subway Station */
-node|z13-[railway=station][transport=subway][city=brussels] {icon-image: subway-brussel-s.svg;}
-node|z15-[railway=station][transport=subway][city=brussels] {icon-image: subway-brussel-m.svg;}
-node|z16-[railway=subway_entrance][city=brussels] {icon-image: subway-brussel-s.svg;}
-node|z18-[railway=subway_entrance][city=brussels] {icon-image: subway-brussel-m.svg;}
+node|z13-|railway-station-subway-brussels
+{icon-image: subway-brussel-s.svg;}
+node|z15-|railway-station-subway-brussels
+{icon-image: subway-brussel-m.svg;}
+node|z16-|railway-subway_entrance-brussels
+{icon-image: subway-brussel-s.svg;}
+node|z18-|railway-subway_entrance-brussels
+{icon-image: subway-brussel-m.svg;}
 
 /* Bucharest Subway Station */
-node|z13-[railway=station][transport=subway][city=bucharest] {icon-image: subway-bucharest-s.svg;}
-node|z15-[railway=station][transport=subway][city=bucharest] {icon-image: subway-bucharest-m.svg;}
-node|z16-[railway=subway_entrance][city=bucharest] {icon-image: subway-bucharest-s.svg;}
-node|z18-[railway=subway_entrance][city=bucharest] {icon-image: subway-bucharest-m.svg;}
+node|z13-|railway-station-subway-bucharest
+{icon-image: subway-bucharest-s.svg;}
+node|z15-|railway-station-subway-bucharest
+{icon-image: subway-bucharest-m.svg;}
+node|z16-|railway-subway_entrance-bucharest
+{icon-image: subway-bucharest-s.svg;}
+node|z18-|railway-subway_entrance-bucharest
+{icon-image: subway-bucharest-m.svg;}
 
 /* Budapest Subway Station */
-node|z13-[railway=station][transport=subway][city=budapest] {icon-image: subway-budapest-s.svg;}
-node|z15-[railway=station][transport=subway][city=budapest] {icon-image: subway-budapest-m.svg;}
-node|z16-[railway=subway_entrance][city=budapest] {icon-image: subway-budapest-s.svg;}
-node|z18-[railway=subway_entrance][city=budapest] {icon-image: subway-budapest-m.svg;}
+node|z13-|railway-station-subway-budapest
+{icon-image: subway-budapest-s.svg;}
+node|z15-|railway-station-subway-budapest
+{icon-image: subway-budapest-m.svg;}
+node|z16-|railway-subway_entrance-budapest
+{icon-image: subway-budapest-s.svg;}
+node|z18-|railway-subway_entrance-budapest
+{icon-image: subway-budapest-m.svg;}
 
 /* Buenos Aires Subway Station */
-node|z12-[railway=station][transport=subway][city=buenos_aires] {icon-image: subway-buenosaires-s.svg;}
-node|z15-[railway=station][transport=subway][city=buenos_aires] {icon-image: subway-buenosaires-m.svg;}
-node|z16-[railway=subway_entrance][city=buenos_aires] {icon-image: subway-buenosaires-s.svg;}
-node|z18-[railway=subway_entrance][city=buenos_aires] {icon-image: subway-buenosaires-m.svg;}
+node|z12-|railway-station-subway-buenos_aires
+{icon-image: subway-buenosaires-s.svg;}
+node|z15-|railway-station-subway-buenos_aires
+{icon-image: subway-buenosaires-m.svg;}
+node|z16-|railway-subway_entrance-buenos_aires
+{icon-image: subway-buenosaires-s.svg;}
+node|z18-|railway-subway_entrance-buenos_aires
+{icon-image: subway-buenosaires-m.svg;}
 
 /* Bursaray Subway Station */
-node|z13-[railway=station][transport=subway][city=bursa] {icon-image: subway-bursaray-s.svg;}
-node|z15-[railway=station][transport=subway][city=bursa] {icon-image: subway-bursaray-m.svg;}
-node|z16-[railway=subway_entrance][city=bursa] {icon-image: subway-bursaray-s.svg;}
-node|z18-[railway=subway_entrance][city=bursa] {icon-image: subway-bursaray-m.svg;}
+node|z13-|railway-station-subway-bursa
+{icon-image: subway-bursaray-s.svg;}
+node|z15-|railway-station-subway-bursa
+{icon-image: subway-bursaray-m.svg;}
+node|z16-|railway-subway_entrance-bursa
+{icon-image: subway-bursaray-s.svg;}
+node|z18-|railway-subway_entrance-bursa
+{icon-image: subway-bursaray-m.svg;}
 
 /* Cairo Subway Station */
-node|z13-[railway=station][transport=subway][city=cairo] {icon-image: subway-cairo-s.svg;}
-node|z15-[railway=station][transport=subway][city=cairo] {icon-image: subway-cairo-m.svg;}
-node|z16-[railway=subway_entrance][city=cairo] {icon-image: subway-cairo-s.svg;}
-node|z18-[railway=subway_entrance][city=cairo] {icon-image: subway-cairo-m.svg;}
+node|z13-|railway-station-subway-cairo
+{icon-image: subway-cairo-s.svg;}
+node|z15-|railway-station-subway-cairo
+{icon-image: subway-cairo-m.svg;}
+node|z16-|railway-subway_entrance-cairo
+{icon-image: subway-cairo-s.svg;}
+node|z18-|railway-subway_entrance-cairo
+{icon-image: subway-cairo-m.svg;}
 
 /* Caracas Subway Station */
-node|z13-[railway=station][transport=subway][city=caracas] {icon-image: subway-caracas-s.svg;}
-node|z15-[railway=station][transport=subway][city=caracas] {icon-image: subway-caracas-m.svg;}
-node|z16-[railway=subway_entrance][city=caracas] {icon-image: subway-caracas-s.svg;}
-node|z18-[railway=subway_entrance][city=caracas] {icon-image: subway-caracas-m.svg;}
+node|z13-|railway-station-subway-caracas
+{icon-image: subway-caracas-s.svg;}
+node|z15-|railway-station-subway-caracas
+{icon-image: subway-caracas-m.svg;}
+node|z16-|railway-subway_entrance-caracas
+{icon-image: subway-caracas-s.svg;}
+node|z18-|railway-subway_entrance-caracas
+{icon-image: subway-caracas-m.svg;}
 
 /* Catania Subway Station */
-node|z13-[railway=station][transport=subway][city=catania] {icon-image: subway-catania-s.svg;}
-node|z15-[railway=station][transport=subway][city=catania] {icon-image: subway-catania-m.svg;}
-node|z16-[railway=subway_entrance][city=catania] {icon-image: subway-catania-s.svg;}
-node|z18-[railway=subway_entrance][city=catania] {icon-image: subway-catania-m.svg;}
+node|z13-|railway-station-subway-catania
+{icon-image: subway-catania-s.svg;}
+node|z15-|railway-station-subway-catania
+{icon-image: subway-catania-m.svg;}
+node|z16-|railway-subway_entrance-catania
+{icon-image: subway-catania-s.svg;}
+node|z18-|railway-subway_entrance-catania
+{icon-image: subway-catania-m.svg;}
 
 /* Changchun Subway Station */
-node|z13-[railway=station][transport=subway][city=changchun] {icon-image: subway-changchun-s.svg;}
-node|z15-[railway=station][transport=subway][city=changchun] {icon-image: subway-changchun-m.svg;}
-node|z16-[railway=subway_entrance][city=changchun] {icon-image: subway-changchun-s.svg;}
-node|z18-[railway=subway_entrance][city=changchun] {icon-image: subway-changchun-m.svg;}
+node|z13-|railway-station-subway-changchun
+{icon-image: subway-changchun-s.svg;}
+node|z15-|railway-station-subway-changchun
+{icon-image: subway-changchun-m.svg;}
+node|z16-|railway-subway_entrance-changchun
+{icon-image: subway-changchun-s.svg;}
+node|z18-|railway-subway_entrance-changchun
+{icon-image: subway-changchun-m.svg;}
 
 /* Chengdu Subway Station */
-node|z13-[railway=station][transport=subway][city=chengdu] {icon-image: subway-chengdu-s.svg;}
-node|z15-[railway=station][transport=subway][city=chengdu] {icon-image: subway-chengdu-m.svg;}
-node|z16-[railway=subway_entrance][city=chengdu] {icon-image: subway-chengdu-s.svg;}
-node|z18-[railway=subway_entrance][city=chengdu] {icon-image: subway-chengdu-m.svg;}
+node|z13-|railway-station-subway-chengdu
+{icon-image: subway-chengdu-s.svg;}
+node|z15-|railway-station-subway-chengdu
+{icon-image: subway-chengdu-m.svg;}
+node|z16-|railway-subway_entrance-chengdu
+{icon-image: subway-chengdu-s.svg;}
+node|z18-|railway-subway_entrance-chengdu
+{icon-image: subway-chengdu-m.svg;}
 
 /* Chicago Subway Station */
-node|z13-[railway=station][transport=subway][city=chicago] {icon-image: subway-chicago-s.svg;}
-node|z15-[railway=station][transport=subway][city=chicago] {icon-image: subway-chicago-m.svg;}
-node|z16-[railway=subway_entrance][city=chicago] {icon-image: subway-chicago-s.svg;}
-node|z18-[railway=subway_entrance][city=chicago] {icon-image: subway-chicago-m.svg;}
+node|z13-|railway-station-subway-chicago
+{icon-image: subway-chicago-s.svg;}
+node|z15-|railway-station-subway-chicago
+{icon-image: subway-chicago-m.svg;}
+node|z16-|railway-subway_entrance-chicago
+{icon-image: subway-chicago-s.svg;}
+node|z18-|railway-subway_entrance-chicago
+{icon-image: subway-chicago-m.svg;}
 
 /* Chongqing Subway Station */
-node|z13-[railway=station][transport=subway][city=chongqing] {icon-image: subway-chongqing-s.svg;}
-node|z15-[railway=station][transport=subway][city=chongqing] {icon-image: subway-chongqing-m.svg;}
-node|z16-[railway=subway_entrance][city=chongqing] {icon-image: subway-chongqing-s.svg;}
-node|z18-[railway=subway_entrance][city=chongqing] {icon-image: subway-chongqing-m.svg;}
+node|z13-|railway-station-subway-chongqing
+{icon-image: subway-chongqing-s.svg;}
+node|z15-|railway-station-subway-chongqing
+{icon-image: subway-chongqing-m.svg;}
+node|z16-|railway-subway_entrance-chongqing
+{icon-image: subway-chongqing-s.svg;}
+node|z18-|railway-subway_entrance-chongqing
+{icon-image: subway-chongqing-m.svg;}
 
 /* Dalian Subway Station */
-node|z13-[railway=station][transport=subway][city=dalian] {icon-image: subway-dalian-s.svg;}
-node|z15-[railway=station][transport=subway][city=dalian] {icon-image: subway-dalian-m.svg;}
-node|z16-[railway=subway_entrance][city=dalian] {icon-image: subway-dalian-s.svg;}
-node|z18-[railway=subway_entrance][city=dalian] {icon-image: subway-dalian-m.svg;}
+node|z13-|railway-station-subway-dalian
+{icon-image: subway-dalian-s.svg;}
+node|z15-|railway-station-subway-dalian
+{icon-image: subway-dalian-m.svg;}
+node|z16-|railway-subway_entrance-dalian
+{icon-image: subway-dalian-s.svg;}
+node|z18-|railway-subway_entrance-dalian
+{icon-image: subway-dalian-m.svg;}
 
 /* Delhi Subway Station */
-node|z13-[railway=station][transport=subway][city=delhi] {icon-image: subway-delhi-s.svg;}
-node|z15-[railway=station][transport=subway][city=delhi] {icon-image: subway-delhi-m.svg;}
-node|z16-[railway=subway_entrance][city=delhi] {icon-image: subway-delhi-s.svg;}
-node|z18-[railway=subway_entrance][city=delhi] {icon-image: subway-delhi-m.svg;}
+node|z13-|railway-station-subway-delhi
+{icon-image: subway-delhi-s.svg;}
+node|z15-|railway-station-subway-delhi
+{icon-image: subway-delhi-m.svg;}
+node|z16-|railway-subway_entrance-delhi
+{icon-image: subway-delhi-s.svg;}
+node|z18-|railway-subway_entrance-delhi
+{icon-image: subway-delhi-m.svg;}
 
 /* Dnepro Subway Station */
-node|z13-[railway=station][transport=subway][city=dnepro] {icon-image: subway-dnepro-s.svg;}
-node|z15-[railway=station][transport=subway][city=dnepro] {icon-image: subway-dnepro-m.svg;}
-node|z16-[railway=subway_entrance][city=dnepro] {icon-image: subway-dnepro-s.svg;}
-node|z18-[railway=subway_entrance][city=dnepro] {icon-image: subway-dnepro-m.svg;}
+node|z13-|railway-station-subway-dnepro
+{icon-image: subway-dnepro-s.svg;}
+node|z15-|railway-station-subway-dnepro
+{icon-image: subway-dnepro-m.svg;}
+node|z16-|railway-subway_entrance-dnepro
+{icon-image: subway-dnepro-s.svg;}
+node|z18-|railway-subway_entrance-dnepro
+{icon-image: subway-dnepro-m.svg;}
 
 /* Dubai Subway Station */
-node|z13-[railway=station][transport=subway][city=dubai] {icon-image: subway-dubai-s.svg;}
-node|z15-[railway=station][transport=subway][city=dubai] {icon-image: subway-dubai-m.svg;}
-node|z16-[railway=subway_entrance][city=dubai] {icon-image: subway-dubai-s.svg;}
-node|z18-[railway=subway_entrance][city=dubai] {icon-image: subway-dubai-m.svg;}
+node|z13-|railway-station-subway-dubai
+{icon-image: subway-dubai-s.svg;}
+node|z15-|railway-station-subway-dubai
+{icon-image: subway-dubai-m.svg;}
+node|z16-|railway-subway_entrance-dubai
+{icon-image: subway-dubai-s.svg;}
+node|z18-|railway-subway_entrance-dubai
+{icon-image: subway-dubai-m.svg;}
 
 /* Ekaterinburg Subway Station */
-node|z13-[railway=station][transport=subway][city=ekb] {icon-image: subway-ekb-s.svg;}
-node|z15-[railway=station][transport=subway][city=ekb] {icon-image: subway-ekb-m.svg;}
-node|z16-[railway=subway_entrance][city=ekb] {icon-image: subway-ekb-s.svg;}
-node|z18-[railway=subway_entrance][city=ekb] {icon-image: subway-ekb-m.svg;}
+node|z13-|railway-station-subway-ekb
+{icon-image: subway-ekb-s.svg;}
+node|z15-|railway-station-subway-ekb
+{icon-image: subway-ekb-m.svg;}
+node|z16-|railway-subway_entrance-ekb
+{icon-image: subway-ekb-s.svg;}
+node|z18-|railway-subway_entrance-ekb
+{icon-image: subway-ekb-m.svg;}
 
 /* Fukuoka Subway Station */
-node|z13-[railway=station][transport=subway][city=fukuoka] {icon-image: subway-fukuoka-s.svg;}
-node|z15-[railway=station][transport=subway][city=fukuoka] {icon-image: subway-fukuoka-m.svg;}
-node|z16-[railway=subway_entrance][city=fukuoka] {icon-image: subway-fukuoka-s.svg;}
-node|z18-[railway=subway_entrance][city=fukuoka] {icon-image: subway-fukuoka-m.svg;}
+node|z13-|railway-station-subway-fukuoka
+{icon-image: subway-fukuoka-s.svg;}
+node|z15-|railway-station-subway-fukuoka
+{icon-image: subway-fukuoka-m.svg;}
+node|z16-|railway-subway_entrance-fukuoka
+{icon-image: subway-fukuoka-s.svg;}
+node|z18-|railway-subway_entrance-fukuoka
+{icon-image: subway-fukuoka-m.svg;}
 
 /* Glasgow Subway Station */
-node|z13-[railway=station][transport=subway][city=glasgow] {icon-image: subway-glasgow-s.svg;}
-node|z15-[railway=station][transport=subway][city=glasgow] {icon-image: subway-glasgow-m.svg;}
-node|z16-[railway=subway_entrance][city=glasgow] {icon-image: subway-glasgow-s.svg;}
-node|z18-[railway=subway_entrance][city=glasgow] {icon-image: subway-glasgow-m.svg;}
+node|z13-|railway-station-subway-glasgow
+{icon-image: subway-glasgow-s.svg;}
+node|z15-|railway-station-subway-glasgow
+{icon-image: subway-glasgow-m.svg;}
+node|z16-|railway-subway_entrance-glasgow
+{icon-image: subway-glasgow-s.svg;}
+node|z18-|railway-subway_entrance-glasgow
+{icon-image: subway-glasgow-m.svg;}
 
 /* Guangzhou Subway Station */
-node|z13-[railway=station][transport=subway][city=guangzhou] {icon-image: subway-guangzhou-s.svg;}
-node|z15-[railway=station][transport=subway][city=guangzhou] {icon-image: subway-guangzhou-m.svg;}
-node|z16-[railway=subway_entrance][city=guangzhou] {icon-image: subway-guangzhou-s.svg;}
-node|z18-[railway=subway_entrance][city=guangzhou] {icon-image: subway-guangzhou-m.svg;}
+node|z13-|railway-station-subway-guangzhou
+{icon-image: subway-guangzhou-s.svg;}
+node|z15-|railway-station-subway-guangzhou
+{icon-image: subway-guangzhou-m.svg;}
+node|z16-|railway-subway_entrance-guangzhou
+{icon-image: subway-guangzhou-s.svg;}
+node|z18-|railway-subway_entrance-guangzhou
+{icon-image: subway-guangzhou-m.svg;}
 
 /* Hamburg Subway Station */
-node|z13-[railway=station][transport=subway][city=hamburg] {icon-image: subway-ubahn-s.svg;}
-node|z15-[railway=station][transport=subway][city=hamburg] {icon-image: subway-ubahn-m.svg;}
-node|z16-[railway=subway_entrance][city=hamburg] {icon-image: subway-ubahn-s.svg;}
-node|z18-[railway=subway_entrance][city=hamburg] {icon-image: subway-ubahn-m.svg;}
+node|z13-|railway-station-subway-hamburg
+{icon-image: subway-ubahn-s.svg;}
+node|z15-|railway-station-subway-hamburg
+{icon-image: subway-ubahn-m.svg;}
+node|z16-|railway-subway_entrance-hamburg
+{icon-image: subway-ubahn-s.svg;}
+node|z18-|railway-subway_entrance-hamburg
+{icon-image: subway-ubahn-m.svg;}
 
 /* Helsinki Subway Station */
-node|z13-[railway=station][transport=subway][city=helsinki] {icon-image: subway-helsinki-s.svg;}
-node|z15-[railway=station][transport=subway][city=helsinki] {icon-image: subway-helsinki-m.svg;}
-node|z16-[railway=subway_entrance][city=helsinki] {icon-image: subway-helsinki-s.svg;}
-node|z18-[railway=subway_entrance][city=helsinki] {icon-image: subway-helsinki-m.svg;}
+node|z13-|railway-station-subway-helsinki
+{icon-image: subway-helsinki-s.svg;}
+node|z15-|railway-station-subway-helsinki
+{icon-image: subway-helsinki-m.svg;}
+node|z16-|railway-subway_entrance-helsinki
+{icon-image: subway-helsinki-s.svg;}
+node|z18-|railway-subway_entrance-helsinki
+{icon-image: subway-helsinki-m.svg;}
 
 /* Hirosima Subway Station */
-node|z13-[railway=station][transport=subway][city=hiroshima] {icon-image: subway-hirosima-s.svg;}
-node|z15-[railway=station][transport=subway][city=hiroshima] {icon-image: subway-hirosima-m.svg;}
-node|z16-[railway=subway_entrance][city=hiroshima] {icon-image: subway-hirosima-s.svg;}
-node|z18-[railway=subway_entrance][city=hiroshima] {icon-image: subway-hirosima-m.svg;}
+node|z13-|railway-station-subway-hiroshima
+{icon-image: subway-hirosima-s.svg;}
+node|z15-|railway-station-subway-hiroshima
+{icon-image: subway-hirosima-m.svg;}
+node|z16-|railway-subway_entrance-hiroshima
+{icon-image: subway-hirosima-s.svg;}
+node|z18-|railway-subway_entrance-hiroshima
+{icon-image: subway-hirosima-m.svg;}
 
 /* Isfahan Subway Station */
-node|z13-[railway=station][transport=subway][city=isfahan] {icon-image: subway-isfahan-s.svg;}
-node|z15-[railway=station][transport=subway][city=isfahan] {icon-image: subway-isfahan-m.svg;}
-node|z16-[railway=subway_entrance][city=isfahan] {icon-image: subway-isfahan-s.svg;}
-node|z18-[railway=subway_entrance][city=isfahan] {icon-image: subway-isfahan-m.svg;}
+node|z13-|railway-station-subway-isfahan
+{icon-image: subway-isfahan-s.svg;}
+node|z15-|railway-station-subway-isfahan
+{icon-image: subway-isfahan-m.svg;}
+node|z16-|railway-subway_entrance-isfahan
+{icon-image: subway-isfahan-s.svg;}
+node|z18-|railway-subway_entrance-isfahan
+{icon-image: subway-isfahan-m.svg;}
 
 /* Istanbul Subway Station */
-node|z12-[railway=station][transport=subway][city=istanbul] {icon-image: subway-istanbul-s.svg;}
-node|z15-[railway=station][transport=subway][city=istanbul] {icon-image: subway-istanbul-m.svg;}
-node|z16-[railway=subway_entrance][city=istanbul] {icon-image: subway-istanbul-s.svg;}
-node|z18-[railway=subway_entrance][city=istanbul] {icon-image: subway-istanbul-m.svg;}
+node|z12-|railway-station-subway-istanbul
+{icon-image: subway-istanbul-s.svg;}
+node|z15-|railway-station-subway-istanbul
+{icon-image: subway-istanbul-m.svg;}
+node|z16-|railway-subway_entrance-istanbul
+{icon-image: subway-istanbul-s.svg;}
+node|z18-|railway-subway_entrance-istanbul
+{icon-image: subway-istanbul-m.svg;}
 
 /* Izmir Subway Station */
-node|z13-[railway=station][transport=subway][city=izmir] {icon-image: subway-izmir-s.svg;}
-node|z15-[railway=station][transport=subway][city=izmir] {icon-image: subway-izmir-m.svg;}
-node|z16-[railway=subway_entrance][city=izmir] {icon-image: subway-izmir-s.svg;}
-node|z18-[railway=subway_entrance][city=izmir] {icon-image: subway-izmir-m.svg;}
+node|z13-|railway-station-subway-izmir
+{icon-image: subway-izmir-s.svg;}
+node|z15-|railway-station-subway-izmir
+{icon-image: subway-izmir-m.svg;}
+node|z16-|railway-subway_entrance-izmir
+{icon-image: subway-izmir-s.svg;}
+node|z18-|railway-subway_entrance-izmir
+{icon-image: subway-izmir-m.svg;}
 
 /* Kazan Subway Station */
-node|z13-[railway=station][transport=subway][city=kazan] {icon-image: subway-kazan-s.svg;}
-node|z15-[railway=station][transport=subway][city=kazan] {icon-image: subway-kazan-m.svg;}
-node|z16-[railway=subway_entrance][city=kazan] {icon-image: subway-kazan-s.svg;}
-node|z18-[railway=subway_entrance][city=kazan] {icon-image: subway-kazan-m.svg;}
+node|z13-|railway-station-subway-kazan
+{icon-image: subway-kazan-s.svg;}
+node|z15-|railway-station-subway-kazan
+{icon-image: subway-kazan-m.svg;}
+node|z16-|railway-subway_entrance-kazan
+{icon-image: subway-kazan-s.svg;}
+node|z18-|railway-subway_entrance-kazan
+{icon-image: subway-kazan-m.svg;}
 
 /* Kharkiv Subway Station */
-node|z13-[railway=station][transport=subway][city=kharkiv] {icon-image: subway-kharkiv-s.svg;}
-node|z15-[railway=station][transport=subway][city=kharkiv] {icon-image: subway-kharkiv-m.svg;}
-node|z16-[railway=subway_entrance][city=kharkiv] {icon-image: subway-kharkiv-s.svg;}
-node|z18-[railway=subway_entrance][city=kharkiv] {icon-image: subway-kharkiv-m.svg;}
+node|z13-|railway-station-subway-kharkiv
+{icon-image: subway-kharkiv-s.svg;}
+node|z15-|railway-station-subway-kharkiv
+{icon-image: subway-kharkiv-m.svg;}
+node|z16-|railway-subway_entrance-kharkiv
+{icon-image: subway-kharkiv-s.svg;}
+node|z18-|railway-subway_entrance-kharkiv
+{icon-image: subway-kharkiv-m.svg;}
 
 /* Kiev Subway Station */
-node|z12-13[railway=station][transport=subway][city=kiev] {icon-image: subway-kiev-s.svg;text-offset: 1;font-size: 10;text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 0.7;text-halo-color: @label_halo_light;}
-node|z14[railway=station][transport=subway][city=kiev] {icon-image: subway-kiev-s.svg;}
-node|z15-16[railway=station][transport=subway][city=kiev] {icon-image: subway-kiev-m.svg;}
-node|z17-[railway=station][transport=subway][city=kiev] {icon-image: none;text: none;} /*only show subway entrance past z17*/
-node|z17-[railway=station][transport=subway][city=kiev]::int_name {icon-image: none;text: none;}
-node|z16-[railway=subway_entrance][city=kiev] {icon-image: subway-kiev-m.svg;}
+node|z12-13|railway-station-subway-kiev
+{icon-image: subway-kiev-s.svg;text-offset: 1;font-size: 10;text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 0.7;text-halo-color: @label_halo_light;}
+node|z14|railway-station-subway-kiev
+{icon-image: subway-kiev-s.svg;}
+node|z15-16|railway-station-subway-kiev
+{icon-image: subway-kiev-m.svg;}
+node|z17-|railway-station-subway-kiev
+{icon-image: none;text: none;} /*only show subway entrance past z17*/
+node|z17-|railway-station-subway-kiev::int_name {icon-image: none;text: none;}
+node|z16-|railway-subway_entrance-kiev
+{icon-image: subway-kiev-m.svg;}
 
 /* Kobe Subway Station */
-node|z13-[railway=station][transport=subway][city=kobe] {icon-image: subway-kobe-s.svg;}
-node|z15-[railway=station][transport=subway][city=kobe] {icon-image: subway-kobe-m.svg;}
-node|z16-[railway=subway_entrance][city=kobe] {icon-image: subway-kobe-s.svg;}
-node|z18-[railway=subway_entrance][city=kobe] {icon-image: subway-kobe-m.svg;}
+node|z13-|railway-station-subway-kobe
+{icon-image: subway-kobe-s.svg;}
+node|z15-|railway-station-subway-kobe
+{icon-image: subway-kobe-m.svg;}
+node|z16-|railway-subway_entrance-kobe
+{icon-image: subway-kobe-s.svg;}
+node|z18-|railway-subway_entrance-kobe
+{icon-image: subway-kobe-m.svg;}
 
 /* Kolkata Subway Station */
-node|z13-[railway=station][transport=subway][city=kolkata] {icon-image: subway-kolkata-s.svg;}
-node|z15-[railway=station][transport=subway][city=kolkata] {icon-image: subway-kolkata-m.svg;}
-node|z16-[railway=subway_entrance][city=kolkata] {icon-image: subway-kolkata-s.svg;}
-node|z18-[railway=subway_entrance][city=kolkata] {icon-image: subway-kolkata-m.svg;}
+node|z13-|railway-station-subway-kolkata
+{icon-image: subway-kolkata-s.svg;}
+node|z15-|railway-station-subway-kolkata
+{icon-image: subway-kolkata-m.svg;}
+node|z16-|railway-subway_entrance-kolkata
+{icon-image: subway-kolkata-s.svg;}
+node|z18-|railway-subway_entrance-kolkata
+{icon-image: subway-kolkata-m.svg;}
 
 /* Kunming Subway Station */
-node|z13-[railway=station][transport=subway][city=kunming] {icon-image: subway-kunming-s.svg;}
-node|z15-[railway=station][transport=subway][city=kunming] {icon-image: subway-kunming-m.svg;}
-node|z16-[railway=subway_entrance][city=kunming] {icon-image: subway-kunming-s.svg;}
-node|z18-[railway=subway_entrance][city=kunming] {icon-image: subway-kunming-m.svg;}
+node|z13-|railway-station-subway-kunming
+{icon-image: subway-kunming-s.svg;}
+node|z15-|railway-station-subway-kunming
+{icon-image: subway-kunming-m.svg;}
+node|z16-|railway-subway_entrance-kunming
+{icon-image: subway-kunming-s.svg;}
+node|z18-|railway-subway_entrance-kunming
+{icon-image: subway-kunming-m.svg;}
 
 /* Kyoto Subway Station */
-node|z13-[railway=station][transport=subway][city=kyoto] {icon-image: subway-kyoto-s.svg;}
-node|z15-[railway=station][transport=subway][city=kyoto] {icon-image: subway-kyoto-m.svg;}
-node|z16-[railway=subway_entrance][city=kyoto] {icon-image: subway-kyoto-s.svg;}
-node|z18-[railway=subway_entrance][city=kyoto] {icon-image: subway-kyoto-m.svg;}
+node|z13-|railway-station-subway-kyoto
+{icon-image: subway-kyoto-s.svg;}
+node|z15-|railway-station-subway-kyoto
+{icon-image: subway-kyoto-m.svg;}
+node|z16-|railway-subway_entrance-kyoto
+{icon-image: subway-kyoto-s.svg;}
+node|z18-|railway-subway_entrance-kyoto
+{icon-image: subway-kyoto-m.svg;}
 
 /* Lausanne Subway Station */
-node|z13-[railway=station][transport=subway][city=lausanne] {icon-image: subway-lausanne-s.svg;}
-node|z15-[railway=station][transport=subway][city=lausanne] {icon-image: subway-lausanne-m.svg;}
-node|z16-[railway=subway_entrance][city=lausanne] {icon-image: subway-lausanne-s.svg;}
-node|z18-[railway=subway_entrance][city=lausanne] {icon-image: subway-lausanne-m.svg;}
+node|z13-|railway-station-subway-lausanne
+{icon-image: subway-lausanne-s.svg;}
+node|z15-|railway-station-subway-lausanne
+{icon-image: subway-lausanne-m.svg;}
+node|z16-|railway-subway_entrance-lausanne
+{icon-image: subway-lausanne-s.svg;}
+node|z18-|railway-subway_entrance-lausanne
+{icon-image: subway-lausanne-m.svg;}
 
 /* Lille Subway Station */
-node|z13-[railway=station][transport=subway][city=lille] {icon-image: subway-lille-s.svg;}
-node|z15-[railway=station][transport=subway][city=lille] {icon-image: subway-lille-m.svg;}
-node|z16-[railway=subway_entrance][city=lille] {icon-image: subway-lille-s.svg;}
-node|z18-[railway=subway_entrance][city=lille] {icon-image: subway-lille-m.svg;}
+node|z13-|railway-station-subway-lille
+{icon-image: subway-lille-s.svg;}
+node|z15-|railway-station-subway-lille
+{icon-image: subway-lille-m.svg;}
+node|z16-|railway-subway_entrance-lille
+{icon-image: subway-lille-s.svg;}
+node|z18-|railway-subway_entrance-lille
+{icon-image: subway-lille-m.svg;}
 
 /* Lima Subway Station */
-node|z13-[railway=station][transport=subway][city=lima] {icon-image: subway-lima-s.svg;}
-node|z15-[railway=station][transport=subway][city=lima] {icon-image: subway-lima-m.svg;}
-node|z16-[railway=subway_entrance][city=lima] {icon-image: subway-lima-s.svg;}
-node|z18-[railway=subway_entrance][city=lima] {icon-image: subway-lima-m.svg;}
+node|z13-|railway-station-subway-lima
+{icon-image: subway-lima-s.svg;}
+node|z15-|railway-station-subway-lima
+{icon-image: subway-lima-m.svg;}
+node|z16-|railway-subway_entrance-lima
+{icon-image: subway-lima-s.svg;}
+node|z18-|railway-subway_entrance-lima
+{icon-image: subway-lima-m.svg;}
 
 /* Lisboa Subway Station */
-node|z12-[railway=station][transport=subway][city=lisboa] {icon-image: subway-lisboa-s.svg;}
-node|z15-[railway=station][transport=subway][city=lisboa] {icon-image: subway-lisboa-m.svg;}
-node|z16-[railway=subway_entrance][city=lisboa] {icon-image: subway-lisboa-s.svg;}
-node|z18-[railway=subway_entrance][city=lisboa] {icon-image: subway-lisboa-m.svg;}
+node|z12-|railway-station-subway-lisboa
+{icon-image: subway-lisboa-s.svg;}
+node|z15-|railway-station-subway-lisboa
+{icon-image: subway-lisboa-m.svg;}
+node|z16-|railway-subway_entrance-lisboa
+{icon-image: subway-lisboa-s.svg;}
+node|z18-|railway-subway_entrance-lisboa
+{icon-image: subway-lisboa-m.svg;}
 
 /* London Subway Station */
-node|z12-[railway=station][transport=subway][city=london] {icon-image: subway-london-s.svg;}
-node|z15-[railway=station][transport=subway][city=london] {icon-image: subway-london-m.svg;}
-node|z16-[railway=subway_entrance][city=london] {icon-image: subway_entrance-london-s.svg;}
-node|z18-[railway=subway_entrance][city=london] {icon-image: subway_entrance-london-m.svg;}
+node|z12-|railway-station-subway-london
+{icon-image: subway-london-s.svg;}
+node|z15-|railway-station-subway-london
+{icon-image: subway-london-m.svg;}
+node|z16-|railway-subway_entrance-london
+{icon-image: subway_entrance-london-s.svg;}
+node|z18-|railway-subway_entrance-london
+{icon-image: subway_entrance-london-m.svg;}
 
 /* Los Angeles Subway Station */
-node|z12-[railway=station][transport=subway][city=la] {icon-image: subway-losangeles-s.svg;}
-node|z15-[railway=station][transport=subway][city=la] {icon-image: subway-losangeles-m.svg;}
-node|z16-[railway=subway_entrance][city=la] {icon-image: subway-losangeles-s.svg;}
-node|z18-[railway=subway_entrance][city=la] {icon-image: subway-losangeles-m.svg;}
+node|z12-|railway-station-subway-la
+{icon-image: subway-losangeles-s.svg;}
+node|z15-|railway-station-subway-la
+{icon-image: subway-losangeles-m.svg;}
+node|z16-|railway-subway_entrance-la
+{icon-image: subway-losangeles-s.svg;}
+node|z18-|railway-subway_entrance-la
+{icon-image: subway-losangeles-m.svg;}
 
 /* Lyon Subway Station */
-node|z13-[railway=station][transport=subway][city=lyon] {icon-image: subway-lyon-s.svg;}
-node|z15-[railway=station][transport=subway][city=lyon] {icon-image: subway-lyon-m.svg;}
-node|z16-[railway=subway_entrance][city=lyon] {icon-image: subway-lyon-s.svg;}
-node|z18-[railway=subway_entrance][city=lyon] {icon-image: subway-lyon-m.svg;}
+node|z13-|railway-station-subway-lyon
+{icon-image: subway-lyon-s.svg;}
+node|z15-|railway-station-subway-lyon
+{icon-image: subway-lyon-m.svg;}
+node|z16-|railway-subway_entrance-lyon
+{icon-image: subway-lyon-s.svg;}
+node|z18-|railway-subway_entrance-lyon
+{icon-image: subway-lyon-m.svg;}
 
 /* Madrid Subway Station */
-node|z12-[railway=station][transport=subway][city=madrid] {icon-image: subway-madrid-s.svg;}
-node|z15-[railway=station][transport=subway][city=madrid] {icon-image: subway-madrid-m.svg;}
-node|z16-[railway=subway_entrance][city=madrid] {icon-image: subway-madrid-s.svg;}
-node|z18-[railway=subway_entrance][city=madrid] {icon-image: subway-madrid-m.svg;}
+node|z12-|railway-station-subway-madrid
+{icon-image: subway-madrid-s.svg;}
+node|z15-|railway-station-subway-madrid
+{icon-image: subway-madrid-m.svg;}
+node|z16-|railway-subway_entrance-madrid
+{icon-image: subway-madrid-s.svg;}
+node|z18-|railway-subway_entrance-madrid
+{icon-image: subway-madrid-m.svg;}
 
 /* Malaga Subway Station */
-node|z13-[railway=station][transport=subway][city=malaga] {icon-image: subway-malaga-s.svg;}
-node|z15-[railway=station][transport=subway][city=malaga] {icon-image: subway-malaga-m.svg;}
-node|z16-[railway=subway_entrance][city=malaga] {icon-image: subway-malaga-s.svg;}
-node|z18-[railway=subway_entrance][city=malaga] {icon-image: subway-malaga-m.svg;}
+node|z13-|railway-station-subway-malaga
+{icon-image: subway-malaga-s.svg;}
+node|z15-|railway-station-subway-malaga
+{icon-image: subway-malaga-m.svg;}
+node|z16-|railway-subway_entrance-malaga
+{icon-image: subway-malaga-s.svg;}
+node|z18-|railway-subway_entrance-malaga
+{icon-image: subway-malaga-m.svg;}
 
 /* Manila Subway Station */
-node|z13-[railway=station][transport=subway][city=manila] {icon-image: subway-manila-s.svg;}
-node|z15-[railway=station][transport=subway][city=manila] {icon-image: subway-manila-m.svg;}
-node|z16-[railway=subway_entrance][city=manila] {icon-image: subway-manila-s.svg;}
-node|z18-[railway=subway_entrance][city=manila] {icon-image: subway-manila-m.svg;}
+node|z13-|railway-station-subway-manila
+{icon-image: subway-manila-s.svg;}
+node|z15-|railway-station-subway-manila
+{icon-image: subway-manila-m.svg;}
+node|z16-|railway-subway_entrance-manila
+{icon-image: subway-manila-s.svg;}
+node|z18-|railway-subway_entrance-manila
+{icon-image: subway-manila-m.svg;}
 
 /* Maracaibo Subway Station */
-node|z13-[railway=station][transport=subway][city=maracaibo] {icon-image: subway-maracaibo-s.svg;}
-node|z15-[railway=station][transport=subway][city=maracaibo] {icon-image: subway-maracaibo-m.svg;}
-node|z16-[railway=subway_entrance][city=maracaibo] {icon-image: subway-maracaibo-s.svg;}
-node|z18-[railway=subway_entrance][city=maracaibo] {icon-image: subway-maracaibo-m.svg;}
+node|z13-|railway-station-subway-maracaibo
+{icon-image: subway-maracaibo-s.svg;}
+node|z15-|railway-station-subway-maracaibo
+{icon-image: subway-maracaibo-m.svg;}
+node|z16-|railway-subway_entrance-maracaibo
+{icon-image: subway-maracaibo-s.svg;}
+node|z18-|railway-subway_entrance-maracaibo
+{icon-image: subway-maracaibo-m.svg;}
 
 /* Mashhad Subway Station */
-node|z13-[railway=station][transport=subway][city=mashhad] {icon-image: subway-mashhad-s.svg;}
-node|z15-[railway=station][transport=subway][city=mashhad] {icon-image: subway-mashhad-m.svg;}
-node|z16-[railway=subway_entrance][city=mashhad] {icon-image: subway-mashhad-s.svg;}
-node|z18-[railway=subway_entrance][city=mashhad] {icon-image: subway-mashhad-m.svg;}
+node|z13-|railway-station-subway-mashhad
+{icon-image: subway-mashhad-s.svg;}
+node|z15-|railway-station-subway-mashhad
+{icon-image: subway-mashhad-m.svg;}
+node|z16-|railway-subway_entrance-mashhad
+{icon-image: subway-mashhad-s.svg;}
+node|z18-|railway-subway_entrance-mashhad
+{icon-image: subway-mashhad-m.svg;}
 
 /* Mecca Subway Station */
-node|z13-[railway=station][transport=subway][city=mecca] {icon-image: subway-mecca-s.svg;}
-node|z15-[railway=station][transport=subway][city=mecca] {icon-image: subway-mecca-m.svg;}
-node|z16-[railway=subway_entrance][city=mecca] {icon-image: subway-mecca-s.svg;}
-node|z18-[railway=subway_entrance][city=mecca] {icon-image: subway-mecca-m.svg;}
+node|z13-|railway-station-subway-mecca
+{icon-image: subway-mecca-s.svg;}
+node|z15-|railway-station-subway-mecca
+{icon-image: subway-mecca-m.svg;}
+node|z16-|railway-subway_entrance-mecca
+{icon-image: subway-mecca-s.svg;}
+node|z18-|railway-subway_entrance-mecca
+{icon-image: subway-mecca-m.svg;}
 
 /* Medellin Subway Station */
-node|z13-[railway=station][transport=subway][city=medellin] {icon-image: subway-medellin-s.svg;}
-node|z15-[railway=station][transport=subway][city=medellin] {icon-image: subway-medellin-m.svg;}
-node|z16-[railway=subway_entrance][city=medellin] {icon-image: subway-medellin-s.svg;}
-node|z18-[railway=subway_entrance][city=medellin] {icon-image: subway-medellin-m.svg;}
+node|z13-|railway-station-subway-medellin
+{icon-image: subway-medellin-s.svg;}
+node|z15-|railway-station-subway-medellin
+{icon-image: subway-medellin-m.svg;}
+node|z16-|railway-subway_entrance-medellin
+{icon-image: subway-medellin-s.svg;}
+node|z18-|railway-subway_entrance-medellin
+{icon-image: subway-medellin-m.svg;}
 
 /* Mexico Subway Station */
-node|z12-[railway=station][transport=subway][city=mexico] {icon-image: subway-mexico-s.svg;}
-node|z15-[railway=station][transport=subway][city=mexico] {icon-image: subway-mexico-m.svg;}
-node|z16-[railway=subway_entrance][city=mexico] {icon-image: subway-mexico-s.svg;}
-node|z18-[railway=subway_entrance][city=mexico] {icon-image: subway-mexico-m.svg;}
+node|z12-|railway-station-subway-mexico
+{icon-image: subway-mexico-s.svg;}
+node|z15-|railway-station-subway-mexico
+{icon-image: subway-mexico-m.svg;}
+node|z16-|railway-subway_entrance-mexico
+{icon-image: subway-mexico-s.svg;}
+node|z18-|railway-subway_entrance-mexico
+{icon-image: subway-mexico-m.svg;}
 
 /* Milan Subway Station */
-node|z13-[railway=station][transport=subway][city=milan] {icon-image: subway-milan-s.svg;}
-node|z15-[railway=station][transport=subway][city=milan] {icon-image: subway-milan-m.svg;}
-node|z16-[railway=subway_entrance][city=milan] {icon-image: subway-milan-s.svg;}
-node|z18-[railway=subway_entrance][city=milan] {icon-image: subway-milan-m.svg;}
+node|z13-|railway-station-subway-milan
+{icon-image: subway-milan-s.svg;}
+node|z15-|railway-station-subway-milan
+{icon-image: subway-milan-m.svg;}
+node|z16-|railway-subway_entrance-milan
+{icon-image: subway-milan-s.svg;}
+node|z18-|railway-subway_entrance-milan
+{icon-image: subway-milan-m.svg;}
 
 /* Minsk Subway Station */
-node|z12-13[railway=station][transport=subway][city=minsk] {icon-image: subway-minsk-s.svg;text-offset: 1;font-size: 10;text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 0.7;text-halo-color: @label_halo_light;}
-node|z14[railway=station][transport=subway][city=minsk] {icon-image: subway-minsk-s.svg;}
-node|z15-16[railway=station][transport=subway][city=minsk] {icon-image: subway-minsk-m.svg;}
-node|z17-[railway=station][transport=subway][city=minsk] {icon-image: none;text: none;} /*only show subway_entrance past z17*/
-node|z17-[railway=station][transport=subway][city=minsk]::int_name {icon-image: none;text: none;}
-node|z16-[railway=subway_entrance][city=minsk] {icon-image: subway-minsk-m.svg;}
+node|z12-13|railway-station-subway-minsk
+{icon-image: subway-minsk-s.svg;text-offset: 1;font-size: 10;text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 0.7;text-halo-color: @label_halo_light;}
+node|z14|railway-station-subway-minsk
+{icon-image: subway-minsk-s.svg;}
+node|z15-16|railway-station-subway-minsk
+{icon-image: subway-minsk-m.svg;}
+node|z17-|railway-station-subway-minsk
+{icon-image: none;text: none;} /*only show subway_entrance past z17*/
+node|z17-|railway-station-subway-minsk::int_name {icon-image: none;text: none;}
+node|z16-|railway-subway_entrance-minsk
+{icon-image: subway-minsk-m.svg;}
 
 /* Moscow Subway Station TODO: simplify?*/
-node|z12-[railway=station][transport=subway][city=moscow],
-node|z15-[railway=subway_entrance][city=moscow],
+node|z12-|railway-station-subway-moscow,
+node|z15-|railway-subway_entrance-moscow,
 {text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 1;text-halo-color: @label_halo_light;}
-node|z12-[railway=station][transport=subway][city=moscow]::int_name,
-node|z15-[railway=subway_entrance][city=moscow]::int_name,
+node|z12-|railway-station-subway-moscow::int_name,
+node|z15-|railway-subway_entrance-moscow::int_name,
 {text: int_name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 1;text-halo-color: @label_halo_light;}
 
-node|z11[railway=station][transport=subway][city=moscow]
+node|z11|railway-station-subway-moscow
 {icon-image: subway-moscow-s.svg;}
-node|z12-13[railway=station][transport=subway][city=moscow]
+node|z12-13|railway-station-subway-moscow
 {icon-image: subway-moscow-s.svg;text-offset: 1;font-size: 10;text-halo-opacity: 0.7;}
-node|z12-13[railway=station][transport=subway][city=moscow]::int_name
+node|z12-13|railway-station-subway-moscow::int_name
 {text-offset: 1;font-size: 9;text-halo-opacity: 0.7;}
-node|z14[railway=station][transport=subway][city=moscow]
+node|z14|railway-station-subway-moscow
 {icon-image: subway-moscow-s.svg;text-offset: 1;font-size: 11;}
-node|z14[railway=station][transport=subway][city=moscow]::int_name
+node|z14|railway-station-subway-moscow::int_name
 {text-offset: 1;font-size: 9;}
-node|z15[railway=station][transport=subway][city=moscow]
+node|z15|railway-station-subway-moscow
 {icon-image: subway-moscow-m.svg;text-offset: 1;font-size: 12;}
-node|z15[railway=station][transport=subway][city=moscow]::int_name
+node|z15|railway-station-subway-moscow::int_name
 {text-offset: 1;font-size: 10;}
 
 /* Do not draw main metro icon, because entrances will be visible now */
-node|z16-[railway=station][transport=subway][city=moscow]
+node|z16-|railway-station-subway-moscow
 {icon-image: none;text: none;}
-node|z16-[railway=station][transport=subway][city=moscow]::int_name
+node|z16-|railway-station-subway-moscow::int_name
 {text: none;}
 
 /* Moscow Subway Station entrance */
 
-node|z15[railway=subway_entrance][city=moscow]
+node|z15|railway-subway_entrance-moscow
 {icon-image: subway-moscow-s.svg;text-offset: 1;font-size: 11;}
-node|z15[railway=subway_entrance][city=moscow]::int_name
+node|z15|railway-subway_entrance-moscow::int_name
 {text-offset: 25;font-size: 9;}
 
-node|z16[railway=subway_entrance][city=moscow]
+node|z16|railway-subway_entrance-moscow
 {icon-image: subway-moscow-m.svg;text-offset: 1;font-size: 12;}
-node|z16[railway=subway_entrance][city=moscow]::int_name
+node|z16|railway-subway_entrance-moscow::int_name
 {text-offset: 25;font-size: 10;}
-node|z17[railway=subway_entrance][city=moscow]
+node|z17|railway-subway_entrance-moscow
 {icon-image: subway-moscow-m.svg;text-offset: 1;font-size: 12;}
-node|z17[railway=subway_entrance][city=moscow]::int_name
+node|z17|railway-subway_entrance-moscow::int_name
 {text-offset: 25;font-size: 11;}
-node|z18-[railway=subway_entrance][city=moscow]
+node|z18-|railway-subway_entrance-moscow
 {icon-image: subway-moscow-m.svg;text-offset: 1;font-size: 13;}
-node|z18-[railway=subway_entrance][city=moscow]::int_name
+node|z18-|railway-subway_entrance-moscow::int_name
 {text-offset: 25;font-size: 11;}
 
 /* Montreal Subway Station */
-node|z13-[railway=station][transport=subway][city=montreal] {icon-image: subway-montreal-s.svg;}
-node|z15-[railway=station][transport=subway][city=montreal] {icon-image: subway-montreal-m.svg;}
-node|z16-[railway=subway_entrance][city=montreal] {icon-image: subway-montreal-s.svg;}
-node|z18-[railway=subway_entrance][city=montreal] {icon-image: subway-montreal-m.svg;}
+node|z13-|railway-station-subway-montreal
+{icon-image: subway-montreal-s.svg;}
+node|z15-|railway-station-subway-montreal
+{icon-image: subway-montreal-m.svg;}
+node|z16-|railway-subway_entrance-montreal
+{icon-image: subway-montreal-s.svg;}
+node|z18-|railway-subway_entrance-montreal
+{icon-image: subway-montreal-m.svg;}
 
 /* Munchen Subway Station */
-node|z13-[railway=station][transport=subway][city=munchen] {icon-image: subway-ubahn-s.svg;}
-node|z15-[railway=station][transport=subway][city=munchen] {icon-image: subway-ubahn-m.svg;}
-node|z16-[railway=subway_entrance][city=munchen] {icon-image: subway-ubahn-s.svg;}
-node|z18-[railway=subway_entrance][city=munchen] {icon-image: subway-ubahn-m.svg;}
+node|z13-|railway-station-subway-munchen
+{icon-image: subway-ubahn-s.svg;}
+node|z15-|railway-station-subway-munchen
+{icon-image: subway-ubahn-m.svg;}
+node|z16-|railway-subway_entrance-munchen
+{icon-image: subway-ubahn-s.svg;}
+node|z18-|railway-subway_entrance-munchen
+{icon-image: subway-ubahn-m.svg;}
 
 /* Nagoya Subway Station */
-node|z13-[railway=station][transport=subway][city=nagoya] {icon-image: subway-nagoya-s.svg;}
-node|z15-[railway=station][transport=subway][city=nagoya] {icon-image: subway-nagoya-m.svg;}
-node|z16-[railway=subway_entrance][city=nagoya] {icon-image: subway-nagoya-s.svg;}
-node|z18-[railway=subway_entrance][city=nagoya] {icon-image: subway-nagoya-m.svg;}
+node|z13-|railway-station-subway-nagoya
+{icon-image: subway-nagoya-s.svg;}
+node|z15-|railway-station-subway-nagoya
+{icon-image: subway-nagoya-m.svg;}
+node|z16-|railway-subway_entrance-nagoya
+{icon-image: subway-nagoya-s.svg;}
+node|z18-|railway-subway_entrance-nagoya
+{icon-image: subway-nagoya-m.svg;}
 
 /* New York Subway Station */
-node|z12-[railway=station][transport=subway][city=newyork] {icon-image: subway-newyork-s.svg;}
-node|z15-[railway=station][transport=subway][city=newyork] {icon-image: subway-newyork-m.svg;}
-node|z16-[railway=subway_entrance][city=newyork] {icon-image: subway-newyork-s.svg;}
+node|z12-|railway-station-subway-newyork
+{icon-image: subway-newyork-s.svg;}
+node|z15-|railway-station-subway-newyork
+{icon-image: subway-newyork-m.svg;}
+node|z16-|railway-subway_entrance-newyork
+{icon-image: subway-newyork-s.svg;}
 
 /* Nizhniy Novgorod Subway Station */
-node|z13-[railway=station][transport=subway][city=nnov] {icon-image: subway-nnov-s.svg;}
-node|z15-[railway=station][transport=subway][city=nnov] {icon-image: subway-nnov-m.svg;}
-node|z16-[railway=subway_entrance][city=nnov] {icon-image: subway-nnov-s.svg;}
+node|z13-|railway-station-subway-nnov
+{icon-image: subway-nnov-s.svg;}
+node|z15-|railway-station-subway-nnov
+{icon-image: subway-nnov-m.svg;}
+node|z16-|railway-subway_entrance-nnov
+{icon-image: subway-nnov-s.svg;}
 
 /* Novosibirsk Subway Station */
-node|z13-[railway=station][transport=subway][city=novosibirsk] {icon-image: subway-novosibirsk-s.svg;}
-node|z15-[railway=station][transport=subway][city=novosibirsk] {icon-image: subway-novosibirsk-m.svg;}
-node|z16-[railway=subway_entrance][city=novosibirsk] {icon-image: subway-novosibirsk-s.svg;}
+node|z13-|railway-station-subway-novosibirsk
+{icon-image: subway-novosibirsk-s.svg;}
+node|z15-|railway-station-subway-novosibirsk
+{icon-image: subway-novosibirsk-m.svg;}
+node|z16-|railway-subway_entrance-novosibirsk
+{icon-image: subway-novosibirsk-s.svg;}
 
 /* Osaka Subway Station */
-node|z13-[railway=station][transport=subway][city=osaka] {icon-image: subway-osaka-s.svg;}
-node|z15-[railway=station][transport=subway][city=osaka] {icon-image: subway-osaka-m.svg;}
-node|z16-[railway=subway_entrance][city=osaka] {icon-image: subway-osaka-s.svg;}
+node|z13-|railway-station-subway-osaka
+{icon-image: subway-osaka-s.svg;}
+node|z15-|railway-station-subway-osaka
+{icon-image: subway-osaka-m.svg;}
+node|z16-|railway-subway_entrance-osaka
+{icon-image: subway-osaka-s.svg;}
 
 /* Oslo Subway Station */
-node|z13-[railway=station][transport=subway][city=oslo] {icon-image: subway-oslo-s.svg;}
-node|z15-[railway=station][transport=subway][city=oslo] {icon-image: subway-oslo-m.svg;}
-node|z16-[railway=subway_entrance][city=oslo] {icon-image: subway-oslo-s.svg;}
+node|z13-|railway-station-subway-oslo
+{icon-image: subway-oslo-s.svg;}
+node|z15-|railway-station-subway-oslo
+{icon-image: subway-oslo-m.svg;}
+node|z16-|railway-subway_entrance-oslo
+{icon-image: subway-oslo-s.svg;}
 
 /* Palma Subway Station */
-node|z13-[railway=station][transport=subway][city=palma] {icon-image: subway-palma-s.svg;}
-node|z15-[railway=station][transport=subway][city=palma] {icon-image: subway-palma-m.svg;}
-node|z16-[railway=subway_entrance][city=palma] {icon-image: subway-palma-s.svg;}
+node|z13-|railway-station-subway-palma
+{icon-image: subway-palma-s.svg;}
+node|z15-|railway-station-subway-palma
+{icon-image: subway-palma-m.svg;}
+node|z16-|railway-subway_entrance-palma
+{icon-image: subway-palma-s.svg;}
 
 /* Panama Subway Station */
-node|z13-[railway=station][transport=subway][city=panama] {icon-image: subway-panama-s.svg;}
-node|z15-[railway=station][transport=subway][city=panama] {icon-image: subway-panama-m.svg;}
-node|z16-[railway=subway_entrance][city=panama] {icon-image: subway-panama-s.svg;}
+node|z13-|railway-station-subway-panama
+{icon-image: subway-panama-s.svg;}
+node|z15-|railway-station-subway-panama
+{icon-image: subway-panama-m.svg;}
+node|z16-|railway-subway_entrance-panama
+{icon-image: subway-panama-s.svg;}
 
 /* Paris Subway Station */
-node|z12-[railway=station][transport=subway][city=paris] {icon-image: subway-paris-s.svg;}
-node|z15-[railway=station][transport=subway][city=paris] {icon-image: subway-paris-m.svg;}
-node|z16-[railway=subway_entrance][city=paris] {icon-image: subway-paris-s.svg;}
+node|z12-|railway-station-subway-paris
+{icon-image: subway-paris-s.svg;}
+node|z15-|railway-station-subway-paris
+{icon-image: subway-paris-m.svg;}
+node|z16-|railway-subway_entrance-paris
+{icon-image: subway-paris-s.svg;}
 
 /* Philadelphia Subway Station */
-node|z13-[railway=station][transport=subway][city=philadelphia] {icon-image: subway-philadelphia-s.svg;}
-node|z15-[railway=station][transport=subway][city=philadelphia] {icon-image: subway-philadelphia-m.svg;}
-node|z16-[railway=subway_entrance][city=philadelphia] {icon-image: subway-philadelphia-s.svg;}
+node|z13-|railway-station-subway-philadelphia
+{icon-image: subway-philadelphia-s.svg;}
+node|z15-|railway-station-subway-philadelphia
+{icon-image: subway-philadelphia-m.svg;}
+node|z16-|railway-subway_entrance-philadelphia
+{icon-image: subway-philadelphia-s.svg;}
 
 /* Pyongyang Subway Station */
-node|z13-[railway=station][transport=subway][city=pyongyang] {icon-image: subway-pyongyang-s.svg;}
-node|z15-[railway=station][transport=subway][city=pyongyang] {icon-image: subway-pyongyang-m.svg;}
-node|z16-[railway=subway_entrance][city=pyongyang] {icon-image: subway-pyongyang-s.svg;}
+node|z13-|railway-station-subway-pyongyang
+{icon-image: subway-pyongyang-s.svg;}
+node|z15-|railway-station-subway-pyongyang
+{icon-image: subway-pyongyang-m.svg;}
+node|z16-|railway-subway_entrance-pyongyang
+{icon-image: subway-pyongyang-s.svg;}
 
 /* Rennes Subway Station */
-node|z13-[railway=station][transport=subway][city=rennes] {icon-image: subway-rennes-s.svg;}
-node|z15-[railway=station][transport=subway][city=rennes] {icon-image: subway-rennes-m.svg;}
-node|z16-[railway=subway_entrance][city=rennes] {icon-image: subway-rennes-s.svg;}
+node|z13-|railway-station-subway-rennes
+{icon-image: subway-rennes-s.svg;}
+node|z15-|railway-station-subway-rennes
+{icon-image: subway-rennes-m.svg;}
+node|z16-|railway-subway_entrance-rennes
+{icon-image: subway-rennes-s.svg;}
 
 /* Rio De Janeiro Subway Station */
-node|z13-[railway=station][transport=subway][city=rio] {icon-image: subway-riodejaneiro-s.svg;}
-node|z15-[railway=station][transport=subway][city=rio] {icon-image: subway-riodejaneiro-m.svg;}
-node|z16-[railway=subway_entrance][city=rio] {icon-image: subway-riodejaneiro-s.svg;}
+node|z13-|railway-station-subway-rio
+{icon-image: subway-riodejaneiro-s.svg;}
+node|z15-|railway-station-subway-rio
+{icon-image: subway-riodejaneiro-m.svg;}
+node|z16-|railway-subway_entrance-rio
+{icon-image: subway-riodejaneiro-s.svg;}
 
 /* Roma Subway Station */
-node|z12-[railway=station][transport=subway][city=roma] {icon-image: subway-rome-s.svg;}
-node|z15-[railway=station][transport=subway][city=roma] {icon-image: subway-rome-m.svg;}
-node|z17-[railway=station][transport=subway][city=roma] {icon-image: none;text: none;} /*only show subway_entrance past z17*/
-node|z17-[railway=station][transport=subway][city=roma]::int_name {icon-image: none;text: none;}
-node|z16-[railway=subway_entrance][city=roma] {icon-image: subway-rome-m.svg;}
+node|z12-|railway-station-subway-roma
+{icon-image: subway-rome-s.svg;}
+node|z15-|railway-station-subway-roma
+{icon-image: subway-rome-m.svg;}
+node|z17-|railway-station-subway-roma
+{icon-image: none;text: none;} /*only show subway_entrance past z17*/
+node|z17-|railway-station-subway-roma::int_name {icon-image: none;text: none;}
+node|z16-|railway-subway_entrance-roma
+{icon-image: subway-rome-m.svg;}
 
 /* Rotterdam Subway Station */
-node|z13-[railway=station][transport=subway][city=rotterdam] {icon-image: subway-rotterdam-s.svg;}
-node|z15-[railway=station][transport=subway][city=rotterdam] {icon-image: subway-rotterdam-m.svg;}
-node|z16-[railway=subway_entrance][city=rotterdam] {icon-image: subway-rotterdam-s.svg;}
+node|z13-|railway-station-subway-rotterdam
+{icon-image: subway-rotterdam-s.svg;}
+node|z15-|railway-station-subway-rotterdam
+{icon-image: subway-rotterdam-m.svg;}
+node|z16-|railway-subway_entrance-rotterdam
+{icon-image: subway-rotterdam-s.svg;}
 
 /* Samara Subway Station */
-node|z13-[railway=station][transport=subway][city=samara] {icon-image: subway-samara-s.svg;}
-node|z15-[railway=station][transport=subway][city=samara] {icon-image: subway-samara-m.svg;}
-node|z16-[railway=subway_entrance][city=samara] {icon-image: subway-samara-s.svg;}
+node|z13-|railway-station-subway-samara
+{icon-image: subway-samara-s.svg;}
+node|z15-|railway-station-subway-samara
+{icon-image: subway-samara-m.svg;}
+node|z16-|railway-subway_entrance-samara
+{icon-image: subway-samara-s.svg;}
 
 /* San Francisco Subway Station */
-node|z12-[railway=station][transport=subway][city=sf] {icon-image: subway-sanfrancisco-s.svg;}
-node|z15-[railway=station][transport=subway][city=sf] {icon-image: subway-sanfrancisco-m.svg;}
-node|z16-[railway=subway_entrance][city=sf] {icon-image: subway-sanfrancisco-s.svg;}
+node|z12-|railway-station-subway-sf
+{icon-image: subway-sanfrancisco-s.svg;}
+node|z15-|railway-station-subway-sf
+{icon-image: subway-sanfrancisco-m.svg;}
+node|z16-|railway-subway_entrance-sf
+{icon-image: subway-sanfrancisco-s.svg;}
 
 /* Santiago Subway Station */
-node|z13-[railway=station][transport=subway][city=santiago] {icon-image: subway-santiago-s.svg;}
-node|z15-[railway=station][transport=subway][city=santiago] {icon-image: subway-santiago-m.svg;}
-node|z16-[railway=subway_entrance][city=santiago] {icon-image: subway-santiago-s.svg;}
+node|z13-|railway-station-subway-santiago
+{icon-image: subway-santiago-s.svg;}
+node|z15-|railway-station-subway-santiago
+{icon-image: subway-santiago-m.svg;}
+node|z16-|railway-subway_entrance-santiago
+{icon-image: subway-santiago-s.svg;}
 
 /* Santo Domingo Subway Station */
-node|z13-[railway=station][transport=subway][city=santo_domingo] {icon-image: subway-santodomingo-s.svg;}
-node|z15-[railway=station][transport=subway][city=santo_domingo] {icon-image: subway-santodomingo-m.svg;}
-node|z16-[railway=subway_entrance][city=santo_domingo] {icon-image: subway-santodomingo-s.svg;}
+node|z13-|railway-station-subway-santo_domingo
+{icon-image: subway-santodomingo-s.svg;}
+node|z15-|railway-station-subway-santo_domingo
+{icon-image: subway-santodomingo-m.svg;}
+node|z16-|railway-subway_entrance-santo_domingo
+{icon-image: subway-santodomingo-s.svg;}
 
 /* Sao Paulo Subway Station */
-node|z13-[railway=station][transport=subway][city=saopaulo] {icon-image: subway-saopaulo-s.svg;}
-node|z15-[railway=station][transport=subway][city=saopaulo] {icon-image: subway-saopaulo-m.svg;}
-node|z16-[railway=subway_entrance][city=saopaulo] {icon-image: subway-saopaulo-s.svg;}
+node|z13-|railway-station-subway-saopaulo
+{icon-image: subway-saopaulo-s.svg;}
+node|z15-|railway-station-subway-saopaulo
+{icon-image: subway-saopaulo-m.svg;}
+node|z16-|railway-subway_entrance-saopaulo
+{icon-image: subway-saopaulo-s.svg;}
 
 /* Sapporo Subway Station */
-node|z13-[railway=station][transport=subway][city=sapporo] {icon-image: subway-sapporo-s.svg;}
-node|z15-[railway=station][transport=subway][city=sapporo] {icon-image: subway-sapporo-m.svg;}
-node|z16-[railway=subway_entrance][city=sapporo] {icon-image: subway-sapporo-s.svg;}
+node|z13-|railway-station-subway-sapporo
+{icon-image: subway-sapporo-s.svg;}
+node|z15-|railway-station-subway-sapporo
+{icon-image: subway-sapporo-m.svg;}
+node|z16-|railway-subway_entrance-sapporo
+{icon-image: subway-sapporo-s.svg;}
 
 /* Sendai Subway Station */
-node|z13-[railway=station][transport=subway][city=sendai] {icon-image: subway-sendai-s.svg;}
-node|z15-[railway=station][transport=subway][city=sendai] {icon-image: subway-sendai-m.svg;}
-node|z16-[railway=subway_entrance][city=sendai] {icon-image: subway-sendai-s.svg;}
+node|z13-|railway-station-subway-sendai
+{icon-image: subway-sendai-s.svg;}
+node|z15-|railway-station-subway-sendai
+{icon-image: subway-sendai-m.svg;}
+node|z16-|railway-subway_entrance-sendai
+{icon-image: subway-sendai-s.svg;}
 
 /* Shanghai Subway Station */
-node|z12-[railway=station][transport=subway][city=shanghai] {icon-image: subway-shanghai-s.svg;}
-node|z15-[railway=station][transport=subway][city=shanghai] {icon-image: subway-shanghai-m.svg;}
-node|z16-[railway=subway_entrance][city=shanghai] {icon-image: subway-shanghai-s.svg;}
+node|z12-|railway-station-subway-shanghai
+{icon-image: subway-shanghai-s.svg;}
+node|z15-|railway-station-subway-shanghai
+{icon-image: subway-shanghai-m.svg;}
+node|z16-|railway-subway_entrance-shanghai
+{icon-image: subway-shanghai-s.svg;}
 
 /* Shiraz Subway Station */
-node|z13-[railway=station][transport=subway][city=shiraz] {icon-image: subway-shiraz-s.svg;}
-node|z15-[railway=station][transport=subway][city=shiraz] {icon-image: subway-shiraz-m.svg;}
-node|z16-[railway=subway_entrance][city=shiraz] {icon-image: subway-shiraz-s.svg;}
+node|z13-|railway-station-subway-shiraz
+{icon-image: subway-shiraz-s.svg;}
+node|z15-|railway-station-subway-shiraz
+{icon-image: subway-shiraz-m.svg;}
+node|z16-|railway-subway_entrance-shiraz
+{icon-image: subway-shiraz-s.svg;}
 
 /* Singapore Subway Station */
-node|z13-[railway=station][transport=subway][city=singapore] {icon-image: subway-singapore-s.svg;}
-node|z15-[railway=station][transport=subway][city=singapore] {icon-image: subway-singapore-m.svg;}
-node|z16-[railway=subway_entrance][city=singapore] {icon-image: subway-singapore-s.svg;}
+node|z13-|railway-station-subway-singapore
+{icon-image: subway-singapore-s.svg;}
+node|z15-|railway-station-subway-singapore
+{icon-image: subway-singapore-m.svg;}
+node|z16-|railway-subway_entrance-singapore
+{icon-image: subway-singapore-s.svg;}
 
 /* Sofia Subway Station */
-node|z13-[railway=station][transport=subway][city=sofia] {icon-image: subway-sofia-s.svg;}
-node|z15-[railway=station][transport=subway][city=sofia] {icon-image: subway-sofia-m.svg;}
-node|z16-[railway=subway_entrance][city=sofia] {icon-image: subway-sofia-s.svg;}
+node|z13-|railway-station-subway-sofia
+{icon-image: subway-sofia-s.svg;}
+node|z15-|railway-station-subway-sofia
+{icon-image: subway-sofia-m.svg;}
+node|z16-|railway-subway_entrance-sofia
+{icon-image: subway-sofia-s.svg;}
 
 /* Saint Petersburg Subway Station TODO: simplify?*/
-node|z12-[railway=station][transport=subway][city=spb],
-node|z16-[railway=subway_entrance][city=spb],
+node|z12-|railway-station-subway-spb,
+node|z16-|railway-subway_entrance-spb,
 {text: name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 1;text-halo-color: @label_halo_light;}
-node|z12-[railway=station][transport=subway][city=spb]::int_name,
-node|z16-[railway=subway_entrance][city=spb]::int_name,
+node|z12-|railway-station-subway-spb::int_name,
+node|z16-|railway-subway_entrance-spb::int_name,
 {text: int_name;text-color: @label_dark;text-halo-radius: 1;text-halo-opacity: 1;text-halo-color: @label_halo_light;}
 
-node|z11[railway=station][transport=subway][city=spb]
+node|z11|railway-station-subway-spb
 {icon-image: subway-spb-s.svg;}
-node|z12[railway=station][transport=subway][city=spb]
+node|z12|railway-station-subway-spb
 {icon-image: subway-spb-s.svg;text-offset: 1;font-size: 10;text-halo-opacity: 0.6;}
-node|z12[railway=station][transport=subway][city=spb]::int_name
+node|z12|railway-station-subway-spb::int_name
 {text-offset: 1;font-size: 9;text-halo-opacity: 0.6;}
-node|z13[railway=station][transport=subway][city=spb]
+node|z13|railway-station-subway-spb
 {icon-image: subway-spb-s.svg;text-offset: 1;font-size: 11;text-halo-opacity: 0.6;}
-node|z13[railway=station][transport=subway][city=spb]::int_name
+node|z13|railway-station-subway-spb::int_name
 {text-offset: 1;font-size: 10;text-halo-opacity: 0.6;}
-node|z14[railway=station][transport=subway][city=spb]
+node|z14|railway-station-subway-spb
 {icon-image: subway-spb-s.svg;font-size: 11;text-halo-opacity: 0.7;}
-node|z14[railway=station][transport=subway][city=spb]::int_name
+node|z14|railway-station-subway-spb::int_name
 {font-size: 10;text-halo-opacity: 0.7;}
-node|z15[railway=station][transport=subway][city=spb]
+node|z15|railway-station-subway-spb
 {icon-image: subway-spb-m.svg;font-size: 11;text-halo-opacity: 0.8;}
-node|z15[railway=station][transport=subway][city=spb]::int_name
+node|z15|railway-station-subway-spb::int_name
 {font-size: 10;text-halo-opacity: 0.8;}
-node|z16[railway=station][transport=subway][city=spb]
+node|z16|railway-station-subway-spb
 {icon-image: subway-spb-m.svg;font-size: 12;}
-node|z16[railway=station][transport=subway][city=spb]::int_name
+node|z16|railway-station-subway-spb::int_name
 {font-size: 10;}
 
 /* Do not draw station metro icon, because entrances will be visible now */
-node|z17-[railway=station][transport=subway][city=spb]
+node|z17-|railway-station-subway-spb
 {icon-image: none;text: none;}
-node|z17-[railway=station][transport=subway][city=spb]::int_name
+node|z17-|railway-station-subway-spb::int_name
 {text: none;}
 
 /* Saint Petersburg Subway Station entrance */
-node|z15[railway=subway_entrance][city=spb]
+node|z15|railway-subway_entrance-spb
 {icon-image: subway-spb-s.svg;}
-node|z16[railway=subway_entrance][city=spb]
+node|z16|railway-subway_entrance-spb
 {icon-image: subway-spb-m.svg;text-offset: 1;font-size: 13;text-halo-opacity: 0.8;}
-node|z16[railway=subway_entrance][city=spb]::int_name
+node|z16|railway-subway_entrance-spb::int_name
 {text-offset: 25;font-size: 11;text-halo-opacity: 0.8;}
-node|z17[railway=subway_entrance][city=spb]
+node|z17|railway-subway_entrance-spb
 {icon-image: subway-spb-m.svg;text-offset: 1;font-size: 13;text-halo-opacity: 0.8;}
-node|z17[railway=subway_entrance][city=spb]::int_name
+node|z17|railway-subway_entrance-spb::int_name
 {text-offset: 25;font-size: 11;text-halo-opacity: 0.8;}
-node|z18-[railway=subway_entrance][city=spb]
+node|z18-|railway-subway_entrance-spb
 {icon-image: subway-spb-m.svg;text-offset: 1;font-size: 13;text-halo-opacity: 0.8;}
-node|z18-[railway=subway_entrance][city=spb]::int_name
+node|z18-|railway-subway_entrance-spb::int_name
 {text-offset: 25;font-size: 12;text-halo-opacity: 0.8;}
 
 /* Stockholm Subway Station */
-node|z12-[railway=station][transport=subway][city=stockholm] {icon-image: subway-stockholm-s.svg;}
-node|z15-[railway=station][transport=subway][city=stockholm] {icon-image: subway-stockholm-m.svg;}
-node|z16-[railway=subway_entrance][city=stockholm] {icon-image: subway-stockholm-s.svg;}
+node|z12-|railway-station-subway-stockholm
+{icon-image: subway-stockholm-s.svg;}
+node|z15-|railway-station-subway-stockholm
+{icon-image: subway-stockholm-m.svg;}
+node|z16-|railway-subway_entrance-stockholm
+{icon-image: subway-stockholm-s.svg;}
 
 /* Tabriz Subway Station */
-node|z13-[railway=station][transport=subway][city=tabriz] {icon-image: subway-tabriz-s.svg;}
-node|z15-[railway=station][transport=subway][city=tabriz] {icon-image: subway-tabriz-m.svg;}
-node|z16-[railway=subway_entrance][city=tabriz] {icon-image: subway-tabriz-s.svg;}
+node|z13-|railway-station-subway-tabriz
+{icon-image: subway-tabriz-s.svg;}
+node|z15-|railway-station-subway-tabriz
+{icon-image: subway-tabriz-m.svg;}
+node|z16-|railway-subway_entrance-tabriz
+{icon-image: subway-tabriz-s.svg;}
 
 /* Taipei Subway Station */
-node|z13-[railway=station][transport=subway][city=taipei] {icon-image: subway-taipei-s.svg;}
-node|z15-[railway=station][transport=subway][city=taipei] {icon-image: subway-taipei-m.svg;}
-node|z16-[railway=subway_entrance][city=taipei] {icon-image: subway-taipei-s.svg;}
+node|z13-|railway-station-subway-taipei
+{icon-image: subway-taipei-s.svg;}
+node|z15-|railway-station-subway-taipei
+{icon-image: subway-taipei-m.svg;}
+node|z16-|railway-subway_entrance-taipei
+{icon-image: subway-taipei-s.svg;}
 
 /* Taoyuan Subway Station */
-node|z13-[railway=station][transport=subway][city=taoyuan] {icon-image: subway-taoyuan-s.svg;}
-node|z15-[railway=station][transport=subway][city=taoyuan] {icon-image: subway-taoyuan-m.svg;}
-node|z16-[railway=subway_entrance][city=taoyuan] {icon-image: subway-taoyuan-s.svg;}
+node|z13-|railway-station-subway-taoyuan
+{icon-image: subway-taoyuan-s.svg;}
+node|z15-|railway-station-subway-taoyuan
+{icon-image: subway-taoyuan-m.svg;}
+node|z16-|railway-subway_entrance-taoyuan
+{icon-image: subway-taoyuan-s.svg;}
 
 /* Tashkent Subway Station */
-node|z13-[railway=station][transport=subway][city=tashkent] {icon-image: subway-tashkent-s.svg;}
-node|z15-[railway=station][transport=subway][city=tashkent] {icon-image: subway-tashkent-m.svg;}
-node|z16-[railway=subway_entrance][city=tashkent] {icon-image: subway-tashkent-s.svg;}
+node|z13-|railway-station-subway-tashkent
+{icon-image: subway-tashkent-s.svg;}
+node|z15-|railway-station-subway-tashkent
+{icon-image: subway-tashkent-m.svg;}
+node|z16-|railway-subway_entrance-tashkent
+{icon-image: subway-tashkent-s.svg;}
 
 /* Tbilisi Subway Station */
-node|z13-[railway=station][transport=subway][city=tbilisi] {icon-image: subway-tbilisi-s.svg;}
-node|z15-[railway=station][transport=subway][city=tbilisi] {icon-image: subway-tbilisi-m.svg;}
-node|z16-[railway=subway_entrance][city=tbilisi] {icon-image: subway-tbilisi-s.svg;}
+node|z13-|railway-station-subway-tbilisi
+{icon-image: subway-tbilisi-s.svg;}
+node|z15-|railway-station-subway-tbilisi
+{icon-image: subway-tbilisi-m.svg;}
+node|z16-|railway-subway_entrance-tbilisi
+{icon-image: subway-tbilisi-s.svg;}
 
 /* Tehran Subway Station */
-node|z13-[railway=station][transport=subway][city=tehran] {icon-image: subway-tehran-s.svg;}
-node|z15-[railway=station][transport=subway][city=tehran] {icon-image: subway-tehran-m.svg;}
-node|z16-[railway=subway_entrance][city=tehran] {icon-image: subway-tehran-s.svg;}
+node|z13-|railway-station-subway-tehran
+{icon-image: subway-tehran-s.svg;}
+node|z15-|railway-station-subway-tehran
+{icon-image: subway-tehran-m.svg;}
+node|z16-|railway-subway_entrance-tehran
+{icon-image: subway-tehran-s.svg;}
 
 /* Tianjin Subway Station */
-node|z13-[railway=station][transport=subway][city=tianjin] {icon-image: subway-tianjin-s.svg;}
-node|z15-[railway=station][transport=subway][city=tianjin] {icon-image: subway-tianjin-m.svg;}
-node|z16-[railway=subway_entrance][city=tianjin] {icon-image: subway-tianjin-s.svg;}
+node|z13-|railway-station-subway-tianjin
+{icon-image: subway-tianjin-s.svg;}
+node|z15-|railway-station-subway-tianjin
+{icon-image: subway-tianjin-m.svg;}
+node|z16-|railway-subway_entrance-tianjin
+{icon-image: subway-tianjin-s.svg;}
 
 /* Tokyo Subway Station */
-node|z14-[railway=station][transport=subway][city=tokyo] {icon-image: subway-tokyo-s.svg;}
-node|z15-[railway=station][transport=subway][city=tokyo] {icon-image: subway-tokyo-m.svg;}
-node|z16-[railway=subway_entrance][city=tokyo] {icon-image: subway-tokyo-s.svg;}
+node|z14-|railway-station-subway-tokyo
+{icon-image: subway-tokyo-s.svg;}
+node|z15-|railway-station-subway-tokyo
+{icon-image: subway-tokyo-m.svg;}
+node|z16-|railway-subway_entrance-tokyo
+{icon-image: subway-tokyo-s.svg;}
 
 /* Valencia Subway Station */
-node|z13-[railway=station][transport=subway][city=valencia] {icon-image: subway-valencia-s.svg;}
-node|z15-[railway=station][transport=subway][city=valencia] {icon-image: subway-valencia-m.svg;}
-node|z16-[railway=subway_entrance][city=valencia] {icon-image: subway-valencia-s.svg;}
+node|z13-|railway-station-subway-valencia
+{icon-image: subway-valencia-s.svg;}
+node|z15-|railway-station-subway-valencia
+{icon-image: subway-valencia-m.svg;}
+node|z16-|railway-subway_entrance-valencia
+{icon-image: subway-valencia-s.svg;}
 
 /* Vienna Subway Station */
-node|z12-[railway=station][transport=subway][city=vienna] {icon-image: subway-vienna-s.svg;}
-node|z15-[railway=station][transport=subway][city=vienna] {icon-image: subway-vienna-m.svg;}
-node|z16-[railway=subway_entrance][city=vienna] {icon-image: subway-vienna-s.svg;}
+node|z12-|railway-station-subway-vienna
+{icon-image: subway-vienna-s.svg;}
+node|z15-|railway-station-subway-vienna
+{icon-image: subway-vienna-m.svg;}
+node|z16-|railway-subway_entrance-vienna
+{icon-image: subway-vienna-s.svg;}
 
 /* Washington Subway Station */
-node|z13-[railway=station][transport=subway][city=washington] {icon-image: subway-washington-s.svg;}
-node|z15-[railway=station][transport=subway][city=washington] {icon-image: subway-washington-m.svg;}
-node|z16-[railway=subway_entrance][city=washington] {icon-image: subway-washington-s.svg;}
+node|z13-|railway-station-subway-washington
+{icon-image: subway-washington-s.svg;}
+node|z15-|railway-station-subway-washington
+{icon-image: subway-washington-m.svg;}
+node|z16-|railway-subway_entrance-washington
+{icon-image: subway-washington-s.svg;}
 
 /* Wuhan Subway Station */
-node|z13-[railway=station][transport=subway][city=wuhan] {icon-image: subway-wuhan-s.svg;}
-node|z15-[railway=station][transport=subway][city=wuhan] {icon-image: subway-wuhan-m.svg;}
-node|z16-[railway=subway_entrance][city=wuhan] {icon-image: subway-wuhan-s.svg;}
+node|z13-|railway-station-subway-wuhan
+{icon-image: subway-wuhan-s.svg;}
+node|z15-|railway-station-subway-wuhan
+{icon-image: subway-wuhan-m.svg;}
+node|z16-|railway-subway_entrance-wuhan
+{icon-image: subway-wuhan-s.svg;}
 
 /* Warszawa Subway Station */
-node|z13-[railway=station][transport=subway][city=warszawa] {icon-image: subway-warszawa-s.svg;}
-node|z15-[railway=station][transport=subway][city=warszawa] {icon-image: subway-warszawa-m.svg;}
-node|z16-[railway=subway_entrance][city=warszawa] {icon-image: subway-warszawa-s.svg;}
+node|z13-|railway-station-subway-warszawa
+{icon-image: subway-warszawa-s.svg;}
+node|z15-|railway-station-subway-warszawa
+{icon-image: subway-warszawa-m.svg;}
+node|z16-|railway-subway_entrance-warszawa
+{icon-image: subway-warszawa-s.svg;}
 
 /* Yerevan Subway Station */
-node|z13-[railway=station][transport=subway][city=yerevan] {icon-image: subway-yerevan-s.svg;}
-node|z15-[railway=station][transport=subway][city=yerevan] {icon-image: subway-yerevan-m.svg;}
-node|z16-[railway=subway_entrance][city=yerevan] {icon-image: subway-yerevan-s.svg;}
+node|z13-|railway-station-subway-yerevan
+{icon-image: subway-yerevan-s.svg;}
+node|z15-|railway-station-subway-yerevan
+{icon-image: subway-yerevan-m.svg;}
+node|z16-|railway-subway_entrance-yerevan
+{icon-image: subway-yerevan-s.svg;}
 
 /* Yokohama Subway Station */
-node|z13-[railway=station][transport=subway][city=yokohama] {icon-image: subway-yokohama-s.svg;}
-node|z15-[railway=station][transport=subway][city=yokohama] {icon-image: subway-yokohama-m.svg;}
-node|z16-[railway=subway_entrance][city=yokohama] {icon-image: subway-yokohama-s.svg;}
+node|z13-|railway-station-subway-yokohama
+{icon-image: subway-yokohama-s.svg;}
+node|z15-|railway-station-subway-yokohama
+{icon-image: subway-yokohama-m.svg;}
+node|z16-|railway-subway_entrance-yokohama
+{icon-image: subway-yokohama-s.svg;}
 
 
 
@@ -798,9 +1194,13 @@ node|z16-[railway=subway_entrance][city=yokohama] {icon-image: subway-yokohama-s
 
 
 /* London Light Rail Station (DLR) */
-node|z13-[railway=station][station=light_rail][city=london] {icon-image: light_rail-dlr-london-s.svg;}
-node|z15-[railway=station][station=light_rail][city=london] {icon-image: light_rail-dlr-london-m.svg;}
+node|z13-|railway-station-light_rail-london
+{icon-image: light_rail-dlr-london-s.svg;}
+node|z15-|railway-station-light_rail-london
+{icon-image: light_rail-dlr-london-m.svg;}
 
 /* Porto Light Rail Station */
-node|z13-[railway=station][station=light_rail][city=porto] {icon-image: light_rail-porto-s.svg;}
-node|z15-[railway=station][station=light_rail][city=porto] {icon-image: light_rail-porto-m.svg;}
+node|z13-|railway-station-light_rail-porto
+{icon-image: light_rail-porto-s.svg;}
+node|z15-|railway-station-light_rail-porto
+{icon-image: light_rail-porto-m.svg;}

--- a/tools/unix/generate_drules.sh
+++ b/tools/unix/generate_drules.sh
@@ -22,34 +22,34 @@ function BuildDrawingRules() {
 }
 
 # Cleanup
-cleanup=(classificator.txt types.txt visibility.txt colors.txt patterns.txt)
-for item in ${cleanup[*]}
-do
-  rm $DATA_PATH/$item || true
-done
+#cleanup=(classificator.txt types.txt visibility.txt colors.txt patterns.txt)
+#for item in ${cleanup[*]}
+#do
+#  rm $DATA_PATH/$item || true
+#done
 
 # Building drawing rules
 BuildDrawingRules default  light _default_light
-BuildDrawingRules default  dark _default_dark
-BuildDrawingRules outdoors  light _outdoors_light
-BuildDrawingRules outdoors  dark _outdoors_dark
+#BuildDrawingRules default  dark _default_dark
+#BuildDrawingRules outdoors  light _outdoors_light
+#BuildDrawingRules outdoors  dark _outdoors_dark
 # Keep vehicle style last to produce same visibility.txt & classificator.txt
-BuildDrawingRules vehicle  light _vehicle_light
-BuildDrawingRules vehicle  dark _vehicle_dark
+#BuildDrawingRules vehicle  light _vehicle_light
+#BuildDrawingRules vehicle  dark _vehicle_dark
 
 # In designer mode we use drules_proto_design file instead of standard ones
-cp $OMIM_PATH/data/drules_proto_default_light.bin $OMIM_PATH/data/drules_proto_default_design.bin
+#cp $OMIM_PATH/data/drules_proto_default_light.bin $OMIM_PATH/data/drules_proto_default_design.bin
 
-echo "Exporting transit colors..."
-python3 "$OMIM_PATH/tools/python/transit/transit_colors_export.py" \
-  "$DATA_PATH/colors.txt" > /dev/null
+#echo "Exporting transit colors..."
+#python3 "$OMIM_PATH/tools/python/transit/transit_colors_export.py" \
+#  "$DATA_PATH/colors.txt" > /dev/null
 
-echo "Merging default and vehicle styles..."
-python3 "$OMIM_PATH/tools/python/stylesheet/drules_merge.py" \
-  "$DATA_PATH/drules_proto_default_light.bin" "$DATA_PATH/drules_proto_vehicle_light.bin" \
-  "$DATA_PATH/drules_proto.bin.tmp" > /dev/null
-echo "Merging in outdoors style..."
-python3 "$OMIM_PATH/tools/python/stylesheet/drules_merge.py" \
-  "$DATA_PATH/drules_proto.bin.tmp" "$DATA_PATH/drules_proto_outdoors_light.bin" \
-  "$DATA_PATH/drules_proto.bin" "$DATA_PATH/drules_proto.txt" > /dev/null
-rm "$DATA_PATH/drules_proto.bin.tmp" || true
+#echo "Merging default and vehicle styles..."
+#python3 "$OMIM_PATH/tools/python/stylesheet/drules_merge.py" \
+#  "$DATA_PATH/drules_proto_default_light.bin" "$DATA_PATH/drules_proto_vehicle_light.bin" \
+#  "$DATA_PATH/drules_proto.bin.tmp" > /dev/null
+#echo "Merging in outdoors style..."
+#python3 "$OMIM_PATH/tools/python/stylesheet/drules_merge.py" \
+#  "$DATA_PATH/drules_proto.bin.tmp" "$DATA_PATH/drules_proto_outdoors_light.bin" \
+#  "$DATA_PATH/drules_proto.bin" "$DATA_PATH/drules_proto.txt" > /dev/null
+#rm "$DATA_PATH/drules_proto.bin.tmp" || true


### PR DESCRIPTION
Migrate mapcss files from pseudo-tags notation to direct usage of OM feature types.

E.g.
```diff
-area|z13-[natural=water][water=ditch],
-area|z13-[natural=water][water=drain],
-area|z12-[natural=water][water=wastewater],
+area|z13-|natural-water-ditch,
+area|z13-|natural-water-drain,
+area|z12-|natural-water-wastewater,
 {fill-color: @water_bad;}
```

Depends on https://github.com/organicmaps/kothic/pull/31

TODO:
- manually migrate marked cases, e.g. `area|z15-|[natural=water][tunnel] /*NO-TYPE-MATCH*/,` (might have to fix/rewrite current style rules to some extent)
- update kothic to read and use the new notation/syntax
(at that stage we can also move from a standalone kothic repo to e.g. `styles_compiler/` subfolder in the main repo and rename `*.mapcss` files to e.g. `*.style` files)

See https://github.com/organicmaps/organicmaps/issues/4317#issuecomment-1411759991 for the background.