### PR TITLE
Show OSM login to offline users

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
@@ -350,7 +350,7 @@ public class EditorHostFragment extends BaseMwmToolbarFragment implements View.O
   private void processEditedFeatures()
   {
     Context context = requireContext();
-    if (OsmOAuth.isAuthorized(context) || !ConnectionState.INSTANCE.isConnected())
+    if (OsmOAuth.isAuthorized(context))
     {
       Utils.navigateToParent(requireActivity());
       return;


### PR DESCRIPTION
Show login to offline users to educate / inform them that logging in is necessary to finish the editing process. This avoids confusion for people who use the app offline and wonder why their edits are not uploaded.

**Before**
Login is shown after editing when the user is not logged in **and** internet is available.

**Now**
Login is shown after editing when the user is not logged in.