### PR TITLE
[Strings] Renamed "world map" to  "world overview map" for better user clarity

### DIFF
--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -52,7 +52,7 @@
     <string name="disconnect_usb_cable">Bitte USB-Kabel entfernen oder Speicherkarte einsetzen, um Organic Maps zu verwenden</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="not_enough_free_space_on_sdcard">Bitte zuerst Speicherplatz auf SD-Karte/USB-Speicher freigeben, um die Anwendung zu nutzen</string>
-    <string name="download_resources">Bevor Sie starten, laden Sie die allgemeine Weltkarte auf Ihr Gerät herunter.
+    <string name="download_resources">Bevor Sie die App verwenden, laden Sie bitte die weltweite Übersichtskarte herunter.
 \nEs werden %s Speicherplatz benötigt.</string>
     <string name="download_resources_continue">Zur Karte</string>
     <string name="downloading_country_can_proceed">%s wird heruntergeladen. Sie können jetzt
@@ -779,7 +779,7 @@
     <string name="elevation_profile_time">Dauer:</string>
     <string name="isolines_toast_zooms_1_10">Karte vergrößern, um Höhelinien sichtbar zu machen</string>
     <string name="downloader_loading_ios">Herunterladen</string>
-    <string name="download_map_title">Herunterladen der Weltkarte</string>
+    <string name="download_map_title">Laden Sie die weltweite Übersichtskarte herunter</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="disk_error">Ordner kann nicht erstellt und Dateien können nicht auf den Gerätespeicher oder die SD-Karte verschoben werden</string>
     <!-- Used in DownloadResources startup screen -->

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -777,7 +777,7 @@
     <string name="elevation_profile_time">Tiempo:</string>
     <string name="isolines_toast_zooms_1_10">Amplíe el mapa para ver las isolíneas</string>
     <string name="downloader_loading_ios">Descargando</string>
-    <string name="download_map_title">Descarga el mapa mundial</string>
+    <string name="download_map_title">Descarga el mapa mundial de previsualización</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="disk_error">No se ha podido crear la carpeta y mover los ficheros en la memoria interna del dispositivo o en la tarjeta SD</string>
     <!-- Used in DownloadResources startup screen -->

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -777,7 +777,7 @@
     <string name="elevation_profile_time">Denbora:</string>
     <string name="isolines_toast_zooms_1_10">Handitu mapa sestra kurbak ikusteko</string>
     <string name="downloader_loading_ios">Deskargatzen</string>
-    <string name="download_map_title">Deskargatu munduko mapa</string>
+    <string name="download_map_title">Deskargatu munduko aurrebista mapa</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="disk_error">Ezin da karpeta sortu eta fitxategiak mugitu barneko gailuaren memorian edo sd txartelan</string>
     <!-- Used in DownloadResources startup screen -->

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -784,7 +784,7 @@
     <string name="elevation_profile_time">Temps :</string>
     <string name="isolines_toast_zooms_1_10">Zoomez pour voir les courbes de niveaux</string>
     <string name="downloader_loading_ios">Téléchargement</string>
-    <string name="download_map_title">Télécharger la carte du monde</string>
+    <string name="download_map_title">Télécharger la carte générale du monde</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="disk_error">Impossible de créer un dossier et de déplacer les fichiers vers la mémoire interne de l\'appareil ou la carte SD</string>
     <!-- Used in DownloadResources startup screen -->

--- a/android/app/src/main/res/values-lv/strings.xml
+++ b/android/app/src/main/res/values-lv/strings.xml
@@ -52,8 +52,8 @@
     <string name="disconnect_usb_cable">Lai lietotu „Organic Maps“, atvienojiet USB kabeli vai ievietojiet atmiņas karti.</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="not_enough_free_space_on_sdcard">Lietotnes izmantošanai atbrīvojiet vietu ierīces krātuvē</string>
-    <string name="download_resources">Pirms lietotnes izmantošanas lejupielādējiet kopējo pasaules karti.
-\nTā ierīce krātuvē aizņems %s vietas.</string>
+    <string name="download_resources">Pirms sākt izmantot lietotni lejupielādējiet pasaules pārskata karti.
+\nTā ierīces krātuvē aizņems %s vietas.</string>
     <string name="download_resources_continue">Iet uz karti</string>
     <string name="downloading_country_can_proceed">Lejupielādē „%s“. Tagad varat
 \niet uz karti.</string>
