### PR TITLE
[android] Update AGP, Gradle, NDK and deps

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,7 +22,7 @@ buildscript {
       googleFirebaseServicesDefault
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:8.7.2'
+    classpath 'com.android.tools.build:gradle:8.7.3'
 
     if (googleFirebaseServicesEnabled) {
       println('Building with Google Firebase Services')

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -100,7 +100,7 @@ android {
   // All properties are read from gradle.properties file
   compileSdk propCompileSdkVersion.toInteger()
 
-  ndkVersion '27.1.12297006'
+  ndkVersion '27.2.12479018'
 
   defaultConfig {
     // Default package name is taken from the manifest and should be app.organicmaps

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -363,7 +363,7 @@ android {
 }
 
 dependencies {
-  coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.3'
+  coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
 
   // Google Play Location Services
   //
@@ -379,7 +379,7 @@ dependencies {
   huaweiImplementation 'com.google.android.gms:play-services-location:21.3.0'
   // This is the microG project's re-implementation which is permissible on
   // F-droid because it's Apache-2.0.
-  fdroidImplementation 'org.microg.gms:play-services-location:0.3.4.240913'
+  fdroidImplementation 'org.microg.gms:play-services-location:0.3.6.244735'
 
   // Google Firebase Services
   if (googleFirebaseServicesEnabled) {
@@ -396,11 +396,11 @@ dependencies {
   // We don't use Kotlin, but some dependencies are actively using it.
   // See https://stackoverflow.com/a/75719642
   implementation 'androidx.core:core:1.15.0'
-  implementation(platform('org.jetbrains.kotlin:kotlin-bom:2.0.21'))
+  implementation(platform('org.jetbrains.kotlin:kotlin-bom:2.1.10'))
   implementation 'androidx.annotation:annotation:1.9.1'
   implementation 'androidx.appcompat:appcompat:1.7.0'
-  implementation 'androidx.car.app:app:1.7.0-beta03'
-  implementation 'androidx.car.app:app-projected:1.7.0-beta03'
+  implementation 'androidx.car.app:app:1.7.0-rc01'
+  implementation 'androidx.car.app:app-projected:1.7.0-rc01'
   implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
   implementation 'androidx.fragment:fragment:1.8.5'
   implementation 'androidx.preference:preference:1.2.1'
@@ -417,7 +417,7 @@ dependencies {
   // Test Dependencies
   androidTestImplementation 'androidx.test.ext:junit:1.2.1'
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'org.mockito:mockito-core:5.12.0'
+  testImplementation 'org.mockito:mockito-core:5.15.2'
   testImplementation 'org.mockito:mockito-inline:5.2.0'
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.7.2' apply false
-    id 'com.android.library' version '8.7.2' apply false
+    id 'com.android.application' version '8.7.3' apply false
+    id 'com.android.library' version '8.7.3' apply false
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
I followed a conservative approach here and didn't include updates that don't have any patch releases yet (like the newest AGP 8.8.0).