### PR TITLE
[android] Show error message when download fails due to internet connection

### DIFF
--- a/android/app/src/main/java/app/organicmaps/downloader/OnmapDownloader.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/OnmapDownloader.java
@@ -31,6 +31,7 @@ public class OnmapDownloader implements MwmActivity.LeftAnimationTrackListener
   private final TextView mParent;
   private final TextView mTitle;
   private final TextView mSize;
+  private final TextView mError;
   private final WheelProgressView mProgress;
   private final Button mButton;
 
@@ -51,6 +52,9 @@ public class OnmapDownloader implements MwmActivity.LeftAnimationTrackListener
       {
         if (!item.isLeafNode)
           continue;
+
+        if (mError.getVisibility() == View.VISIBLE)
+          mError.setVisibility(View.GONE);
 
         if (item.newStatus == CountryItem.STATUS_FAILED)
           MapManager.showError(mActivity, item, null);
@@ -172,6 +176,13 @@ public class OnmapDownloader implements MwmActivity.LeftAnimationTrackListener
               }
             }
 
+            if (!ConnectionState.INSTANCE.isConnected() &&
+                failed)
+            {
+              if (!(mError.getVisibility() == View.VISIBLE))
+                mError.setVisibility(View.VISIBLE);
+              mError.setText("Downloading failed, please check your internet connection");
+            }
             mButton.setText(failed ? R.string.downloader_retry
                                    : R.string.download);
           }
@@ -191,6 +202,7 @@ public class OnmapDownloader implements MwmActivity.LeftAnimationTrackListener
     mParent = mFrame.findViewById(R.id.downloader_parent);
     mTitle = mFrame.findViewById(R.id.downloader_title);
     mSize = mFrame.findViewById(R.id.downloader_size);
+    mError = mFrame.findViewById(R.id.downloader_error);
 
     View controls = mFrame.findViewById(R.id.downloader_controls_frame);
     mProgress = controls.findViewById(R.id.wheel_downloader_progress);
@@ -207,6 +219,9 @@ public class OnmapDownloader implements MwmActivity.LeftAnimationTrackListener
       mCurrentCountry.id, () -> {
       if (mCurrentCountry == null)
         return;
+
+      if (mError.getVisibility() == View.VISIBLE)
+        mError.setVisibility(View.GONE);
 
       boolean retry = (mCurrentCountry.status == CountryItem.STATUS_FAILED);
       if (retry)

--- a/android/app/src/main/res/layout/onmap_downloader.xml
+++ b/android/app/src/main/res/layout/onmap_downloader.xml
@@ -46,6 +46,16 @@
       android:textAppearance="@style/MwmTextAppearance.Body2"
       android:gravity="center_horizontal"
       tools:text="1000 MB"/>
+    <TextView
+      android:id="@+id/downloader_error"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="@dimen/margin_eighth"
+      android:textAppearance="@style/MwmTextAppearance.Body4"
+      android:gravity="center_horizontal"
+      android:visibility="gone"
+      android:textColor="@color/base_red"
+      tools:text="some error very loooooooooong error"/>
     <FrameLayout
       android:id="@+id/downloader_controls_frame"
       android:layout_width="180dp"


### PR DESCRIPTION
- Fixes issue #9828 
- Signed-off-by: DevarshVasani [vasanidevarsh@gmail.com](mailto:vasanidevarsh@gmail.com)

## Changes
- Added the `textview` in the `android/app/src/main/res/layout/onmap_downloader.xml` file to display an error message if the internet is not present.
- The visibility of the `textview` is controlled in the `android/app/src/main/java/app/organicmaps/downloader/OnmapDownloader.java` file.
- The `textview` will only be visible when users fail to download the map due to a lack of internet connection.

## Working Demo

https://github.com/user-attachments/assets/ad5f0beb-b6b4-4a9a-abe2-703e9250ffeb

