### PR TITLE
[android-auto] Make AA background service

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -448,14 +448,16 @@
     <service
         android:name="app.organicmaps.car.CarAppService"
         android:exported="true"
-        android:foregroundServiceType="specialUse"
         tools:ignore="ExportedService">
       <intent-filter>
         <action android:name="androidx.car.app.CarAppService" />
         <category android:name="androidx.car.app.category.NAVIGATION" />
       </intent-filter>
-      <property android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-          android:value="@string/android_auto_fgs_explanation_for_special_use"/>
+      <intent-filter>
+        <action android:name="androidx.car.app.action.NAVIGATE" />
+        <category android:name="android.intent.category.DEFAULT"/>
+        <data android:scheme="geo" />
+      </intent-filter>
     </service>
 
     <service

--- a/android/app/src/main/java/app/organicmaps/car/CarAppService.java
+++ b/android/app/src/main/java/app/organicmaps/car/CarAppService.java
@@ -1,6 +1,5 @@
 package app.organicmaps.car;
 
-import android.app.Notification;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.net.Uri;
@@ -23,7 +22,6 @@ import androidx.lifecycle.LifecycleOwner;
 import app.organicmaps.BuildConfig;
 import app.organicmaps.R;
 import app.organicmaps.api.Const;
-import app.organicmaps.routing.NavigationService;
 
 public final class CarAppService extends androidx.car.app.CarAppService
 {
@@ -53,20 +51,7 @@ public final class CarAppService extends androidx.car.app.CarAppService
   public Session onCreateSession(@Nullable SessionInfo sessionInfo)
   {
     createNotificationChannel();
-    startForeground(NOTIFICATION_ID, getNotification());
-    final CarAppSession carAppSession = new CarAppSession(sessionInfo);
-    carAppSession.getLifecycle().addObserver(new DefaultLifecycleObserver()
-    {
-      @Override
-      public void onDestroy(@NonNull LifecycleOwner owner)
-      {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
-          stopForeground(STOP_FOREGROUND_REMOVE);
-        else
-          stopForeground(true);
-      }
-    });
-    return carAppSession;
+    return new CarAppSession(sessionInfo);
   }
 
   @NonNull
@@ -103,14 +88,5 @@ public final class CarAppService extends androidx.car.app.CarAppService
             .setVibrationEnabled(false) // less annoying
             .build();
     notificationManager.createNotificationChannel(notificationChannel);
-  }
-
-  @NonNull
-  private Notification getNotification()
-  {
-    return NavigationService.getNotificationBuilder(this)
-        .setChannelId(ANDROID_AUTO_NOTIFICATION_CHANNEL_ID)
-        .setContentTitle(getString(R.string.aa_connected_to_car_notification_title))
-        .build();
   }
 }

--- a/android/app/src/main/res/values/donottranslate.xml
+++ b/android/app/src/main/res/values/donottranslate.xml
@@ -68,6 +68,4 @@
   <string name="placepage_behavior" translatable="false">com.google.android.material.bottomsheet.BottomSheetBehavior</string>
 
   <string name="car_notification_channel_name" translatable="false">Car</string>
-
-  <string name="android_auto_fgs_explanation_for_special_use" translatable="false">Since Android 14, every Foreground Service must have a type. There is no specific service type for Android Auto.</string>
 </resources>


### PR DESCRIPTION
Related to: https://github.com/organicmaps/organicmaps/issues/7263

The issue was fixed by google: https://issuetracker.google.com/issues/322622698
They provided the correct example of how to deal with AA service

The solution is to make AA service a background service instead of a foreground service. Now we don't need to show a notification that our app is launched on AA and we don't need a `specialUse` foreground service type for it.
However, we still need to run foreground NavigationService to be able to constantly fetch location.
This is still not implemented.

There is an unused string left `aa_connected_to_car_notification_title`. It could be used as a notification text for NavigationService.