### PR TITLE
[github] Drop appstream-glib in favor of appstream cli

### DIFF
--- a/.github/workflows/appstream-check.yaml
+++ b/.github/workflows/appstream-check.yaml
@@ -25,11 +25,7 @@ jobs:
           sudo apt install -y \
               flatpak
           sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          sudo flatpak install -y org.freedesktop.appstream-glib org.flatpak.Builder
-
-      - name: Validate appstream data
-        shell: bash
-        run: flatpak run org.freedesktop.appstream-glib validate --nonet packaging/app.organicmaps.desktop.metainfo.xml
+          sudo flatpak install -y org.flatpak.Builder
 
       - name: Lint appstream data with flatpak Builder
         shell: bash


### PR DESCRIPTION
As the warning says in the [README](
https://github.com/hughsie/appstream-glib/blob/3bbf7e94243de5a2c4e0838c751dda1c4063d437/README.md?plain=1#L1) `appstream-glib` has been in maintenance mode for 2 years, apparently the flatpak runtimes are also not updated anymore. Their own recommendation is to use appstream cli,
that our CI already uses, so there is less and less benefit for keeping it in the CI.