### PR TITLE
Disable .so libraries compression in the apk

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -360,6 +360,12 @@ android {
     sourceCompatibility JavaVersion.VERSION_17
     targetCompatibility JavaVersion.VERSION_17
   }
+
+  packagingOptions {
+    jniLibs {
+      useLegacyPackaging = false
+    }
+  }
 }
 
 dependencies {


### PR DESCRIPTION
This change affects only APK distributions. In App Bundle distribution format which is used by Google Play Store native libraries are not compressed already.