### PR TITLE
[Android] Add insets handling in ProfileFragment

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/ProfileFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/ProfileFragment.java
@@ -12,14 +12,17 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmToolbarFragment;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
+import app.organicmaps.util.WindowInsetUtils;
 import app.organicmaps.util.concurrency.ThreadPool;
 import app.organicmaps.util.concurrency.UiThread;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import java.text.NumberFormat;
 
 public class ProfileFragment extends BaseMwmToolbarFragment
@@ -59,6 +62,14 @@ public class ProfileFragment extends BaseMwmToolbarFragment
     view.findViewById(R.id.osm_history).setOnClickListener((v) -> Utils.openUrl(requireActivity(), OsmOAuth.getHistoryUrl(requireContext())));
     view.findViewById(R.id.osm_notes).setOnClickListener((v) -> Utils.openUrl(requireActivity(), OsmOAuth.getNotesUrl(requireContext())));
 
+    View buttonsContainer = view.findViewById(R.id.buttons_container);
+    ViewCompat.setOnApplyWindowInsetsListener(
+        buttonsContainer,
+        new WindowInsetUtils.PaddingInsetsListener
+            .Builder()
+            .setInsetsTypeMask(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout())
+            .setExcludeTop()
+            .build());
   }
 
   private void refreshViews()

--- a/android/app/src/main/res/layout/fragment_osm_profile.xml
+++ b/android/app/src/main/res/layout/fragment_osm_profile.xml
@@ -88,10 +88,10 @@
   </FrameLayout>
 
   <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/buttons_container"
       android:layout_width="match_parent"
       android:layout_height="0dp"
-      android:layout_weight="1"
-      android:padding="@dimen/margin_base">
+      android:layout_weight="1">
 
     <TextView
         android:id="@+id/osm_history"
@@ -100,6 +100,9 @@
         android:layout_alignParentTop="true"
         android:background="?clickableBackground"
         android:gravity="center"
+        android:layout_marginTop="@dimen/margin_base"
+        android:layout_marginStart="@dimen/margin_base"
+        android:layout_marginEnd="@dimen/margin_base"
         android:paddingTop="@dimen/margin_half"
         android:paddingBottom="@dimen/margin_half"
         android:text="@string/editor_osm_history"
@@ -114,6 +117,8 @@
         android:layout_alignParentTop="true"
         android:background="?clickableBackground"
         android:gravity="center"
+        android:layout_marginStart="@dimen/margin_base"
+        android:layout_marginEnd="@dimen/margin_base"
         android:paddingTop="@dimen/margin_half"
         android:paddingBottom="@dimen/margin_half"
         android:text="@string/editor_osm_notes"
@@ -128,13 +133,16 @@
         android:layout_alignParentBottom="true"
         android:background="?clickableBackground"
         android:gravity="center"
+        android:layout_marginStart="@dimen/margin_base"
+        android:layout_marginEnd="@dimen/margin_base"
+        android:layout_marginBottom="@dimen/margin_base"
         android:paddingTop="@dimen/margin_half"
         android:paddingBottom="@dimen/margin_half"
         android:text="@string/editor_more_about_osm"
         android:textAppearance="@style/MwmTextAppearance.Body3"
         android:textColor="?colorAccent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/osm_history"
+        app:layout_constraintTop_toBottomOf="@+id/osm_notes"
         app:layout_constraintVertical_bias="1" />
   </androidx.constraintlayout.widget.ConstraintLayout>
 </LinearLayout>


### PR DESCRIPTION
- Add insets handling to `ProfileFragment`
- Had to use margins on buttons instead of padding on container, so common `PaddingInsetsListener` can be used
- Fix layout for buttons: use correct constraint for `about_osm` button (regression from #9794)

Fixes #10019