### PR TITLE
[drape_frontend] Fix `memcpy` of non-trivial GLM type

### DIFF
--- a/drape_frontend/arrow3d.cpp
+++ b/drape_frontend/arrow3d.cpp
@@ -497,10 +497,7 @@ std::pair<glsl::mat4, glsl::mat4> Arrow3d::CalculateTransform(ScreenBase const &
 
   if (screen.isPerspective())
   {
-    glm::mat4 pTo3dView;
-    auto const m = math::Matrix<float, 4, 4>(screen.Pto3dMatrix());
-    static_assert(sizeof(m) == sizeof(pTo3dView));
-    memcpy(&pTo3dView, &m, sizeof(pTo3dView));
+    glm::mat4 pTo3dView = glm::make_mat4x4(screen.Pto3dMatrix().m_data);
     auto postProjectionPerspective = pTo3dView * modelTransform;
     return std::make_pair(postProjectionPerspective, normalMatrix);
   }


### PR DESCRIPTION
Fixes the following GCC warning:

````
drape_frontend/arrow3d.cpp:503:11: warning: ‘void* memcpy(void*, const void*, size_t)’
copying an object of non-trivial type ‘glm::mat4’ {aka ‘struct glm::mat<4, 4, float, glm::packed_highp>’}
from an array of ‘const struct math::Matrix<float, 4, 4>’ [-Wclass-memaccess]
  503 |     memcpy(&pTo3dView, &m, sizeof(pTo3dView));
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
````