### PR TITLE
Use htmlmin2 to work on newer python versions

### DIFF
--- a/tools/python/descriptions/requirements.txt
+++ b/tools/python/descriptions/requirements.txt
@@ -1,4 +1,4 @@
-htmlmin==0.1.12
+htmlmin2==0.1.13
 requests>=2.31.0
 beautifulsoup4==4.9.1
 wikidata==0.6.1

--- a/tools/python/descriptions/requirements_dev.txt
+++ b/tools/python/descriptions/requirements_dev.txt
@@ -1,4 +1,4 @@
-htmlmin==0.1.12
+htmlmin2==0.1.13
 requests>=2.31.0
 beautifulsoup4==4.9.1
 wikidata==0.6.1


### PR DESCRIPTION
I updated to Fedora 41 with python 3.13.1 the other day. The `htmlmin` module doesn't work on this python version any more as `cgi` was removed (1). As the development of `htmlmin` is stale and the module wasn't updated since 2017 (2) I switched to the fork `htmlmin2`. That fixed the problem for me.

(1) https://docs.python.org/3/library/cgi.html
(2) https://github.com/mankyd/htmlmin/issues/66