### PR TITLE
Update in Mobile Internet Settings - Fix Inconsistent Phrasing

### DIFF
--- a/android/app/src/main/res/layout-land/dialog_stacked_buttons.xml
+++ b/android/app/src/main/res/layout-land/dialog_stacked_buttons.xml
@@ -29,7 +29,7 @@
   <TextView
     android:id="@+id/btn__positive"
     style="@style/MwmWidget.Button.StackedButtonsDialog"
-    tools:text="Use Always"/>
+    tools:text="Always Use"/>
 
   <LinearLayout
     android:orientation="horizontal"

--- a/android/app/src/main/res/layout/dialog_stacked_buttons.xml
+++ b/android/app/src/main/res/layout/dialog_stacked_buttons.xml
@@ -29,7 +29,7 @@
   <TextView
     android:id="@+id/btn__positive"
     style="@style/MwmWidget.Button.StackedButtonsDialog"
-    tools:text="Use Always"/>
+    tools:text="Always Use"/>
 
   <TextView
     android:id="@+id/btn__neutral"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -618,7 +618,7 @@
     <!-- For the first routing -->
     <string name="decline">Decline</string>
     <string name="mobile_data_dialog">Use mobile internet to show detailed information?</string>
-    <string name="mobile_data_option_always">Use Always</string>
+    <string name="mobile_data_option_always">Always Use</string>
     <string name="mobile_data_option_today">Only Today</string>
     <string name="mobile_data_option_not_today">Do not Use Today</string>
     <string name="mobile_data">Mobile Internet</string>


### PR DESCRIPTION
### Description:  
In the **Mobile Internet** section, the option **"Use Always"** is inconsistent with the other options. The phrasing should be uniform for clarity. 

### Issue:  
- **Current phrasing**:
-  "Always Ask" ✅, 
- "Use Always" ❌, 
- "Never Use" ✅
- **Inconsistency**: "Use Always" deviates from the pattern of the other two options.

### Suggested Fix:  
Change **"Use Always"** to **"Always Use"** to match the style:

- ✅ **Always Ask**
- ✅ **Always Use**
- ✅ **Never Use**

### Screenshots:
- **Before**:  
![68d14198-581e-4546-84bc-ad718196df4b](https://github.com/user-attachments/assets/16ddb338-3fa4-42bd-80c7-043c1356d59e)


- **After**:  
![0113d0c9-8215-4c13-ab5f-32f741b68b71](https://github.com/user-attachments/assets/c5011a3e-2715-4943-9e02-09ae4d7ae332)

