### PR TITLE
[strings] Fix plurals for pl, ru, uk

### DIFF
--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -637,7 +637,9 @@
     <string name="bookmark_lists_hide_all">Ukryj wszystkie</string>
     <string name="bookmark_lists_show_all">Pokaż wszystkie</string>
     <plurals name="bookmarks_places">
-        <item quantity="other">Zakładki: %d</item>
+        <item quantity="one">%d zakładka</item>
+        <item quantity="few">%d zakładki</item>
+        <item quantity="other">%d zakładek</item>
     </plurals>
     <string name="bookmarks_create_new_group">Utwórz nową listę</string>
     <!-- Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files -->
@@ -662,8 +664,7 @@
     <plurals name="tracks">
         <item quantity="one">%d trasa</item>
         <item quantity="few">%d trasy</item>
-        <item quantity="many">%d tras</item>
-        <item quantity="other">%d trasy</item>
+        <item quantity="other">%d tras</item>
     </plurals>
     <!-- Settings privacy group in settings screen -->
     <string name="privacy">Prywatność</string>

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -666,6 +666,8 @@
     </plurals>
     <string name="restore">Відновити</string>
     <plurals name="tracks">
+        <item quantity="one">%d трек</item>
+        <item quantity="few">%d треки</item>
         <item quantity="other">%d треків</item>
     </plurals>
     <!-- Settings privacy group in settings screen -->

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -22581,7 +22581,9 @@
     mr:other = %d खूणपत्रे
     nb = %d bokmerker
     nl = %d bladwijzers
-    pl = Zakładki: %d
+    pl:few = %d zakładki
+    pl:one = %d zakładka
+    pl:other = %d zakładek
     pt-BR:one = %d favorito
     pt-BR:other = %d favoritos
     pt:one = %d favorito
@@ -23830,9 +23832,8 @@
     nb = %d stier
     nl = %d tracks
     pl:few = %d trasy
-    pl:many = %d tras
     pl:one = %d trasa
-    pl:other = %d trasy
+    pl:other = %d tras
     pt-BR:one = %d trilha
     pt-BR:other = %d trilhas
     pt:one = %d trajeto
@@ -23850,7 +23851,9 @@
     sw = Njia %d
     th = %d ติดตามต่าง ๆ
     tr = %d rota
-    uk = %d треків
+    uk:few = %d треки
+    uk:one = %d трек
+    uk:other = %d треків
     vi = %d các chặn đường
     zh-Hans = %d 个轨迹
     zh-Hant = %d 個軌跡

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.stringsdict
@@ -15,8 +15,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
+			<key>one</key>
+			<string>%d zakładka</string>
+			<key>few</key>
+			<string>%d zakładki</string>
 			<key>other</key>
-			<string>Zakładki: %d</string>
+			<string>%d zakładek</string>
 		</dict>
 	</dict>
 
@@ -53,10 +57,8 @@
 			<string>%d trasa</string>
 			<key>few</key>
 			<string>%d trasy</string>
-			<key>many</key>
-			<string>%d tras</string>
 			<key>other</key>
-			<string>%d trasy</string>
+			<string>%d tras</string>
 		</dict>
 	</dict>
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.stringsdict
@@ -53,6 +53,10 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
+			<key>one</key>
+			<string>%d трек</string>
+			<key>few</key>
+			<string>%d треки</string>
 			<key>other</key>
 			<string>%d треків</string>
 		</dict>


### PR DESCRIPTION
**pl**:

    zero → %d zakładek ✅
        "0 zakładek" is correct because zero follows "many" in Polish.
    one → %d zakładka ✅
        "1 zakładka" is correct (nominative singular).
    few → %d zakładki ✅
        "2, 3, 4 zakładki" is correct (nominative plural).
    many → %d zakładek ✅
        "5-9, 0, 11-14, 100 zakładek" follows genitive plural.
    other → %d zakładek ✅
        Required by ICU/Android, and in Polish, "other" behaves like "many".

**ru**:

    zero → %d меток ✅
        "0 меток" is correct because zero follows "many" in Russian.
    one → %d метка ✅
        "1 метка" is correct (nominative singular).
    few → %d метки ✅
        "2, 3, 4 метки" is correct (genitive singular).
    many → %d меток ✅
        "5-9, 0, 11-14, 100 меток" follows genitive plural.
    other → %d меток ✅
        Required by ICU/Android, and in Russian, "other" behaves like "many".

**uk**:

    zero → %d міток ✅
        "0 міток" is correct because zero follows "many" in Ukrainian.
    one → %d мітка ✅
        "1 мітка" is correct (nominative singular).
    few → %d мітки ✅
        "2, 3, 4 мітки" is correct (nominative plural).
    many → %d міток ✅
        "5-9, 0, 11-14, 100 міток" follows genitive plural.
    other → %d міток ✅
        Required by ICU/Android, and in Ukrainian, "other" behaves like "many".


Weblate has zero, one, few, other for all three languages.

<img width="1381" alt="image" src="https://github.com/user-attachments/assets/b8b4ebf9-5981-40ae-964b-4b11b3a0a4b0" />
<img width="1405" alt="image" src="https://github.com/user-attachments/assets/3fc3eb94-f2e6-4284-9cfd-a28025ef4fbf" />
<img width="1413" alt="image" src="https://github.com/user-attachments/assets/c8b1a3a7-d420-429a-b76c-c2f34a79544f" />