### PR TITLE
[android] Add track recording widget to the map screen

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -590,14 +590,14 @@ public class MwmActivity extends BaseMwmFragmentActivity
     ViewCompat.setOnApplyWindowInsetsListener(mPointChooser, (view, windowInsets) -> {
       UiUtils.setViewInsetsPaddingBottom(mPointChooser, windowInsets);
       UiUtils.setViewInsetsPaddingNoBottom(mPointChooserToolbar, windowInsets);
-
+      final int trackRecorderOffset = TrackRecorder.nativeIsTrackRecordingEnabled() ? UiUtils.dimen(this, R.dimen.map_button_size) : 0;
       mNavBarHeight = isFullscreen() ? 0 : windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
       // For the first loading, set compass top margin to status bar size
       // The top inset will be then be updated by the routing controller
       if (mCurrentWindowInsets == null)
-        updateCompassOffset(windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).top, windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).right);
-      else
-        updateCompassOffset(-1, windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).right);
+      {
+        updateCompassOffset(trackRecorderOffset + windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).top, windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).right);
+      }
       refreshLightStatusBar();
       updateBottomWidgetsOffset(windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).left);
       mCurrentWindowInsets = windowInsets;
@@ -814,6 +814,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
         showBottomSheet(MAIN_MENU_ID);
       }
       case help -> showHelp();
+      case trackRecordingStatus -> showTrackSaveDialog();
     }
   }
 
@@ -1500,14 +1501,30 @@ public class MwmActivity extends BaseMwmFragmentActivity
     if (mCurrentWindowInsets == null) {
       return;
     }
-    int offset = mCurrentWindowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
+    int offsetY = mCurrentWindowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
+    int offsetX = mCurrentWindowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).right;
     if (show && mRoutingPlanInplaceController != null)
     {
       final int height = mRoutingPlanInplaceController.calcHeight();
       if (height != 0)
-        offset = height;
+        offsetY = height;
     }
-    updateCompassOffset(offset);
+    final int orientation = getResources().getConfiguration().orientation;
+    final boolean isTrackRecordingEnabled = TrackRecorder.nativeIsTrackRecordingEnabled();
+    if (isTrackRecordingEnabled && (orientation != Configuration.ORIENTATION_LANDSCAPE))
+      offsetY += UiUtils.dimen(this, R.dimen.map_button_size);
+    if (orientation == Configuration.ORIENTATION_LANDSCAPE)
+    {
+      if (show)
+      {
+        final boolean isSmallScreen = UiUtils.getDisplayTotalHeight(this) < UiUtils.dimen(this, R.dimen.dp_400);
+        if (!isSmallScreen || TrackRecorder.nativeIsTrackRecordingEnabled())
+          offsetX += UiUtils.dimen(this, R.dimen.map_button_size);
+      }
+      else if (isTrackRecordingEnabled)
+        offsetY += UiUtils.dimen(this, R.dimen.map_button_size);
+    }
+    updateCompassOffset(offsetY, offsetX);
   }
 
   @Override
@@ -2311,6 +2328,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     requestPostNotificationsPermission();
 
+    if (mCurrentWindowInsets != null)
+    {
+      final int offset = mCurrentWindowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
+      updateCompassOffset(offset + UiUtils.dimen(this, R.dimen.map_button_size));
+    }
     Toast.makeText(this, R.string.track_recording, Toast.LENGTH_SHORT).show();
     TrackRecordingService.startForegroundService(getApplicationContext());
     mMapButtonsViewModel.setTrackRecorderState(true);
@@ -2319,6 +2341,18 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   private void stopTrackRecording()
   {
+    if (mCurrentWindowInsets != null)
+    {
+      int offsetY = mCurrentWindowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
+      final int offsetX = mCurrentWindowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).right;
+      if (RoutingController.get().isPlanning() && mRoutingPlanInplaceController != null)
+      {
+        final int height = mRoutingPlanInplaceController.calcHeight();
+        if (height != 0)
+          offsetY = height;
+      }
+      updateCompassOffset(offsetY, offsetX);
+    }
     TrackRecordingService.stopService(getApplicationContext());
     mMapButtonsViewModel.setTrackRecorderState(false);
   }

