### PR TITLE
small fix to allow the foldername to be empty

### DIFF
--- a/base/file_name_utils.hpp
+++ b/base/file_name_utils.hpp
@@ -40,7 +40,12 @@ template <typename... Args>
 std::string JoinPath(std::string const & folder, Args &&... args)
 {
   if (folder.empty())
-    return {};
+  {
+    if (sizeof...(args) == 0)
+      return {};
+    else
+      return impl::JoinPath(std::forward<Args>(args)...);
+  }
 
   return AddSlashIfNeeded(folder) + impl::JoinPath(std::forward<Args>(args)...);
 }
@@ -50,7 +55,6 @@ std::string JoinPath(std::string const & folder, Args &&... args)
 template <typename... Args>
 std::string JoinPath(std::string const & dir, std::string const & fileOrDir, Args &&... args)
 {
-  ASSERT(!dir.empty(), ("JoinPath dir is empty"));
   ASSERT(!fileOrDir.empty(), ("JoinPath fileOrDir is empty"));
   return impl::JoinPath(dir, fileOrDir, std::forward<Args>(args)...);
 }


### PR DESCRIPTION
This fixes my issue #9900 

I basically had the issue that during map-generation I ran in to an Assertion error in `file_name_utils.hpp` that the variable `dir` in the `JoinPath`-function is not allowed to be empty. This fix allows `dir` to be empty.