### PR TITLE
[android] Show a toast every time FS mode is entered

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1287,7 +1287,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
     if (isFullscreen())
     {
       closePlacePage();
-      showFullscreenToastIfNeeded();
+      // Show the toast every time so that users don't forget and don't get trapped in the FS mode.
+      // TODO(pastk): there are better solutions, see https://github.com/organicmaps/organicmaps/issues/9344
+      Toast.makeText(this, R.string.long_tap_toast, Toast.LENGTH_LONG).show();
     }
   }
 
@@ -1307,16 +1309,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
     // Buttons are hidden in position chooser mode but we are not in fullscreen
     return Boolean.TRUE.equals(mMapButtonsViewModel.getButtonsHidden().getValue()) &&
         Framework.nativeGetChoosePositionMode() == Framework.ChoosePositionMode.NONE;
-  }
-
-  private void showFullscreenToastIfNeeded()
-  {
-    // Show the toast only once so new behaviour doesn't confuse users
-    if (!Config.wasLongTapToastShown(this))
-    {
-      Toast.makeText(this, R.string.long_tap_toast, Toast.LENGTH_LONG).show();
-      Config.setLongTapToastShown(this, true);
-    }
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/util/Config.java
+++ b/android/app/src/main/java/app/organicmaps/util/Config.java
@@ -35,7 +35,6 @@ public final class Config
   private static final String KEY_MISC_AGPS_TIMESTAMP = "AGPSTimestamp";
   private static final String KEY_DONATE_URL = "DonateUrl";
   private static final String KEY_PREF_SEARCH_HISTORY = "SearchHistoryEnabled";
-  private static final String KEY_PREF_LONG_TAP_TOAST_SHOWN = "LongTapToastShown";
 
   /**
    * The total number of app launches.
@@ -415,18 +414,6 @@ public final class Config
         .edit()
         .putBoolean(KEY_MISC_FIRST_START_DIALOG_SEEN, true)
         .apply();
-  }
-
-  public static boolean wasLongTapToastShown(@NonNull Context context)
-  {
-    return MwmApplication.prefs(context).getBoolean(KEY_PREF_LONG_TAP_TOAST_SHOWN, false);
-  }
-
-  public static void setLongTapToastShown(@NonNull Context context, Boolean newValue)
-  {
-    MwmApplication.prefs(context).edit()
-         .putBoolean(KEY_PREF_LONG_TAP_TOAST_SHOWN, newValue)
-         .apply();
   }
 
   public static boolean isSearchHistoryEnabled()


### PR DESCRIPTION
A temporary improvement until a better solution is implemented for
- https://github.com/organicmaps/organicmaps/issues/9344

> Today a friend of mine complained that the "buttons sometimes disappear when using OM for too long without closing the app". They did not know how to leave the full-screen mode so they used to close the app every time this happened.
