### PR TITLE
[core] [ios] Observe track recording updates

### DIFF
--- a/iphone/CoreApi/CoreApi.xcodeproj/project.pbxproj
+++ b/iphone/CoreApi/CoreApi.xcodeproj/project.pbxproj
@@ -92,6 +92,9 @@
 		ED49D75B2CEF8BD2004AF27E /* ProductsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED49D7562CEF850F004AF27E /* ProductsConfiguration.swift */; };
 		ED49D75F2CEFA8C0004AF27E /* Product+Core.h in Headers */ = {isa = PBXBuildFile; fileRef = ED49D75E2CEFA8C0004AF27E /* Product+Core.h */; };
 		ED49D7612CEFA8E1004AF27E /* Product+Core.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED49D7602CEFA8E1004AF27E /* Product+Core.mm */; };
+		ED7306F42D0C5D2400523AA1 /* TrackRecordingInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED7306F12D0C5D2400523AA1 /* TrackRecordingInfo.mm */; };
+		ED7306F52D0C5D2400523AA1 /* TrackRecordingInfo+Core.h in Headers */ = {isa = PBXBuildFile; fileRef = ED7306F22D0C5D2400523AA1 /* TrackRecordingInfo+Core.h */; };
+		ED7306F62D0C5D2400523AA1 /* TrackRecordingInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = ED7306F02D0C5D2400523AA1 /* TrackRecordingInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED965B0D2CD67A470049E39E /* DistanceFormatter.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED965B0A2CD67A470049E39E /* DistanceFormatter.mm */; };
 		ED965B102CD67A470049E39E /* DistanceFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = ED965B092CD67A470049E39E /* DistanceFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED965B132CD67A9B0049E39E /* AltitudeFormatter.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED965B122CD67A9B0049E39E /* AltitudeFormatter.mm */; };
