### PR TITLE
Modified startForeground() method call to adapt for android 14+

### DIFF
--- a/android/app/src/main/java/app/organicmaps/downloader/DownloaderService.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/DownloaderService.java
@@ -3,13 +3,14 @@ package app.organicmaps.downloader;
 import static android.Manifest.permission.POST_NOTIFICATIONS;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 
-import android.app.ForegroundServiceStartNotAllowedException;
 import android.app.Service;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.os.IBinder;
 
 import androidx.annotation.Nullable;
+import androidx.core.app.ServiceCompat;
 import androidx.core.content.ContextCompat;
 
 import java.util.List;
@@ -40,19 +41,11 @@ public class DownloaderService extends Service implements MapManager.StorageCall
     Logger.i(TAG, "Downloading: " + MapManager.nativeIsDownloading());
 
     var notification = mNotifier.buildProgressNotification();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-    {
-      try
-      {
-        startForeground(DownloaderNotifier.NOTIFICATION_ID, notification);
-      } catch (ForegroundServiceStartNotAllowedException e)
-      {
-        Logger.e(TAG, "Oops! ForegroundService is not allowed", e);
-      }
-    } else
-    {
-      startForeground(DownloaderNotifier.NOTIFICATION_ID, notification);
-    }
+    Logger.i(TAG, "Starting Downloader Foreground Service");
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+      ServiceCompat.startForeground(this, DownloaderNotifier.NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+    else
+      ServiceCompat.startForeground(this, DownloaderNotifier.NOTIFICATION_ID, notification, 0);
 
     return START_NOT_STICKY;
   }

--- a/android/app/src/main/java/app/organicmaps/location/TrackRecordingService.java
+++ b/android/app/src/main/java/app/organicmaps/location/TrackRecordingService.java
@@ -1,11 +1,11 @@
 package app.organicmaps.location;
 
-import android.app.ForegroundServiceStartNotAllowedException;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.location.Location;
 import android.os.Build;
 import android.os.IBinder;
@@ -17,6 +17,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationChannelCompat;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
+import androidx.core.app.ServiceCompat;
 import androidx.core.content.ContextCompat;
 import app.organicmaps.MwmActivity;
 import app.organicmaps.MwmApplication;
@@ -158,21 +159,11 @@ public class TrackRecordingService extends Service implements LocationListener
       return START_NOT_STICKY;
     }
 
-    Logger.i(TAG, "Starting foreground service");
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-    {
-      try
-      {
-        startForeground(TrackRecordingService.TRACK_REC_NOTIFICATION_ID, getNotificationBuilder(this).build());
-      } catch (ForegroundServiceStartNotAllowedException e)
-      {
-        Logger.e(TAG, "Oops! ForegroundService is not allowed", e);
-      }
-    }
+    Logger.i(TAG, "Starting Track Recording Foreground service");
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+      ServiceCompat.startForeground(this, TrackRecordingService.TRACK_REC_NOTIFICATION_ID, getNotificationBuilder(this).build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
     else
-    {
-      startForeground(TrackRecordingService.TRACK_REC_NOTIFICATION_ID, getNotificationBuilder(this).build());
-    }
+      ServiceCompat.startForeground(this, TrackRecordingService.TRACK_REC_NOTIFICATION_ID, getNotificationBuilder(this).build(), 0);
 
     final LocationHelper locationHelper = LocationHelper.from(this);
 

--- a/android/app/src/main/java/app/organicmaps/routing/NavigationService.java
+++ b/android/app/src/main/java/app/organicmaps/routing/NavigationService.java
@@ -7,12 +7,12 @@ import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static app.organicmaps.util.Constants.Vendor.XIAOMI;
 
 import android.annotation.SuppressLint;
-import android.app.ForegroundServiceStartNotAllowedException;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.location.Location;
@@ -27,6 +27,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationChannelCompat;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
+import androidx.core.app.ServiceCompat;
 import androidx.core.content.ContextCompat;
 
 import app.organicmaps.Framework;
@@ -224,21 +225,11 @@ public class NavigationService extends Service implements LocationListener
       return START_NOT_STICKY; // The service will be stopped by stopSelf().
     }
 
-    Logger.i(TAG, "Starting foreground");
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-    {
-      try
-      {
-        startForeground(NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build());
-      } catch (ForegroundServiceStartNotAllowedException e)
-      {
-        Logger.e(TAG, "Oops! ForegroundService is not allowed", e);
-      }
-    }
+    Logger.i(TAG, "Starting Navigation Foreground service");
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+      ServiceCompat.startForeground(this, NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
     else
-    {
-      startForeground(NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build());
-    }
+      ServiceCompat.startForeground(this, NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build(), 0);
 
     final LocationHelper locationHelper = LocationHelper.from(this);
 


### PR DESCRIPTION
Fixes #9395

Its not sure it fixes the crash or not but this could be the cause of crash since in android api 34 and above we need to specify the foreground service type while calling the startForegound method for track recording and navigation.

Reference android documentation - https://developer.android.com/develop/background-work/services/foreground-services#start


Please test and provide feedback if its solves the crash or not

