### PR TITLE
[strings] Fixed Estonian description of San Marino

### DIFF
--- a/data/countries_names.txt
+++ b/data/countries_names.txt
@@ -57592,7 +57592,7 @@
   da = San Marino
   el = Σίτι του Σαν Μαρίνο, Σεραβάλε, Μπόργκο Ματζιόρε
   es = San Marino
-  et = San Marino, Chita, Krasnokamensk, Borzya
+  et = San Marino, Serravalle, Borgo Maggiore
   fi = San Marino
   fr = Ville de Saint-Marin
   he = סן מרינו


### PR DESCRIPTION
Chita, Krasnokamensk, Borzya are located in Zabaykalsky Krai (Russia), not in San Marino.