@@ -779,7 +779,7 @@
     <string name="elevation_profile_time">Laiks:</string>
     <string name="isolines_toast_zooms_1_10">Pietuviniet, lai izpētītu izolīnijas</string>
     <string name="downloader_loading_ios">Lejupielādē</string>
-    <string name="download_map_title">Lejupielādēt pasaules karti</string>
+    <string name="download_map_title">Lejupielādēt pasaules pārskata karti</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="disk_error">Neizdevās izveidot mapi un pārvietot datnes iekšējā atmiņā vai SD kartē</string>
     <!-- Used in DownloadResources startup screen -->
@@ -802,7 +802,7 @@
     <!-- App tip #01 -->
     <string name="app_tip_01">Ar jūsu ziedojumiem un atbalstu varam izveidot pasaulē labākās kartes!</string>
     <!-- App tip #02 -->
-    <string name="app_tip_02">lv = Vai jums patīk mūsu lietotne? Lūdzam ziedot tās attīstībai! Varbūt tā nepatīk? Tādā gadījumā lūdzam mums pastāstīt, kas tajā nepatīk, lai varam „Organic Maps“ uzlabot!</string>
+    <string name="app_tip_02">Vai jums patīk mūsu lietotne? Lūdzam ziedot tās attīstībai! Varbūt tā nepatīk? Tādā gadījumā lūdzam mums pastāstīt, kas tajā nepatīk, lai varam „Organic Maps“ uzlabot!</string>
     <!-- App tip #03 -->
     <string name="app_tip_03">Ja pazīstat kādu programmatūras izstrādātāju, varat viņam vai viņai palūgt ieviest funkciju, kas jums pietrūkst.</string>
     <!-- App tip #05 -->

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -48,8 +48,8 @@
     <string name="disconnect_usb_cable">Por favor desconecte o cabo USB ou insira um cartão de memória para utilizar o Organic Maps</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="not_enough_free_space_on_sdcard">Por favor libere primeiro algum espaço no cartão SD/armazenamento USB para utilizar o app</string>
-    <string name="download_resources">Antes de começar, vamos baixar um mapa mundial geral para o seu dispositivo.
-\n%s de memória serão utilizados.</string>
+    <string name="download_resources">Antes de começar, vamos baixar a visão geral mundial para o seu dispositivo.
+\nÉ necessário %s de armazenamento.</string>
     <string name="download_resources_continue">Ir para o mapa</string>
     <string name="downloading_country_can_proceed">Baixando %s. Você pode
 \ncontinuar para o mapa agora.</string>
@@ -698,7 +698,7 @@
     <string name="elevation_profile_time">Tempo:</string>
     <string name="isolines_toast_zooms_1_10">Use o zoom para explorar as isolinhas</string>
     <string name="downloader_loading_ios">Baixando</string>
-    <string name="download_map_title">Baixar mapa mundial</string>
+    <string name="download_map_title">Baixar a visão geral mundial</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="disk_error">Não foi possível criar a pasta e mover os arquivos à memória interna ou sdcard do dispositivo</string>
     <!-- Used in DownloadResources startup screen -->

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -52,7 +52,7 @@
     <string name="disconnect_usb_cable">Por favor desligue o cabo USB ou introduza um cartão de memória para utilizar o Organic Maps</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="not_enough_free_space_on_sdcard">Por favor liberte primeiro algum espaço no cartão SD ou armazenamento USB para utilizar a aplicação</string>
-    <string name="download_resources">Antes de começar, é recomendável descarregar o mapa mundial geral para o seu dispositivo.
+    <string name="download_resources">Antes de começar, é recomendável descarregar a visão geral mundial para o seu dispositivo.
 \nÉ necessário %s de espaço disponível.</string>
     <string name="download_resources_continue">Ir ao mapa</string>
     <string name="downloading_country_can_proceed">A descarregar %s. Agora pode
@@ -755,7 +755,7 @@
     <string name="elevation_profile_time">Tempo:</string>
     <string name="isolines_toast_zooms_1_10">Amplie o mapa para ver as curvas de nível</string>
     <string name="downloader_loading_ios">A descarregar</string>
-    <string name="download_map_title">Descarregar o mapa mundial</string>
+    <string name="download_map_title">Descarregar a visão geral mundial</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="connection_failure">Falha na coneção</string>
     <string name="enable_keep_screen_on">Mantém o ecrã ligado</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -55,8 +55,8 @@
     <string name="disconnect_usb_cable">Отключите USB кабель или вставьте SD-карту</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="not_enough_free_space_on_sdcard">Недостаточно свободного места на SD карте/в памяти устройства для использования программы</string>
