### PR TITLE
Add spacing between Wikipedia field and horizontal divider

### DIFF
--- a/android/app/src/main/res/layout/place_page_description_layout.xml
+++ b/android/app/src/main/res/layout/place_page_description_layout.xml
@@ -31,6 +31,7 @@
     android:layout_gravity="start|bottom"
     android:layout_marginEnd="@dimen/margin_base"
     android:layout_marginStart="@dimen/margin_base"
+    android:layout_marginBottom="@dimen/margin_base"
     android:textAppearance="?android:attr/textAppearance"
     android:gravity="start|top"
     android:textColor="?attr/colorAccent"


### PR DESCRIPTION
It looks better with some space between "...more" and the horizontal divider

| Before | Now |
|--------|--------|
| ![Screenshot_2024-12-16-18-53-43-576_app organicmaps](https://github.com/user-attachments/assets/9cec8c93-f141-48c8-95e3-c19953ac4e2c) | ![Screenshot_2024-12-16-18-53-23-430_app organicmaps debug](https://github.com/user-attachments/assets/6fafbb25-aca1-4401-a6ed-a86a50cc9d59) | 


