### PR TITLE
[ios] Fix the Manage Route button visibility in dark mode on iPad

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/BaseRoutePreviewStatus.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/BaseRoutePreviewStatus.swift
@@ -6,9 +6,7 @@ final class BaseRoutePreviewStatus: SolidTouchView {
   @IBOutlet private weak var manageRouteBox: UIView!
   @IBOutlet weak var manageRouteBoxBackground: UIView! {
     didSet {
-      iPhoneSpecific {
         manageRouteBoxBackground.setStyle(.blackOpaqueBackground)
-      }
     }
   }
 


### PR DESCRIPTION
 Closes #9456
Before the Manage route option in dark mode on iPad was showing as white on white and was impossible to see.

Before,
![image](https://github.com/user-attachments/assets/83b2cf9d-bed8-409d-970a-08d79eaad68b)

After,

<img width="1470" alt="Screenshot 2025-02-02 at 4 13 48 AM" src="https://github.com/user-attachments/assets/a5ea9c94-407c-499f-8e8d-b8dd2c531aa7" />
<img width="275" alt="Screenshot 2025-02-02 at 4 13 38 AM" src="https://github.com/user-attachments/assets/469e129e-7f05-4191-89cf-7b082d29f7c4" />

https://github.com/user-attachments/assets/d7a0aea0-53b4-49af-89cd-2ab66609948e







Author: Mandalorian7773, Committer: Mandalorian7773;