### PR TITLE
Revert "[ios] Use today's commits count and two numbers from commit hash in the build number"

### DIFF
--- a/tools/unix/version.sh
+++ b/tools/unix/version.sh
@@ -31,9 +31,7 @@ function ios_version {
 }
 
 function ios_build {
-  MINOR=$((16#${GIT_HASH:0:4}))
-  PATCH=$((16#${GIT_HASH:4:4}))
-  echo "$COUNT.$MINOR.$PATCH"
+  echo "$COUNT"
 }
 
 function  android_name {


### PR DESCRIPTION
This reverts commit ee36eb8d125c9a4535964e2b50642a66b74aca9b. That patch was a bit controversial from the start, and I had my doubts. @vng and @pastk aren’t buying it at all.