-    <string name="download_resources">Перед началом работы разрешите нам загрузить общую карту мира на ваше устройство.
-\nЭто потребует %s данных.</string>
+    <string name="download_resources">Для начала работы скачайте, пожалуйста, обзорную карту мира на ваше устройство.
+\nПотребуется %s данных.</string>
     <string name="download_resources_continue">Перейти на карту</string>
     <string name="downloading_country_can_proceed">Пока загружается %s,
 \nвы можете пользоваться картой.</string>
@@ -791,7 +791,7 @@
     <string name="elevation_profile_time">В пути:</string>
     <string name="isolines_toast_zooms_1_10">Увеличьте карту, чтобы увидеть изолинии</string>
     <string name="downloader_loading_ios">Загрузка</string>
-    <string name="download_map_title">Скачать карту мира</string>
+    <string name="download_map_title">Скачать обзорную карту мира</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="disk_error">Не могу создать папку и переместить файлы на устройстве</string>
     <!-- Used in DownloadResources startup screen -->

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -55,7 +55,7 @@
     <string name="disconnect_usb_cable">Please disconnect USB cable or insert memory card to use Organic Maps</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="not_enough_free_space_on_sdcard">Please free up some space on the SD card/USB storage first in order to use the app</string>
-    <string name="download_resources">Before you start using the app, please download the general world map to your device.
+    <string name="download_resources">Before you start using the app, please download the world overview map to your device.
 \nIt will use %s of storage.</string>
     <string name="download_resources_continue">Go to Map</string>
     <string name="downloading_country_can_proceed">Downloading %s. You can now
@@ -810,7 +810,7 @@
     <string name="elevation_profile_time">Time:</string>
     <string name="isolines_toast_zooms_1_10">Zoom in to explore isolines</string>
     <string name="downloader_loading_ios">Downloading</string>
-    <string name="download_map_title">Download the world map</string>
+    <string name="download_map_title">Download the world overview map</string>
     <!-- Used in DownloadResources startup screen -->
     <string name="disk_error">Unable to create folder and move files on internal device\'s memory or sdcard</string>
     <!-- Used in DownloadResources startup screen -->

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -29991,7 +29991,7 @@
     nl = Download de wereldkaart
     pl = Pobierz mapę świata
     pt = Descarregar a visão geral mundial
-	pt-BR = Baixar a visão geral mundial
+    pt-BR = Baixar a visão geral mundial
     ro = Descarcă harta lumii
     ru = Скачать обзорную карту мира
     sk = Stiahnuť mapu sveta

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -1571,7 +1571,7 @@
 
   [download_resources]
     tags = android
-    en = Before you start using the app, please download the general world map to your device.\nIt will use %@ of storage.
+    en = Before you start using the app, please download the world overview map to your device.\nIt will use %@ of storage.
     af = Voordat u die toep begin gebruik, moet u asb. die algemene wêreldkaart na u toestel aflaai.\nDit sal %@ se spasie opneem.
     ar = قبل أن تبدأ باستخدام التطبيق، سنقوم بتنزيل خريطة العالم العامة على جهازك.\nستحتاج إلى %@ من البيانات.
     az = Başlamazdan əvvəl gəlin ümumi dünya xəritəsini cihazınıza endirək.\n%@ yer tələb olunur.
@@ -1580,7 +1580,7 @@
     ca = Abans d’usar l’aplicació, autoritzeu que baixem el mapa del món general al vostre aparell.\nUsarà %@ d’emmagatzematge.
     cs = Ještě než začnete, bude třeba stáhnout obecnou mapu světa.\nZabere to %@.
     da = Før du starter, så lad os downloade det generelle verdenskort til din enhed.\nIt behøver %@ af data.
-    de = Bevor Sie starten, laden Sie die allgemeine Weltkarte auf Ihr Gerät herunter.\nEs werden %@ Speicherplatz benötigt.
+    de = Bevor Sie die App verwenden, laden Sie bitte die weltweite Übersichtskarte herunter.\nEs werden %@ Speicherplatz benötigt.
     el = Πριν ξεκινήσετε τη χρήση της εφαρμογής, επιτρέψτε μας να κατεβάσουμε το γενικό παγκόσμιο χάρτη στη συσκευή σας.\nΘα χρησιμοποιήσει %@ αποθηκευτικού χώρου.
     es = Antes de comenzar, permita que descarguemos en su dispositivo un mapamundi general.\nSe requieren %@ de almacenamiento.
     et = Ennem rakenduse kasutamise alustamist luba meil laadida seadmesse alla maailma üldkaart.\nSee kasutab %@ mälumahtu.
