### PR TITLE
[android] Track saving dialog buttons fix

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -66,7 +66,7 @@
     <item name="android:textColor">?buttonDialogTextColor</item>
     <item name="android:textAllCaps">true</item>
     <item name="android:fontFamily">@string/robotoMedium</item>
-    <item name="android:lines">1</item>
+    <item name="android:lines">2</item>
     <item name="android:gravity">center_vertical|end</item>
   </style>
 


### PR DESCRIPTION
Fixed multiline button style for DialogStackedButton. Closes #9727

Dialog is defined in `StackedButtonsDialog`. Layout is defined in `dialog_stacked_buttons.xml`. Each button has style `MwmWidget.Button.StackedButtonsDialog`. Modified the style to allow 2 lines for the buttons:

<img width="300" alt="TrackSaveDialog-fix-1" src="https://github.com/user-attachments/assets/995ccc42-f66f-4ea7-a34c-4927b90c41b6"/>

## Maybe with separators?

I also tried to add horizontal separators (**not in this PR yet**):

<img width="329" alt="TrackSaveDialog-fix-3" src="https://github.com/user-attachments/assets/bee9de07-919f-4afb-b1cc-2087ba2f6025"> <img width="334" alt="TrackSaveDialog-fix-2" src="https://github.com/user-attachments/assets/514813ee-f6db-437a-ac53-3ea1f86e60ac">

What do you think?