### PR TITLE
[android] Fix visibility of "More about OpenStreetMap" link hidden by system navbar #10019

### DIFF
--- a/android/app/src/main/res/layout/fragment_osm_profile.xml
+++ b/android/app/src/main/res/layout/fragment_osm_profile.xml
@@ -24,7 +24,7 @@
       android:scaleType="center"
       app:srcCompat="@drawable/ic_logout"
       android:contentDescription="@string/logout" />
-    </androidx.appcompat.widget.Toolbar>
+  </androidx.appcompat.widget.Toolbar>
   <FrameLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
@@ -135,6 +135,7 @@
         android:textColor="?colorAccent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/osm_history"
-        app:layout_constraintVertical_bias="1" />
+        app:layout_constraintVertical_bias="1"
+        android:layout_marginBottom="60dp" /> 
   </androidx.constraintlayout.widget.ConstraintLayout>
 </LinearLayout>


### PR DESCRIPTION
## Description:
This implementation fixes issue #10019, where the "More about OpenStreetMap" link was hidden behind the system navigation bar (e.g., Back, Home, and Recent buttons) on devices with visible navigation buttons. The link was not fully accessible and overlapped with the navigation bar, causing a poor user experience.


### *Fixes:*
- Fixes *#10019* by adding a margin to ensure it remains visible on all devices.



### Changes Implemented:
- *Before*: The "More about OpenStreetMap" link was placed at the bottom of the screen using app:layout_constraintBottom_toBottomOf="parent". This placement made the link vulnerable to being hidden behind the system navigation bar, as it was tightly aligned to the bottom edge of the screen.
  
- *After*: A bottom margin (android:layout_marginBottom="50dp") was added to the TextView containing the link. This ensures there is always a gap between the link and the bottom of the screen, preventing it from being overlapped by the system navigation bar. 

### Impact:
- This change ensures that the "More about OpenStreetMap" link is always visible, even on devices with a navigation bar at the bottom of the screen.
- Improves the user experience by preventing the overlap of UI elements with the system navigation controls.


---

### *Additional Context:*
Below are two screenshots showcasing the difference:

*Current Layout:*


![ca9d97cd-a0fe-4f29-ad92-e0c96778a4ad](https://github.com/user-attachments/assets/b9a0f2bc-52be-4b16-8bb8-d441380f2f23)


*Suggested Layout:*


![5805cb09-1e53-401b-8216-131448c844ff](https://github.com/user-attachments/assets/185f095a-9b3c-4cd1-8a52-3083b0dd00d3)
