### PR TITLE
[core] Allow for rotation when scale is max. 

### DIFF
--- a/drape_frontend/navigator.cpp
+++ b/drape_frontend/navigator.cpp
@@ -180,21 +180,6 @@ bool Navigator::ScaleImpl(m2::PointD const & newPt1, m2::PointD const & newPt2,
                                                       true);
   ScreenBase tmp = screen;
   tmp.SetGtoPMatrix(newM);
-  if (tmp.isPerspective())
-    tmp.MatchGandP3d(centerG, center3d);
-
-  if (!skipMinScaleAndBordersCheck && !CheckMinScale(tmp))
-    return false;
-
-  m2::RectD const & worldR = df::GetWorldRect();
-
-  if (!skipMinScaleAndBordersCheck && !CheckBorders(tmp))
-  {
-    if (CanShrinkInto(tmp, worldR))
-      tmp = ShrinkInto(tmp, worldR);
-    else
-      return false;     
-  }
 
   if (!CheckMaxScale(tmp))
   {
@@ -213,6 +198,21 @@ bool Navigator::ScaleImpl(m2::PointD const & newPt1, m2::PointD const & newPt2,
   }
   }
 
+  if (tmp.isPerspective())
+    tmp.MatchGandP3d(centerG, center3d);
+
+  if (!skipMinScaleAndBordersCheck && !CheckMinScale(tmp))
+    return false;
+
+  m2::RectD const & worldR = df::GetWorldRect();
+
+  if (!skipMinScaleAndBordersCheck && !CheckBorders(tmp))
+  {
+    if (CanShrinkInto(tmp, worldR))
+      tmp = ShrinkInto(tmp, worldR);
+    else
+      return false;     
+  }
 
   // re-checking the borders, as we might violate them a bit (don't know why).
   if (!CheckBorders(tmp))

--- a/drape_frontend/navigator.cpp
+++ b/drape_frontend/navigator.cpp
@@ -211,7 +211,7 @@ bool Navigator::ScaleImpl(m2::PointD const & newPt1, m2::PointD const & newPt2,
     if (CanShrinkInto(tmp, worldR))
       tmp = ShrinkInto(tmp, worldR);
     else
-      return false;     
+      return false;
   }
 
   // re-checking the borders, as we might violate them a bit (don't know why).

--- a/drape_frontend/navigator.cpp
+++ b/drape_frontend/navigator.cpp
@@ -176,7 +176,8 @@ bool Navigator::ScaleImpl(m2::PointD const & newPt1, m2::PointD const & newPt2,
   math::Matrix<double, 3, 3> const newM =
       screen.GtoPMatrix() * ScreenBase::CalcTransform(oldPt1 + offset, oldPt2 + offset,
                                                       newPt1 + offset, newPt2 + offset,
-                                                      doRotateScreen);
+                                                      doRotateScreen,
+                                                      true);
   ScreenBase tmp = screen;
   tmp.SetGtoPMatrix(newM);
   if (tmp.isPerspective())
@@ -196,7 +197,19 @@ bool Navigator::ScaleImpl(m2::PointD const & newPt1, m2::PointD const & newPt2,
   }
 
   if (!CheckMaxScale(tmp))
+  {
+    if (doRotateScreen){
+      math::Matrix<double, 3, 3> const tmpM =
+        screen.GtoPMatrix() * ScreenBase::CalcTransform(oldPt1 + offset, oldPt2 + offset,
+                                                        newPt1 + offset, newPt2 + offset,
+                                                        doRotateScreen,
+                                                        false);
+      tmp.SetGtoPMatrix(tmpM);
+    }
+    else
     return false;
+  }
+
 
   // re-checking the borders, as we might violate them a bit (don't know why).
   if (!CheckBorders(tmp))