@@ -1596,16 +1596,16 @@
     ja = 利用を開始する前におおまかな世界地図をダウンロードします。これには%@の空き容量が必要です。
     ko = 시작하시기 전에 일반 세계 지도를 귀하의 장치로 다운로드하겠습니다.\n%@ 데이터가 필요합니다.
     lt = Leiskite mums atsisiųsti bendrąjį pasaulio žemėlapį į jūsų įrenginį prieš pradėdami naudotis programėle.\nTai užims %@ saugyklos.
-    lv = Pirms lietotnes izmantošanas lejupielādējiet kopējo pasaules karti.\nTā ierīce krātuvē aizņems %@ vietas.
+    lv = Pirms sākt izmantot lietotni lejupielādējiet pasaules pārskata karti.\nTā ierīces krātuvē aizņems %@ vietas.
     mr = ऍपचा वापर सुरू करण्यापूर्वी, आम्हाला तुमच्या उपकरणावर जगाचा सामान्य नकाशा डाउनलोड करण्याची परवानगी द्या.\nते %@ जागा वापरेल.
     mt = Qabel ma tibda tuża l-applikazzjoni, niżżel il-mappa ġenerali tad-dinja fuq l-apparat. \nDan ser juża %@ ta' storage.
     nb = Før du begynner, la oss laste ned det generelle verdenskartet til enheten. Det trengs %@ med data.
     nl = Voordat u start, laten we de algemene wereldkaart naar uw apparaat downloaden.\nDeze neemt %@ in beslag.
     pl = Przed rozpoczęciem prosimy o pobranie ogólnej mapy świata na urządzenie.\nWymaga to %@ danych.
-    pt = Antes de começar, é recomendável descarregar o mapa mundial geral para o seu dispositivo.\nÉ necessário %@ de espaço disponível.
-    pt-BR = Antes de começar, vamos baixar um mapa mundial geral para o seu dispositivo.\n%@ de memória serão utilizados.
+    pt = Antes de começar, é recomendável descarregar a visão geral mundial para o seu dispositivo.\nÉ necessário %@ de espaço disponível.
+    pt-BR = Antes de começar, vamos baixar a visão geral mundial para o seu dispositivo.\nÉ necessário %@ de armazenamento.
     ro = Înainte de a începe, trebuie descărcată harta generală a lumii în dispozitivul tău.\nSe vor descărca %@.
-    ru = Перед началом работы разрешите нам загрузить общую карту мира на ваше устройство.\nЭто потребует %@ данных.
+    ru = Для начала работы скачайте, пожалуйста, обзорную карту мира на ваше устройство.\nПотребуется %@ данных.
     sk = Skôr ako začnete, bude treba stiahnuť základnú mapu sveta.\nZaberie to %@.
     sr = Пре него што почнете да користите апликацију, прво преузмите на ваш уређај општу мапу света.\nЗа то ће бити потребно %@ меморије.
     sv = Innan du startar, låt oss ladda ner den allmäna världskartan på din enhet.\nDen behöver %@ data.
@@ -29965,7 +29965,7 @@
 
   [download_map_title]
     tags = android
-    en = Download the world map
+    en = Download the world overview map
     af = Laai die wêreldkaart af
     ar = تنزيل خريطة العالم
     az = Dünya xəritəsini yükləyin
@@ -29973,27 +29973,27 @@
     bg = Изтегляне на картата на света
     ca = Baixa el mapa mundial
     cs = Stáhnout mapu světa
-    de = Herunterladen der Weltkarte
+    de = Laden Sie die weltweite Übersichtskarte herunter
     el = Κατέβασμα παγκόσμιου χάρτη
-    es = Descarga el mapa mundial
+    es = Descarga el mapa mundial de previsualización
     et = Maailma kaardi allalaadimine
-    eu = Deskargatu munduko mapa
+    eu = Deskargatu munduko aurrebista mapa
     fi = Lataa maailmankartta
-    fr = Télécharger la carte du monde
+    fr = Télécharger la carte générale du monde
     he = הורד את מפת העולם
     hi = विश्व मानचित्र डाउनलोड करें
     it = Scarica la mappa del mondo
     ja = 世界地図をダウンロード
     lt = Atsisiųsti pasaulio žemėlapį
