### PR TITLE
[android] Fix SpeedLimitView

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/util/StringUtils.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/util/StringUtils.cpp
@@ -49,6 +49,12 @@ Java_app_organicmaps_util_StringUtils_nativeFilterContainsNormalized(JNIEnv * en
   return jni::ToJavaStringArray(env, filtered);
 }
 
+JNIEXPORT jint JNICALL Java_app_organicmaps_util_StringUtils_nativeFormatSpeed(
+    JNIEnv * env, jclass thiz, jdouble metersPerSecond)
+{
+  return measurement_utils::FormatSpeed(metersPerSecond, measurement_utils::GetMeasurementUnits());
+}
+
 JNIEXPORT jobject JNICALL Java_app_organicmaps_util_StringUtils_nativeFormatSpeedAndUnits(
     JNIEnv * env, jclass thiz, jdouble metersPerSecond)
 {

--- a/android/app/src/main/java/app/organicmaps/routing/NavigationController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/NavigationController.java
@@ -16,6 +16,7 @@ import app.organicmaps.Framework;
 import app.organicmaps.R;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.maplayer.traffic.TrafficManager;
+import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
 import app.organicmaps.widget.LanesView;
@@ -249,10 +250,10 @@ public class NavigationController implements TrafficManager.TrafficCallback,
   {
     final Location location = LocationHelper.from(mFrame.getContext()).getSavedLocation();
     if (location == null) {
-      mSpeedLimit.setSpeedLimitMps(0);
+      mSpeedLimit.setSpeedLimit(0, false);
       return;
     }
-    mSpeedLimit.setCurrentSpeed(location.getSpeed());
-    mSpeedLimit.setSpeedLimitMps(info.speedLimitMps);
+    final boolean speedLimitExceeded = info.speedLimitMps < location.getSpeed();
+    mSpeedLimit.setSpeedLimit(StringUtils.nativeFormatSpeed(info.speedLimitMps), speedLimitExceeded);
   }
 }

--- a/android/app/src/main/java/app/organicmaps/util/StringUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/StringUtils.java
@@ -49,6 +49,7 @@ public class StringUtils
   public static native boolean nativeContainsNormalized(String str, String substr);
   public static native String[] nativeFilterContainsNormalized(String[] strings, String substr);
 
+  public static native int nativeFormatSpeed(double metersPerSecond);
   public static native Pair<String, String> nativeFormatSpeedAndUnits(double metersPerSecond);
   public static native Distance nativeFormatDistance(double meters);
   @NonNull

--- a/android/app/src/main/java/app/organicmaps/widget/LanesView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/LanesView.java
@@ -59,14 +59,14 @@ public class LanesView extends View
 
     try (TypedArray data = context.getTheme().obtainStyledAttributes(attrs, R.styleable.LanesView, 0, 0))
     {
-      backgroundColor = getAttrColor(data, R.styleable.LanesView_backgroundColor, DefaultValues.BACKGROUND_COLOR);
-      mActiveLaneTintColor = getAttrColor(data, R.styleable.LanesView_activeLaneTintColor, DefaultValues.ACTIVE_LANE_TINT_COLOR);
-      mInactiveLaneTintColor = getAttrColor(data, R.styleable.LanesView_inactiveLaneTintColor, DefaultValues.INACTIVE_LANE_TINT_COLOR);
-      mCornerRadius = (int) Math.max(data.getDimension(R.styleable.LanesView_cornerRadius, DefaultValues.CORNER_RADIUS), 0.0f);
+      backgroundColor = getAttrColor(data, R.styleable.LanesView_lanesBackgroundColor, DefaultValues.BACKGROUND_COLOR);
+      mActiveLaneTintColor = getAttrColor(data, R.styleable.LanesView_lanesActiveLaneTintColor, DefaultValues.ACTIVE_LANE_TINT_COLOR);
+      mInactiveLaneTintColor = getAttrColor(data, R.styleable.LanesView_lanesInactiveLaneTintColor, DefaultValues.INACTIVE_LANE_TINT_COLOR);
+      mCornerRadius = (int) Math.max(data.getDimension(R.styleable.LanesView_lanesCornerRadius, DefaultValues.CORNER_RADIUS), 0.0f);
 
       if (isInEditMode())
       {
-        final int lanesCount = Math.max(1, data.getInt(R.styleable.LanesView_editModeLanesCount, DefaultValues.LANES_COUNT));
+        final int lanesCount = Math.max(1, data.getInt(R.styleable.LanesView_lanesEditModeLanesCount, DefaultValues.LANES_COUNT));
         createLanesForEditMode(lanesCount);
       }
     }

