### PR TITLE
Define manageSpaceActivity

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -79,6 +79,7 @@
       android:resizeableActivity="true"
       android:supportsRtl="true"
       android:networkSecurityConfig="@xml/network_security_config"
+      android:manageSpaceActivity="${applicationId}.ManageSpaceActivity"
       tools:targetApi="33">
 
     <!-- Allows for config and orientation change without killing/restarting main activity -->
@@ -361,6 +362,11 @@
         android:launchMode="singleTask"
         android:configChanges="uiMode"
         android:windowSoftInputMode="stateAlwaysHidden|adjustPan"/>
+
+    <activity-alias
+        android:name="${applicationId}.ManageSpaceActivity"
+        android:exported="true"
+        android:targetActivity=".SplashActivity" />
 
     <activity
         android:name="app.organicmaps.downloader.DownloaderActivity"

--- a/android/app/src/main/java/app/organicmaps/SplashActivity.java
+++ b/android/app/src/main/java/app/organicmaps/SplashActivity.java
@@ -19,6 +19,7 @@ import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
 
 import app.organicmaps.display.DisplayManager;
+import app.organicmaps.downloader.DownloaderActivity;
 import app.organicmaps.intent.Factory;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.util.Config;
@@ -178,7 +179,13 @@ public class SplashActivity extends AppCompatActivity
     // Re-use original intent with the known safe subset of flags to retain security permissions.
     // https://github.com/organicmaps/organicmaps/issues/6944
     final Intent intent = Objects.requireNonNull(getIntent());
-    intent.setComponent(new ComponentName(this, DownloadResourcesLegacyActivity.class));
+
+    if (isManageSpaceActivity(intent)) {
+      intent.setComponent(new ComponentName(this, DownloaderActivity.class));
+    } else {
+      intent.setComponent(new ComponentName(this, DownloadResourcesLegacyActivity.class));
+    }
+
     // FLAG_ACTIVITY_NEW_TASK and FLAG_ACTIVITY_RESET_TASK_IF_NEEDED break the cold start.
     // https://github.com/organicmaps/organicmaps/pull/7287
     // FORWARD_RESULT_FLAG conflicts with the ActivityResultLauncher.
@@ -195,5 +202,16 @@ public class SplashActivity extends AppCompatActivity
     Config.setFirstStartDialogSeen(this);
     startActivity(intent);
     finish();
+  }
+
+  private boolean isManageSpaceActivity(Intent intent) {
+    var component = intent.getComponent();
+
+    if (!Intent.ACTION_VIEW.equals(intent.getAction())) return false;
+    if (component == null) return false;
+
+    var manageSpaceActivityName = BuildConfig.APPLICATION_ID + ".ManageSpaceActivity";
+
+    return manageSpaceActivityName.equals(component.getClassName());
   }
 }


### PR DESCRIPTION
This is a nice feature to reduce amount of uninstalls and full cleans.

Consider the case:
1. You don't have enough free space on your phone.
2. You go to the Settings -> Storage -> Apps to see which apps eats the space.
3. You see Organic Maps, click on it and click on Clean storage.
4. But instead of performing a full clean you see a screen to manage maps you have on the device.

Third-party storage managment apps could support this as well.

Resolves #1079