### PR TITLE
[core] [map] Calculate ElevationInfo data for the Track Recording live updates

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1739,6 +1739,11 @@ void Framework::SetTrackRecordingUpdateHandler(TrackRecordingUpdateHandler && tr
     m_trackRecordingUpdateHandler(GpsTracker::Instance().GetTrackStatistics());
 }
 
+const ElevationInfo & Framework::GetTrackRecordingElevationInfo()
+{
+  return GpsTracker::Instance().GetElevationInfo();
+}
+
 void Framework::StopTrackRecording()
 {
   m_connectToGpsTrack = false;

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -444,6 +444,9 @@ public:
   void SaveTrackRecordingWithName(std::string const & name);
   bool IsTrackRecordingEmpty() const;
   bool IsTrackRecordingEnabled() const;
+  /// Returns the elevation profile data of the currently recorded track.
+  /// To get the data on the every track recording state update, this function should be called after receiving the callback from the `SetTrackRecordingUpdateHandler`.
+  static const ElevationInfo & GetTrackRecordingElevationInfo();
 
   void SetMapStyle(MapStyle mapStyle);
   void MarkMapStyle(MapStyle mapStyle);

--- a/map/gps_track.cpp
+++ b/map/gps_track.cpp
@@ -84,6 +84,11 @@ TrackStatistics GpsTrack::GetTrackStatistics() const
   return m_collection ? m_collection->GetTrackStatistics() : TrackStatistics();
 }
 
+const ElevationInfo & GpsTrack::GetElevationInfo() const
+{
+  return m_collection->UpdateAndGetElevationInfo();
+}
+
 void GpsTrack::Clear()
 {
   {

--- a/map/gps_track.hpp
+++ b/map/gps_track.hpp
@@ -32,7 +32,8 @@ public:
 
   /// Returns track statistics
   TrackStatistics GetTrackStatistics() const;
-
+  const ElevationInfo & GetElevationInfo() const;
+  
   /// Clears any previous tracking info
   /// @note Callback is called with 'toRemove' points, if some points were removed.
   void Clear();

--- a/map/gps_track_collection.hpp
+++ b/map/gps_track_collection.hpp
@@ -41,6 +41,8 @@ public:
 
   /// Returns track statistics.
   const TrackStatistics GetTrackStatistics() const { return m_statistics; }
+  /// Updates the elevation info with the missed points and returns a reference.
+  const ElevationInfo & UpdateAndGetElevationInfo();
 
   /// Enumerates items in the collection.
   /// @param f - callable object, which is called with params - item and item id,
@@ -67,4 +69,6 @@ private:
 
   size_t m_lastId;
   TrackStatistics m_statistics;
+  ElevationInfo m_elevationInfo;
+  bool m_elevationInfoDirty;
 };

--- a/map/gps_tracker.cpp
+++ b/map/gps_tracker.cpp
@@ -85,6 +85,11 @@ TrackStatistics GpsTracker::GetTrackStatistics() const
   return m_track.GetTrackStatistics();
 }
 
+const ElevationInfo & GpsTracker::GetElevationInfo() const
+{
+  return m_track.GetElevationInfo();
+}
+
 void GpsTracker::Connect(TGpsTrackDiffCallback const & fn)
 {
   m_track.SetCallback(fn);

--- a/map/gps_tracker.hpp
+++ b/map/gps_tracker.hpp
@@ -19,6 +19,7 @@ public:
   bool IsEmpty() const;
   size_t GetTrackSize() const;
   TrackStatistics GetTrackStatistics() const;
+  const ElevationInfo & GetElevationInfo() const;
 
   using TGpsTrackDiffCallback =
       std::function<void(std::vector<std::pair<size_t, location::GpsInfo>> && toAdd,


### PR DESCRIPTION
This PR implements the calculation of the `ElevationInfo` drawing data for the track recording.
The `ElevationInfo` will be calculated by adding the missed points from the `GpsTrackCollection` only by request. It means that when the data isn't needed ( the track recording place page is not displayed: the place page is closed, not implemented or the phone is locked) it will not be calculated.

___
This PR is needed for the #9942.