--- a/android/app/src/main/res/layout-land/layout_nav_top.xml
+++ b/android/app/src/main/res/layout-land/layout_nav_top.xml
@@ -116,20 +116,19 @@
       app:layout_constraintStart_toEndOf="@+id/nav_speed_limit"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintTop_toBottomOf="@id/street_frame"
-      app:activeLaneTintColor="?navLaneArrowActiveColor"
-      app:inactiveLaneTintColor="?navLaneArrowInactiveColor"
-      app:backgroundColor="?colorAccent"
-      app:cornerRadius="@dimen/margin_quarter"
-      app:editModeLanesCount="10"
+      app:lanesActiveLaneTintColor="?navLaneArrowActiveColor"
+      app:lanesInactiveLaneTintColor="?navLaneArrowInactiveColor"
+      app:lanesBackgroundColor="?colorAccent"
+      app:lanesCornerRadius="@dimen/margin_quarter"
+      app:lanesEditModeLanesCount="10"
       tools:visibility="visible" />
 
   <app.organicmaps.widget.SpeedLimitView
     android:id="@+id/nav_speed_limit"
+    style="@style/MwmWidget.SpeedLimit"
     android:layout_width="60dp"
     android:layout_height="60dp"
     android:layout_margin="@dimen/margin_half"
-    app:editModeCurrentSpeed="90"
-    app:editModeSpeedLimit="120"
     app:layout_constraintStart_toEndOf="@id/nav_next_turn_container"
     app:layout_constraintTop_toBottomOf="@id/street_frame" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/layout_nav_top.xml
+++ b/android/app/src/main/res/layout/layout_nav_top.xml
@@ -117,20 +117,19 @@
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toEndOf="@id/nav_next_turn_container"
       app:layout_constraintTop_toBottomOf="@id/street_frame"
-      app:activeLaneTintColor="?navLaneArrowActiveColor"
-      app:inactiveLaneTintColor="?navLaneArrowInactiveColor"
-      app:backgroundColor="?navLanesBackgroundColor"
-      app:cornerRadius="@dimen/margin_quarter"
-      app:editModeLanesCount="5"
+      app:lanesActiveLaneTintColor="?navLaneArrowActiveColor"
+      app:lanesInactiveLaneTintColor="?navLaneArrowInactiveColor"
+      app:lanesBackgroundColor="?navLanesBackgroundColor"
+      app:lanesCornerRadius="@dimen/margin_quarter"
+      app:lanesEditModeLanesCount="5"
       tools:visibility="visible" />
 
   <app.organicmaps.widget.SpeedLimitView
     android:id="@+id/nav_speed_limit"
+    style="@style/MwmWidget.SpeedLimit"
     android:layout_width="60dp"
     android:layout_height="60dp"
     android:layout_margin="@dimen/margin_half"
-    app:editModeCurrentSpeed="90"
-    app:editModeSpeedLimit="120"
     app:layout_constraintEnd_toEndOf="@id/nav_next_turn_container"
     app:layout_constraintStart_toStartOf="@id/nav_next_turn_container"
     app:layout_constraintTop_toBottomOf="@id/nav_next_turn_container" />