@@ -197,6 +200,9 @@
 		ED49D7562CEF850F004AF27E /* ProductsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsConfiguration.swift; sourceTree = "<group>"; };
 		ED49D75E2CEFA8C0004AF27E /* Product+Core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Product+Core.h"; sourceTree = "<group>"; };
 		ED49D7602CEFA8E1004AF27E /* Product+Core.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "Product+Core.mm"; sourceTree = "<group>"; };
+		ED7306F02D0C5D2400523AA1 /* TrackRecordingInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackRecordingInfo.h; sourceTree = "<group>"; };
+		ED7306F12D0C5D2400523AA1 /* TrackRecordingInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TrackRecordingInfo.mm; sourceTree = "<group>"; };
+		ED7306F22D0C5D2400523AA1 /* TrackRecordingInfo+Core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TrackRecordingInfo+Core.h"; sourceTree = "<group>"; };
 		ED965B092CD67A470049E39E /* DistanceFormatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DistanceFormatter.h; sourceTree = "<group>"; };
 		ED965B0A2CD67A470049E39E /* DistanceFormatter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DistanceFormatter.mm; sourceTree = "<group>"; };
 		ED965B112CD67A9B0049E39E /* AltitudeFormatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AltitudeFormatter.h; sourceTree = "<group>"; };
@@ -244,6 +250,7 @@
 		470015F12342509C00EBF03D /* CoreApi */ = {
 			isa = PBXGroup;
 			children = (
+				ED7306F32D0C5D2400523AA1 /* TrackRecorder */,
 				ED965B0B2CD67A470049E39E /* Formatting */,
 				47F4F1F623A333280022FD56 /* Storage */,
 				9957FAE5237AE59C00855F48 /* Logger */,
@@ -450,6 +457,16 @@
 			path = ElevationProfile;
 			sourceTree = "<group>";
 		};
+		ED7306F32D0C5D2400523AA1 /* TrackRecorder */ = {
+			isa = PBXGroup;
+			children = (
+				ED7306F02D0C5D2400523AA1 /* TrackRecordingInfo.h */,
+				ED7306F12D0C5D2400523AA1 /* TrackRecordingInfo.mm */,
+				ED7306F22D0C5D2400523AA1 /* TrackRecordingInfo+Core.h */,
+			);
+			path = TrackRecorder;
+			sourceTree = "<group>";
+		};
 		ED965B0B2CD67A470049E39E /* Formatting */ = {
 			isa = PBXGroup;
 			children = (
@@ -488,6 +505,8 @@
 				ED965B102CD67A470049E39E /* DistanceFormatter.h in Headers */,
 				47942D6D237CC3E300DEFAE3 /* PlacePagePreviewData.h in Headers */,
 				47CA68DD2502022400671019 /* MWMBookmark.h in Headers */,
+				ED7306F52D0C5D2400523AA1 /* TrackRecordingInfo+Core.h in Headers */,
+				ED7306F62D0C5D2400523AA1 /* TrackRecordingInfo.h in Headers */,
 				9940622023EAC57900493D1A /* ElevationHeightPoint.h in Headers */,
 				9957FACE237AB01400855F48 /* DeepLinkParser.h in Headers */,
 				9974CA2D23DF197B003FE824 /* ElevationProfileData+Core.h in Headers */,
@@ -625,6 +644,7 @@
 				479F7062234FBC4700011E2E /* MWMCarPlayBookmarkObject.mm in Sources */,
 				47942D6C237CC3DE00DEFAE3 /* PlacePageData.mm in Sources */,
 				479F705E234FBB8C00011E2E /* MWMBookmarkGroup.m in Sources */,
+				ED7306F42D0C5D2400523AA1 /* TrackRecordingInfo.mm in Sources */,
 				47F0D2162516847F00BC685E /* MWMBookmarksSection.m in Sources */,
 				479F7057234FB7F200011E2E /* MWMBookmarksManager.mm in Sources */,
 				47942D71237CC40800DEFAE3 /* PlacePageInfoData.mm in Sources */,

--- a/iphone/CoreApi/CoreApi/CoreApi.h
+++ b/iphone/CoreApi/CoreApi/CoreApi.h
@@ -31,6 +31,7 @@ FOUNDATION_EXPORT const unsigned char CoreApiVersionString[];
 #import "CoreApi/DistanceFormatter.h"
 #import "CoreApi/AltitudeFormatter.h"
 #import "CoreApi/DurationFormatter.h"
+#import "CoreApi/TrackRecordingInfo.h"
 
 #pragma mark - Place Page
 

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.h
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.h
@@ -4,6 +4,7 @@
 #import "MWMTypes.h"
 
 @class MWMMapSearchResult;
+@class TrackRecordingInfo;
 
 typedef NS_ENUM(NSUInteger, MWMZoomMode) { MWMZoomModeIn = 0, MWMZoomModeOut };
 
@@ -17,10 +18,12 @@ typedef NS_ENUM(NSInteger, ProductsPopupCloseReason) {
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^SearchInDownloaderCompletions)(NSArray<MWMMapSearchResult *> *results, BOOL finished);
+typedef void (^TrackRecordingUpdatedHandler)(TrackRecordingInfo * _Nonnull trackStatistics);
 
 @protocol TrackRecorder <NSObject>
 
 + (void)startTrackRecording;
++ (void)setTrackRecordingUpdateHandler:(TrackRecordingUpdatedHandler _Nullable)trackRecordingDidUpdate;
 + (void)stopTrackRecording;
 + (void)saveTrackRecordingWithName:(nullable NSString *)name;
 + (BOOL)isTrackRecordingEnabled;

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
@@ -2,6 +2,7 @@
 #import "MWMMapSearchResult+Core.h"
 #import "ProductsConfiguration+Core.h"
 #import "Product+Core.h"
+#import "TrackRecordingInfo+Core.h"
 
 #include "Framework.h"
 
@@ -215,6 +216,18 @@ static Framework::ProductsPopupCloseReason ConvertProductPopupCloseReasonToCore(
 
 + (void)startTrackRecording {
   GetFramework().StartTrackRecording();
+}
+
++ (void)setTrackRecordingUpdateHandler:(TrackRecordingUpdatedHandler _Nullable)trackRecordingDidUpdate {
+  if (!trackRecordingDidUpdate)
+  {
+    GetFramework().SetTrackRecordingUpdateHandler(nullptr);
+    return;
+  }
+  GetFramework().SetTrackRecordingUpdateHandler([trackRecordingDidUpdate](GpsTrackInfo const & gpsTrackInfo) {
+    TrackRecordingInfo * info = [[TrackRecordingInfo alloc] initWithGpsTrackInfo:gpsTrackInfo];
+    trackRecordingDidUpdate(info);
+  });
 }
 
 + (void)stopTrackRecording {

--- a/iphone/CoreApi/CoreApi/TrackRecorder/TrackRecordingInfo+Core.h
+++ b/iphone/CoreApi/CoreApi/TrackRecorder/TrackRecordingInfo+Core.h
@@ -1,0 +1,10 @@
+#import "TrackRecordingInfo.h"
+
+#include <CoreApi/Framework.h>
+#include "map/gps_track_collection.hpp"
+
+@interface TrackRecordingInfo (Core)
+
+- (instancetype)initWithGpsTrackInfo:(GpsTrackInfo const &)info;
+
+@end

--- a/iphone/CoreApi/CoreApi/TrackRecorder/TrackRecordingInfo.h
+++ b/iphone/CoreApi/CoreApi/TrackRecorder/TrackRecordingInfo.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TrackRecordingInfo : NSObject
+
+@property (nonatomic, readonly) NSString * distance;
+@property (nonatomic, readonly) NSString * duration;
+@property (nonatomic, readonly) NSString * ascent;
+@property (nonatomic, readonly) NSString * descent;
+@property (nonatomic, readonly) NSString * maxElevation;
+@property (nonatomic, readonly) NSString * minElevation;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iphone/CoreApi/CoreApi/TrackRecorder/TrackRecordingInfo.mm
+++ b/iphone/CoreApi/CoreApi/TrackRecorder/TrackRecordingInfo.mm
@@ -1,0 +1,24 @@
+#import "TrackRecordingInfo+Core.h"
+#import "AltitudeFormatter.h"
+#import "DistanceFormatter.h"
+#import "DurationFormatter.h"
+
+@implementation TrackRecordingInfo
+
+@end
+
+@implementation TrackRecordingInfo (Core)
+
+- (instancetype)initWithGpsTrackInfo:(GpsTrackInfo const &)trackInfo {
+  if (self = [super init]) {
+    _distance = [DistanceFormatter distanceStringFromMeters:trackInfo.m_length];
+    _duration = [DurationFormatter durationStringFromTimeInterval:trackInfo.m_duration];
+    _ascent = [AltitudeFormatter altitudeStringFromMeters:trackInfo.m_ascent];
+    _descent = [AltitudeFormatter altitudeStringFromMeters:trackInfo.m_descent];
+    _maxElevation = [AltitudeFormatter altitudeStringFromMeters:trackInfo.m_maxElevation];
+    _minElevation = [AltitudeFormatter altitudeStringFromMeters:trackInfo.m_minElevation];
+  }
+  return self;
+}
+
+@end

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1728,7 +1728,7 @@ void Framework::SetTrackRecordingUpdateHandler(TrackRecordingUpdateHandler && tr
 {
   m_trackRecordingUpdateHandler = std::move(trackRecordingDidUpdate);
   if (m_trackRecordingUpdateHandler)
-    m_trackRecordingUpdateHandler(std::move(GpsTracker::Instance().GetTrackInfo()));
+    m_trackRecordingUpdateHandler(GpsTracker::Instance().GetTrackInfo());
 }
 
 void Framework::StopTrackRecording()
@@ -1789,7 +1789,7 @@ void Framework::OnUpdateGpsTrackPointsCallback(vector<pair<size_t, location::Gps
   m_drapeEngine->UpdateGpsTrackPoints(std::move(pointsAdd), std::move(indicesRemove));
 
   if (m_trackRecordingUpdateHandler)
-    m_trackRecordingUpdateHandler(std::move(trackInfo));
+    m_trackRecordingUpdateHandler(trackInfo);
 }
 
 void Framework::MarkMapStyle(MapStyle mapStyle)

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -17,6 +17,7 @@
 #include "map/track.hpp"
 #include "map/traffic_manager.hpp"
 #include "map/transit/transit_reader.hpp"
+#include "map/gps_track_collection.hpp"
 
 #include "drape_frontend/gui/skin.hpp"
 #include "drape_frontend/drape_api.hpp"
@@ -435,7 +436,9 @@ public:
   void ConnectToGpsTracker();
   void DisconnectFromGpsTracker();
 
+  using TrackRecordingUpdateHandler = platform::SafeCallback<void(GpsTrackInfo const & trackInfo)>;
   void StartTrackRecording();
+  void SetTrackRecordingUpdateHandler(TrackRecordingUpdateHandler && trackRecordingDidUpdate);
   void StopTrackRecording();
   void SaveTrackRecordingWithName(std::string const & name);
   bool IsTrackRecordingEmpty() const;
@@ -463,7 +466,10 @@ private:
   TCurrentCountryChanged m_currentCountryChanged;
 
   void OnUpdateGpsTrackPointsCallback(std::vector<std::pair<size_t, location::GpsInfo>> && toAdd,
-                                      std::pair<size_t, size_t> const & toRemove);
+                                      std::pair<size_t, size_t> const & toRemove,
+                                      GpsTrackInfo const & trackInfo);
+
+  TrackRecordingUpdateHandler m_trackRecordingUpdateHandler;
 
   CachingRankTableLoader m_popularityLoader;
 

--- a/map/gps_track.cpp
+++ b/map/gps_track.cpp
@@ -303,7 +303,7 @@ void GpsTrack::NotifyCallback(pair<size_t, size_t> const & addedIds, pair<size_t
     if (toAdd.empty())
       return; // nothing to send
 
-    m_callback(std::move(toAdd), make_pair(kInvalidId, kInvalidId));
+    m_callback(std::move(toAdd), make_pair(kInvalidId, kInvalidId), std::move(m_collection->GetTrackInfo()));
   }
   else
   {
@@ -324,6 +324,6 @@ void GpsTrack::NotifyCallback(pair<size_t, size_t> const & addedIds, pair<size_t
     if (toAdd.empty() && evictedIds.first == kInvalidId)
       return; // nothing to send
 
-    m_callback(std::move(toAdd), evictedIds);
+    m_callback(std::move(toAdd), evictedIds, std::move(m_collection->GetTrackInfo()));
   }
 }

--- a/map/gps_track.cpp
+++ b/map/gps_track.cpp
@@ -303,7 +303,7 @@ void GpsTrack::NotifyCallback(pair<size_t, size_t> const & addedIds, pair<size_t
     if (toAdd.empty())
       return; // nothing to send
 
-    m_callback(std::move(toAdd), make_pair(kInvalidId, kInvalidId), std::move(m_collection->GetTrackInfo()));
+    m_callback(std::move(toAdd), make_pair(kInvalidId, kInvalidId), m_collection->GetTrackInfo());
   }
   else
   {
@@ -324,6 +324,6 @@ void GpsTrack::NotifyCallback(pair<size_t, size_t> const & addedIds, pair<size_t
     if (toAdd.empty() && evictedIds.first == kInvalidId)
       return; // nothing to send
 
-    m_callback(std::move(toAdd), evictedIds, std::move(m_collection->GetTrackInfo()));
+    m_callback(std::move(toAdd), evictedIds, m_collection->GetTrackInfo());
   }
 }

--- a/map/gps_track.cpp
+++ b/map/gps_track.cpp
@@ -79,6 +79,11 @@ void GpsTrack::AddPoints(vector<location::GpsInfo> const & points)
   ScheduleTask();
 }
 
+GpsTrackInfo GpsTrack::GetTrackInfo() const
+{
+  return m_collection ? m_collection->GetTrackInfo() : GpsTrackInfo();
+}
+
 void GpsTrack::Clear()
 {
   {

--- a/map/gps_track.hpp
+++ b/map/gps_track.hpp
@@ -30,6 +30,9 @@ public:
   void AddPoint(location::GpsInfo const & point);
   void AddPoints(std::vector<location::GpsInfo> const & points);
 
+  /// Returns track statistics
+  GpsTrackInfo GetTrackInfo() const;
+
   /// Clears any previous tracking info
   /// @note Callback is called with 'toRemove' points, if some points were removed.
   void Clear();

--- a/map/gps_track.hpp
+++ b/map/gps_track.hpp
@@ -46,7 +46,8 @@ public:
   /// @note Calling of a GpsTrack.SetCallback function from the callback causes deadlock.
   using TGpsTrackDiffCallback =
       std::function<void(std::vector<std::pair<size_t, location::GpsInfo>> && toAdd,
-                         std::pair<size_t, size_t> const & toRemove)>;
+                         std::pair<size_t, size_t> const & toRemove,
+                         GpsTrackInfo const & trackInfo)>;
 
   /// Sets callback on change of gps track.
   /// @param callback - callback callable object

--- a/map/gps_track_collection.cpp
+++ b/map/gps_track_collection.cpp
@@ -2,7 +2,7 @@
 
 #include "base/assert.hpp"
 
-#include "geometry/mercator.hpp"
+#include "geometry/distance_on_sphere.hpp"
 
 #include <algorithm>
 
@@ -59,7 +59,7 @@ std::pair<size_t, size_t> GpsTrackCollection::Add(std::vector<TItem> const & ite
     else
     {
       auto const & lastItem = m_items.back();
-      m_trackInfo.m_length += mercator::DistanceOnEarth(lastItem.GetPoint(), item.GetPoint());
+      m_trackInfo.m_length += ms::DistanceOnEarth(lastItem.GetLatLon(), item.GetLatLon());
       m_trackInfo.m_duration = item.m_timestamp - m_items.front().m_timestamp;
 
       auto const deltaAltitude = item.m_altitude - lastItem.m_altitude;

--- a/map/gps_track_collection.cpp
+++ b/map/gps_track_collection.cpp
@@ -66,7 +66,7 @@ std::pair<size_t, size_t> GpsTrackCollection::Add(std::vector<TItem> const & ite
       if (item.m_altitude > lastItem.m_altitude)
         m_trackInfo.m_ascent += deltaAltitude;
       if (item.m_altitude < lastItem.m_altitude)
-        m_trackInfo.m_descent += deltaAltitude;
+        m_trackInfo.m_descent -= deltaAltitude;
 
       m_trackInfo.m_maxElevation = std::max(static_cast<double>(m_trackInfo.m_maxElevation), item.m_altitude);
       m_trackInfo.m_minElevation = std::min(static_cast<double>(m_trackInfo.m_minElevation), item.m_altitude);
@@ -106,7 +106,7 @@ std::pair<size_t, size_t> GpsTrackCollection::Clear(bool resetIds)
 
   m_items.clear();
   m_items.shrink_to_fit();
-  m_trackInfo = GpsTrackInfo();
+  m_trackInfo = {};
 
   if (resetIds)
     m_lastId = 0;

--- a/map/gps_track_collection.cpp
+++ b/map/gps_track_collection.cpp
@@ -36,20 +36,6 @@ GpsTrackCollection::GpsTrackCollection()
 {
 }
 
-size_t GpsTrackCollection::Add(TItem const & item)
-{
-  if (!m_items.empty() && m_items.back().m_timestamp > item.m_timestamp)
-  {
-    // Invalid timestamp order
-    return kInvalidId; // Nothing was added
-  }
-
-  m_items.emplace_back(item);
-  ++m_lastId;
-
-  return m_lastId - 1;
-}
-
 std::pair<size_t, size_t> GpsTrackCollection::Add(std::vector<TItem> const & items)
 {
   size_t startId = m_lastId;
@@ -112,12 +98,4 @@ size_t GpsTrackCollection::GetSize() const
 bool GpsTrackCollection::IsEmpty() const
 {
   return m_items.empty();
-}
-
-std::pair<size_t, size_t> GpsTrackCollection::RemoveUntil(std::deque<TItem>::iterator i)
-{
-  auto const res = std::make_pair(m_lastId - m_items.size(),
-                             m_lastId - m_items.size() + distance(m_items.begin(), i) - 1);
-  m_items.erase(m_items.begin(), i);
-  return res;
 }

--- a/map/gps_track_collection.hpp
+++ b/map/gps_track_collection.hpp
@@ -17,11 +17,6 @@ public:
   /// Constructor
   GpsTrackCollection();
 
-  /// Adds new point in the collection.
-  /// @param item - item to be added.
-  /// @returns the item unique identifier or kInvalidId if point has incorrect time.
-  size_t Add(TItem const & item);
-
   /// Adds set of new points in the collection.
   /// @param items - set of items to be added.
   /// @returns range of identifiers of added items or pair(kInvalidId,kInvalidId) if nothing was added
@@ -62,13 +57,6 @@ public:
   }
 
 private:
-  // Removes items in range [m_items.begin(), i) and returnd
-  // range of identifiers of removed items
-  std::pair<size_t, size_t> RemoveUntil(std::deque<TItem>::iterator i);
-
-  // Removes items extra by timestamp
-  std::pair<size_t, size_t> RemoveExtraItems();
-
   std::deque<TItem> m_items;  // asc. sorted by timestamp
 
   size_t m_lastId;

--- a/map/gps_track_collection.hpp
+++ b/map/gps_track_collection.hpp
@@ -7,6 +7,16 @@
 #include <utility>
 #include <vector>
 
+struct GpsTrackInfo
+{
+  double m_length;
+  double m_duration;
+  uint32_t m_ascent;
+  uint32_t m_descent;
+  int16_t m_minElevation;
+  int16_t m_maxElevation;
+};
+
 class GpsTrackCollection final
 {
 public:
@@ -36,6 +46,8 @@ public:
   /// Returns number of items in the collection
   size_t GetSize() const;
 
+  GpsTrackInfo GetTrackInfo() const { return m_trackInfo; }
+
   /// Enumerates items in the collection.
   /// @param f - callable object, which is called with params - item and item id,
   /// if f returns false, then enumeration is stopped.
@@ -60,4 +72,5 @@ private:
   std::deque<TItem> m_items;  // asc. sorted by timestamp
 
   size_t m_lastId;
+  GpsTrackInfo m_trackInfo;
 };

--- a/map/gps_tracker.hpp
+++ b/map/gps_tracker.hpp
@@ -21,7 +21,8 @@ public:
 
   using TGpsTrackDiffCallback =
       std::function<void(std::vector<std::pair<size_t, location::GpsInfo>> && toAdd,
-                         std::pair<size_t, size_t> const & toRemove)>;
+                         std::pair<size_t, size_t> const & toRemove,
+                         GpsTrackInfo const & trackInfo)>;
 
   void Connect(TGpsTrackDiffCallback const & fn);
   void Disconnect();

--- a/map/gps_tracker.hpp
+++ b/map/gps_tracker.hpp
@@ -17,6 +17,7 @@ public:
 
   bool IsEmpty() const;
   size_t GetTrackSize() const;
+  GpsTrackInfo GetTrackInfo() const { return m_track.GetTrackInfo(); }
 
   using TGpsTrackDiffCallback =
       std::function<void(std::vector<std::pair<size_t, location::GpsInfo>> && toAdd,

--- a/map/map_tests/gps_track_collection_test.cpp
+++ b/map/map_tests/gps_track_collection_test.cpp
@@ -38,9 +38,9 @@ UNIT_TEST(GpsTrackCollection_Simple)
   for (size_t i = 0; i < 50; ++i)
   {
     auto info = MakeGpsTrackInfo(timestamp + i, ms::LatLon(-90 + i, -180 + i), i);
-    size_t addedId = collection.Add(info);
-    TEST_EQUAL(addedId, i, ());
-    data[addedId] = info;
+    std::pair<size_t, size_t> addedIds = collection.Add({info});
+    TEST_EQUAL(addedIds.second, i, ());
+    data[addedIds.second] = info;
   }
 
   TEST_EQUAL(50, collection.GetSize(), ());

--- a/platform/location.hpp
+++ b/platform/location.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "geometry/point2d.hpp"
-#include "geometry/mercator.hpp"
+#include "geometry/latlon.hpp"
 
 #include "base/base.hpp"
 
@@ -61,8 +61,7 @@ namespace location
     bool HasBearing() const { return m_bearing >= 0.0; }
     bool HasSpeed() const { return m_speed >= 0.0; }
     bool HasVerticalAccuracy() const { return m_verticalAccuracy >= 0.0; }
-
-    m2::PointD GetPoint() const { return mercator::FromLatLon(m_latitude, m_longitude); }
+    ms::LatLon GetLatLon() const { return {m_latitude, m_longitude}; }
   };
 
   class CompassInfo

--- a/platform/location.hpp
+++ b/platform/location.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "geometry/point2d.hpp"
+#include "geometry/mercator.hpp"
 
 #include "base/base.hpp"
 
@@ -60,6 +61,8 @@ namespace location
     bool HasBearing() const { return m_bearing >= 0.0; }
     bool HasSpeed() const { return m_speed >= 0.0; }
     bool HasVerticalAccuracy() const { return m_verticalAccuracy >= 0.0; }
+
+    m2::PointD GetPoint() const { return mercator::FromLatLon(m_latitude, m_longitude); }
   };
 
   class CompassInfo


### PR DESCRIPTION
This PR:
1. Adds `GpsTrackInfo` entity that accumulates the track recording state info during the recording process. The calculation is almost the same as for the `ElevationInfo`, but the main difference is that that ElevationInfo stores all the points for drawing the elevation profile from the selected `multigeometry`. `GpsTrackInfo` is lightweight and only stores the current state to update the observers. The elevation profile drawing of the _recorded track_ seems to be an overhead and may impact the battery life. We can implement it later.
2. Add`SetTrackRecordingUpdateHandler(TrackRecordingUpdateHandler && trackRecordingDidUpdate);` to subscribe on the track recording updates
3. Removes unused code from the `GpsTrackCollection`