### PR TITLE
[strings] fix typo in Japanese

### DIFF
--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -33480,7 +33480,7 @@
     hu = Útvonal rögzítése
     id = Merekam jalur
     it = Registra percorso
-    ja = トラックを録音する
+    ja = トラックを記録する
     ko = 트랙 녹음
     lt = Įrašyti maršrutą
     mr = ट्रॅक रेकॉर्ड करा


### PR DESCRIPTION
In Japanese, we use the word "録音" when we record sound. (sound is "音".)
"track" is not sound, so "記録" should be used here.