### PR TITLE
[android] Fixes Bookmark List Title UI Uneven Spacing 

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
@@ -447,13 +447,11 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
         TextView moreBtn = desc.findViewById(R.id.more_btn);
         TextView text = desc.findViewById(R.id.text);
         TextView title = desc.findViewById(R.id.title);
-        TextView author = desc.findViewById(R.id.author);
         setMoreButtonVisibility(text, moreBtn);
         holder = new Holders.DescriptionViewHolder(desc, mSectionsDataSource.getCategory());
         text.setOnClickListener(v -> onMoreButtonClicked(text, moreBtn));
         moreBtn.setOnClickListener(v -> onMoreButtonClicked(text, moreBtn));
         title.setOnClickListener(v -> onMoreButtonClicked(text, moreBtn));
-        author.setOnClickListener(v -> onMoreButtonClicked(text, moreBtn));
         break;
     }
 

--- a/android/app/src/main/res/layout/item_category_description.xml
+++ b/android/app/src/main/res/layout/item_category_description.xml
@@ -13,18 +13,11 @@
       android:textAppearance="@style/MwmTextAppearance.Body2.Primary"
       app:layout_constraintTop_toTopOf="parent" />
 
-  <TextView
-      android:id="@+id/author"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:textAppearance="@style/MwmTextAppearance.Body3"
-      app:layout_constraintTop_toBottomOf="@id/title" />
-
   <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="vertical"
-      app:layout_constraintTop_toBottomOf="@id/author">
+      app:layout_constraintTop_toBottomOf="@id/title">
 
     <TextView
         android:id="@+id/text"
@@ -42,7 +35,6 @@
         android:background="@android:color/transparent"
         android:clickable="true"
         android:gravity="start|top"
-        android:padding="@dimen/margin_base"
         android:text="@string/category_desc_more"
         android:textColor="?attr/colorAccent"
         android:layout_marginTop="2dp" />


### PR DESCRIPTION

There is uneven Gaping below Title in bookmark List Screen

BEFORE :

![6b8ffd90-e58a-4472-90d5-0b3c4a595998](https://github.com/user-attachments/assets/55d8f5e6-3fa0-419b-be6b-27a0a266fcdd)

AFTER:

![3432d347-ed7c-46b6-a3e6-0e80fcd3f016](https://github.com/user-attachments/assets/e46d1054-45a4-4370-9cdb-0924ec989abf)

Problem Solved - There are two elements in the xml file who's visibility was on even when there was no text which was causing uneven gap so i have set the default visibility off those elements as gone since in the adopter no data is inserted in those two 