--- a/drape_frontend/navigator.cpp
+++ b/drape_frontend/navigator.cpp
@@ -193,12 +193,13 @@ bool Navigator::ScaleImpl(m2::PointD const & newPt1, m2::PointD const & newPt2,
     if (CanShrinkInto(tmp, worldR))
       tmp = ShrinkInto(tmp, worldR);
     else
-      return false;
+      return false;     
   }
 
   if (!CheckMaxScale(tmp))
   {
-    if (doRotateScreen){
+    if (doRotateScreen)
+    {
       math::Matrix<double, 3, 3> const tmpM =
         screen.GtoPMatrix() * ScreenBase::CalcTransform(oldPt1 + offset, oldPt2 + offset,
                                                         newPt1 + offset, newPt2 + offset,
@@ -207,7 +208,9 @@ bool Navigator::ScaleImpl(m2::PointD const & newPt1, m2::PointD const & newPt2,
       tmp.SetGtoPMatrix(tmpM);
     }
     else
+    {
     return false;
+  }
   }
 
 

--- a/drape_frontend/navigator.cpp
+++ b/drape_frontend/navigator.cpp
@@ -194,8 +194,8 @@ bool Navigator::ScaleImpl(m2::PointD const & newPt1, m2::PointD const & newPt2,
     }
     else
     {
-    return false;
-  }
+      return false;
+    }
   }
 
   if (tmp.isPerspective())

--- a/geometry/geometry_tests/screen_test.cpp
+++ b/geometry/geometry_tests/screen_test.cpp
@@ -151,7 +151,8 @@ UNIT_TEST(ScreenBase_CalcTransform)
                                           m2::PointD(0, 1), m2::PointD(1, 1),
                                           m2::PointD(             s * sin(a) + dx,               s * cos(a) + dy),
                                           m2::PointD(s * cos(a) + s * sin(a) + dx, -s * sin(a) + s * cos(a) + dy),
-                                          true /* allow rotate */);
+                                          true /* allow rotate */,
+                                          true /* allow scale*/);
 
   ScreenBase::ExtractGtoPParams(m, a1, s1, dx1, dy1);
 

--- a/geometry/screenbase.cpp
+++ b/geometry/screenbase.cpp
@@ -225,9 +225,12 @@ int ScreenBase::GetHeight() const { return base::SignedRound(m_PixelRect.SizeY()
 ScreenBase::MatrixT const ScreenBase::CalcTransform(m2::PointD const & oldPt1,
                                                     m2::PointD const & oldPt2,
                                                     m2::PointD const & newPt1,
-                                                    m2::PointD const & newPt2, bool allowRotate)
+                                                    m2::PointD const & newPt2, 
+                                                    bool allowRotate,
+                                                    bool allowScale)
 {
-  double const s = newPt1.Length(newPt2) / oldPt1.Length(oldPt2);
+  
+  double const s = allowScale ? newPt1.Length(newPt2) / oldPt1.Length(oldPt2) : 1.0;
   double const a = allowRotate ? ang::AngleTo(newPt1, newPt2) - ang::AngleTo(oldPt1, oldPt2) : 0.0;
 
   MatrixT m = math::Shift(

--- a/geometry/screenbase.hpp
+++ b/geometry/screenbase.hpp
@@ -124,7 +124,7 @@ public:
   /// newPt2)
   static MatrixT const CalcTransform(m2::PointD const & oldPt1, m2::PointD const & oldPt2,
                                      m2::PointD const & newPt1, m2::PointD const & newPt2,
-                                     bool allowRotate);
+                                     bool allowRotate, bool allowScale);
 
   /// Setting GtoP matrix extracts the Angle and m_Org parameters, leaving PixelRect intact
   void SetGtoPMatrix(MatrixT const & m);


### PR DESCRIPTION
Found that when zoomed all the way in the `CheckMaxScale` if condition would discard the `tmp` screen so that then we will no rotate the screen at all. 
Added a new matrix transformation to keep the rotation but discard the scale in this case.