### PR TITLE
Add alternative Argentinian post code format

### DIFF
--- a/indexer/postcodes_matcher.cpp
+++ b/indexer/postcodes_matcher.cpp
@@ -30,7 +30,8 @@ char const * const g_patterns[] = {
     "aann naa",  "aannaa",     "aannnaa",     "aannnn",   "an naa",   "ana naa",  "ana nan",
     "ananan",    "ann aann",   "ann naa",     "annnnaaa", "nn nnn",   "nnn",      "nnn nn",
     "nnn nnn",   "nnn nnnn",   "nnnn",        "nnnn aa",  "nnnn nnn", "nnnnaa",   "nnnnn",
-    "nnnnn nnn", "nnnnn nnnn", "nnnnn nnnnn", "nnnnnn",   "nnnnnnn",  "nnnnnnnn", "〒nnn nnnn"};
+    "nnnnn nnn", "nnnnn nnnn", "nnnnn nnnnn", "nnnnnn",   "nnnnnnn",  "nnnnnnnn", "〒nnn nnnn",
+    "annnn"};
 
 UniChar SimplifyChar(UniChar const & c)
 {


### PR DESCRIPTION
Added the `annnn` format for Argentinian post codes (a := letter, n := number). This way e.g. V9418 is recognized as a valid post code.

Most addresses in Argentina use `nnnn` which is the old address format. The official address format is `annnnaaa`, but the format `annnn` is also used in several places. So it's better to support it as well.

Examples:
https://www.openstreetmap.org/way/829421469
https://www.openstreetmap.org/node/10560533672
https://www.openstreetmap.org/way/849380896

Wikipedia: https://en.wikipedia.org/wiki/Postal_codes_in_Argentina

related to #5116