### PR TITLE
[map] Fix unused variable warning

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2250,7 +2250,7 @@ place_page::Info Framework::BuildPlacePageInfo(place_page::BuildInfo const & bui
     {
       auto const & track = *GetBookmarkManager().GetTrack(buildInfo.m_trackId);
       auto rect = track.GetLimitRect();
-      track.UpdateSelectionInfo(track.GetLimitRect(), trackSelectionInfo);
+      track.UpdateSelectionInfo(rect, trackSelectionInfo);
     }
     else
       trackSelectionInfo = FindTrackInTapPosition(buildInfo);

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2249,8 +2249,7 @@ place_page::Info Framework::BuildPlacePageInfo(place_page::BuildInfo const & bui
     if (buildInfo.m_trackId != kml::kInvalidTrackId)
     {
       auto const & track = *GetBookmarkManager().GetTrack(buildInfo.m_trackId);
-      auto rect = track.GetLimitRect();
-      track.UpdateSelectionInfo(rect, trackSelectionInfo);
+      track.UpdateSelectionInfo(track.GetLimitRect(), trackSelectionInfo);
     }
     else
       trackSelectionInfo = FindTrackInTapPosition(buildInfo);


### PR DESCRIPTION
Fixes the following warning:
````
map/framework.cpp:2252:12: warning: variable ‘rect’ set but not used [-Wunused-but-set-variable]
````