### PR TITLE
[android] Fix bookmark edits not updating in place page on screen rotation

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/EditBookmarkFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/EditBookmarkFragment.java
@@ -181,6 +181,14 @@ public class EditBookmarkFragment extends BaseMwmDialogFragment implements View.
     }
   }
 
+  @Override
+  public void onAttach(@NonNull Context context)
+  {
+    super.onAttach(context);
+    if (mListener == null && getParentFragment() instanceof EditBookmarkListener)
+      mListener = (EditBookmarkListener) getParentFragment();
+  }
+
   private void initToolbar(View view)
   {
     Toolbar toolbar = view.findViewById(R.id.toolbar);

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageBookmarkFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageBookmarkFragment.java
@@ -127,7 +127,7 @@ public class PlacePageBookmarkFragment extends Fragment implements View.OnClickL
     EditBookmarkFragment.editBookmark(currentBookmark.getCategoryId(),
                                       currentBookmark.getBookmarkId(),
                                       activity,
-                                      activity.getSupportFragmentManager(),
+                                      getChildFragmentManager(),
                                       PlacePageBookmarkFragment.this);
   }
 


### PR DESCRIPTION
Fixes #2418

The callback listener supposed to be invoked after bookmark edits (`mListener` in `EditBookmarkFragment`) was made null on configuration changes. This change fixes the issue by leveraging the fact that the parent fragment (for cases when the issue occurs, i.e. `PlacePageBookmarkFragment`) itself implements the listener.

### On master branch

https://github.com/user-attachments/assets/74f786e1-fbed-4bab-9efe-fae4d45985fc

### On this branch


https://github.com/user-attachments/assets/77a27cd3-341c-4cbb-840d-7cec117c84a5


