### PR TITLE
[github] Don't require Design team to review each map icon change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,10 +7,6 @@ android/app/src/main/res/mipmap*/ @organicmaps/design
 data/*.ttf @organicmaps/design
 data/resources*/ @organicmaps/design
 data/search-icons/ @organicmaps/design
-data/styles/default/light/**/*.png @organicmaps/design
-data/styles/default/light/**/*.svg @organicmaps/design
-data/styles/default/dark/**/*.png @organicmaps/design
-data/styles/default/dark/**/*.svg @organicmaps/design
 iphone/Maps/Images.xcassets/ @organicmaps/design
 # Android.
 android/ @organicmaps/android


### PR DESCRIPTION
Otherwise too much time spend to chase reviewers from different teams on a typical "add a new poi" PR.

If help is needed with map icons then its better to mention the design team explicitly.