### PR TITLE
[android] Fix the title after editing the name of a boomark.

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
@@ -810,7 +810,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
   public void onActivityResult(int requestCode, int resultCode, Intent data)
   {
     super.onActivityResult(requestCode, resultCode, data);
-    getAdapter().notifyDataSetChanged();
+    getBookmarkListAdapter().notifyDataSetChanged();
     ActionBar actionBar = ((AppCompatActivity) requireActivity()).getSupportActionBar();
     actionBar.setTitle(mCategoryDataSource.getData().getName());
   }


### PR DESCRIPTION
CategoryDataSource is connected to that one.

Resolves #10005