### PR TITLE
Revert "[android-auto] Put back location type for AA service"

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -446,7 +446,7 @@
     <service
         android:name="app.organicmaps.car.CarAppService"
         android:exported="true"
-        android:foregroundServiceType="specialUse|location"
+        android:foregroundServiceType="specialUse"
         tools:ignore="ExportedService">
       <intent-filter>
         <action android:name="androidx.car.app.CarAppService" />


### PR DESCRIPTION
Reverts organicmaps/organicmaps#9965

It's not a good fix. On Android 14+ devices when location mode "Ask every time" is selected the app will fail every time :)
We need another solution here.
F.e. let's start NavigationService for AA even without navigation. With this approach, we will start the navigation service only after location permissions have been granted and there will be no issues with non-working location service in AA in free drive mode 