### PR TITLE
[core] Limit server-set set settings to DonateUrl and NY

### DIFF
--- a/platform/platform_tests/downloader_utils_tests.cpp
+++ b/platform/platform_tests/downloader_utils_tests.cpp
@@ -1,10 +1,10 @@
 #include "testing/testing.hpp"
 
 #include "platform/downloader_utils.hpp"
-#include "platform/servers_list.hpp"
 #include "platform/local_country_file_utils.hpp"
 #include "platform/mwm_version.hpp"
 #include "platform/platform.hpp"
+#include "platform/servers_list.hpp"
 
 #include "base/file_name_utils.hpp"
 
@@ -99,17 +99,18 @@ UNIT_TEST(Downloader_ParseMetaConfig)
     {
       "servers": [ "https://url1/", "https://url2/" ],
       "settings": {
-        "key1": "value1",
-        "key2": "value2"
+        "DonateUrl": "value1",
+        "NY": "value2",
+        "key3": "value3"
       }
     }
   )")), ());
   TEST_EQUAL(cfg->m_serversList.size(), 2, ());
   TEST_EQUAL(cfg->m_serversList[0], "https://url1/", ());
   TEST_EQUAL(cfg->m_serversList[1], "https://url2/", ());
-  TEST_EQUAL(cfg->m_settings.size(), 2, ());
-  TEST_EQUAL(cfg->m_settings["key1"], "value1", ());
-  TEST_EQUAL(cfg->m_settings["key2"], "value2", ());
+  TEST_EQUAL(cfg->m_settings.size(), 2, ()); // "key3" is ignored
+  TEST_EQUAL(cfg->m_settings["DonateUrl"], "value1", ());
+  TEST_EQUAL(cfg->m_settings["NY"], "value2", ());
 
   TEST(!downloader::ParseMetaConfig(R"(broken json)"), ());
 

--- a/platform/platform_tests/meta_config_tests.cpp
+++ b/platform/platform_tests/meta_config_tests.cpp
@@ -1,8 +1,7 @@
 #include "testing/testing.hpp"
 
-#include "platform/servers_list.hpp"
-
 #include "platform/products.hpp"
+#include "platform/servers_list.hpp"
 
 #include "cppjansson/cppjansson.hpp"
 
@@ -40,7 +39,7 @@ UNIT_TEST(MetaConfig_JSONParser_NewFormatWithoutProducts)
   std::string newFormatJson = R"({
     "servers": ["http://url1", "http://url2"],
     "settings": {
-      "key1": "value1",
+      "DonateUrl": "value1",
       "key2": "value2"
     }
   })";
@@ -49,9 +48,8 @@ UNIT_TEST(MetaConfig_JSONParser_NewFormatWithoutProducts)
   TEST_EQUAL(result->m_serversList.size(), 2, ());
   TEST_EQUAL(result->m_serversList[0], "http://url1", ());
   TEST_EQUAL(result->m_serversList[1], "http://url2", ());
-  TEST_EQUAL(result->m_settings.size(), 2, ());
-  TEST_EQUAL(result->m_settings["key1"], "value1", ());
-  TEST_EQUAL(result->m_settings["key2"], "value2", ());
+  TEST_EQUAL(result->m_settings.size(), 1, ());
+  TEST_EQUAL(result->m_settings["DonateUrl"], "value1", ());
   TEST(result->m_productsConfig.empty(), ());
 }
 
@@ -60,7 +58,7 @@ UNIT_TEST(MetaConfig_JSONParser_NewFormatWithProducts)
   std::string newFormatJson = R"({
     "servers": ["http://url1", "http://url2"],
     "settings": {
-      "key1": "value1",
+      "DonateUrl": "value1",
       "key2": "value2"
     },
     "productsConfig": {
@@ -84,9 +82,8 @@ UNIT_TEST(MetaConfig_JSONParser_NewFormatWithProducts)
   TEST_EQUAL(result->m_serversList.size(), 2, ());
   TEST_EQUAL(result->m_serversList[0], "http://url1", ());
   TEST_EQUAL(result->m_serversList[1], "http://url2", ());
-  TEST_EQUAL(result->m_settings.size(), 2, ());
-  TEST_EQUAL(result->m_settings["key1"], "value1", ());
-  TEST_EQUAL(result->m_settings["key2"], "value2", ());
+  TEST_EQUAL(result->m_settings.size(), 1, ());
+  TEST_EQUAL(result->m_settings["DonateUrl"], "value1", ());
 
   TEST(!result->m_productsConfig.empty(), ());
   auto const productsConfigResult = products::ProductsConfig::Parse(result->m_productsConfig);

--- a/platform/servers_list.cpp
+++ b/platform/servers_list.cpp
@@ -2,6 +2,7 @@
 
 #include "platform/http_request.hpp"
 #include "platform/platform.hpp"
+#include "platform/settings.hpp"
 
 #include "base/logging.hpp"
 #include "base/assert.hpp"
@@ -38,9 +39,12 @@ std::optional<MetaConfig> ParseMetaConfig(std::string const & jsonStr)
       const json_t * value;
       json_object_foreach(settings, key, value)
       {
-        const char * valueStr = json_string_value(value);
-        if (key && value)
-          outMetaConfig.m_settings[key] = valueStr;
+        if (key == settings::kDonateUrl || key == settings::kNY)
+        {
+          const char * valueStr = json_string_value(value);
+          if (value)
+            outMetaConfig.m_settings[key] = valueStr;
+        }
       }
 
       servers = json_object_get(root.get(), kServers);

--- a/platform/settings.cpp
+++ b/platform/settings.cpp
@@ -23,8 +23,9 @@ using namespace std;
 std::string_view kMeasurementUnits = "Units";
 std::string_view kMapLanguageCode = "MapLanguageCode";
 std::string_view kDeveloperMode = "DeveloperMode";
-std::string_view kDonateUrl = "DonateUrl";
 std::string_view kNightMode = "NightMode";
+std::string_view kDonateUrl = "DonateUrl";
+std::string_view kNY = "NY";
 
 StringStorage::StringStorage() : StringStorageBase(GetPlatform().SettingsPathForFile(SETTINGS_FILE_NAME)) {}
 

--- a/platform/settings.hpp
+++ b/platform/settings.hpp
@@ -12,8 +12,10 @@ namespace settings
 extern std::string_view kMeasurementUnits;
 extern std::string_view kDeveloperMode;
 extern std::string_view kMapLanguageCode;
-extern std::string_view kDonateUrl;
 extern std::string_view kNightMode;
+// The following two settings are configured externally at the metaserver.
+extern std::string_view kDonateUrl;
+extern std::string_view kNY;
 
 template <class T>
 bool FromString(std::string const & str, T & outValue);


### PR DESCRIPTION
At the moment user-set settings could be potentially overridden by settings externally configured at the metaserver.
Its not nice. 

Limit them only to DonateUrl and NY which could originate **only** from the server.