### PR TITLE
[Android] Fix the layout height

### DIFF
--- a/android/app/src/main/res/layout/item_track.xml
+++ b/android/app/src/main/res/layout/item_track.xml
@@ -4,7 +4,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
-  android:layout_height="@dimen/height_item_multiline"
+  android:layout_height="wrap_content"
   android:background="@drawable/bg_clickable_card">
   <ImageView
     android:id="@+id/iv__bookmark_color"
@@ -46,6 +46,7 @@
     android:id="@+id/more"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
+    android:layout_centerInParent="true"
     android:layout_alignParentEnd="true"
     android:background="?selectableItemBackgroundBorderless"
     android:paddingHorizontal="@dimen/margin_half"


### PR DESCRIPTION
Fix #9726 
## Description
The text in the Track box gets cut off when displayed in a larger font.

## Screenshot

### After fix the issue in different Font Size:

![track_solve1](https://github.com/user-attachments/assets/323dc5ab-c30f-45d9-bd72-916368c2adf9)
![track_Solve2](https://github.com/user-attachments/assets/d4fd990d-4314-4c68-9311-0509e9caff13)

### Before Fix the Issue:

![track_issue](https://github.com/user-attachments/assets/0122c94a-b943-497e-ab3a-1ec7a88f92f8)