--- a/android/app/src/main/res/values/attrs.xml
+++ b/android/app/src/main/res/values/attrs.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <declare-styleable name="SpeedLimitView">
-    <attr name="BackgroundColor" format="color" />
-    <attr name="borderColor" format="color" />
-    <attr name="alertColor" format="color" />
-    <attr name="textColor" format="color" />
-    <attr name="textAlertColor" format="color" />
+    <attr name="speedLimitBackgroundColor" format="color" />
+    <attr name="speedLimitBorderColor" format="color" />
+    <attr name="speedLimitAlertColor" format="color" />
+    <attr name="speedLimitTextColor" format="color" />
+    <attr name="speedLimitTextAlertColor" format="color" />
     <!-- These values are used only in edit mode -->
-    <attr name="editModeSpeedLimit" format="integer" />
-    <attr name="editModeCurrentSpeed" format="integer" />
+    <attr name="speedLimitEditModeSpeedLimit" format="integer" />
+    <attr name="speedLimitEditModeAlert" format="boolean" />
   </declare-styleable>
 
   <declare-styleable name="LanesView">
-    <attr name="activeLaneTintColor" format="reference" />
-    <attr name="inactiveLaneTintColor" format="color" />
-    <attr name="backgroundColor" format="color" />
-    <attr name="cornerRadius" format="dimension" />
+    <attr name="lanesActiveLaneTintColor" format="reference" />
+    <attr name="lanesInactiveLaneTintColor" format="color" />
+    <attr name="lanesBackgroundColor" format="color" />
+    <attr name="lanesCornerRadius" format="dimension" />
     <!-- These values are used only in edit mode -->
-    <attr name="editModeLanesCount" format="integer" />
+    <attr name="lanesEditModeLanesCount" format="integer" />
   </declare-styleable>
 
   <declare-styleable name="WheelProgressView">

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -5,6 +5,11 @@
 
   <style name="MwmWidget.ProgressWheel"/>
 
+  <style name="MwmWidget.SpeedLimit">
+    <item name="speedLimitAlertColor">@color/base_red</item>
+    <item name="speedLimitBorderColor">@color/base_red</item>
+  </style>
+
   <style name="MwmWidget.FrameLayout"/>
 
   <style name="MwmWidget.Downloader"/>

--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -199,11 +199,14 @@ double MpsToUnits(double metersPerSecond, Units units)
   UNREACHABLE();
 }
 
+int FormatSpeed(double metersPerSecond, Units units)
+{
+  return static_cast<int>(std::round(MpsToUnits(metersPerSecond, units)));
+}
+
 std::string FormatSpeedNumeric(double metersPerSecond, Units units)
 {
-  double const unitsPerHour = MpsToUnits(metersPerSecond, units);
-  double roundedValue = std::round(unitsPerHour);
-  return std::to_string(static_cast<int>(roundedValue));
+  return std::to_string(FormatSpeed(metersPerSecond, units));
 }
 
 std::string FormatOsmLink(double lat, double lon, int zoom)

--- a/platform/measurement_utils.hpp
+++ b/platform/measurement_utils.hpp
@@ -33,6 +33,8 @@ inline double constexpr KmphToMps(double kmph) { return kmph * 1000 / 3600; }
 double ToSpeedKmPH(double speed, Units units);
 double MpsToUnits(double mps, Units units);
 
+/// @return Speed value in km/h for Metric and in mph for Imperial.
+int FormatSpeed(double metersPerSecond, Units units);
 /// @return Speed value string (without suffix) in km/h for Metric and in mph for Imperial.
 std::string FormatSpeedNumeric(double metersPerSecond, Units units);
 


### PR DESCRIPTION
Closes: #10092

Added `measurement_utils::FormatSpeed` function which converts speed from double mps to int local units
Created `MwmWidget.SpeedLimit` style with config for the app
Added prefixes for style attributes for SpeedLimitView and LanesView
SpeedLimitView class is a standalone Android view which is not depended on OM's code
Handle motion events on the view - do nothing.
