### PR TITLE
[ios] fix layers menu bug

### DIFF
--- a/iphone/Maps/UI/BottomMenu/Menu/BottomMenuViewController.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/BottomMenuViewController.swift
@@ -43,6 +43,7 @@ class BottomMenuViewController: MWMViewController {
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
+    tableView.setNeedsLayout()
     tableView.layoutIfNeeded()
     heightConstraint.constant = min(tableView.contentSize.height, view.height)
     tableView.isScrollEnabled = tableView.contentSize.height > heightConstraint.constant;

--- a/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuLayersCell.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuLayersCell.swift
@@ -25,8 +25,15 @@ class BottomMenuLayersCell: UITableViewCell {
     super.awakeFromNib()
     MapOverlayManager.add(self)
     closeButton.setImage(UIImage(named: "ic_close"))
+    setupButtons()
   }
-  
+
+  private func setupButtons() {
+    outdoorButton.setupWith(image: UIImage(resource: .btnMenuOutdoors), text: L("button_layer_outdoor"))
+    isoLinesButton.setupWith(image: UIImage(resource: .btnMenuIsomaps), text: L("button_layer_isolines"))
+    subwayButton.setupWith(image: UIImage(resource: .btnMenuSubway), text: L("button_layer_subway"))
+  }
+
   deinit {
     MapOverlayManager.remove(self)
   }
@@ -87,5 +94,14 @@ extension BottomMenuLayersCell: MapOverlayManagerObserver {
 private extension BottomMenuLayersCell {
   func styleFor(_ enabled: Bool) -> MapStyleSheet {
     enabled ? .mapMenuButtonEnabled : .mapMenuButtonDisabled
+  }
+}
+
+private extension BottomMenuLayerButton {
+  func setupWith(image: UIImage, text: String) {
+    self.image = image
+    spacing = 10
+    numberOfLines = 2
+    localizedText = text
   }
 }

--- a/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuLayersCell.xib
+++ b/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuLayersCell.xib
@@ -83,16 +83,6 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g13-pK-Eig" userLabel="Outdoor Button" customClass="BottomMenuLayerButton" customModule="Organic_Maps" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="102.5" height="64"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="image" keyPath="image" value="btn_menu_outdoors"/>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="spacing">
-                                        <real key="value" value="10"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="numberOfLines">
-                                        <integer key="value" value="2"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="button_layer_outdoor"/>
-                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="onOutdoorButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="UQ2-jj-fPc"/>
                                 </connections>
@@ -100,16 +90,6 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="edA-Mo-3Vx" customClass="BottomMenuLayerButton" customModule="Organic_Maps" customModuleProvider="target">
                                 <rect key="frame" x="102.5" y="0.0" width="103" height="64"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="image" keyPath="image" value="btn_menu_isomaps"/>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="spacing">
-                                        <real key="value" value="10"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="numberOfLines">
-                                        <integer key="value" value="2"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="button_layer_isolines"/>
-                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="onIsoLinesButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="3LS-C2-2Mc"/>
                                 </connections>
@@ -117,16 +97,6 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4US-fZ-cyg" customClass="BottomMenuLayerButton" customModule="Organic_Maps" customModuleProvider="target">
                                 <rect key="frame" x="205.5" y="0.0" width="102.5" height="64"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="image" keyPath="image" value="btn_menu_subway"/>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="spacing">
-                                        <real key="value" value="10"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="numberOfLines">
-                                        <integer key="value" value="2"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="button_layer_subway"/>
-                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="onSubwayButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="xxM-kP-gT1"/>
                                 </connections>
@@ -178,9 +148,4 @@
             <point key="canvasLocation" x="137.6953125" y="201.953125"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <image name="btn_menu_isomaps" width="151" height="151"/>
-        <image name="btn_menu_outdoors" width="151" height="151"/>
-        <image name="btn_menu_subway" width="151" height="151"/>
-    </resources>
 </document>


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/10143

On some ios versions the `tableView.layoutIfNeeded()` is called but the view isn't marked as it should be re-layouted. This bug is found on the iPhone Xs Max 18.2.

Also, this PR contains a small `BottomMenuLayerButton` refactoring.

![Simulator Screen Recording - iPhone Xs Max - 2025-01-29 at 14 16 41](https://github.com/user-attachments/assets/8eb4a53f-0462-44c6-a75f-d3d217deabea)
