### PR TITLE
Reordered place page details

### DIFF
--- a/android/app/src/main/res/layout/place_page_details.xml
+++ b/android/app/src/main/res/layout/place_page_details.xml
@@ -39,18 +39,9 @@
 
     <include layout="@layout/place_page_entrance"/>
 
-    <androidx.fragment.app.FragmentContainerView
-      android:id="@+id/place_page_phone_fragment"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      tools:layout="@layout/place_page_phone_fragment" />
-
     <include layout="@layout/place_page_operator"/>
 
     <include layout="@layout/place_page_network"/>
-
-    <include layout="@layout/place_page_wifi"/>
-    <include layout="@layout/place_page_outdoor_seating"/>
 
     <androidx.fragment.app.FragmentContainerView
       android:id="@+id/place_page_links_fragment"
@@ -60,15 +51,19 @@
 
     <include layout="@layout/place_page_level" />
 
-    <include layout="@layout/place_page_atm" />
-
     <include layout="@layout/place_page_capacity" />
 
     <include layout="@layout/place_page_wheelchair" />
 
+    <include layout="@layout/place_page_wifi"/>
+
+    <include layout="@layout/place_page_atm" />
+
     <include layout="@layout/place_page_drive_through" />
 
     <include layout="@layout/place_page_self_service" />
+
+    <include layout="@layout/place_page_outdoor_seating"/>
 
     <!-- ToDo: Address is missing compared with iOS. It's shown in title but anyway .. -->
 

--- a/android/app/src/main/res/layout/place_page_links_fragment.xml
+++ b/android/app/src/main/res/layout/place_page_links_fragment.xml
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical">
   <include layout="@layout/place_page_website" />
   <include layout="@layout/place_page_website_menu" />
+  <androidx.fragment.app.FragmentContainerView
+      android:id="@+id/place_page_phone_fragment"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      tools:layout="@layout/place_page_phone_fragment" />
   <include layout="@layout/place_page_email" />
   <include layout="@layout/place_page_facebook" />
   <include layout="@layout/place_page_instagram" />


### PR DESCRIPTION
Reordered place page details to make the ordering more structured

- Moved phone down and grouped it with website and email (_websites are more important nowadays than phone numbers_)
- Moved wifi and outdoor_seating down to the other less important details
- Grouped level, capacity and wheelchair together

| Now | Before |
|--------|--------|
| ![Screenshot_20250106_153017_Debug Organic Maps](https://github.com/user-attachments/assets/3c613a4a-0e22-43a9-b911-6b969c186bd8) | ![Screenshot_20250106_153025_Organic Maps](https://github.com/user-attachments/assets/0006b92e-467c-4849-b07f-f260060b1002) | 
| ![Bildschirmfoto vom 2025-01-06 15-33-22](https://github.com/user-attachments/assets/764c2a33-ac19-4389-9808-02d5026cf814) | ![Bildschirmfoto vom 2025-01-06 15-33-46](https://github.com/user-attachments/assets/cfaa6e9c-7821-4651-8b96-23745a84e6fa) |

