### PR TITLE
[android][sdk] Refactor Framework class

### DIFF
--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -22,6 +22,10 @@ set(SRC
   app/organicmaps/vulkan/android_vulkan_context_factory.hpp
 
   # JNI sources
+  app/organicmaps/sdk/routing/RouteRecommendationType.hpp
+  app/organicmaps/sdk/ChoosePositionMode.cpp
+  app/organicmaps/sdk/MapStyle.cpp
+  app/organicmaps/sdk/Router.cpp
   app/organicmaps/core/jni_helper.cpp
   app/organicmaps/core/jni_java_methods.cpp
   app/organicmaps/core/logging.cpp

--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -4,6 +4,7 @@
 #include "app/organicmaps/UserMarkHelper.hpp"
 #include "app/organicmaps/opengl/androidoglcontextfactory.hpp"
 #include "app/organicmaps/platform/AndroidPlatform.hpp"
+#include "app/organicmaps/sdk/routing/RouteRecommendationType.hpp"
 #include "app/organicmaps/util/Distance.hpp"
 #include "app/organicmaps/util/FeatureIdBuilder.hpp"
 #include "app/organicmaps/util/NetworkPolicy.hpp"
@@ -804,8 +805,8 @@ void CallRouteRecommendationListener(shared_ptr<jobject> listener,
                                      RoutingManager::Recommendation recommendation)
 {
   JNIEnv * env = jni::GetEnv();
-  jmethodID const methodId = jni::GetMethodID(env, *listener, "onRecommend", "(I)V");
-  env->CallVoidMethod(*listener, methodId, static_cast<int>(recommendation));
+  jmethodID const methodId = jni::GetMethodID(env, *listener, "onRecommend", "(Lapp/organicmaps/sdk/routing/RouteRecommendationType;)V");
+  env->CallVoidMethod(*listener, methodId, GetRouteRecommendationType(env, recommendation));
 }
 
 void CallSetRoutingLoadPointsListener(shared_ptr<jobject> listener, bool success)
@@ -1501,66 +1502,6 @@ Java_app_organicmaps_Framework_nativeDeactivateMapSelectionCircle(JNIEnv * env, 
 }
 
 JNIEXPORT void JNICALL
-Java_app_organicmaps_Framework_nativeSetMapStyle(JNIEnv * env, jclass, jint mapStyle)
-{
-  MapStyle const val = static_cast<MapStyle>(mapStyle);
-  if (val != g_framework->GetMapStyle())
-    g_framework->SetMapStyle(val);
-}
-
-JNIEXPORT jint JNICALL
-Java_app_organicmaps_Framework_nativeGetMapStyle(JNIEnv * env, jclass)
-{
-  return g_framework->GetMapStyle();
-}
-
-JNIEXPORT void JNICALL
-Java_app_organicmaps_Framework_nativeMarkMapStyle(JNIEnv * env, jclass, jint mapStyle)
-{
-  MapStyle const val = static_cast<MapStyle>(mapStyle);
-  if (val != g_framework->GetMapStyle())
-    g_framework->MarkMapStyle(val);
-}
-
-JNIEXPORT void JNICALL
-Java_app_organicmaps_Framework_nativeSetRouter(JNIEnv * env, jclass, jint routerType)
-{
-  using Type = routing::RouterType;
-  Type type = Type::Vehicle;
-  switch (routerType)
-  {
-    case 0: break;
-    case 1: type = Type::Pedestrian; break;
-    case 2: type = Type::Bicycle; break;
-    case 3: type = Type::Transit; break;
-    case 4: type = Type::Ruler; break;
-    default: assert(false); break;
-  }
-  g_framework->GetRoutingManager().SetRouter(type);
-}
-
-JNIEXPORT jint JNICALL
-Java_app_organicmaps_Framework_nativeGetRouter(JNIEnv * env, jclass)
-{
-  return static_cast<jint>(g_framework->GetRoutingManager().GetRouter());
-}
-
-JNIEXPORT jint JNICALL
-Java_app_organicmaps_Framework_nativeGetLastUsedRouter(JNIEnv * env, jclass)
-{
-  return static_cast<jint>(g_framework->GetRoutingManager().GetLastUsedRouter());
-}
-
-JNIEXPORT jint JNICALL
-Java_app_organicmaps_Framework_nativeGetBestRouter(JNIEnv * env, jclass,
-                                                       jdouble srcLat, jdouble srcLon,
-                                                       jdouble dstLat, jdouble dstLon)
-{
-  return static_cast<jint>(frm()->GetRoutingManager().GetBestRouter(
-      mercator::FromLatLon(srcLat, srcLon), mercator::FromLatLon(dstLat, dstLon)));
-}
-
-JNIEXPORT void JNICALL
 Java_app_organicmaps_Framework_nativeAddRoutePoint(JNIEnv * env, jclass, jstring title,
                                                        jstring subtitle, jint markType,
                                                        jint intermediateIndex,
@@ -1806,25 +1747,6 @@ Java_app_organicmaps_Framework_nativeGetPoiContactUrl(JNIEnv *env, jclass, jint 
   if (osm::isSocialContactTag(metaID))
     return jni::ToJavaString(env, osm::socialContactToURL(metaID, value));
   return jni::ToJavaString(env, value);
-}
-
-JNIEXPORT void JNICALL
-Java_app_organicmaps_Framework_nativeSetChoosePositionMode(JNIEnv *, jclass, jint mode, jboolean isBusiness,
-                                                           jboolean applyPosition)
-{
-  // TODO(AB): Move this code into the Framework to share with iOS and other platforms.
-  auto const f = frm();
-  if (applyPosition && f->HasPlacePageInfo())
-    g_framework->SetChoosePositionMode(static_cast<android::ChoosePositionMode>(mode), isBusiness,
-                                       &f->GetCurrentPlacePageInfo().GetMercator());
-  else
-    g_framework->SetChoosePositionMode(static_cast<android::ChoosePositionMode>(mode), isBusiness, nullptr);
-}
-
-JNIEXPORT jint JNICALL
-Java_app_organicmaps_Framework_nativeGetChoosePositionMode(JNIEnv *, jclass)
-{
-  return static_cast<jint>(g_framework->GetChoosePositionMode());
 }
 
 JNIEXPORT jboolean JNICALL

--- a/android/app/src/main/cpp/app/organicmaps/sdk/ChoosePositionMode.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/sdk/ChoosePositionMode.cpp
@@ -1,0 +1,26 @@
+#include "app/organicmaps/core/jni_helper.hpp"
+
+#include "app/organicmaps/Framework.hpp"
+
+#include "indexer/map_style.hpp"
+
+extern "C"
+{
+JNIEXPORT void JNICALL Java_app_organicmaps_sdk_ChoosePositionMode_nativeSet(JNIEnv *, jclass, jint mode,
+                                                                             jboolean isBusiness,
+                                                                             jboolean applyPosition)
+{
+  // TODO(AB): Move this code into the Framework to share with iOS and other platforms.
+  auto const f = frm();
+  if (applyPosition && f->HasPlacePageInfo())
+    g_framework->SetChoosePositionMode(static_cast<android::ChoosePositionMode>(mode), isBusiness,
+                                       &f->GetCurrentPlacePageInfo().GetMercator());
+  else
+    g_framework->SetChoosePositionMode(static_cast<android::ChoosePositionMode>(mode), isBusiness, nullptr);
+}
+
+JNIEXPORT jint JNICALL Java_app_organicmaps_sdk_ChoosePositionMode_nativeGet(JNIEnv *, jclass)
+{
+  return static_cast<jint>(g_framework->GetChoosePositionMode());
+}
+}

--- a/android/app/src/main/cpp/app/organicmaps/sdk/MapStyle.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/sdk/MapStyle.cpp
@@ -1,0 +1,27 @@
+#include "app/organicmaps/core/jni_helper.hpp"
+
+#include "app/organicmaps/Framework.hpp"
+
+#include "indexer/map_style.hpp"
+
+extern "C"
+{
+JNIEXPORT void JNICALL Java_app_organicmaps_sdk_MapStyle_nativeSet(JNIEnv *, jclass, jint mapStyle)
+{
+  auto const val = static_cast<MapStyle>(mapStyle);
+  if (val != g_framework->GetMapStyle())
+    g_framework->SetMapStyle(val);
+}
+
+JNIEXPORT jint JNICALL Java_app_organicmaps_sdk_MapStyle_nativeGet(JNIEnv *, jclass)
+{
+  return g_framework->GetMapStyle();
+}
+
+JNIEXPORT void JNICALL Java_app_organicmaps_sdk_MapStyle_nativeMark(JNIEnv *, jclass, jint mapStyle)
+{
+  auto const val = static_cast<MapStyle>(mapStyle);
+  if (val != g_framework->GetMapStyle())
+    g_framework->MarkMapStyle(val);
+}
+}

--- a/android/app/src/main/cpp/app/organicmaps/sdk/Router.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/sdk/Router.cpp
@@ -1,0 +1,41 @@
+#include "app/organicmaps/core/jni_helper.hpp"
+
+#include "app/organicmaps/Framework.hpp"
+
+#include "indexer/map_style.hpp"
+
+extern "C"
+{
+JNIEXPORT void JNICALL Java_app_organicmaps_sdk_Router_nativeSet(JNIEnv *, jclass, jint routerType)
+{
+  using Type = routing::RouterType;
+  Type type;
+  switch (routerType)
+  {
+  case 0: type = Type::Vehicle; break;
+  case 1: type = Type::Pedestrian; break;
+  case 2: type = Type::Bicycle; break;
+  case 3: type = Type::Transit; break;
+  case 4: type = Type::Ruler; break;
+  default: assert(false); break;
+  }
+  frm()->GetRoutingManager().SetRouter(type);
+}
+
+JNIEXPORT jint JNICALL Java_app_organicmaps_sdk_Router_nativeGet(JNIEnv *, jclass)
+{
+  return static_cast<jint>(frm()->GetRoutingManager().GetRouter());
+}
+
+JNIEXPORT jint JNICALL Java_app_organicmaps_sdk_Router_nativeGetLastUsed(JNIEnv *, jclass)
+{
+  return static_cast<jint>(frm()->GetRoutingManager().GetLastUsedRouter());
+}
+
+JNIEXPORT jint JNICALL Java_app_organicmaps_sdk_Router_nativeGetBest(JNIEnv *, jclass, jdouble srcLat, jdouble srcLon,
+                                                                     jdouble dstLat, jdouble dstLon)
+{
+  return static_cast<jint>(frm()->GetRoutingManager().GetBestRouter(mercator::FromLatLon(srcLat, srcLon),
+                                                                    mercator::FromLatLon(dstLat, dstLon)));
+}
+}

--- a/android/app/src/main/cpp/app/organicmaps/sdk/routing/RouteRecommendationType.hpp
+++ b/android/app/src/main/cpp/app/organicmaps/sdk/routing/RouteRecommendationType.hpp
@@ -1,0 +1,36 @@
+#include "app/organicmaps/core/jni_helper.hpp"
+
+jobject GetRebuildAfterPointsLoading(JNIEnv * env)
+{
+  static jobject rebuildAfterPointsLoading = nullptr;
+  if (rebuildAfterPointsLoading)
+    return rebuildAfterPointsLoading;
+
+  // Find the RouteRecommendationType class
+  jclass routeRecommendationTypeClass = env->FindClass("app/organicmaps/sdk/routing/RouteRecommendationType");
+  ASSERT(routeRecommendationTypeClass, ());
+
+  // Get the values() method of RouteRecommendationType
+  jmethodID valuesMethod = env->GetStaticMethodID(routeRecommendationTypeClass, "values",
+                                                  "()[Lapp/organicmaps/sdk/routing/RouteRecommendationType;");
+  ASSERT(valuesMethod, ());
+
+  // Call values() to get all enum constants
+  jobjectArray enumConstants = (jobjectArray)env->CallStaticObjectMethod(routeRecommendationTypeClass, valuesMethod);
+  ASSERT(enumConstants, ());
+
+  // Retrieve the first (and only) constant, RebuildAfterPointsLoading
+  rebuildAfterPointsLoading = env->NewGlobalRef(env->GetObjectArrayElement(enumConstants, 0));
+  ASSERT(rebuildAfterPointsLoading, ());
+
+  return rebuildAfterPointsLoading;
+}
+
+jobject GetRouteRecommendationType(JNIEnv * env, RoutingManager::Recommendation recommendation)
+{
+  switch (recommendation)
+  {
+  case RoutingManager::Recommendation::RebuildAfterPointsLoading: return GetRebuildAfterPointsLoading(env);
+  default: ASSERT_FAIL("Unknown recommendation type");
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/Framework.java
+++ b/android/app/src/main/java/app/organicmaps/Framework.java
@@ -2,9 +2,7 @@ package app.organicmaps;
 
 import android.graphics.Bitmap;
 
-import androidx.annotation.IntDef;
 import androidx.annotation.Keep;
-import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Size;
@@ -20,12 +18,14 @@ import app.organicmaps.routing.RouteMarkData;
 import app.organicmaps.routing.RoutePointInfo;
 import app.organicmaps.routing.RoutingInfo;
 import app.organicmaps.routing.TransitRouteInfo;
+import app.organicmaps.sdk.PlacePageActivationListener;
+import app.organicmaps.sdk.routing.RoutingListener;
+import app.organicmaps.sdk.routing.RoutingLoadPointsListener;
+import app.organicmaps.sdk.routing.RoutingProgressListener;
+import app.organicmaps.sdk.routing.RoutingRecommendationListener;
 import app.organicmaps.settings.SettingsPrefsFragment;
-import app.organicmaps.widget.placepage.PlacePageData;
 import app.organicmaps.util.Constants;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -37,87 +37,6 @@ import java.util.Locale;
  */
 public class Framework
 {
-  @Retention(RetentionPolicy.SOURCE)
-  @IntDef({MAP_STYLE_CLEAR, MAP_STYLE_DARK, MAP_STYLE_VEHICLE_CLEAR, MAP_STYLE_VEHICLE_DARK, MAP_STYLE_OUTDOORS_CLEAR, MAP_STYLE_OUTDOORS_DARK})
-
-  public @interface MapStyle {}
-
-  public static final int MAP_STYLE_CLEAR = 0;
-  public static final int MAP_STYLE_DARK = 1;
-  public static final int MAP_STYLE_VEHICLE_CLEAR = 3;
-  public static final int MAP_STYLE_VEHICLE_DARK = 4;
-  public static final int MAP_STYLE_OUTDOORS_CLEAR = 5;
-  public static final int MAP_STYLE_OUTDOORS_DARK = 6;
-
-  @Retention(RetentionPolicy.SOURCE)
-  @IntDef({ ROUTER_TYPE_VEHICLE, ROUTER_TYPE_PEDESTRIAN, ROUTER_TYPE_BICYCLE, ROUTER_TYPE_TRANSIT, ROUTER_TYPE_RULER })
-
-  public @interface RouterType {}
-
-  public static final int ROUTER_TYPE_VEHICLE = 0;
-  public static final int ROUTER_TYPE_PEDESTRIAN = 1;
-  public static final int ROUTER_TYPE_BICYCLE = 2;
-  public static final int ROUTER_TYPE_TRANSIT = 3;
-  public static final int ROUTER_TYPE_RULER = 4;
-
-  @Retention(RetentionPolicy.SOURCE)
-  @IntDef({ROUTE_REBUILD_AFTER_POINTS_LOADING})
-  public @interface RouteRecommendationType {}
-
-  public static final int ROUTE_REBUILD_AFTER_POINTS_LOADING = 0;
-
-  public interface PlacePageActivationListener
-  {
-    // Called from JNI.
-    @Keep
-    @SuppressWarnings("unused")
-    void onPlacePageActivated(@NonNull PlacePageData data);
-
-    // Called from JNI
-    @Keep
-    @SuppressWarnings("unused")
-    void onPlacePageDeactivated();
-
-    // Called from JNI
-    @Keep
-    @SuppressWarnings("unused")
-    void onSwitchFullScreenMode();
-  }
-
-  public interface RoutingListener
-  {
-    // Called from JNI
-    @Keep
-    @SuppressWarnings("unused")
-    @MainThread
-    void onRoutingEvent(int resultCode, String[] missingMaps);
-  }
-
-  public interface RoutingProgressListener
-  {
-    // Called from JNI.
-    @Keep
-    @SuppressWarnings("unused")
-    @MainThread
-    void onRouteBuildingProgress(float progress);
-  }
-
-  public interface RoutingRecommendationListener
-  {
-    // Called from JNI.
-    @Keep
-    @SuppressWarnings("unused")
-    void onRecommend(@RouteRecommendationType int recommendation);
-  }
-
-  public interface RoutingLoadPointsListener
-  {
-    // Called from JNI.
-    @Keep
-    @SuppressWarnings("unused")
-    void onRoutePointsLoaded(boolean success);
-  }
-
   // Used by JNI.
   @Keep
   @SuppressWarnings("unused")
@@ -299,37 +218,15 @@ public class Framework
 
   private static native void nativeSetSpeedCamManagerMode(int mode);
 
-  public static native void nativeSetRoutingListener(RoutingListener listener);
+  public static native void nativeSetRoutingListener(@NonNull RoutingListener listener);
 
-  public static native void nativeSetRouteProgressListener(RoutingProgressListener listener);
+  public static native void nativeSetRouteProgressListener(@NonNull RoutingProgressListener listener);
 
-  public static native void nativeSetRoutingRecommendationListener(RoutingRecommendationListener listener);
+  public static native void nativeSetRoutingRecommendationListener(@NonNull RoutingRecommendationListener listener);
 
-  public static native void nativeSetRoutingLoadPointsListener(
-      @Nullable RoutingLoadPointsListener listener);
+  public static native void nativeSetRoutingLoadPointsListener(@NonNull RoutingLoadPointsListener listener);
 
   public static native void nativeShowCountry(String countryId, boolean zoomToDownloadButton);
-
-  public static native void nativeSetMapStyle(int mapStyle);
-
-  @MapStyle
-  public static native int nativeGetMapStyle();
-
-  /**
-   * This method allows to set new map style without immediate applying. It can be used before
-   * engine recreation instead of nativeSetMapStyle to avoid huge flow of OpenGL invocations.
-   * @param mapStyle style index
-   */
-  public static native void nativeMarkMapStyle(int mapStyle);
-
-  public static native void nativeSetRouter(@RouterType int routerType);
-  @RouterType
-  public static native int nativeGetRouter();
-  @RouterType
-  public static native int nativeGetLastUsedRouter();
-  @RouterType
-  public static native int nativeGetBestRouter(double srcLat, double srcLon,
-                                               double dstLat, double dstLon);
 
   public static native void nativeAddRoutePoint(String title, String subtitle,
                                                 @RoutePointInfo.RouteMarkType int markType,
@@ -390,23 +287,6 @@ public class Framework
 
   public static native void nativeZoomToPoint(double lat, double lon, int zoom, boolean animate);
 
-  @Retention(RetentionPolicy.SOURCE)
-  @IntDef({ChoosePositionMode.NONE, ChoosePositionMode.EDITOR, ChoosePositionMode.API})
-  public @interface ChoosePositionMode
-  {
-    // Keep in sync with `enum ChoosePositionMode` in Framework.hpp.
-    public static final int NONE = 0;
-    public static final int EDITOR = 1;
-    public static final int API = 2;
-  }
-  /**
-   * @param mode - see ChoosePositionMode values.
-   * @param isBusiness selection area will be bounded by building borders, if its true (eg. true for businesses in buildings).
-   * @param applyPosition if true, map'll be animated to currently selected object.
-   */
-  public static native void nativeSetChoosePositionMode(@ChoosePositionMode int mode, boolean isBusiness,
-                                                        boolean applyPosition);
-  public static native @ChoosePositionMode int nativeGetChoosePositionMode();
   public static native boolean nativeIsDownloadedMapAtScreenCenter();
 
   public static native String nativeGetActiveObjectFormattedCuisine();
@@ -432,7 +312,7 @@ public class Framework
 
   public static native void nativeMakeCrash();
 
-    public static native void nativeSetPowerManagerFacility(int facilityType, boolean state);
+  public static native void nativeSetPowerManagerFacility(int facilityType, boolean state);
   public static native int nativeGetPowerManagerScheme();
   public static native void nativeSetPowerManagerScheme(int schemeType);
   public static native void nativeSetViewportCenter(double lat, double lon, int zoom);

--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -40,7 +40,6 @@ import androidx.fragment.app.FragmentFactory;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
-import app.organicmaps.Framework.PlacePageActivationListener;
 import app.organicmaps.api.Const;
 import app.organicmaps.base.BaseMwmFragmentActivity;
 import app.organicmaps.base.OnBackPressListener;
@@ -87,6 +86,9 @@ import app.organicmaps.routing.RoutingErrorDialogFragment;
 import app.organicmaps.routing.RoutingOptions;
 import app.organicmaps.routing.RoutingPlanFragment;
 import app.organicmaps.routing.RoutingPlanInplaceController;
+import app.organicmaps.sdk.ChoosePositionMode;
+import app.organicmaps.sdk.PlacePageActivationListener;
+import app.organicmaps.sdk.Router;
 import app.organicmaps.search.FloatingSearchToolbarController;
 import app.organicmaps.search.SearchActivity;
 import app.organicmaps.search.SearchEngine;
@@ -577,7 +579,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     UiUtils.setLightStatusBar(this, !(
         ThemeUtils.isNightTheme(this)
         || RoutingController.get().isPlanning()
-        || Framework.nativeGetChoosePositionMode() != Framework.ChoosePositionMode.NONE
+        || ChoosePositionMode.get() != ChoosePositionMode.None
     ));
   }
 
@@ -638,9 +640,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mPointChooser.findViewById(R.id.done).setOnClickListener(
         v ->
         {
-          switch (Framework.nativeGetChoosePositionMode())
+          switch (ChoosePositionMode.get())
           {
-          case Framework.ChoosePositionMode.API:
+          case Api:
             final Intent apiResult = new Intent();
             final double[] center = Framework.nativeGetScreenRectCenter();
             apiResult.putExtra(Const.EXTRA_POINT_LAT, center[0]);
@@ -649,7 +651,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
             setResult(Activity.RESULT_OK, apiResult);
             finish();
             break;
-          case Framework.ChoosePositionMode.EDITOR:
+          case Editor:
             if (Framework.nativeIsDownloadedMapAtScreenCenter())
               startActivity(new Intent(MwmActivity.this, FeatureCategoryActivity.class));
             else
@@ -662,7 +664,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
                     .show();
             }
             break;
-          case Framework.ChoosePositionMode.NONE:
+          case None:
             throw new IllegalStateException("Unexpected Framework.nativeGetChoosePositionMode()");
           }
           closePositionChooser();
@@ -698,7 +700,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   public void showPositionChooserForAPI(@Nullable String appName)
   {
-    showPositionChooser(Framework.ChoosePositionMode.API, false, false);
+    showPositionChooser(ChoosePositionMode.Api, false, false);
     if (!TextUtils.isEmpty(appName))
     {
       setTitle(appName);
@@ -708,26 +710,26 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   public void showPositionChooserForEditor(boolean isBusiness, boolean applyPosition)
   {
-    showPositionChooser(Framework.ChoosePositionMode.EDITOR, isBusiness, applyPosition);
+    showPositionChooser(ChoosePositionMode.Editor, isBusiness, applyPosition);
   }
 
-  private void showPositionChooser(@Framework.ChoosePositionMode int mode, boolean isBusiness, boolean applyPosition)
+  private void showPositionChooser(ChoosePositionMode mode, boolean isBusiness, boolean applyPosition)
   {
     closeFloatingToolbarsAndPanels(false);
     UiUtils.show(mPointChooser);
     mMapButtonsViewModel.setButtonsHidden(true);
-    Framework.nativeSetChoosePositionMode(mode, isBusiness, applyPosition);
+    ChoosePositionMode.set(mode, isBusiness, applyPosition);
     refreshLightStatusBar();
   }
 
   private void hidePositionChooser()
   {
     UiUtils.hide(mPointChooser);
-    @Framework.ChoosePositionMode int mode = Framework.nativeGetChoosePositionMode();
-    Framework.nativeSetChoosePositionMode(Framework.ChoosePositionMode.NONE, false, false);
+    ChoosePositionMode mode = ChoosePositionMode.get();
+    ChoosePositionMode.set(ChoosePositionMode.None, false, false);
     mMapButtonsViewModel.setButtonsHidden(false);
     refreshLightStatusBar();
-    if (mode == Framework.ChoosePositionMode.API)
+    if (mode == ChoosePositionMode.Api)
       finish();
   }
 
@@ -1094,7 +1096,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     ThemeSwitcher.INSTANCE.restart(isMapRendererActive());
     refreshSearchToolbar();
     setFullscreen(isFullscreen());
-    if (Framework.nativeGetChoosePositionMode() != Framework.ChoosePositionMode.NONE)
+    if (ChoosePositionMode.get() != ChoosePositionMode.None)
     {
       UiUtils.show(mPointChooser);
       mMapButtonsViewModel.setButtonsHidden(true);
@@ -1308,7 +1310,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     // Buttons are hidden in position chooser mode but we are not in fullscreen
     return Boolean.TRUE.equals(mMapButtonsViewModel.getButtonsHidden().getValue()) &&
-        Framework.nativeGetChoosePositionMode() == Framework.ChoosePositionMode.NONE;
+        ChoosePositionMode.get() == ChoosePositionMode.None;
   }
 
   @Override
@@ -1546,7 +1548,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   }
 
   @Override
-  public void updateBuildProgress(int progress, @Framework.RouterType int router)
+  public void updateBuildProgress(int progress, Router router)
   {
     if (mIsTabletLayout)
     {

--- a/android/app/src/main/java/app/organicmaps/api/ParsedRoutingData.java
+++ b/android/app/src/main/java/app/organicmaps/api/ParsedRoutingData.java
@@ -2,7 +2,7 @@ package app.organicmaps.api;
 
 import androidx.annotation.Keep;
 
-import app.organicmaps.Framework;
+import app.organicmaps.sdk.Router;
 
 /**
  * Represents Framework::ParsedRoutingData from core.
@@ -13,11 +13,10 @@ import app.organicmaps.Framework;
 public class ParsedRoutingData
 {
   public final RoutePoint[] mPoints;
-  @Framework.RouterType
-  public final int mRouterType;
+  public final Router mRouterType;
 
   public ParsedRoutingData(RoutePoint[] points, int routerType) {
     this.mPoints = points;
-    this.mRouterType = routerType;
+    this.mRouterType = Router.valueOf(routerType);
   }
 }

--- a/android/app/src/main/java/app/organicmaps/car/CarAppSession.java
+++ b/android/app/src/main/java/app/organicmaps/car/CarAppSession.java
@@ -35,6 +35,7 @@ import app.organicmaps.display.DisplayManager;
 import app.organicmaps.display.DisplayType;
 import app.organicmaps.location.LocationState;
 import app.organicmaps.routing.RoutingController;
+import app.organicmaps.sdk.PlacePageActivationListener;
 import app.organicmaps.util.Config;
 import app.organicmaps.util.LocationUtils;
 import app.organicmaps.util.log.Logger;
@@ -45,7 +46,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public final class CarAppSession extends Session implements DefaultLifecycleObserver,
-    LocationState.ModeChangeListener, DisplayChangedListener, Framework.PlacePageActivationListener
+    LocationState.ModeChangeListener, DisplayChangedListener, PlacePageActivationListener
 {
   private static final String TAG = CarAppSession.class.getSimpleName();
 

--- a/android/app/src/main/java/app/organicmaps/car/screens/PlaceScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/PlaceScreen.java
@@ -42,13 +42,14 @@ import app.organicmaps.location.LocationHelper;
 import app.organicmaps.routing.ResultCodesHelper;
 import app.organicmaps.routing.RoutingController;
 import app.organicmaps.routing.RoutingInfo;
+import app.organicmaps.sdk.Router;
 import app.organicmaps.util.Config;
 
 import java.util.Objects;
 
 public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.Callback, RoutingController.Container
 {
-  private static final int ROUTER_TYPE = Framework.ROUTER_TYPE_VEHICLE;
+  private static final Router ROUTER = Router.Vehicle;
 
   @Nullable
   private MapObject mMapObject;
@@ -83,7 +84,7 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
   public void onCreate(@NonNull LifecycleOwner owner)
   {
     mRoutingController.restore();
-    if (mRoutingController.isNavigating() && mRoutingController.getLastRouterType() == ROUTER_TYPE)
+    if (mRoutingController.isNavigating() && mRoutingController.getLastRouterType() == ROUTER)
     {
       showNavigation(true);
       return;
@@ -95,11 +96,11 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
     else
     {
       final boolean hasIncorrectEndPoint = mRoutingController.isPlanning() && (!MapObject.same(mMapObject, mRoutingController.getEndPoint()));
-      final boolean hasIncorrectRouterType = mRoutingController.getLastRouterType() != ROUTER_TYPE;
+      final boolean hasIncorrectRouterType = mRoutingController.getLastRouterType() != ROUTER;
       final boolean isNotPlanningMode = !mRoutingController.isPlanning();
       if (hasIncorrectRouterType)
       {
-        mRoutingController.setRouterType(ROUTER_TYPE);
+        mRoutingController.setRouterType(ROUTER);
         mRoutingController.rebuildLastRoute();
       }
       else if (hasIncorrectEndPoint || isNotPlanningMode)

--- a/android/app/src/main/java/app/organicmaps/car/util/ThemeUtils.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/ThemeUtils.java
@@ -12,6 +12,7 @@ import androidx.car.app.CarContext;
 import app.organicmaps.Framework;
 import app.organicmaps.R;
 import app.organicmaps.routing.RoutingController;
+import app.organicmaps.sdk.MapStyle;
 
 public final class ThemeUtils
 {
@@ -60,15 +61,14 @@ public final class ThemeUtils
   {
     final ThemeMode newThemeMode = oldThemeMode == ThemeMode.AUTO ? (context.isDarkMode() ? ThemeMode.NIGHT : ThemeMode.LIGHT) : oldThemeMode;
 
-    @Framework.MapStyle
-    int newMapStyle;
+    MapStyle newMapStyle;
     if (newThemeMode == ThemeMode.NIGHT)
-      newMapStyle = RoutingController.get().isVehicleNavigation() ? Framework.MAP_STYLE_VEHICLE_DARK : Framework.MAP_STYLE_DARK;
+      newMapStyle = RoutingController.get().isVehicleNavigation() ? MapStyle.VehicleDark : MapStyle.Dark;
     else
-      newMapStyle = RoutingController.get().isVehicleNavigation() ? Framework.MAP_STYLE_VEHICLE_CLEAR : Framework.MAP_STYLE_CLEAR;
+      newMapStyle = RoutingController.get().isVehicleNavigation() ? MapStyle.VehicleClear : MapStyle.Clear;
 
-    if (Framework.nativeGetMapStyle() != newMapStyle)
-      Framework.nativeSetMapStyle(newMapStyle);
+    if (MapStyle.get() != newMapStyle)
+      MapStyle.set(newMapStyle);
   }
 
   public static boolean isNightMode(@NonNull CarContext context)

--- a/android/app/src/main/java/app/organicmaps/routing/NavigationController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/NavigationController.java
@@ -16,6 +16,7 @@ import app.organicmaps.Framework;
 import app.organicmaps.R;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.maplayer.traffic.TrafficManager;
+import app.organicmaps.sdk.Router;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
 import app.organicmaps.widget.LanesView;
@@ -139,7 +140,7 @@ public class NavigationController implements TrafficManager.TrafficCallback,
     if (info == null)
       return;
 
-    if (Framework.nativeGetRouter() == Framework.ROUTER_TYPE_PEDESTRIAN)
+    if (Router.get() == Router.Pedestrian)
       updatePedestrian(info);
     else
       updateVehicle(info);

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingController.java
@@ -16,6 +16,11 @@ import app.organicmaps.R;
 import app.organicmaps.bookmarks.data.FeatureId;
 import app.organicmaps.bookmarks.data.MapObject;
 import app.organicmaps.location.LocationHelper;
+import app.organicmaps.sdk.Router;
+import app.organicmaps.sdk.routing.RouteRecommendationType;
+import app.organicmaps.sdk.routing.RoutingListener;
+import app.organicmaps.sdk.routing.RoutingLoadPointsListener;
+import app.organicmaps.sdk.routing.RoutingProgressListener;
 import app.organicmaps.widget.placepage.CoordinatesFormat;
 import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.Utils;
@@ -67,7 +72,7 @@ public class RoutingController
     /**
      * @param progress progress to be displayed.
      * */
-    default void updateBuildProgress(@IntRange(from = 0, to = 100) int progress, @Framework.RouterType int router) {}
+    default void updateBuildProgress(@IntRange(from = 0, to = 100) int progress, Router router) {}
     default void onStartRouteBuilding() {}
   }
 
@@ -82,8 +87,7 @@ public class RoutingController
   //@RoutePointInfo.RouteMarkType
   private int mWaitingPoiPickType = NO_WAITING_POI_PICK;
   private int mLastBuildProgress;
-  @Framework.RouterType
-  private int mLastRouterType;
+  private Router mLastRouterType;
 
   private boolean mHasContainerSavedState;
   private boolean mContainsCachedResult;
@@ -98,7 +102,7 @@ public class RoutingController
   private int mRemovingIntermediatePointsTransactionId;
 
   @SuppressWarnings("FieldCanBeLocal")
-  private final Framework.RoutingListener mRoutingListener = new Framework.RoutingListener()
+  private final RoutingListener mRoutingListener = new RoutingListener()
   {
     @MainThread
     @Override
@@ -124,10 +128,11 @@ public class RoutingController
       processRoutingEvent();
     }
   };
+
   private void onBuiltRoute()
   {
     mCachedRoutingInfo = Framework.nativeGetRouteFollowingInfo();
-    if (mLastRouterType == Framework.ROUTER_TYPE_TRANSIT)
+    if (mLastRouterType == Router.Transit)
       mCachedTransitRouteInfo = Framework.nativeGetTransitRouteInfo();
     setBuildState(BuildState.BUILT);
     mLastBuildProgress = 100;
@@ -135,23 +140,15 @@ public class RoutingController
       mContainer.onBuiltRoute();
   }
 
-  private final Framework.RoutingProgressListener mRoutingProgressListener = new Framework.RoutingProgressListener()
-  {
-    @MainThread
-    @Override
-    public void onRouteBuildingProgress(float progress)
-    {
-      mLastBuildProgress = (int) progress;
-      updateProgress();
-    }
+  private final RoutingProgressListener mRoutingProgressListener = progress -> {
+    mLastBuildProgress = (int) progress;
+    updateProgress();
   };
 
-  @SuppressWarnings("FieldCanBeLocal")
-  private final Framework.RoutingLoadPointsListener mRoutingLoadPointsListener =
-    success -> {
-      if (success)
-        prepare(getStartPoint(), getEndPoint());
-    };
+  private final RoutingLoadPointsListener mRoutingLoadPointsListener = success -> {
+    if (success)
+      prepare(getStartPoint(), getEndPoint());
+  };
 
   public static RoutingController get()
   {
@@ -254,14 +251,14 @@ public class RoutingController
 
   public void initialize(@NonNull Context context)
   {
-    mLastRouterType = Framework.nativeGetLastUsedRouter();
+    mLastRouterType = Router.getLastUsed();
     mInvalidRoutePointsTransactionId = Framework.nativeInvalidRoutePointsTransactionId();
     mRemovingIntermediatePointsTransactionId = mInvalidRoutePointsTransactionId;
 
     Framework.nativeSetRoutingListener(mRoutingListener);
     Framework.nativeSetRouteProgressListener(mRoutingProgressListener);
     Framework.nativeSetRoutingRecommendationListener(recommendation -> UiThread.run(() -> {
-      if (recommendation == Framework.ROUTE_REBUILD_AFTER_POINTS_LOADING)
+      if (recommendation == RouteRecommendationType.RebuildAfterPointsLoading)
         setStartPoint(LocationHelper.from(context).getMyPosition());
     }));
     Framework.nativeSetRoutingLoadPointsListener(mRoutingLoadPointsListener);
@@ -353,13 +350,13 @@ public class RoutingController
   {
     if (shouldForceTransitRoute(fromApi))
     {
-      mLastRouterType = Framework.ROUTER_TYPE_TRANSIT;
+      mLastRouterType = Router.Transit;
       return;
     }
 
     if (startPoint != null && endPoint != null)
-      mLastRouterType = Framework.nativeGetBestRouter(startPoint.getLat(), startPoint.getLon(),
-                                                      endPoint.getLat(), endPoint.getLon());
+      mLastRouterType = Router.getBest(startPoint.getLat(), startPoint.getLon(),
+                                       endPoint.getLat(), endPoint.getLon());
   }
 
   private boolean isSubwayEnabled()
@@ -373,13 +370,13 @@ public class RoutingController
   }
 
   public void prepare(final @Nullable MapObject startPoint, final @Nullable MapObject endPoint,
-                      @Framework.RouterType int routerType)
+                      Router routerType)
   {
     cancel();
     setState(State.PREPARE);
 
     mLastRouterType = routerType;
-    Framework.nativeSetRouter(mLastRouterType);
+    Router.set(mLastRouterType);
 
     if (startPoint != null || endPoint != null)
       setPointsInternal(startPoint, endPoint);
@@ -565,17 +562,17 @@ public class RoutingController
 
   public boolean isTransitType()
   {
-    return mLastRouterType == Framework.ROUTER_TYPE_TRANSIT;
+    return mLastRouterType == Router.Transit;
   }
 
   public boolean isVehicleRouterType()
   {
-    return mLastRouterType == Framework.ROUTER_TYPE_VEHICLE;
+    return mLastRouterType == Router.Vehicle;
   }
 
   boolean isRulerRouterType()
   {
-    return mLastRouterType == Framework.ROUTER_TYPE_RULER;
+    return mLastRouterType == Router.Ruler;
   }
 
   public boolean isNavigating()
@@ -834,7 +831,7 @@ public class RoutingController
       mContainer.updateMenu();
   }
 
-  public void setRouterType(@Framework.RouterType int router)
+  public void setRouterType(Router router)
   {
     Logger.d(TAG, "setRouterType: " + mLastRouterType + " -> " + router);
 
@@ -844,7 +841,7 @@ public class RoutingController
       return;
 
     mLastRouterType = router;
-    Framework.nativeSetRouter(router);
+    Router.set(router);
 
     cancelRemovingIntermediatePointsTransaction();
 
@@ -852,8 +849,7 @@ public class RoutingController
       build();
   }
 
-  @Framework.RouterType
-  public int getLastRouterType()
+  public Router getLastRouterType()
   {
     return mLastRouterType;
   }

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingPlanController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingPlanController.java
@@ -16,6 +16,7 @@ import androidx.core.view.WindowInsetsCompat;
 import app.organicmaps.Framework;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
+import app.organicmaps.sdk.Router;
 import app.organicmaps.settings.DrivingOptionsActivity;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.WindowInsetUtils.PaddingInsetsListener;
@@ -140,27 +141,27 @@ public class RoutingPlanController extends ToolbarController
 
   private void onTransitModeSelected(@NonNull View v)
   {
-    RoutingController.get().setRouterType(Framework.ROUTER_TYPE_TRANSIT);
+    RoutingController.get().setRouterType(Router.Transit);
   }
 
   private void onBicycleModeSelected(@NonNull View v)
   {
-    RoutingController.get().setRouterType(Framework.ROUTER_TYPE_BICYCLE);
+    RoutingController.get().setRouterType(Router.Bicycle);
   }
 
   private void onRulerModeSelected(@NonNull View v)
   {
-    RoutingController.get().setRouterType(Framework.ROUTER_TYPE_RULER);
+    RoutingController.get().setRouterType(Router.Ruler);
   }
 
   private void onPedestrianModeSelected(@NonNull View v)
   {
-    RoutingController.get().setRouterType(Framework.ROUTER_TYPE_PEDESTRIAN);
+    RoutingController.get().setRouterType(Router.Pedestrian);
   }
 
   private void onVehicleModeSelected(@NonNull View v)
   {
-    RoutingController.get().setRouterType(Framework.ROUTER_TYPE_VEHICLE);
+    RoutingController.get().setRouterType(Router.Vehicle);
   }
 
   @Override
@@ -215,35 +216,35 @@ public class RoutingPlanController extends ToolbarController
     mRoutingBottomMenuController.showAltitudeChartAndRoutingDetails();
   }
 
-  public void updateBuildProgress(int progress, @Framework.RouterType int router)
+  public void updateBuildProgress(int progress, @NonNull Router router)
   {
     UiUtils.invisible(mProgressVehicle, mProgressPedestrian, mProgressTransit,
                       mProgressBicycle, mProgressRuler);
     WheelProgressView progressView;
     switch (router)
     {
-    case Framework.ROUTER_TYPE_VEHICLE:
+    case Vehicle:
       mRouterTypes.check(R.id.vehicle);
       progressView = mProgressVehicle;
       break;
-    case Framework.ROUTER_TYPE_PEDESTRIAN:
+    case Pedestrian:
       mRouterTypes.check(R.id.pedestrian);
       progressView = mProgressPedestrian;
       break;
-    //case Framework.ROUTER_TYPE_TAXI:
+    //case Taxi:
     //    {
     //      mRouterTypes.check(R.id.taxi);
     //      progressView = mProgressTaxi;
     //    }
-    case Framework.ROUTER_TYPE_TRANSIT:
+    case Transit:
       mRouterTypes.check(R.id.transit);
       progressView = mProgressTransit;
       break;
-    case Framework.ROUTER_TYPE_BICYCLE:
+    case Bicycle:
       mRouterTypes.check(R.id.bicycle);
       progressView = mProgressBicycle;
       break;
-    case Framework.ROUTER_TYPE_RULER:
+    case Ruler:
       mRouterTypes.check(R.id.ruler);
       progressView = mProgressRuler;
       break;

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingPlanFragment.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingPlanFragment.java
@@ -9,9 +9,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 
-import app.organicmaps.Framework;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmFragment;
+import app.organicmaps.sdk.Router;
 
 public class RoutingPlanFragment extends BaseMwmFragment
 {
@@ -33,7 +33,7 @@ public class RoutingPlanFragment extends BaseMwmFragment
     return res;
   }
 
-  public void updateBuildProgress(int progress, @Framework.RouterType int router)
+  public void updateBuildProgress(int progress, Router router)
   {
     mPlanController.updateBuildProgress(progress, router);
   }

--- a/android/app/src/main/java/app/organicmaps/sdk/ChoosePositionMode.java
+++ b/android/app/src/main/java/app/organicmaps/sdk/ChoosePositionMode.java
@@ -1,0 +1,37 @@
+package app.organicmaps.sdk;
+
+import androidx.annotation.NonNull;
+
+public enum ChoosePositionMode
+{
+  None(0),
+  Editor(1),
+  Api(2);
+
+  ChoosePositionMode(int mode)
+  {
+    this.mode = mode;
+  }
+
+  /**
+   * @param isBusiness    selection area will be bounded by building borders, if its true (eg. true for businesses in buildings).
+   * @param applyPosition if true, map will be animated to currently selected object.
+   */
+  public static void set(@NonNull ChoosePositionMode mode, boolean isBusiness, boolean applyPosition)
+  {
+    nativeSet(mode.mode, isBusiness, applyPosition);
+  }
+
+  public static ChoosePositionMode get()
+  {
+    return ChoosePositionMode.values()[nativeGet()];
+  }
+
+  private final int mode;
+
+
+  private static native void nativeSet(int mode, boolean isBusiness,
+                                                         boolean applyPosition);
+
+  private static native int nativeGet();
+}

--- a/android/app/src/main/java/app/organicmaps/sdk/MapStyle.java
+++ b/android/app/src/main/java/app/organicmaps/sdk/MapStyle.java
@@ -1,0 +1,59 @@
+package app.organicmaps.sdk;
+
+import androidx.annotation.NonNull;
+
+public enum MapStyle
+{
+  Clear(0),
+  Dark(1),
+  VehicleClear(3),
+  VehicleDark(4),
+  OutdoorsClear(5),
+  OutdoorsDark(6);
+
+  MapStyle(int value)
+  {
+    this.value = value;
+  }
+
+  @NonNull
+  public static MapStyle get()
+  {
+    return valueOf(nativeGet());
+  }
+
+  public static void set(@NonNull MapStyle mapStyle)
+  {
+    nativeSet(mapStyle.value);
+  }
+
+  /**
+   * This method allows to set new map style without immediate applying. It can be used before
+   * engine recreation instead of nativeSetMapStyle to avoid huge flow of OpenGL invocations.
+   *
+   * @param mapStyle style index
+   */
+  public static void mark(@NonNull MapStyle mapStyle)
+  {
+    nativeMark(mapStyle.value);
+  }
+
+  @NonNull
+  public static MapStyle valueOf(int value)
+  {
+    for (MapStyle mapStyle : MapStyle.values())
+    {
+      if (mapStyle.value == value)
+        return mapStyle;
+    }
+    throw new IllegalArgumentException("Unknown map style value: " + value);
+  }
+
+  private final int value;
+
+  private static native void nativeSet(int mapStyle);
+
+  private static native int nativeGet();
+
+  private static native void nativeMark(int mapStyle);
+}

--- a/android/app/src/main/java/app/organicmaps/sdk/PlacePageActivationListener.java
+++ b/android/app/src/main/java/app/organicmaps/sdk/PlacePageActivationListener.java
@@ -1,0 +1,24 @@
+package app.organicmaps.sdk;
+
+import androidx.annotation.Keep;
+import androidx.annotation.NonNull;
+
+import app.organicmaps.widget.placepage.PlacePageData;
+
+public interface PlacePageActivationListener
+{
+  // Called from JNI.
+  @Keep
+  @SuppressWarnings("unused")
+  void onPlacePageActivated(@NonNull PlacePageData data);
+
+  // Called from JNI
+  @Keep
+  @SuppressWarnings("unused")
+  void onPlacePageDeactivated();
+
+  // Called from JNI
+  @Keep
+  @SuppressWarnings("unused")
+  void onSwitchFullScreenMode();
+}

--- a/android/app/src/main/java/app/organicmaps/sdk/Router.java
+++ b/android/app/src/main/java/app/organicmaps/sdk/Router.java
@@ -1,0 +1,53 @@
+package app.organicmaps.sdk;
+
+import androidx.annotation.NonNull;
+
+public enum Router
+{
+  Vehicle(0),
+  Pedestrian(1),
+  Bicycle(2),
+  Transit(3),
+  Ruler(4);
+
+  Router(int type)
+  {
+    this.type = type;
+  }
+
+  public static void set(@NonNull Router routerType)
+  {
+    nativeSet(routerType.type);
+  }
+
+  public static Router get()
+  {
+    return valueOf(nativeGet());
+  }
+
+  public static Router getLastUsed()
+  {
+    return valueOf(nativeGetLastUsed());
+  }
+
+  public static Router getBest(double srcLat, double srcLon, double dstLat, double dstLon)
+  {
+    return Router.values()[nativeGetBest(srcLat, srcLon, dstLat, dstLon)];
+  }
+
+  public static Router valueOf(int type)
+  {
+    return Router.values()[type];
+  }
+
+  private final int type;
+
+  private static native void nativeSet(int routerType);
+
+  private static native int nativeGet();
+
+  private static native int nativeGetLastUsed();
+
+  private static native int nativeGetBest(double srcLat, double srcLon,
+                                          double dstLat, double dstLon);
+}

--- a/android/app/src/main/java/app/organicmaps/sdk/routing/RouteRecommendationType.java
+++ b/android/app/src/main/java/app/organicmaps/sdk/routing/RouteRecommendationType.java
@@ -1,0 +1,6 @@
+package app.organicmaps.sdk.routing;
+
+public enum RouteRecommendationType
+{
+  RebuildAfterPointsLoading
+}

--- a/android/app/src/main/java/app/organicmaps/sdk/routing/RoutingListener.java
+++ b/android/app/src/main/java/app/organicmaps/sdk/routing/RoutingListener.java
@@ -1,0 +1,13 @@
+package app.organicmaps.sdk.routing;
+
+import androidx.annotation.Keep;
+import androidx.annotation.MainThread;
+
+public interface RoutingListener
+{
+  // Called from JNI
+  @Keep
+  @SuppressWarnings("unused")
+  @MainThread
+  void onRoutingEvent(int resultCode, String[] missingMaps);
+}

--- a/android/app/src/main/java/app/organicmaps/sdk/routing/RoutingLoadPointsListener.java
+++ b/android/app/src/main/java/app/organicmaps/sdk/routing/RoutingLoadPointsListener.java
@@ -1,0 +1,11 @@
+package app.organicmaps.sdk.routing;
+
+import androidx.annotation.Keep;
+
+public interface RoutingLoadPointsListener
+{
+  // Called from JNI.
+  @Keep
+  @SuppressWarnings("unused")
+  void onRoutePointsLoaded(boolean success);
+}

--- a/android/app/src/main/java/app/organicmaps/sdk/routing/RoutingProgressListener.java
+++ b/android/app/src/main/java/app/organicmaps/sdk/routing/RoutingProgressListener.java
@@ -1,0 +1,13 @@
+package app.organicmaps.sdk.routing;
+
+import androidx.annotation.Keep;
+import androidx.annotation.MainThread;
+
+public interface RoutingProgressListener
+{
+  // Called from JNI.
+  @Keep
+  @SuppressWarnings("unused")
+  @MainThread
+  void onRouteBuildingProgress(float progress);
+}

--- a/android/app/src/main/java/app/organicmaps/sdk/routing/RoutingRecommendationListener.java
+++ b/android/app/src/main/java/app/organicmaps/sdk/routing/RoutingRecommendationListener.java
@@ -1,0 +1,11 @@
+package app.organicmaps.sdk.routing;
+
+import androidx.annotation.Keep;
+
+public interface RoutingRecommendationListener
+{
+  // Called from JNI.
+  @Keep
+  @SuppressWarnings("unused")
+  void onRecommend(RouteRecommendationType recommendation);
+}

--- a/android/app/src/main/java/app/organicmaps/util/ThemeSwitcher.java
+++ b/android/app/src/main/java/app/organicmaps/util/ThemeSwitcher.java
@@ -15,6 +15,7 @@ import app.organicmaps.display.DisplayManager;
 import app.organicmaps.downloader.DownloaderStatusIcon;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.routing.RoutingController;
+import app.organicmaps.sdk.MapStyle;
 import app.organicmaps.util.concurrency.UiThread;
 
 public enum ThemeSwitcher
@@ -68,7 +69,7 @@ public enum ThemeSwitcher
   /**
    * Changes the UI theme of application and the map style if necessary. If the contract regarding
    * the input parameter is broken, the UI will be frozen during attempting to change the map style
-   * through the synchronous method {@link Framework#nativeSetMapStyle(int)}.
+   * through the synchronous method {@link MapStyle#set(MapStyle)}.
    *
    * @param isRendererActive Indicates whether OpenGL renderer is active or not. Must be
    *                         <code>true</code> only if the map is rendered and visible on the screen
@@ -93,11 +94,8 @@ public enum ThemeSwitcher
   {
     UiModeManager uiModeManager = (UiModeManager) mContext.getSystemService(Context.UI_MODE_SERVICE);
     String oldTheme = Config.getCurrentUiTheme(mContext);
-    @Framework.MapStyle
-    int oldStyle = Framework.nativeGetMapStyle();
 
-    @Framework.MapStyle
-    int style;
+    MapStyle style;
     if (ThemeUtils.isNightTheme(mContext, theme))
     {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
@@ -106,11 +104,11 @@ public enum ThemeSwitcher
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
 
       if (RoutingController.get().isVehicleNavigation())
-        style = Framework.MAP_STYLE_VEHICLE_DARK;
+        style = MapStyle.VehicleDark;
       else if (Framework.nativeIsOutdoorsLayerEnabled())
-        style = Framework.MAP_STYLE_OUTDOORS_DARK;
+        style = MapStyle.OutdoorsDark;
       else
-        style = Framework.MAP_STYLE_DARK;
+        style = MapStyle.Dark;
     }
     else
     {
@@ -120,11 +118,11 @@ public enum ThemeSwitcher
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
 
       if (RoutingController.get().isVehicleNavigation())
-        style = Framework.MAP_STYLE_VEHICLE_CLEAR;
+        style = MapStyle.VehicleClear;
       else if (Framework.nativeIsOutdoorsLayerEnabled())
-        style = Framework.MAP_STYLE_OUTDOORS_CLEAR;
+        style = MapStyle.OutdoorsClear;
       else
-        style = Framework.MAP_STYLE_CLEAR;
+        style = MapStyle.Clear;
     }
 
     if (!theme.equals(oldTheme))
@@ -139,14 +137,14 @@ public enum ThemeSwitcher
     else
     {
       // If the UI theme is not changed we just need to change the map style if needed.
-      int currentStyle = Framework.nativeGetMapStyle();
+      final MapStyle currentStyle = MapStyle.get();
       if (currentStyle == style)
         return;
       SetMapStyle(style);
     }
   }
 
-  private void SetMapStyle(@Framework.MapStyle int style)
+  private void SetMapStyle(MapStyle style)
   {
     // Because of the distinct behavior in auto theme, Android Auto employs its own mechanism for theme switching.
     // For the Android Auto theme switcher, please consult the app.organicmaps.car.util.ThemeUtils module.
@@ -155,8 +153,8 @@ public enum ThemeSwitcher
     // If rendering is not active we can mark map style, because all graphics
     // will be recreated after rendering activation.
     if (mRendererActive)
-      Framework.nativeSetMapStyle(style);
+      MapStyle.set(style);
     else
-      Framework.nativeMarkMapStyle(style);
+      MapStyle.mark(style);
   }
 }


### PR DESCRIPTION
Framework class decomposition.
Internal interfaces and enums are moved to `app.organicmaps.sdk` package.
Some of the functions are moved to related enum classes. F.e. `nativeSetMapStyle` is moved to the newly created enum class `MapStyle`. It's not a final solution but I feel that it's better to keep these methods close to the types during refactoring.