### PR TITLE
Qt 6.7 fix

### DIFF
--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -268,8 +268,10 @@ void MapWidget::Build()
                            QVector4D(1.0, -1.0, 1.0, 0.0)};
   m_vbo->allocate(static_cast<void*>(vertices), sizeof(vertices));
   QOpenGLFunctions *f = QOpenGLContext::currentContext()->functions();
+  // 0-index of the buffer is linked to "a_position" attribute in vertex shader.
+  // Introduced in https://github.com/organicmaps/organicmaps/pull/9814
   f->glEnableVertexAttribArray(0);
-  f->glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat), nullptr);
+  f->glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, sizeof(QVector4D), nullptr);
   m_vbo->release();
 
   m_program->release();

--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -267,6 +267,10 @@ void MapWidget::Build()
                            QVector4D(-1.0, -1.0, 0.0, 0.0),
                            QVector4D(1.0, -1.0, 1.0, 0.0)};
   m_vbo->allocate(static_cast<void*>(vertices), sizeof(vertices));
+  QOpenGLFunctions *f = QOpenGLContext::currentContext()->functions();
+  f->glEnableVertexAttribArray(0);
+  f->glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat), nullptr);
+  m_vbo->release();
 
   m_program->release();
   m_vao->release();
@@ -420,10 +424,7 @@ void MapWidget::paintGL()
     int const samplerSizeLocation = m_program->uniformLocation("u_samplerSize");
     m_program->setUniformValue(samplerSizeLocation, samplerSize);
 
-    m_program->enableAttributeArray("a_position");
-    m_program->setAttributeBuffer("a_position", GL_FLOAT, 0, 4, 0);
-
-    funcs->glClearColor(0.0, 0.0, 0.0, 1.0);
+    funcs->glClearColor(0.5, 0.5, 0.5, 1.0);
     funcs->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     funcs->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);

--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -272,7 +272,6 @@ void MapWidget::Build()
   // Introduced in https://github.com/organicmaps/organicmaps/pull/9814
   f->glEnableVertexAttribArray(0);
   f->glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, sizeof(QVector4D), nullptr);
-  m_vbo->release();
 
   m_program->release();
   m_vao->release();

--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -426,7 +426,7 @@ void MapWidget::paintGL()
     int const samplerSizeLocation = m_program->uniformLocation("u_samplerSize");
     m_program->setUniformValue(samplerSizeLocation, samplerSize);
 
-    funcs->glClearColor(0.5, 0.5, 0.5, 1.0);
+    funcs->glClearColor(0.0, 0.0, 0.0, 1.0);
     funcs->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     funcs->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);


### PR DESCRIPTION
Closes #7838 

**Symptoms:** after call `glDrawArrays(GL_TRIANGLE_STRIP, 0, 4)` in [map_widget.cpp](https://github.com/organicmaps/organicmaps/blob/master/qt/qt_common/map_widget.cpp#L429) we get error: `glGetError()` returns code 1282.

I searched for possible solutions and on Stackoverflow someone supposed this could be vertex buffer issue ([Stackoverflow answer 1](https://stackoverflow.com/a/49304885) and [Stackoverflow answer 2](https://stackoverflow.com/a/32527554)). Shaders in `gl_150.vsh.glsl`, `gles_200.vsh.glsl`, and `gles_300.vsh.glsl` read QVector4D from `"a_position"` input attribute.

I changed `a_position` assignment for OpenGL vertex shader using `glVertexAttribPointer(...)` which I saw in official Qt example https://doc.qt.io/qt-6/qtopengl-hellogles3-example.html

It works on my Mac M2 and Qt 6.7.2 from Brew. Please verify on Linux too.