### PR TITLE
[strings] Make mast & flagpole searchable in the Editor

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -11726,6 +11726,45 @@ uk:4Геодезичний пункт
 mr:सर्वेक्षण बिंदू|सर्व्हे पॉइंट
 es:punto geodésico
 
+man_made-flagpole
+en:Flagpole
+ar:سارية علم
+be:Флагшток
+de:Fahnenmast
+es:Mástil de bandera
+et:Lipumast
+fi:Lipputanko
+fr:Mât de drapeau
+he:עמוד דגל
+it:Alza bandiera
+mr:ध्वजस्तंभ
+nl:Vlaggenpaal
+pl:Maszt flagowy
+ru:Флагшток
+sk:Vlajkový stožiar
+tr:Bayrak Direği
+uk:Флагшток
+zh-Hans:旗杆
+zh-Hant:旗桿
+
+man_made-mast
+en:Mast|pole
+ar:عمود برج
+be:Мачта|вышка
+de:Mast
+es:Mástil
+et:Mast
+fr:Mât
+he:תורן
+it:Pilone
+mr:डोलकाठी
+nl:Mast
+pl:Maszt
+ru:Мачта|вышка
+sk:Stožiar
+tr:Direk
+uk:Щогла|вишка
+
 man_made-tower-communication
 en:Communications Tower|cell tower|cellular tower
 ar:برج الاتصالات

--- a/data/countries-strings/et.json/localize.json
+++ b/data/countries-strings/et.json/localize.json
@@ -2172,7 +2172,7 @@
 "Saint Martin Description":"Philipsburg, Cul-de-Sac, Cole Bay",
 "Saint Vincent and the Grenadines Description":"Kingstown, Clifton, Ashton",
 "Samoa Description":"Āpia, Sālelologa, Asau",
-"San Marino Description":"San Marino, Chita, Krasnokamensk, Borzya",
+"San Marino Description":"San Marino, Serravalle, Borgo Maggiore",
 "Sao Tome and Principe Description":"São Tomé, Neves, São João dos Angolares",
 "Saudi Arabia_North Description":"Jeddah, Mecca, Medina",
 "Saudi Arabia_South Description":"Riyadh, Hofuf, Dammam",


### PR DESCRIPTION
Mast and Flagpole are the only POIs not searchable in the Editor search. Fix it.

Follow-up to
- https://github.com/organicmaps/organicmaps/pull/9551
- https://github.com/organicmaps/organicmaps/issues/8290

@vng they could be removed when the editor search is refactored