### PR TITLE
[bookmarks] Make bookmark's title depend on map language

### DIFF
--- a/map/bookmark_helpers.cpp
+++ b/map/bookmark_helpers.cpp
@@ -709,12 +709,14 @@ void SaveFeatureTypes(feature::TypesHolder const & types, kml::BookmarkData & bm
 
 std::string GetPreferredBookmarkStr(kml::LocalizableString const & name)
 {
-  return kml::GetPreferredBookmarkStr(name, languages::GetCurrentNorm());
+  auto const mapLanguageNorm = languages::Normalize(languages::GetCurrentMapLanguage());
+  return kml::GetPreferredBookmarkStr(name, mapLanguageNorm);
 }
 
 std::string GetPreferredBookmarkStr(kml::LocalizableString const & name, feature::RegionData const & regionData)
 {
-  return kml::GetPreferredBookmarkStr(name, regionData, languages::GetCurrentNorm());
+  auto const mapLanguageNorm = languages::Normalize(languages::GetCurrentMapLanguage());
+  return kml::GetPreferredBookmarkStr(name, regionData, mapLanguageNorm);
 }
 
 std::string GetLocalizedFeatureType(std::vector<uint32_t> const & types)
@@ -751,7 +753,7 @@ std::string GetLocalizedBookmarkBaseType(BookmarkBaseType type)
 
 std::string GetPreferredBookmarkName(kml::BookmarkData const & bmData)
 {
-  return kml::GetPreferredBookmarkName(bmData, languages::GetCurrentOrig());
+  return kml::GetPreferredBookmarkName(bmData, languages::GetCurrentMapLanguage());
 }
 
 void ExpandRectForPreview(m2::RectD & rect)


### PR DESCRIPTION
Fixes #10117 

The title for bookmarks without a custom name was being set based on the system's preferred language, rather than the configured map language. This behavior differed from non-bookmarked places, where the map language was used.

### On master branch
https://github.com/user-attachments/assets/71246dd6-cdd9-49b2-b0d4-b30a8370c774

### On this branch

https://github.com/user-attachments/assets/301770ad-1320-4f32-9efa-c5e5dd8ff27e


