### PR TITLE
[android-auto] Update CarApp lib to 1.7.0-beta03

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -390,8 +390,8 @@ dependencies {
   implementation(platform('org.jetbrains.kotlin:kotlin-bom:2.0.21'))
   implementation 'androidx.annotation:annotation:1.9.1'
   implementation 'androidx.appcompat:appcompat:1.7.0'
-  implementation 'androidx.car.app:app:1.7.0-beta02'
-  implementation 'androidx.car.app:app-projected:1.7.0-beta02'
+  implementation 'androidx.car.app:app:1.7.0-beta03'
+  implementation 'androidx.car.app:app-projected:1.7.0-beta03'
   implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
   implementation 'androidx.fragment:fragment:1.8.5'
   implementation 'androidx.preference:preference:1.2.1'


### PR DESCRIPTION
>Version 1.7.0-beta03
>
>Fixed a security vulnerability and other general bug fixes. If you are using a lower version, <b>please update to use this version</b>.

https://developer.android.com/jetpack/androidx/releases/car-app#1.7.0-beta03