### PR TITLE
[ios] fix encoding for the `empty category selection` text view

### DIFF
--- a/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.mm
+++ b/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.mm
@@ -95,7 +95,7 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
   subtitleTextView.textContainerInset = UIEdgeInsetsZero;
 
   NSString *subtitleHTML = L(@"editor_category_unsuitable_text");
-  NSData *htmlData = [subtitleHTML dataUsingEncoding:NSUTF8StringEncoding];
+  NSData *htmlData = [subtitleHTML dataUsingEncoding:NSUnicodeStringEncoding];
   NSDictionary *options = @{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType};
   NSError *error = nil;
 


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/9812#issuecomment-2558623053

NSUTF8StringEncoding works incorrectly with html data type in the UITextView.

Results:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/4ca97c0e-e0f8-4580-93a5-10c215a3185a" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/3725fdc9-97db-42d8-a740-eec1e6b72bbd" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/b1c0f7f8-e5d3-401d-9901-9594f7bf3b7c" />  <img width="300" alt="image" src="https://github.com/user-attachments/assets/e5f37a92-6f94-42f6-8075-dbf55b6268ef" />

