### PR TITLE
[map] Fix non-stop file read exceptions in the Qt application

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -373,6 +373,7 @@ Framework::Framework(FrameworkParams const & params, bool loadMaps)
   InitTransliteration();
   LOG(LDEBUG, ("Transliterators initialized"));
 
+  GetPowerManager().Init();
   /// @todo No any real config loading here for now.
   GetPowerManager().Subscribe(this);
   GetPowerManager().Load();

--- a/map/power_management/power_manager.cpp
+++ b/map/power_management/power_manager.cpp
@@ -225,4 +225,13 @@ bool PowerManager::Save()
   Load();
   return false;
 }
+
+void PowerManager::Init()
+{
+  FILE* fp = std::fopen(GetConfigPath().c_str(), "r");
+  if (fp)
+    std::fclose(fp);
+  else
+    Save();
+}
 }  // namespace power_management

--- a/map/power_management/power_manager.hpp
+++ b/map/power_management/power_manager.hpp
@@ -40,6 +40,7 @@ public:
 
   void Subscribe(Subscriber * subscriber);
   void UnsubscribeAll();
+  void Init();
 
 private:
   struct Config


### PR DESCRIPTION
Unless the `OMaps/power_manager_config` file has been created on the system by a previous version of OM, or by hand, the current `master` version of the Qt application kept logging the following exception on every single restart:

````
power_management/power_manager.cpp:71 Load(): Cannot read power manager config file. Exception: [...]; READ; No such file or directory
````

This commit fixes that by creating and initializing the file with defaults if it is not found.