### PR TITLE
[Packaging] add environment info to desktop screenshots, fix typo

### DIFF
--- a/packaging/app.organicmaps.desktop.metainfo.xml
+++ b/packaging/app.organicmaps.desktop.metainfo.xml
@@ -96,19 +96,19 @@
 
   <launchable type="desktop-id">app.organicmaps.desktop.desktop</launchable>
   <screenshots>
-    <screenshot type="default">
+    <screenshot type="default" environment="plasma">
       <image>https://organicmaps.app/images/screenshots/Desktop_light_routing.png</image>
-      <caption>Routing in dark mode</caption>
-    </screenshot>
-    <screenshot>
-      <image>https://organicmaps.app/images/screenshots/Desktop_dark_routing.png</image>
       <caption>Routing in light mode</caption>
     </screenshot>
-    <screenshot>
+    <screenshot environment="plasma:dark">
+      <image>https://organicmaps.app/images/screenshots/Desktop_dark_routing.png</image>
+      <caption>Routing in dark mode</caption>
+    </screenshot>
+    <screenshot environment="plasma">
       <image>https://organicmaps.app/images/screenshots/Desktop_light_overview.png</image>
       <caption>Map overview in light mode</caption>
     </screenshot>
-    <screenshot>
+    <screenshot environment="plasma:dark">
       <image>https://organicmaps.app/images/screenshots/Desktop_dark_overview.png</image>
       <caption>Map overview in dark mode</caption>
     </screenshot>


### PR DESCRIPTION
fixes https://github.com/flathub/app.organicmaps.desktop/issues/26#issuecomment-2571709466

And adds screenshot environment info, so store apps can show light/dark screenshots based on desktop theme.