### PR TITLE
[android][l18n] fix localization of percentages in text

### DIFF
--- a/android/app/src/main/java/app/organicmaps/car/screens/download/DownloaderScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/download/DownloaderScreen.java
@@ -150,12 +150,11 @@ class DownloaderScreen extends BaseScreen
       return getCarContext().getString(R.string.downloader_loading_ios);
 
     final long downloadedSize = getDownloadedSize();
-    final float progress = (float) downloadedSize / mTotalSize * 100;
+    final String progressPercent = StringUtils.formatPercent((double) downloadedSize / mTotalSize);
     final String totalSizeStr = StringUtils.getFileSizeString(getCarContext(), mTotalSize);
     final String downloadedSizeStr = StringUtils.getFileSizeString(getCarContext(), downloadedSize);
 
-    return StringUtils.formatUsingSystemLocale("%.2f%%\n%s",
-        progress, downloadedSizeStr + " / " + totalSizeStr);
+    return progressPercent + "\n" + downloadedSizeStr + " / " + totalSizeStr;
   }
 
   private long getDownloadedSize()

--- a/android/app/src/main/java/app/organicmaps/downloader/CountryItem.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/CountryItem.java
@@ -63,7 +63,9 @@ public final class CountryItem implements Comparable<CountryItem>
   public int errorCode;
   public boolean present;
 
-  // Progress
+  /**
+   * This value represents the percentage of download (values span from 0 to 100)
+   */
   public float progress;
   public long downloadedBytes;
   public long bytesToDownload;

--- a/android/app/src/main/java/app/organicmaps/downloader/CountrySuggestFragment.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/CountrySuggestFragment.java
@@ -192,8 +192,7 @@ public class CountrySuggestFragment extends BaseMwmFragment implements View.OnCl
 
   private void updateProgress()
   {
-    String text = StringUtils.formatUsingSystemLocale("%1$s %2$.2f%%", getString(R.string.downloader_downloading),
-      mDownloadingCountry.progress);
+    String text = getString(R.string.downloader_downloading) + " " + StringUtils.formatPercent(mDownloadingCountry.progress / 100);
     mTvProgress.setText(text);
     mWpvDownloadProgress.setProgress(Math.round(mDownloadingCountry.progress));
   }

--- a/android/app/src/main/java/app/organicmaps/downloader/OnmapDownloader.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/OnmapDownloader.java
@@ -140,8 +140,7 @@ public class OnmapDownloader implements MwmActivity.LeftAnimationTrackListener
         {
           mProgress.setPending(false);
           mProgress.setProgress(Math.round(mCurrentCountry.progress));
-          sizeText = StringUtils.formatUsingSystemLocale("%1$s %2$.2f%%",
-              mActivity.getString(R.string.downloader_downloading), mCurrentCountry.progress);
+          sizeText = mActivity.getString(R.string.downloader_downloading) + " " + StringUtils.formatPercent(mCurrentCountry.progress / 100);
         }
         else
         {

--- a/android/app/src/main/java/app/organicmaps/util/StringUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/StringUtils.java
@@ -10,6 +10,7 @@ import androidx.annotation.NonNull;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
 
+import java.text.NumberFormat;
 import java.util.Locale;
 
 public class StringUtils
@@ -22,6 +23,25 @@ public class StringUtils
   public static String formatUsingSystemLocale(String pattern, Object... args)
   {
     return String.format(Locale.getDefault(), pattern, args);
+  }
+
+  /**
+   * This method returns correct string representation of % (percent number) for different locales
+   * For example, that's how the result of  would look like:
+   * — formatPercent(0.2319) will return 23.19% (in US locale)
+   * — formatPercent(0.2319) will return %23.19 (in Turkish locale)
+   * — formatPercent(0.2319) will return 23,19% (in Latvian locale)
+   * — formatPercent(1.23) will return 123%
+   * — formatPercent(0.000145) will return 0.01%
+   * — formatPercent(0.37) will return 37%
+   *
+   * @param fraction a double value, that represents a fraction of a whole
+   * @return correct string representation of percent for different locales
+   */
+  public static String formatPercent(double fraction) {
+    NumberFormat percentFormat = NumberFormat.getPercentInstance();
+    percentFormat.setMaximumFractionDigits(2);
+    return percentFormat.format(fraction);
   }
 
   public static native boolean nativeIsHtml(String text);


### PR DESCRIPTION
I wasn't able to compile the app, but I improved showing localized percentages in Android. Probably it would be nice to have this on other OS as well.