### PR TITLE
[base] Fix warning about deprecated usage of `atomic_store`

### DIFF
--- a/base/atomic_shared_ptr.hpp
+++ b/base/atomic_shared_ptr.hpp
@@ -16,11 +16,11 @@ public:
 
   AtomicSharedPtr() = default;
 
-  void Set(ValueType value) noexcept { atomic_store(&m_wrapped, value); }
-  ValueType Get() const noexcept { return atomic_load(&m_wrapped); }
+  void Set(ValueType value) noexcept { m_wrapped.store(value); }
+  ValueType Get() const noexcept { return m_wrapped.load(); }
 
 private:
-  ValueType m_wrapped = std::make_shared<ContentType>();
+  std::atomic<ValueType> m_wrapped = std::make_shared<ContentType>();
 
   DISALLOW_COPY_AND_MOVE(AtomicSharedPtr);
 };


### PR DESCRIPTION
Fixes the following gcc warnings:
````
base/atomic_shared_ptr.hpp:19:52: warning: ‘void std::atomic_store(shared_ptr<_Tp>*, shared_ptr<_Tp>)
[with _Tp = const editor::EditorConfig]’
is deprecated: use 'std::atomic<std::shared_ptr<T>>' instead [-Wdeprecated-declarations]
   19 |   void Set(ValueType value) noexcept { atomic_store(&m_wrapped, value); }
      |                                        ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
````