### PR TITLE
Issue 9822. Change the search language when the map language changes.

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2449,6 +2449,9 @@ void Framework::SetMapLanguageCode(std::string const & langCode)
   settings::Set(settings::kMapLanguageCode, langCode);
   if (m_drapeEngine)
     ApplyMapLanguageCode(langCode);
+
+  if (m_searchAPI)
+    m_searchAPI->SetLocale(langCode);
 }
 
 void Framework::ApplyMapLanguageCode(std::string const & langCode)

--- a/map/search_api.cpp
+++ b/map/search_api.cpp
@@ -422,6 +422,11 @@ void SearchAPI::SetViewportIfPossible(SearchParams & params)
     params.m_viewport = m_viewport;
 }
 
+void SearchAPI::SetLocale(std::string const & locale)
+{
+  m_engine.SetLocale(locale);
+}
+
 bool SearchAPI::QueryMayBeSkipped(SearchParams const & prevParams,
                                   SearchParams const & currParams) const
 {

--- a/map/search_api.hpp
+++ b/map/search_api.hpp
@@ -21,6 +21,7 @@
 #include <optional>
 #include <unordered_set>
 #include <vector>
+#include <string>
 
 class DataSource;
 
@@ -112,6 +113,8 @@ public:
   void ClearSearchHistory() { m_searchQuerySaver.Clear(); }
 
   void EnableIndexingOfBookmarksDescriptions(bool enable);
+
+  void SetLocale(std::string const & locale);
 
   // By default all created bookmarks are saved in BookmarksProcessor
   // but we do not index them in an attempt to save time and memory.


### PR DESCRIPTION
Fix for https://github.com/organicmaps/organicmaps/issues/9822.
We now change Search API`s language on map language changing.

For English lang:
![image](https://github.com/user-attachments/assets/9ae5c113-8905-40b5-9457-6281e1162b62)

After changint to russian:
![image](https://github.com/user-attachments/assets/44a682f9-2c5a-4858-a0f5-303d1d44ccba)
 