### PR TITLE
[android] Remove display of speed in nav panel

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
@@ -1,7 +1,5 @@
 package app.organicmaps.widget.menu;
 
-import android.location.Location;
-import android.util.Pair;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
@@ -9,16 +7,12 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import app.organicmaps.R;
-import app.organicmaps.location.LocationHelper;
 import app.organicmaps.routing.RoutingInfo;
 import app.organicmaps.sound.TtsPlayer;
 import app.organicmaps.util.Graphics;
-import app.organicmaps.util.StringUtils;
-import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.UiUtils;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
 
@@ -33,14 +27,12 @@ public class NavMenu
   private final View mHeaderFrame;
 
   private final ImageView mTts;
-  private final View mSpeedViewContainer;
-  private final TextView mSpeedValue;
-  private final TextView mSpeedUnits;
+  private final TextView mEtaValue;
+  private final TextView mEtaAmPm;
   private final TextView mTimeHourValue;
   private final TextView mTimeHourUnits;
   private final TextView mTimeMinuteValue;
   private final TextView mTimeMinuteUnits;
-  private final TextView mTimeEstimate;
   private final TextView mDistanceValue;
   private final TextView mDistanceUnits;
   private final LinearProgressIndicator mRouteProgress;
@@ -49,7 +41,6 @@ public class NavMenu
   private final NavMenuListener mNavMenuListener;
 
   private int currentPeekHeight = 0;
-
 
   public interface OnMenuSizeChangedListener
   {
@@ -95,14 +86,12 @@ public class NavMenu
     });
 
     // Bottom frame
-    mSpeedViewContainer = bottomFrame.findViewById(R.id.speed_view_container);
-    mSpeedValue = bottomFrame.findViewById(R.id.speed_value);
-    mSpeedUnits = bottomFrame.findViewById(R.id.speed_dimen);
+    mEtaValue = bottomFrame.findViewById(R.id.eta_value);
+    mEtaAmPm = bottomFrame.findViewById(R.id.eta_am_pm);
     mTimeHourValue = bottomFrame.findViewById(R.id.time_hour_value);
     mTimeHourUnits = bottomFrame.findViewById(R.id.time_hour_dimen);
     mTimeMinuteValue = bottomFrame.findViewById(R.id.time_minute_value);
     mTimeMinuteUnits = bottomFrame.findViewById(R.id.time_minute_dimen);
-    mTimeEstimate = bottomFrame.findViewById(R.id.time_estimate);
     mDistanceValue = bottomFrame.findViewById(R.id.distance_value);
     mDistanceUnits = bottomFrame.findViewById(R.id.distance_dimen);
     mRouteProgress = bottomFrame.findViewById(R.id.navigation_progress);
@@ -174,7 +163,6 @@ public class NavMenu
         : Graphics.tint(mActivity, R.drawable.ic_voice_off));
   }
 
