### PR TITLE
[indexer] Fix the suppression of `deprecated-declarations`

### DIFF
--- a/indexer/drules_include.hpp
+++ b/indexer/drules_include.hpp
@@ -2,14 +2,14 @@
 
 #include "std/target_os.hpp"
 
-// Surprisingly, clang defines __GNUC__
-#if defined(__GNUC__) && !defined(__llvm__) && !defined(__INTEL_COMPILER)
+// Both clang and gcc implements `#pragma GCC`
+#if !defined(__INTEL_COMPILER)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif  // defined(__GNUC__) && !defined(__llvm__) && !defined(__INTEL_COMPILER)
+#endif  // !defined(__INTEL_COMPILER)
 
 #include "indexer/drules_struct.pb.h"
 
-#if defined(__GNUC__) && !defined(__llvm__) && !defined(__INTEL_COMPILER)
+#if !defined(__INTEL_COMPILER)
 #pragma GCC diagnostic pop
-#endif  // defined(__GNUC__) && !defined(__llvm__) && !defined(__INTEL_COMPILER)
+#endif  // !defined(__INTEL_COMPILER)


### PR DESCRIPTION
Fixes the ~40, GCC 14 warnings in the CI job:

````
generated_message_table_driven.h:159:20: warning: 'is_pod<google::protobuf::internal::AuxillaryParseTableField>'
is deprecated: use 'is_standard_layout && is_trivial' instead [-Wdeprecated-declarations]
  159 | static_assert(std::is_pod<AuxillaryParseTableField>::value, "");
````