### PR TITLE
Category in editor not clickable

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
@@ -406,7 +406,6 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
   private void initViews(View view)
   {
     final View categoryBlock = view.findViewById(R.id.category);
-    categoryBlock.setOnClickListener(this);
     // TODO show icon and fill it when core will implement that
     UiUtils.hide(categoryBlock.findViewById(R.id.icon));
     mCategory = categoryBlock.findViewById(R.id.name);
@@ -536,8 +535,6 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
       mParent.editStreet();
     else if (id == R.id.block_cuisine)
       mParent.editCuisine();
-    else if (id == R.id.category)
-      mParent.editCategory();
     else if (id == R.id.more_names || id == R.id.show_additional_names)
     {
       if (!mNamesAdapter.areAdditionalLanguagesShown() || validateNames())

--- a/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
@@ -261,16 +261,6 @@ public class EditorHostFragment extends BaseMwmToolbarFragment implements View.O
                              .commit();
   }
 
-  protected void editCategory()
-  {
-    if (!mIsNewObject)
-      return;
-
-    final Activity host = requireActivity();
-    host.finish();
-    startActivity(new Intent(host, FeatureCategoryActivity.class));
-  }
-
   private void showSearchControls(boolean showSearch)
   {
     ((SearchToolbarController) getToolbarController()).showSearchControls(showSearch);

--- a/android/app/src/main/res/layout/fragment_editor.xml
+++ b/android/app/src/main/res/layout/fragment_editor.xml
@@ -26,7 +26,7 @@
       style="@style/MwmWidget.Editor.CardView">
       <RelativeLayout
         android:id="@+id/category"
-        style="@style/MwmWidget.Editor.MetadataBlock.Clickable"
+        style="@style/MwmWidget.Editor.MetadataBlock"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="0dp"


### PR DESCRIPTION
Changed the category panel in the editor to be not clickable. This solves the problem that users unexpectedly lose input data when they click on the panel.

_An alternative would be to use a confirmation dialog to confirm the deletion of data, but making the panel not clickable at all is the cleaner solution IMO. We can re-activate the button once we have a proper implementation for category changes (#3491)_

**Previous behavior:**
- when creating a new POI, clicking on the panel would delete user input and go back to the category selection list.
- when editing a POI the panel had a click animation, but nothing happened on click.

**New behavior:**
- panel not clickable