### PR TITLE
[search] Add handling for negative case when using comma separators

### DIFF
--- a/search/latlon_match.cpp
+++ b/search/latlon_match.cpp
@@ -18,10 +18,16 @@ namespace
 string const kSpaces = " \t";
 string const kCharsToSkip = " \n\t,;:.()";
 string const kDecimalMarks = ".,";
+string const kNegative = "-";
 
 bool IsDecimalMark(char c)
 {
   return kDecimalMarks.find(c) != string::npos;
+}
+
+bool IsNegativeSymbol(char c)
+{
+  return kNegative.find(c) != string::npos;
 }
 
 template <typename Char>
@@ -99,6 +105,7 @@ double EatDouble(char const * str, char ** strEnd)
   bool gotDigitAfterMark = false;
   char const * markPos = nullptr;
   char const * p = str;
+  double modifier = 1.0;
   while (true)
   {
     if (IsDecimalMark(*p))
@@ -115,6 +122,10 @@ double EatDouble(char const * str, char ** strEnd)
       else
         gotDigitBeforeMark = true;
     }
+    else if (IsNegativeSymbol(*p))
+    {
+      modifier = -1.0;
+    }
     else
     {
       break;
@@ -129,7 +140,7 @@ double EatDouble(char const * str, char ** strEnd)
     *strEnd = const_cast<char *>(p);
     auto const x1 = atof(part1.c_str());
     auto const x2 = atof(part2.c_str());
-    return x1 + x2 * pow(10.0, -static_cast<double>(part2.size()));
+    return x1 + x2 * modifier * pow(10.0, -static_cast<double>(part2.size()));
   }
 
   return strtod(str, strEnd);

--- a/search/latlon_match.cpp
+++ b/search/latlon_match.cpp
@@ -18,7 +18,6 @@ namespace
 string const kSpaces = " \t";
 string const kCharsToSkip = " \n\t,;:.()";
 string const kDecimalMarks = ".,";
-string const kNegative = "-";
 
 bool IsDecimalMark(char c)
 {
@@ -27,7 +26,7 @@ bool IsDecimalMark(char c)
 
 bool IsNegativeSymbol(char c)
 {
-  return kNegative.find(c) != string::npos;
+  return c == '-';
 }
 
 template <typename Char>

--- a/search/search_tests/latlon_match_test.cpp
+++ b/search/search_tests/latlon_match_test.cpp
@@ -46,7 +46,35 @@ UNIT_TEST(LatLon_Match_Smoke)
   TestAlmostEqual(lat, 10.1);
   TestAlmostEqual(lon, 20.2);
 
+  TEST(MatchLatLonDegree("-10,10, 20,20", lat, lon), ());
+  TestAlmostEqual(lat, -10.1);
+  TestAlmostEqual(lon, 20.2);
+  
+  TEST(MatchLatLonDegree("10,10, -20,20", lat, lon), ());
+  TestAlmostEqual(lat, 10.1);
+  TestAlmostEqual(lon, -20.2);
+
+  TEST(MatchLatLonDegree("-10,10, -20,20", lat, lon), ());
+  TestAlmostEqual(lat, -10.1);
+  TestAlmostEqual(lon, -20.2);
+
+  TEST(MatchLatLonDegree("-10,10 20,20", lat, lon), ());
+  TestAlmostEqual(lat, -10.1);
+  TestAlmostEqual(lon, 20.2);
+  
+  TEST(MatchLatLonDegree("10,10 -20,20", lat, lon), ());
+  TestAlmostEqual(lat, 10.1);
+  TestAlmostEqual(lon, -20.2);
+
+  TEST(MatchLatLonDegree("-10,10 -20,20", lat, lon), ());
+  TestAlmostEqual(lat, -10.1);
+  TestAlmostEqual(lon, -20.2);
+
   TEST(MatchLatLonDegree("-22.3534 -42.7076\n", lat, lon), ());
+  TestAlmostEqual(lat, -22.3534);
+  TestAlmostEqual(lon, -42.7076);
+
+  TEST(MatchLatLonDegree("-22,3534 -42,7076\n", lat, lon), ());
   TestAlmostEqual(lat, -22.3534);
   TestAlmostEqual(lon, -42.7076);
 


### PR DESCRIPTION
Found that when coordinates had both a comma separator and a negative the parsing would skip the input. 

Resolves: #7999