### PR TITLE
[API] Allow parsing and sharing coordinates in omaps.app links

### DIFF
--- a/android/app/src/main/java/app/organicmaps/util/SharingUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/SharingUtils.java
@@ -122,9 +122,10 @@ public class SharingUtils
 
     final String geoUrl = Framework.nativeGetGe0Url(loc.getLatitude(), loc.getLongitude(), Framework
         .nativeGetDrawScale(), "");
+    final String coordUrl = String.format("https://omaps.app/%.5f,%.5f", loc.getLatitude(), loc.getLongitude());
     final String httpUrl = Framework.getHttpGe0Url(loc.getLatitude(), loc.getLongitude(), Framework
         .nativeGetDrawScale(), "");
-    final String text = context.getString(R.string.my_position_share_sms, geoUrl, httpUrl);
+    final String text = context.getString(R.string.my_position_share_sms, httpUrl , coordUrl); 
     intent.putExtra(Intent.EXTRA_TEXT, text);
 
     context.startActivity(Intent.createChooser(intent, context.getString(R.string.share)));
@@ -142,10 +143,11 @@ public class SharingUtils
 
     final String geoUrl = Framework.nativeGetGe0Url(object.getLat(), object.getLon(),
                                                     object.getScale(), object.getName());
+    final String coordUrl = String.format("https://omaps.app/%.5f,%.5f", object.getLat(), object.getLon());
     final String httpUrl = Framework.getHttpGe0Url(object.getLat(), object.getLon(),
                                                    object.getScale(), object.getName());
     final String address = TextUtils.isEmpty(object.getAddress()) ? object.getName() : object.getAddress();
-    final String text = context.getString(R.string.my_position_share_email, address, geoUrl, httpUrl);
+    final String text = context.getString(R.string.my_position_share_email, address,httpUrl ,coordUrl );
     intent.putExtra(Intent.EXTRA_TEXT, text);
 
     context.startActivity(Intent.createChooser(intent, context.getString(R.string.share)));
@@ -161,6 +163,8 @@ public class SharingUtils
 
     final String geoUrl = Framework.nativeGetGe0Url(bookmark.getLat(), bookmark.getLon(),
                                                     bookmark.getScale(), bookmark.getName());
+    final String coordUrl = String.format("https://omaps.app/%.5f,%.5f", bookmark.getLat(), bookmark.getLon());
+
     final String httpUrl = Framework.getHttpGe0Url(bookmark.getLat(), bookmark.getLon(),
                                                    bookmark.getScale(), bookmark.getName());
     StringBuilder text = new StringBuilder();
@@ -171,9 +175,9 @@ public class SharingUtils
       text.append(bookmark.getAddress());
     }
     text.append(UiUtils.NEW_STRING_DELIMITER);
-    text.append(geoUrl);
-    text.append(UiUtils.NEW_STRING_DELIMITER);
     text.append(httpUrl);
+    text.append(UiUtils.NEW_STRING_DELIMITER);
+    text.append(coordUrl);
     intent.putExtra(Intent.EXTRA_TEXT, text.toString());
 
     context.startActivity(Intent.createChooser(intent, context.getString(R.string.share)));

--- a/ge0/ge0_tests/parser_tests.cpp
+++ b/ge0/ge0_tests/parser_tests.cpp
@@ -312,4 +312,44 @@ UNIT_TEST(OtherPrefixes)
   TestSuccess("https://omaps.app/Byqqqqqqqq", 45, 0, 4.25, "");
   TestFailure("https://omaps.app/Byqqqqqqq");
 }
