### PR TITLE
[docs] Add mwm_diff_tool to generator instructions

### DIFF
--- a/tools/python/maps_generator/README.md
+++ b/tools/python/maps_generator/README.md
@@ -27,6 +27,7 @@ The app version can be found in the "About" section of Organic Maps app.
 ```sh
 ./tools/unix/build_omim.sh -r generator_tool
 ./tools/unix/build_omim.sh -r world_roads_builder_tool
+./tools/unix/build_omim.sh -r mwm_diff_tool
 ```
 
 3. Go to the `maps_generator` directory:


### PR DESCRIPTION
When following the instructions in the [generator docs](https://github.com/organicmaps/organicmaps/blob/master/tools/python/maps_generator/README.md) you get an error that the `mwm_diff_tool` could not be found. I therefore added building the `mwm_diff_tool` to the docs.