### PR TITLE
[android] Fixes word wrapping around hyphens 

### DIFF
--- a/android/app/src/main/res/layout/place_page_preview.xml
+++ b/android/app/src/main/res/layout/place_page_preview.xml
@@ -41,6 +41,8 @@
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:fontFamily="@string/robotoMedium"
+        android:breakStrategy="high_quality"
+        android:hyphenationFrequency="fullFast"
         android:maxLines="@integer/pp_title_lines"
         android:textAppearance="@style/MwmTextAppearance.Title"
         tools:background="#C0800000"


### PR DESCRIPTION
Fixes : #8913

| Before | After  |
|---------|---------|
| ![before](https://github.com/user-attachments/assets/9f9c416c-c03e-4025-b561-7a02d06535d1) |![after](https://github.com/user-attachments/assets/b9afe3ec-f2a3-465d-9e42-86bdacf40cb4)|
|![After](https://github.com/user-attachments/assets/8fff810d-1579-4f9d-a0b1-f268d9f9d0e3) |   ![Before](https://github.com/user-attachments/assets/0d2b5222-cc1b-4c61-9c5e-1feacca19c52)|





