### PR TITLE
[search] Make peaks, saddles, hot springs and towers more searchable

### DIFF
--- a/data/mapcss-mapping.csv
+++ b/data/mapcss-mapping.csv
@@ -409,7 +409,7 @@ mountain_pass;[mountain_pass];;name;int_name;307;
 highway|raceway;308;
 highway|primary|tunnel;[highway=primary][tunnel?];;name;int_name;309;
 highway|primary_link|bridge;[highway=primary_link][bridge?];;name;int_name;310;
-man_made|tower|communication;[man_made=tower][tower:type=communication];;name;int_name;311;
+man_made|tower|communication;[man_made=tower][tower:type=communication],[man_made=mast][tower:type=communication];;name;int_name;311;
 sport|equestrian;312;
 tourism|information|office;[tourism=information][information=office];;name;int_name;313;
 deprecated:highway|footway|hiking:04.2024;[highway=footway][sac_scale=hiking];x;name;int_name;314;highway|path

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -442,7 +442,7 @@ OneLevelPOIChecker::OneLevelPOIChecker() : ftypes::BaseChecker(1 /* level */)
   Classificator const & c = classif();
 
   for (auto const * path : {"amenity",  "craft", "healthcare", "historic", "leisure", "office", "railway",
-                            "shop", "sport", "tourism"})
+                            "shop", "sport", "tourism", "mountain_pass"})
     m_types.push_back(c.GetTypeByPath({path}));
 }
 
@@ -468,8 +468,11 @@ TwoLevelPOIChecker::TwoLevelPOIChecker() : ftypes::BaseChecker(2 /* level */)
       {"man_made", "water_tap"},
       {"man_made", "water_well"},
       {"natural", "beach"},
-      {"natural", "geyser"},
       {"natural", "cave_entrance"},
+      {"natural", "geyser"},
+      {"natural", "hot_spring"},
+      {"natural", "peak"},
+      {"natural", "saddle"},
       {"natural", "spring"},
       {"natural", "volcano"},
       {"waterway", "waterfall"}

--- a/search/search_integration_tests/smoke_test.cpp
+++ b/search/search_integration_tests/smoke_test.cpp
@@ -251,7 +251,6 @@ UNIT_CLASS_TEST(SmokeTest, CategoriesTest)
       {"man_made", "chimney"},
       {"man_made", "flagpole"},
       {"man_made", "mast"},
-      {"man_made", "tower"},
       {"man_made", "water_tower"},
       {"natural"},
       {"office"},

--- a/search/types_skipper.cpp
+++ b/search/types_skipper.cpp
@@ -29,7 +29,6 @@ TypesSkipper::TypesSkipper()
     {"man_made", "chimney"},
     {"man_made", "flagpole"},
     {"man_made", "mast"},
-    {"man_made", "tower"},
     {"man_made", "water_tower"},
   };
   for (auto const & e : arrSkipEmptyName2)


### PR DESCRIPTION
Follow-up to https://github.com/organicmaps/organicmaps/pull/9885

Rationale for towers:
E.g. a user had been told about an observation tower or a bell tower in the area. How to find it?
There are many other [tower types](https://wiki.openstreetmap.org/wiki/Key:tower:type) a user might want to search for (and many are unnamed, check taginfo).
Before https://github.com/organicmaps/organicmaps/pull/9854 only cell towers were searchable (as they have their own subtype).

Peaks, saddles, passes, hot springs are important outdoor POIs.
This change makes even unnamed features searchable (just like e.g. nameless benches, cave entrances, etc.)
And improves search ranking for them a bit (after this PR the search engine will treat them as `TYPE_SUBPOI`, not a lower rank `TYPE_UNCLASSIFIED`).

E.g. go to Kazbegi mountain peak 42.6969411, 44.5181106 and zoom in closely.
Search for "Kazbegi" - the master desktop version doesn't find it at all, but the result list is full with cafes, hotels, hairdressers, etc (all of them far from the viewport).
After this PR the peak appears number 8th in the list. Still far from perfect, but a good improvement still.

