### PR TITLE
[generator] Suppress false positive `may be used uninitialized`

### DIFF
--- a/generator/maxspeeds_builder.cpp
+++ b/generator/maxspeeds_builder.cpp
@@ -178,7 +178,7 @@ public:
           return;
 
         // 0 - not updated, 1 - goto next iteration, 2 - updated
-        int status;
+        int status = 0;
 
         HwTypeT const hwType = GetHighwayType(fid);
 


### PR DESCRIPTION
The following gcc warning is only emitted when `cmake` has been invoked with `-DCMAKE_CXX_FLAGS='-Og'` for debug purposes.

````
generator/maxspeeds_builder.cpp: In lambda function:
generator/maxspeeds_builder.cpp:249:9: warning: ‘status’ may be used uninitialized [-Wmaybe-uninitialized]
  249 |         if (status == 0)
      |         ^~
generator/maxspeeds_builder.cpp:181:13: note: ‘status’ was declared here
  181 |         int status;
      |             ^~~~~~
````