### PR TITLE
Allow more than one number for level

### DIFF
--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -28,7 +28,6 @@ constexpr char const * kOSMMultivalueDelimiter = ";";
 
 // https://en.wikipedia.org/wiki/List_of_tallest_buildings_in_the_world
 auto constexpr kMaxBuildingLevelsInTheWorld = 167;
-auto constexpr kMinBuildingLevel = -6;
 
 template <class T>
 void RemoveDuplicatesAndKeepOrder(std::vector<T> & vec)
@@ -229,6 +228,7 @@ std::string MetadataTagProcessorImpl::ValidateAndFormat_building_levels(std::str
 {
   // Some mappers use full width unicode digits. We can handle that.
   strings::NormalizeDigits(v);
+  // value of building_levels is only one number
   double levels;
   if (Prefix2Double(v, levels) && levels >= 0 && levels <= kMaxBuildingLevelsInTheWorld)
     return strings::to_string_dac(levels, 1);
@@ -240,11 +240,8 @@ std::string MetadataTagProcessorImpl::ValidateAndFormat_level(std::string v)
 {
   // Some mappers use full width unicode digits. We can handle that.
   strings::NormalizeDigits(v);
-  double levels;
-  if (Prefix2Double(v, levels) && levels >= kMinBuildingLevel && levels <= kMaxBuildingLevelsInTheWorld)
-    return strings::to_string(levels);
-
-  return {};
+  // value of level can be more than one number, so e.g. "1;2" or "3-5"
+  return v;
 }
 
 std::string MetadataTagProcessorImpl::ValidateAndFormat_denomination(std::string const & v)


### PR DESCRIPTION
fixes #9308

Allow more than one number for level. So e.g. "1;2" is allowed as well.

| Now | Before |
|--------|--------|
| ![Screenshot_2025-01-03-20-31-12-630_app organicmaps debug](https://github.com/user-attachments/assets/44c91a8e-32f8-4e3e-9360-be82533a07ed) | ![Screenshot_2025-01-03-20-41-33-026_app organicmaps](https://github.com/user-attachments/assets/cf515906-9f0d-4520-b5e2-683565aa6068) | 

https://www.openstreetmap.org/node/1237345504




_Android editing tested on the dev server: https://master.apis.dev.openstreetmap.org/changeset/397864_