### PR TITLE
[drape_frontend] Fix `memset` of non-trivial `CirclesPackDynamicVertex` type

### DIFF
--- a/drape_frontend/circles_pack_shape.cpp
+++ b/drape_frontend/circles_pack_shape.cpp
@@ -130,7 +130,7 @@ void CirclesPackHandle::SetPoint(size_t index, m2::PointD const & position, floa
 
 void CirclesPackHandle::Clear()
 {
-  memset(m_buffer.data(), 0, m_buffer.size() * sizeof(CirclesPackDynamicVertex));
+  fill(begin(m_buffer), end(m_buffer), CirclesPackDynamicVertex(glsl::vec3(0.0f), glsl::vec4(0.0f)));
   m_needUpdate = true;
 }
 


### PR DESCRIPTION
Fixes the following GCC warning:

````
drape_frontend/circles_pack_shape.cpp:133:9: warning: ‘void* memset(void*, int, size_t)’
clearing an object of non-trivial type ‘struct df::CirclesPackDynamicVertex’;
use assignment or value-initialization instead [-Wclass-memaccess]
  133 |   memset(m_buffer.data(), 0, m_buffer.size() * sizeof(CirclesPackDynamicVertex));
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
````