+
+UNIT_TEST(PlainCoordinateUrl_Valid)
+{
+  TestSuccess("https://omaps.app/0.00000,0.00000", 0.0, 0.0, 18.0, "");
+  TestSuccess("https://omaps.app/45.00000,-90.00000", 45.0, -90.0, 18.0, "");
+  TestSuccess("https://omaps.app/-45.12345,179.99999", -45.12345, 179.99999, 18.0, "");
+  TestSuccess("https://omaps.app/89.99999,-179.99999", 89.99999, -179.99999, 18.0, "");
+  TestSuccess("https://omaps.app/-89.99999,179.99999", -89.99999, 179.99999, 18.0, "");
+
+  TestSuccess("https://omaps.app/12.34567,76.54321/Place", 12.34567, 76.54321, 18.0, "Place");
+  TestSuccess("https://omaps.app/12.34567,76.54321/Place%20Name", 12.34567, 76.54321, 18.0, "Place_Name");
+  TestSuccess("https://omaps.app/12.34567,76.54321/My_Poi", 12.34567, 76.54321, 18.0, "My Poi");
+
+  TestSuccess("https://omaps.app/12.34567,76.54321/%D0%9F%D0%BE%D0%B8", 12.34567, 76.54321, 18.0, "Пои");
+
+  TestSuccess("https://omaps.app/13.02227,77.76043/", 13.02227, 77.76043, 18.0, "");
+}
+
+UNIT_TEST(PlainCoordinateUrl_Invalid)
+{
+
+  TestFailure("https://omaps.app/1302227 77.76043");
+  TestFailure("https://omaps.app/1302227-77.76043");
+
+  TestFailure("https://omaps.app/abc,77.76043");
+  TestFailure("https://omaps.app/13.02227,xyz");
+  TestFailure("https://omaps.app/NaN,77.76043");
+  TestFailure("https://omaps.app/13.02227,Infinity");
+
+  TestFailure("https://omaps.app/13.02227,77.76043,100");
+  TestFailure("https://omaps.app/13.02227,,77.76043");
+
+  TestFailure("https://omaps.app/,");
+  TestFailure("https://omaps.app/,/Name");
+  TestFailure("https://omaps.app//Name");
+
+  TestFailure("https://omaps.app/13.02227,77.76043foo");
+  TestFailure("https://omaps.app/foo13.02227,77.76043");
+}
+
 }  // namespace ge0

--- a/ge0/parser.cpp
+++ b/ge0/parser.cpp
@@ -50,6 +50,32 @@ bool Ge0Parser::Parse(std::string const & url, Result & result)
 
 bool Ge0Parser::ParseAfterPrefix(std::string const & url, size_t from, Result & result)
 {
+  std::string remaining = url.substr(from);
+  if (remaining.find(',') != std::string::npos) {
+    // Optional slash after coordinates
+    size_t slashPos = remaining.find('/');
+    std::string coords = (slashPos == std::string::npos) ? remaining : remaining.substr(0, slashPos);
+
+    size_t commaPos = coords.find(',');
+    if (commaPos == std::string::npos)
+    return false;
+
+    std::string latStr = coords.substr(0, commaPos);
+    std::string lonStr = coords.substr(commaPos + 1);
+
+    double lat, lon;
+    if (!strings::to_double(latStr, lat) || !strings::to_double(lonStr, lon))
+    return false;
+
+    result.m_lat = lat;
+    result.m_lon = lon;
+    result.m_zoomLevel = 18.0;
+
+    if (slashPos != std::string::npos && slashPos + 1 < remaining.size())
+    result.m_name = DecodeName(remaining.substr(slashPos + 1));
+    return true;
+  }
+
   size_t const kEncodedZoomAndCoordinatesLength = 10;
   if (url.size() < from + kEncodedZoomAndCoordinatesLength)
     return false;


### PR DESCRIPTION
Partially Fixes #7482


- When Sharing location , Replaced the `om://`  format  with URL with coordinates 

| before | after |
|---------|---------|
| ![before](https://github.com/user-attachments/assets/784b4657-9934-4248-8467-4237da050329)| ![image](https://github.com/user-attachments/assets/d0a80ec6-8e4a-48c4-9f37-a2a4c186c656)|

- Updated parser to accept coordinate URL's 
# Before

https://github.com/user-attachments/assets/cf5e56fa-de19-4576-809f-6e2165d55bc1

# After
https://github.com/user-attachments/assets/bf054866-6235-435c-a479-f61fee3208ac


- Wrote basic unit tests for the parser

![image](https://github.com/user-attachments/assets/a0465f30-66ae-4427-ab4b-d1bcd9a363bc)


- Next step : Update parser for iOS 
