### PR TITLE
Place edit button below description

### DIFF
--- a/android/app/src/main/res/layout/place_page_bookmark_fragment.xml
+++ b/android/app/src/main/res/layout/place_page_bookmark_fragment.xml
@@ -8,16 +8,6 @@
   android:orientation="vertical">
 
   <TextView
-    android:id="@+id/tv__bookmark_edit"
-    style="@style/PlacePageMetadataText.Button"
-    android:gravity="center"
-    android:layout_height="@dimen/height_block_base"
-    android:background="?clickableBackground"
-    android:paddingEnd="@dimen/margin_base"
-    android:paddingStart="@dimen/margin_base"
-    android:text="@string/placepage_edit_bookmark_button"/>
-
-  <TextView
     android:id="@+id/tv__bookmark_notes"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -27,6 +17,16 @@
     android:layout_marginTop="@dimen/margin_base"
     android:textAppearance="?android:attr/textAppearance"
     tools:text="Long, long text Long, long text Long, long text Long, long text Long, long text Long, long text "/>
+
+  <TextView
+      android:id="@+id/tv__bookmark_edit"
+      style="@style/PlacePageMetadataText.Button"
+      android:gravity="center"
+      android:layout_height="@dimen/height_block_base"
+      android:background="?clickableBackground"
+      android:paddingEnd="@dimen/margin_base"
+      android:paddingStart="@dimen/margin_base"
+      android:text="@string/placepage_edit_bookmark_button"/>
 
   <include
     layout="@layout/divider_horizontal"/>


### PR DESCRIPTION
This PR swaps the placement of the "Edit bookmark" button and the description text.
- Placement is more intuitive (users expect the edit button to be below the content they are editing)
- Makes UI consistent with iOS

| Before | Now |
|--------|--------|
| ![Screenshot_2024-12-16-17-53-31-335_app organicmaps](https://github.com/user-attachments/assets/b9b1d8ef-f081-45fd-be55-81fd9c7d4cc2) | ![Screenshot_2024-12-16-17-51-53-985_app organicmaps debug](https://github.com/user-attachments/assets/c13c3a74-d490-4270-a29d-038784ba7bd7) |
| ![Screenshot_2024-12-16-17-53-45-799_app organicmaps](https://github.com/user-attachments/assets/be910da8-4639-4d16-b593-6f548ae13a70) | ![Screenshot_2024-12-16-17-52-16-513_app organicmaps debug](https://github.com/user-attachments/assets/6006e0a1-5f33-4a2b-882e-4ef9acc6109c) | 













