### PR TITLE
Fix: Improved Italian navigation prompts for street types

### DIFF
--- a/data/strings/sound.txt
+++ b/data/strings/sound.txt
@@ -553,7 +553,7 @@
     hr = na
     hu = a
     id = ke
-    it = sulla
+    it = in
     ja = NULL
     ko = NULL
     mr = वर


### PR DESCRIPTION
Refined the Italian translation for navigation directions. The previous version incorrectly used "sulla" when directing users to turn onto streets or boulevards, leading to grammatically incorrect phrases such as “sulla viale.”

The phrase has been updated to use "in" instead, resulting in more natural and grammatically correct instructions.

This enhancement not only improves the overall fluency of the translation but also addresses grammatical inconsistencies that previously caused errors in the navigation guidance.