-    lv = Lejupielādēt pasaules karti
+    lv = Lejupielādēt pasaules pārskata karti
     mr = जगाचा नकाशा डाउनलोड करा
     nb = Last ned verdenskart
     nl = Download de wereldkaart
     pl = Pobierz mapę świata
-    pt = Descarregar o mapa mundial
-    pt-BR = Baixar mapa mundial
+    pt = Descarregar a visão geral mundial
+	pt-BR = Baixar a visão geral mundial
     ro = Descarcă harta lumii
-    ru = Скачать карту мира
+    ru = Скачать обзорную карту мира
     sk = Stiahnuť mapu sveta
     sr = Преузми мапу света
     tr = Dünya haritasını indir
@@ -30992,7 +30992,7 @@
     it = Ti piace la nostra app? Si prega di donare per sostenere lo sviluppo! Non ti piace ancora? Fatecelo sapere e risolveremo il problema!
     ja = 私たちのアプリは気に入っていますか? 開発をサポートするために寄付をお願いします！ まだ気に入らないですか？ お知らせください。修正させていただきます。
     ko = 우리 앱이 마음에 드시나요? 발전을 위해 기부해주세요! 아직 마음에 들지 않으세요? 알려주시면 수정하겠습니다!
-    lv = lv = Vai jums patīk mūsu lietotne? Lūdzam ziedot tās attīstībai! Varbūt tā nepatīk? Tādā gadījumā lūdzam mums pastāstīt, kas tajā nepatīk, lai varam „Organic Maps“ uzlabot!
+    lv = Vai jums patīk mūsu lietotne? Lūdzam ziedot tās attīstībai! Varbūt tā nepatīk? Tādā gadījumā lūdzam mums pastāstīt, kas tajā nepatīk, lai varam „Organic Maps“ uzlabot!
     mr = तुम्हाला आमचे अॅप आवडते का? कृपया विकासाला पाठिंबा देण्यासाठी देणगी द्या! अजून आवडत नाही? कृपया आम्हाला कळवा आणि आम्ही त्याचे निराकरण करू!
     nb = Liker du appen vår? Vennligst doner for å støtte utviklingen! Liker du det ikke ennå? Gi oss beskjed, så fikser vi det!
     nl = Vind je onze app leuk? Doneer alsjeblieft om de ontwikkeling te ondersteunen! Vind je het nog niet leuk? Laat het ons weten, dan lossen we het op!

--- a/iphone/Maps/LocalizedStrings/lv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/lv.lproj/Localizable.strings
@@ -1288,7 +1288,7 @@
 "app_tip_01" = "Ar jūsu ziedojumiem un atbalstu varam izveidot pasaulē labākās kartes!";
 
 /* App tip #02 */
-"app_tip_02" = "lv = Vai jums patīk mūsu lietotne? Lūdzam ziedot tās attīstībai! Varbūt tā nepatīk? Tādā gadījumā lūdzam mums pastāstīt, kas tajā nepatīk, lai varam „Organic Maps“ uzlabot!";
+"app_tip_02" = "Vai jums patīk mūsu lietotne? Lūdzam ziedot tās attīstībai! Varbūt tā nepatīk? Tādā gadījumā lūdzam mums pastāstīt, kas tajā nepatīk, lai varam „Organic Maps“ uzlabot!";
 
 /* App tip #03 */
 "app_tip_03" = "Ja pazīstat kādu programmatūras izstrādātāju, varat viņam vai viņai palūgt ieviest funkciju, kas jums pietrūkst.";


### PR DESCRIPTION
Fixes #9334 


Strings changed : 

1.  Before : `Download the world map`
     After: `Download the world overview`

2. Before : `Before you start using the app, please download the general world map to your device.`
    After: `Before you start using the app, please download the general world overview to your device.`


"world overview" seems to be more adequate avoiding confusion, feel free to share better alternatives 


- Updated corresponding translations using DeepL API as mentioned in [Translations.md](https://github.com/organicmaps/organicmaps/blob/master/docs/TRANSLATIONS.md) 
- The Updated translated string seems to cause error when running `tools/unix/generate_localizations.sh` , for the languages `fa` &  `zh-Hant` , so i reverted these strings to original version
- Regenerated localizations with `tools/unix/generate_localizations.sh`
