### PR TITLE
[gpx] Use cdata for name field in gpx export

### DIFF
--- a/data/test_data/gpx/export_test.gpx
+++ b/data/test_data/gpx/export_test.gpx
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1">
 <metadata>
-  <name>My route</name>
+  <name><![CDATA[My route ><&"]]></name>
   <desc><![CDATA[You will see this in the document and can use reserved characters like < > & "]]></desc>
 </metadata>
 <wpt lat="48.209846" lon="16.376023">

--- a/kml/serdes_gpx.cpp
+++ b/kml/serdes_gpx.cpp
@@ -488,7 +488,11 @@ void SaveCategoryData(Writer & writer, CategoryData const & categoryData)
 {
   writer << "<metadata>\n";
   if (auto const name = GetDefaultLanguage(categoryData.m_name))
-    writer << kIndent2 << "<name>" << *name << "</name>\n";
+  {
+    writer << kIndent2 << "<name>";
+    SaveStringWithCDATA(writer, *name);
+    writer << "</name>\n";
+  }
   if (auto const description = GetDefaultLanguage(categoryData.m_description))
   {
     writer << kIndent2 << "<desc>";


### PR DESCRIPTION
Issue that is fixed: 
1) Import some gpx file that contains tracks with special symbols in name
2) This file is handled properly because gpx code handles track names with cdata
3) Export single track from this list
4) Exported gpx file has special symbols inside metadata/name (not handled with cdata) and is broken