### PR TITLE
[bookmarks] Updated import bookmarks and tracks icon for consistency

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesAdapter.java
@@ -142,7 +142,7 @@ public class BookmarkCategoriesAdapter extends BaseBookmarkCategoryAdapter<Recyc
       case TYPE_ACTION_ADD ->
       {
         Holders.GeneralViewHolder generalViewHolder = (Holders.GeneralViewHolder) holder;
-        generalViewHolder.getImage().setImageResource(R.drawable.ic_import);
+        generalViewHolder.getImage().setImageResource(R.drawable.ic_add_list);
         generalViewHolder.getText().setText(R.string.bookmarks_create_new_group);
       }
       case TYPE_ACTION_IMPORT ->

--- a/android/app/src/main/res/drawable/ic_add_list.xml
+++ b/android/app/src/main/res/drawable/ic_add_list.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM17,13h-4v4h-2v-4L7,13v-2h4L11,7h2v4h4v2z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_import.xml
+++ b/android/app/src/main/res/drawable/ic_import.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:fillColor="@android:color/white"
-      android:pathData="M19,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM17,13h-4v4h-2v-4L7,13v-2h4L11,7h2v4h4v2z" />
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M520,150v326l104,-104 56,58 -200,200 -200,-200 56,-58 104,104v-326h80ZM240,800q-33,0 -56.5,-23.5T160,720v-120h80v120h480v-120h80v120q0,33 -23.5,56.5T720,800L240,800Z"/>
 </vector>


### PR DESCRIPTION
### **Description:**
This implementation is a solution to **#9951**. It replaces the existing **"+"** icon for importing bookmarks and tracks with a **downward arrow** icon, which is more intuitive and clearly represents the action of importing existing content. The **"+"** icon was not immediately clear, as it is typically associated with adding new items rather than importing.

---

### **Fixes:**
- Fixes **#9951** by updating the icon for importing bookmarks and tracks.

---

### **Changes Implemented:**
- Replaced the **"+"** icon with a **downward arrow** icon.
- The new icon now clearly reflects the action of importing bookmarks and tracks.
- Improved user clarity by aligning the icon with standard expectations for import actions.


### **Additional Context:**
Below are two screenshots showcasing the difference:

**Current Icon:**
[Current Icon]


![1b110ae3-b6a9-4d6a-96af-c550fd9f4f94](https://github.com/user-attachments/assets/6b328641-03d2-4fe3-9cfa-127076bc0733)

**Suggested Icon:**

![2f35fa6a-50fb-4dd1-83d7-431056d12d00](https://github.com/user-attachments/assets/49c78015-c3f8-4813-b7f0-25aead732f62)