--- a/android/app/src/main/java/app/organicmaps/maplayer/MapButtonsViewModel.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/MapButtonsViewModel.java
@@ -9,6 +9,7 @@ public class MapButtonsViewModel extends ViewModel
 {
   private final MutableLiveData<Boolean> mButtonsHidden = new MutableLiveData<>(false);
   private final MutableLiveData<Float> mBottomButtonsHeight = new MutableLiveData<>(0f);
+  private final MutableLiveData<Integer> mTopButtonsMarginTop = new MutableLiveData<>(-1);
   private final MutableLiveData<MapButtonsController.LayoutMode> mLayoutMode = new MutableLiveData<>(MapButtonsController.LayoutMode.regular);
   private final MutableLiveData<Integer> mMyPositionMode = new MutableLiveData<>();
   private final MutableLiveData<SearchWheel.SearchOption> mSearchOption = new MutableLiveData<>();
@@ -32,6 +33,16 @@ public class MapButtonsViewModel extends ViewModel
   public void setBottomButtonsHeight(float height)
   {
     mBottomButtonsHeight.setValue(height);
+  }
+
+  public MutableLiveData<Integer> getTopButtonsMarginTop()
+  {
+    return mTopButtonsMarginTop;
+  }
+
+  public void setTopButtonsMarginTop(int margin)
+  {
+    mTopButtonsMarginTop.setValue(margin);
   }
 
   public MutableLiveData<MapButtonsController.LayoutMode> getLayoutMode()

--- a/android/app/src/main/java/app/organicmaps/routing/NavigationController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/NavigationController.java
@@ -12,16 +12,18 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
+import androidx.lifecycle.ViewModelProvider;
 import app.organicmaps.Framework;
 import app.organicmaps.R;
 import app.organicmaps.location.LocationHelper;
+import app.organicmaps.maplayer.MapButtonsViewModel;
 import app.organicmaps.maplayer.traffic.TrafficManager;
 import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
+import app.organicmaps.util.WindowInsetUtils;
 import app.organicmaps.widget.LanesView;
 import app.organicmaps.widget.SpeedLimitView;
-import app.organicmaps.util.WindowInsetUtils;
 import app.organicmaps.widget.menu.NavMenu;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
@@ -45,6 +47,8 @@ public class NavigationController implements TrafficManager.TrafficCallback,
   @NonNull
   private final SpeedLimitView mSpeedLimit;
 
+  private final MapButtonsViewModel mMapButtonsViewModel;
+
   private final NavMenu mNavMenu;
   View.OnClickListener mOnSettingsClickListener;
 
@@ -60,6 +64,8 @@ public class NavigationController implements TrafficManager.TrafficCallback,
   public NavigationController(AppCompatActivity activity, View.OnClickListener onSettingsClickListener,
                               NavMenu.OnMenuSizeChangedListener onMenuSizeChangedListener)
   {
+    mMapButtonsViewModel = new ViewModelProvider(activity).get(MapButtonsViewModel.class);
+
     mFrame = activity.findViewById(R.id.navigation_frame);
     mNavMenu = new NavMenu(activity, this, onMenuSizeChangedListener);
     mOnSettingsClickListener = onSettingsClickListener;
@@ -157,6 +163,10 @@ public class NavigationController implements TrafficManager.TrafficCallback,
     UiUtils.visibleIf(hasStreet, mStreetFrame);
     if (!TextUtils.isEmpty(info.nextStreet))
       mNextStreet.setText(info.nextStreet);
+    int margin = UiUtils.dimen(mFrame.getContext(), R.dimen.nav_frame_padding);
+    if (hasStreet)
+      margin += mStreetFrame.getHeight();
+    mMapButtonsViewModel.setTopButtonsMarginTop(margin);
   }
 
   public void show(boolean show)

--- a/android/app/src/main/java/app/organicmaps/util/UiUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/UiUtils.java
@@ -9,6 +9,7 @@ import android.graphics.Color;
 import android.graphics.Rect;
 import android.os.Build;
 import android.text.TextUtils;
+import android.util.DisplayMetrics;
 import android.view.TouchDelegate;
 import android.view.View;
 import android.view.ViewGroup;
@@ -206,6 +207,15 @@ public final class UiUtils
   public static int dimen(@NonNull Context context, @DimenRes int id)
   {
     return context.getResources().getDimensionPixelSize(id);
+  }
+
+  // this method returns the total height of the display (in pixels) including notch and other touchable areas
+  public static int getDisplayTotalHeight(Context context)
+  {
+    DisplayMetrics metrics = new DisplayMetrics();
+    WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+    windowManager.getDefaultDisplay().getRealMetrics(metrics);
+    return metrics.heightPixels;
   }
 
   public static void updateRedButton(Button button)

--- a/android/app/src/main/res/drawable/ic_track_recording_status.xml
+++ b/android/app/src/main/res/drawable/ic_track_recording_status.xml
@@ -1,0 +1,14 @@
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="199dp"
+  android:height="199dp"
+  android:viewportWidth="19"
+  android:viewportHeight="19">
+  <path
+    android:pathData="M9.5,4.5a5,5 0,1 0,0 10a5,5 0,0 0,0,-10z"
+    android:fillColor="#000000" />
+  <path
+    android:pathData="M1.5,9.5a8,8 0,1 1,16 0a8,8 0,0 1,-16 0zM9.5,3a6.5,6.5 0,1 0,0 13a6.5,6.5 0 0,0,0,-13z"
+    android:fillColor="#000000"
+    android:fillType="evenOdd" />
+</vector>

--- a/android/app/src/main/res/layout-h400dp-land/map_buttons_layout_navigation.xml
+++ b/android/app/src/main/res/layout-h400dp-land/map_buttons_layout_navigation.xml
@@ -8,6 +8,12 @@
   android:clipChildren="false"
   android:clipToPadding="false"
   tools:background="@color/bg_primary">
+  <View
+    android:id="@+id/touch_interceptor"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:visibility="gone"
+    tools:visibility="visible" />
   <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/map_buttons_inner_left"
     android:layout_width="wrap_content"
@@ -17,6 +23,7 @@
     android:clipChildren="false"
     android:clipToPadding="false"
     android:padding="@dimen/nav_frame_padding"
+    app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintStart_toStartOf="parent">
     <include
       layout="@layout/map_buttons_bookmarks"
@@ -25,6 +32,14 @@
       android:layout_alignParentBottom="true"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent" />
+    <include
+      layout="@layout/map_buttons_search_frame"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_alignParentBottom="true"
+      app:layout_constraintBottom_toBottomOf="@+id/btn_search"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="@+id/btn_search" />
     <include
       layout="@layout/map_buttons_search"
       android:layout_width="wrap_content"
@@ -36,8 +51,7 @@
   </androidx.constraintlayout.widget.ConstraintLayout>
   <include
     layout="@layout/map_status_track_recording"
-    android:layout_marginTop="@dimen/track_recorder_status_top_margin"
-    android:layout_marginHorizontal="@dimen/nav_frame_padding"
+    android:layout_margin="@dimen/nav_frame_padding"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     app:layout_constraintRight_toRightOf="parent"
@@ -46,17 +60,18 @@
     android:id="@+id/map_buttons_inner_right"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
-    android:layout_marginTop="@dimen/map_buttons_bottom_margin"
-    android:layout_marginBottom="@dimen/map_buttons_bottom_margin"
+    android:layout_marginTop="@dimen/action_bar_extended_height"
     android:clipChildren="false"
     android:clipToPadding="false"
     android:padding="@dimen/nav_frame_padding"
+    app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent">
     <include
       layout="@layout/map_buttons_zoom"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
+      android:layout_marginTop="8dp"
       android:layout_marginBottom="@dimen/zoom_buttons_margin"
       app:layout_constraintBottom_toTopOf="@+id/my_position"
       app:layout_constraintEnd_toEndOf="parent" />

--- a/android/app/src/main/res/layout-h400dp-land/map_buttons_layout_planning.xml
+++ b/android/app/src/main/res/layout-h400dp-land/map_buttons_layout_planning.xml
@@ -34,14 +34,6 @@
       app:layout_constraintBottom_toTopOf="@+id/btn_bookmarks"
       app:layout_constraintStart_toStartOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
-  <include
-    layout="@layout/map_status_track_recording"
-    android:layout_marginTop="@dimen/track_recorder_status_top_margin"
-    android:layout_marginHorizontal="@dimen/nav_frame_padding"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    app:layout_constraintRight_toRightOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
   <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/map_buttons_inner_right"
     android:layout_width="wrap_content"

--- a/android/app/src/main/res/layout-h400dp-land/map_buttons_layout_regular.xml
+++ b/android/app/src/main/res/layout-h400dp-land/map_buttons_layout_regular.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<RelativeLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
@@ -9,56 +9,44 @@
   android:clipToPadding="false"
   tools:background="@color/bg_primary">
   <androidx.constraintlayout.widget.ConstraintLayout
-    android:id="@+id/map_buttons_inner_left"
+    android:id="@+id/map_buttons_top"
     android:layout_width="wrap_content"
-    android:layout_height="match_parent"
-    android:layout_marginTop="@dimen/map_buttons_bottom_margin"
-    android:layout_marginBottom="@dimen/map_buttons_bottom_margin"
+    android:layout_height="wrap_content"
+    android:layout_alignParentLeft="true"
+    android:layout_alignParentTop="true"
     android:clipChildren="false"
     android:clipToPadding="false"
-    android:padding="@dimen/nav_frame_padding"
-    app:layout_constraintStart_toStartOf="parent">
+    android:padding="@dimen/nav_frame_padding">
     <include
-      layout="@layout/map_buttons_bookmarks"
+      layout="@layout/map_buttons_layers"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toStartOf="parent" />
-    <include
-      layout="@layout/map_buttons_search"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      android:layout_marginBottom="@dimen/margin_half"
-      app:layout_constraintBottom_toTopOf="@+id/btn_bookmarks"
-      app:layout_constraintStart_toStartOf="parent" />
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
   <include
     layout="@layout/map_status_track_recording"
-    android:layout_marginTop="@dimen/track_recorder_status_top_margin"
-    android:layout_marginHorizontal="@dimen/nav_frame_padding"
+    android:layout_margin="@dimen/nav_frame_padding"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    app:layout_constraintRight_toRightOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+    android:layout_alignParentTop="true"
+    android:layout_alignParentEnd="true" />
   <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/map_buttons_inner_right"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
-    android:layout_marginTop="@dimen/map_buttons_bottom_margin"
-    android:layout_marginBottom="@dimen/map_buttons_bottom_margin"
+    android:layout_alignParentEnd="true"
+    android:layout_below="@+id/map_buttons_top"
     android:clipChildren="false"
     android:clipToPadding="false"
-    android:padding="@dimen/nav_frame_padding"
-    app:layout_constraintEnd_toEndOf="parent">
+    android:padding="@dimen/nav_frame_padding">
     <include
       layout="@layout/map_buttons_zoom"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      android:layout_marginBottom="@dimen/zoom_buttons_margin"
       app:layout_constraintBottom_toTopOf="@+id/my_position"
+      android:layout_marginBottom="@dimen/zoom_buttons_margin"
       app:layout_constraintEnd_toEndOf="parent" />
     <include
       layout="@layout/map_buttons_myposition"
@@ -68,4 +56,10 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+  <include
+    layout="@layout/map_buttons_bottom"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_alignParentBottom="true"
+    android:layout_alignParentStart="true" />
+</RelativeLayout>

--- a/android/app/src/main/res/layout-h400dp/map_buttons_layout_navigation.xml
+++ b/android/app/src/main/res/layout-h400dp/map_buttons_layout_navigation.xml
@@ -49,6 +49,13 @@
       app:layout_constraintBottom_toTopOf="@+id/btn_bookmarks"
       app:layout_constraintStart_toStartOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
+  <include
+    layout="@layout/map_status_track_recording"
+    android:layout_margin="@dimen/nav_frame_padding"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:layout_constraintRight_toRightOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
   <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/map_buttons_inner_right"
     android:layout_width="wrap_content"

--- a/android/app/src/main/res/layout-h400dp/map_buttons_layout_regular.xml
+++ b/android/app/src/main/res/layout-h400dp/map_buttons_layout_regular.xml
@@ -25,6 +25,13 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
+  <include
+    layout="@layout/map_status_track_recording"
+    android:layout_margin="@dimen/nav_frame_padding"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_alignParentTop="true"
+    android:layout_alignParentEnd="true" />
   <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/map_buttons_inner_right"
     android:layout_width="wrap_content"

--- a/android/app/src/main/res/layout-land/map_buttons_layout_navigation.xml
+++ b/android/app/src/main/res/layout-land/map_buttons_layout_navigation.xml
@@ -8,36 +8,50 @@
   android:clipChildren="false"
   android:clipToPadding="false"
   tools:background="@color/bg_primary">
+  <View
+    android:id="@+id/touch_interceptor"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:visibility="gone"
+    tools:visibility="visible" />
   <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/map_buttons_inner_left"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
-    android:layout_marginTop="@dimen/map_buttons_bottom_margin"
-    android:layout_marginBottom="@dimen/map_buttons_bottom_margin"
+    android:layout_marginTop="@dimen/action_bar_extended_height"
+    android:layout_marginBottom="@dimen/nav_menu_height"
     android:clipChildren="false"
     android:clipToPadding="false"
     android:padding="@dimen/nav_frame_padding"
+    app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintStart_toStartOf="parent">
     <include
       layout="@layout/map_buttons_bookmarks"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
+      android:layout_marginStart="@dimen/margin_half"
       app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toStartOf="parent" />
+      app:layout_constraintStart_toEndOf="@+id/btn_search" />
+    <include
+      layout="@layout/map_buttons_search_frame"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_alignParentBottom="true"
+      app:layout_constraintBottom_toBottomOf="@+id/btn_search"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="@+id/btn_search" />
     <include
       layout="@layout/map_buttons_search"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
-      android:layout_marginBottom="@dimen/margin_half"
-      app:layout_constraintBottom_toTopOf="@+id/btn_bookmarks"
+      app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
   <include
     layout="@layout/map_status_track_recording"
-    android:layout_marginTop="@dimen/track_recorder_status_top_margin"
-    android:layout_marginHorizontal="@dimen/nav_frame_padding"
+    android:layout_margin="@dimen/nav_frame_padding"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     app:layout_constraintRight_toRightOf="parent"
@@ -46,18 +60,18 @@
     android:id="@+id/map_buttons_inner_right"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
-    android:layout_marginTop="@dimen/map_buttons_bottom_margin"
-    android:layout_marginBottom="@dimen/map_buttons_bottom_margin"
+    android:layout_marginTop="@dimen/action_bar_extended_height"
     android:clipChildren="false"
     android:clipToPadding="false"
     android:padding="@dimen/nav_frame_padding"
+    app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent">
     <include
       layout="@layout/map_buttons_zoom"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
-      android:layout_marginBottom="@dimen/zoom_buttons_margin"
+      android:layout_marginBottom="@dimen/margin_half"
       app:layout_constraintBottom_toTopOf="@+id/my_position"
       app:layout_constraintEnd_toEndOf="parent" />
     <include

--- a/android/app/src/main/res/layout-land/map_buttons_layout_regular.xml
+++ b/android/app/src/main/res/layout-land/map_buttons_layout_regular.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<RelativeLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
@@ -9,56 +9,44 @@
   android:clipToPadding="false"
   tools:background="@color/bg_primary">
   <androidx.constraintlayout.widget.ConstraintLayout
-    android:id="@+id/map_buttons_inner_left"
+    android:id="@+id/map_buttons_top"
     android:layout_width="wrap_content"
-    android:layout_height="match_parent"
-    android:layout_marginTop="@dimen/map_buttons_bottom_margin"
-    android:layout_marginBottom="@dimen/map_buttons_bottom_margin"
+    android:layout_height="wrap_content"
+    android:layout_alignParentLeft="true"
+    android:layout_alignParentTop="true"
     android:clipChildren="false"
     android:clipToPadding="false"
-    android:padding="@dimen/nav_frame_padding"
-    app:layout_constraintStart_toStartOf="parent">
+    android:padding="@dimen/nav_frame_padding">
     <include
-      layout="@layout/map_buttons_bookmarks"
+      layout="@layout/map_buttons_layers"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toStartOf="parent" />
-    <include
-      layout="@layout/map_buttons_search"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      android:layout_marginBottom="@dimen/margin_half"
-      app:layout_constraintBottom_toTopOf="@+id/btn_bookmarks"
-      app:layout_constraintStart_toStartOf="parent" />
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
   <include
     layout="@layout/map_status_track_recording"
-    android:layout_marginTop="@dimen/track_recorder_status_top_margin"
-    android:layout_marginHorizontal="@dimen/nav_frame_padding"
+    android:layout_margin="@dimen/nav_frame_padding"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    app:layout_constraintRight_toRightOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+    android:layout_alignParentTop="true"
+    android:layout_alignParentEnd="true" />
   <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/map_buttons_inner_right"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
-    android:layout_marginTop="@dimen/map_buttons_bottom_margin"
-    android:layout_marginBottom="@dimen/map_buttons_bottom_margin"
+    android:layout_alignParentEnd="true"
+    android:layout_below="@+id/map_buttons_top"
     android:clipChildren="false"
     android:clipToPadding="false"
-    android:padding="@dimen/nav_frame_padding"
-    app:layout_constraintEnd_toEndOf="parent">
+    android:padding="@dimen/nav_frame_padding">
     <include
       layout="@layout/map_buttons_zoom"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      android:layout_marginBottom="@dimen/zoom_buttons_margin"
       app:layout_constraintBottom_toTopOf="@+id/my_position"
+      android:layout_marginBottom="@dimen/margin_half"
       app:layout_constraintEnd_toEndOf="parent" />
     <include
       layout="@layout/map_buttons_myposition"
@@ -68,4 +56,10 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+  <include
+    layout="@layout/map_buttons_bottom"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_alignParentBottom="true"
+    android:layout_alignParentStart="true" />
+</RelativeLayout>

--- a/android/app/src/main/res/layout/map_buttons_layout_navigation.xml
+++ b/android/app/src/main/res/layout/map_buttons_layout_navigation.xml
@@ -49,6 +49,13 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
+  <include
+    layout="@layout/map_status_track_recording"
+    android:layout_margin="@dimen/nav_frame_padding"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:layout_constraintRight_toRightOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
   <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/map_buttons_inner_right"
     android:layout_width="wrap_content"

--- a/android/app/src/main/res/layout/map_buttons_layout_planning.xml
+++ b/android/app/src/main/res/layout/map_buttons_layout_planning.xml
@@ -35,6 +35,14 @@
       app:layout_constraintBottom_toTopOf="@+id/btn_bookmarks"
       app:layout_constraintStart_toStartOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
+  <include
+    layout="@layout/map_status_track_recording"
+    android:layout_marginHorizontal="@dimen/nav_frame_padding"
+    android:layout_marginTop="@dimen/elevation_profile_half_height"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:layout_constraintRight_toRightOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
   <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/map_buttons_inner_right"
     android:layout_width="wrap_content"

--- a/android/app/src/main/res/layout/map_buttons_layout_regular.xml
+++ b/android/app/src/main/res/layout/map_buttons_layout_regular.xml
@@ -25,6 +25,13 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
+  <include
+    layout="@layout/map_status_track_recording"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_alignParentTop="true"
+    android:layout_alignParentEnd="true"
+    android:layout_margin="@dimen/nav_frame_padding" />
   <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/map_buttons_inner_right"
     android:layout_width="wrap_content"

--- a/android/app/src/main/res/layout/map_status_track_recording.xml
+++ b/android/app/src/main/res/layout/map_status_track_recording.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.floatingactionbutton.FloatingActionButton
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:id="@+id/track_recording_status"
+  style="@style/MwmWidget.MapButton"
+  android:tint="@color/accent_color_selector"
+  app:srcCompat="@drawable/ic_track_recording_status" />

--- a/android/app/src/main/res/values-land/dimens.xml
+++ b/android/app/src/main/res/values-land/dimens.xml
@@ -3,10 +3,12 @@
   <dimen name="tabs_height">48dp</dimen>
 
   <dimen name="map_buttons_bottom_margin">100dp</dimen>
+  <dimen name="margin_compass_top">20dp</dimen>
 
   <!-- Nav menu -->
   <dimen name="nav_menu_content_height">48dp</dimen>
   <dimen name="nav_bottom_gap">24dp</dimen>
+  <dimen name="zoom_buttons_margin">48dp</dimen>
 
   <!-- Altitude chart -->
   <dimen name="altitude_chart_image_width">334dp</dimen>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -4,6 +4,7 @@
   <dimen name="track_circle_size">40dp</dimen>
   <dimen name="select_color_circle_size">24dp</dimen>
   <dimen name="bookmark_icon_size">24dp</dimen>
+  <dimen name="dp_400">400dp</dimen>
 
   <!-- margins -->
   <dimen name="margin_eighth">2dp</dimen>
@@ -66,7 +67,7 @@
   <dimen name="margin_direction_around_center">40dp</dimen>
 
   <!-- map widgets -->
-  <dimen name="margin_compass">32dp</dimen>
+  <dimen name="margin_compass">24dp</dimen>
   <dimen name="margin_compass_top">26dp</dimen>
   <dimen name="margin_ruler">10dp</dimen>
   <dimen name="button_small_corner_radius">2dp</dimen>
@@ -90,6 +91,7 @@
   <dimen name="routing_transit_step_corner_radius">4dp</dimen>
   <dimen name="routing_transit_step_min_height">20dp</dimen>
   <dimen name="routing_transit_setp_min_acceptable_with">104dp</dimen>
+  <dimen name="track_recorder_status_top_margin">64dp</dimen>
 
   <!-- Bottom menu -->
   <dimen name="menu_line_height">48dp</dimen>


### PR DESCRIPTION
This implementation is mirror of #9847 for android devices
Partially Fixes #9173 

It implements track recording widget on Map screen, Route plan screen and Navigation screen.
Redesigns the landscape layout (similar to iOS) to avoid overlaps.

- If the user taps the button the "Save" dialog will be shown.
- The button has a small blinking effect to attract the user slightly.
- The compass view will be moved under this button when it is active.
- The button is always visible when TR is active and cannot be hidden.

<p align="center">
  <img src="https://github.com/user-attachments/assets/1ce25cf3-af9e-47ce-871f-354eb48b5013" alt="Map Screen" height="400">
  <img src="https://github.com/user-attachments/assets/000d9fbe-42c6-4c1d-ae21-b51e1c949a54" alt="Route Planning" height="400">
  <img src="https://github.com/user-attachments/assets/eb0e0319-f05c-4623-bad6-85c304b4a9f2" alt="Navigating" height="400">
</p>


<p align="center">
  <img src="https://github.com/user-attachments/assets/1f1b9c63-a0d4-4f9a-871e-895e43ebe0d5" alt="Map Screen Landscape" height="150">
  <img src="https://github.com/user-attachments/assets/e8aa788a-d99f-4f51-9e7e-a61cf59c5119" alt="Route Planning Landscape" height="150">
  <img src="https://github.com/user-attachments/assets/f3bef216-5000-4a18-802c-837ee93a1143" alt="Navigating Landscape" height="150">
</p>

<p align="center">
  <img src="https://github.com/user-attachments/assets/d5f32c59-d542-49e1-822a-b1563800960b" height="500">
</p>

<p align="center">
  <img src="https://github.com/user-attachments/assets/bb4f5cd5-fe62-4dea-acca-d6a130b7b055" height="150">
</p>