-
   private void updateTime(int seconds)
   {
     updateTimeLeft(seconds);
@@ -200,38 +188,28 @@ public class NavMenu
 
   private void updateTimeEstimate(int seconds)
   {
-    final String format = android.text.format.DateFormat.is24HourFormat(mTimeMinuteValue.getContext())
-            ? "HH:mm" : "h:mm a";
     final LocalTime localTime = LocalTime.now().plusSeconds(seconds);
-    mTimeEstimate.setText(localTime.format(DateTimeFormatter.ofPattern(format)));
-  }
 
-  private void updateSpeedView(@NonNull RoutingInfo info)
-  {
-    final Location last = LocationHelper.from(mActivity).getSavedLocation();
-    if (last == null)
-      return;
+    final String format;
 
-    Pair<String, String> speedAndUnits = StringUtils.nativeFormatSpeedAndUnits(last.getSpeed());
-    mSpeedValue.setText(speedAndUnits.first);
-
-    if (info.speedLimitMps > 0.0 && last.getSpeed() > info.speedLimitMps)
+    if (android.text.format.DateFormat.is24HourFormat(mTimeMinuteValue.getContext()))
     {
-      if (info.isSpeedCamLimitExceeded())
-        mSpeedValue.setTextColor(ContextCompat.getColor(mActivity, R.color.white_primary));
-      else
-        mSpeedValue.setTextColor(ContextCompat.getColor(mActivity, R.color.base_red));
+      // 24 hours time format.
+      format = "HH:mm";
+      mEtaAmPm.setText("");
     }
     else
-      mSpeedValue.setTextColor(ThemeUtils.getColor(mActivity, android.R.attr.textColorPrimary));
+    {
+      // AM/PM time format.
+      format = "h:mm";
+      mEtaAmPm.setText(localTime.format(DateTimeFormatter.ofPattern("a")));
+    }
 
-    mSpeedUnits.setText(speedAndUnits.second);
-    mSpeedViewContainer.setActivated(info.isSpeedCamLimitExceeded());
+    mEtaValue.setText(localTime.format(DateTimeFormatter.ofPattern(format)));
   }
 
   public void update(@NonNull RoutingInfo info)
   {
-    updateSpeedView(info);
     updateTime(info.totalTimeInSeconds);
     mDistanceValue.setText(info.distToTarget.mDistanceStr);
     mDistanceUnits.setText(info.distToTarget.getUnitsStr(mActivity.getApplicationContext()));

--- a/android/app/src/main/res/layout/layout_nav_bottom_numbers.xml
+++ b/android/app/src/main/res/layout/layout_nav_bottom_numbers.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="65sp"
@@ -13,9 +14,9 @@
     android:layout_height="match_parent"
     android:layout_weight="0.5"/>
 
-  <!-- Speed -->
+  <!-- ETA (Estimated Time of Arrival) -->
   <LinearLayout
-    android:id="@+id/speed_view_container"
+    android:id="@+id/eta_view_container"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -23,25 +24,26 @@
     android:gravity="center"
     android:minWidth="@dimen/nav_numbers_side_min_width">
 
+    <!-- ETA value -->
     <TextView
-      android:id="@+id/speed_value"
+      android:id="@+id/eta_value"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:includeFontPadding="false"
       android:lines="1"
       android:textAppearance="@style/MwmTextAppearance.NavMenu.Number"
-      tools:text="999" />
+      tools:text="99:99"/>
 
-    <!-- Speed -->
+    <!-- ETA AM/PM -->
     <TextView
-      android:id="@+id/speed_dimen"
+      android:id="@+id/eta_am_pm"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:includeFontPadding="false"
       android:lines="1"
       android:textAppearance="@style/MwmTextAppearance.NavMenu.Number.Dimension"
       tools:background="#20FF0000"
-      tools:text="km/h" />
+      tools:text="AM/PM"/>
   </LinearLayout>
 
   <Space
@@ -103,14 +105,13 @@
     </LinearLayout>
 
     <TextView
-      android:id="@+id/time_estimate"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:includeFontPadding="false"
       android:lines="1"
       android:textAlignment="center"
       android:textAppearance="@style/MwmTextAppearance.NavMenu.Number.Dimension"
-      tools:text="99:99 AM" />
+      tools:text="----"/>
   </LinearLayout>
 
   <Space
@@ -150,4 +151,5 @@
     android:layout_width="0dp"
     android:layout_height="match_parent"
     android:layout_weight="0.5"/>
+
 </LinearLayout>


### PR DESCRIPTION
Removal of the current speed value in the navigation panel, as it's planned the addition of a specific Speed view according to [PR 9738](https://github.com/organicmaps/organicmaps/pull/9738).

Instead of displaying the current speed, the ETA (Estimated Time of Arrival) is displayed in the left most part of the navigation panel:

**AM/PM ETA Mode:**
![screenshot_1a](https://github.com/user-attachments/assets/74c8acca-00b8-4e92-beba-63293c62aaa5)

**24H ETA Mode:**
![screenshot_1b](https://github.com/user-attachments/assets/99c3991b-0538-4d73-b8af-62911c6040e7)

This new arrange may also be taken as a base for the display of the time & distance display to the next intermediate route stop (according to [PR 9071](https://github.com/organicmaps/organicmaps/pull/9071) and [discussion 8549](https://github.com/orgs/organicmaps/discussions/8549)).