### PR TITLE
[android-auto] Put back location type for AA service

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -446,7 +446,7 @@
     <service
         android:name="app.organicmaps.car.CarAppService"
         android:exported="true"
-        android:foregroundServiceType="specialUse"
+        android:foregroundServiceType="specialUse|location"
         tools:ignore="ExportedService">
       <intent-filter>
         <action android:name="androidx.car.app.CarAppService" />


### PR DESCRIPTION
AA loses location info when the device is locked and OM is not launched.
We already had this issue and this is the only way I know to resolve it.

AA will find the location again during the navigation because it starts NavigationService which has location type.
But during the free drive AA can't fetch location.

The reason why we removed it is that we can't ensure the user has granted location permission before starting the AA app.
And if the service doesn't have specific permissions for its type it will crash within a time limit (5-15s I guess).

It's been almost a year since I reported this issue to Google and still no response. https://issuetracker.google.com/issues/322622698
https://github.com/organicmaps/organicmaps/pull/8860

I think it's better to have some low-chance fails (when the user installs the app and immediately launches it in AA without starting it on the phone first) instead of a constant non-working location.

To summarize:
Without the fix: no location when the app is running only on AA
With the fix: the app may crash for the users (with Android 14) who started the app on AA without granting location permissions before (from the app on the phone)