### PR TITLE
[android]  Displays whole GPS error message in notification 

### DIFF
--- a/android/app/src/main/java/app/organicmaps/location/TrackRecordingService.java
+++ b/android/app/src/main/java/app/organicmaps/location/TrackRecordingService.java
@@ -200,6 +200,8 @@ public class TrackRecordingService extends Service implements LocationListener
         .setSmallIcon(R.drawable.warning_icon)
         .setContentTitle(context.getString(R.string.current_location_unknown_error_title))
         .setContentText(context.getString(R.string.dialog_routing_location_turn_wifi))
+        .setStyle(new NotificationCompat.BigTextStyle()
+            .bigText(context.getString(R.string.dialog_routing_location_turn_wifi)))
         .addAction(0, context.getString(R.string.navigation_stop_button), getExitPendingIntent(context))
         .setContentIntent(getPendingIntent(context))
         .setColor(ContextCompat.getColor(context, R.color.notification_warning));


### PR DESCRIPTION
Fixes: #9288 

- Makes the whole GPS Error message text visible 

| Before | After |
|---------|---------|
| ![before](https://github.com/user-attachments/assets/a818f50e-41ac-47af-8a9f-e0f8558598e3) | ![After](https://github.com/user-attachments/assets/f2cd87ae-89b4-430a-8c29-77931ddb52b2)
 |