### PR TITLE
[drape] Fix disappearing building POIs when in perspective

### DIFF
--- a/drape/overlay_handle.cpp
+++ b/drape/overlay_handle.cpp
@@ -67,7 +67,7 @@ m2::PointD OverlayHandle::GetPivot(ScreenBase const & screen, bool perspective) 
     result.y += size.y;
 
   if (perspective)
-    result = screen.PtoP3d(result, -m_pivotZ / screen.GetScale());
+    result = screen.PtoP3d(result, -m_pivotZ);
 
   return result;
 }
@@ -163,7 +163,7 @@ m2::RectD OverlayHandle::GetPixelRectPerspective(ScreenBase const & screen) cons
   if (m_isBillboard)
   {
     m2::PointD const pxPivot = GetPivot(screen, false);
-    m2::PointD const pxPivotPerspective = screen.PtoP3d(pxPivot, -m_pivotZ / screen.GetScale());
+    m2::PointD const pxPivotPerspective = screen.PtoP3d(pxPivot, -m_pivotZ);
 
     m2::RectD pxRectPerspective = GetPixelRect(screen, false);
     pxRectPerspective.Offset(-pxPivot);

--- a/drape_frontend/text_handle.cpp
+++ b/drape_frontend/text_handle.cpp
@@ -75,7 +75,7 @@ std::string TextHandle::GetOverlayDebugInfo()
 {
   std::ostringstream out;
   out << "Text Priority(" << std::hex << std::setw(16) << std::setfill('0') << GetPriority()
-      << ") " << std::dec << DebugPrint(GetOverlayID()) << " " << strings::ToUtf8(m_text);
+      << ") " << std::dec << DebugPrint(GetOverlayID());
   return out.str();
 }
 #endif


### PR DESCRIPTION
- fixes #8264 

A peculiar bug.

It seems that the intention was to render icons & captions on the top of 3D buildings when in perspective mode (see 2996e48cee3838dc1c1451251e03b4cfa2ef4af6).

The building height offset was taken with a wrong scale which made POI's rect miscalculated to be outside of screen rect, hence the POI was clipped and never displayed.

I'm not 100% sure that the fixed height scale is right now, but it fixes the bug and its the same fix as 09f40ceeb006843c405923afb05c5522f7d9f921 which fixed house numbers, but POI icons were just forgotten it seems.

ATM it doesn't always look like building captions or icons are on the top. Maybe it doesn't work for complex buildings with parts only...

