### PR TITLE
[ios] Fix route planning UI reloading bug

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
@@ -134,8 +134,7 @@ NSString *const kNavigationControlViewXibName = @"NavigationControlView";
   self.navigationInfoView = nil;
   _navigationControlView.isVisible = NO;
   _navigationControlView = nil;
-  [_baseRoutePreviewStatus hide];
-  _baseRoutePreviewStatus = nil;
+  [self.baseRoutePreviewStatus hide];
   [_transportRoutePreviewStatus hide];
   _transportRoutePreviewStatus = nil;
 }
@@ -147,7 +146,7 @@ NSString *const kNavigationControlViewXibName = @"NavigationControlView";
   [routePreview statePrepare];
   [routePreview selectRouter:[MWMRouter type]];
   [self updateGoButtonTitle];
-  [_baseRoutePreviewStatus hide];
+  [self.baseRoutePreviewStatus hide];
   [_transportRoutePreviewStatus hide];
   for (MWMRouteStartButton *button in self.goButtons)
     [button statePrepare];
@@ -204,8 +203,7 @@ NSString *const kNavigationControlViewXibName = @"NavigationControlView";
   self.routePreview = nil;
   self.navigationInfoView.state = MWMNavigationInfoViewStateNavigation;
   self.navigationControlView.isVisible = YES;
-  [_baseRoutePreviewStatus hide];
-  _baseRoutePreviewStatus = nil;
+  [self.baseRoutePreviewStatus hide];
   [_transportRoutePreviewStatus hide];
   _transportRoutePreviewStatus = nil;
   [self onNavigationInfoUpdated];

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/BaseRoutePreviewStatus.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/BaseRoutePreviewStatus.swift
@@ -51,12 +51,8 @@ final class BaseRoutePreviewStatus: SolidTouchView {
 
   private var isVisible = false {
     didSet {
-      guard isVisible != oldValue else { return }
-      if isVisible {
-        addView()
-      } else {
-        self.removeFromSuperview()
-      }
+      addView()
+      isHidden = !isVisible
     }
   }
 
@@ -68,6 +64,7 @@ final class BaseRoutePreviewStatus: SolidTouchView {
     leadingAnchor.constraint(equalTo: lg.leadingAnchor).isActive = true
     trailingAnchor.constraint(equalTo: lg.trailingAnchor).isActive = true
     bottomAnchor.constraint(equalTo: lg.bottomAnchor).isActive = true
+    ownerView.layoutIfNeeded()
   }
 
   private func updateHeight() {


### PR DESCRIPTION
The bottom route status view sometimes jumps from the top to the bottom during the 1st rendering. It happens because the view's frame is not calculated on the `isVisible` and the view is `init/deinit` multiple times during the route building state changing. The bottom view now only changes its visibility and constraints, not the init/deinit on every update

The screenrecs with bug:

https://github.com/user-attachments/assets/6966a9d8-3200-4a87-8cb6-a63559a8c3aa

https://github.com/user-attachments/assets/00bf1260-a389-41d3-ac66-32870a010201

