### PR TITLE
[strings] fix 'sort' in Japanese

### DIFF
--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -726,9 +726,9 @@
     <string name="trip_finished">到着しました!</string>
     <string name="ok">OK</string>
     <!-- max. 10 symbols, both iOS and Android -->
-    <string name="sort">並び替え中…</string>
+    <string name="sort">並べ替え…</string>
     <!-- Android, title, max 20-22 symbols -->
-    <string name="sort_bookmarks">ブックマークの並び替え</string>
+    <string name="sort_bookmarks">ブックマークの並べ替え</string>
     <!-- Android -->
     <string name="by_default">デフォルトで</string>
     <!-- Android -->

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -27336,7 +27336,7 @@
     hu = Rendezd…
     id = Urutkan…
     it = Ordina…
-    ja = 並び替え中…
+    ja = 並べ替え…
     ko = 분류…
     lt = Rikiuoti…
     lv = Kārtot…
@@ -27384,7 +27384,7 @@
     hu = Könyvelzők rendezése
     id = Urutkan bookmark
     it = Ordina i preferiti
-    ja = ブックマークの並び替え
+    ja = ブックマークの並べ替え
     ko = 북마크 분류하기
     lt = Rikiuoti adresyną
     lv = Kārtot grāmatzīmes
@@ -27431,7 +27431,7 @@
     hu = Alapértelmezés szerint
     id = Urutkan standar
     it = Ordina come predefinito
-    ja = デフォルトで並び替え
+    ja = デフォルトで並べ替え
     ko = 기본 값으로 분류
     lt = Rikiuoti numatytai
     lv = Kārtot pēc noklusējuma
@@ -27477,7 +27477,7 @@
     hu = Típus szerint
     id = Urutkan per tipe
     it = Ordina per tipo
-    ja = タイプで並び替え
+    ja = タイプで並べ替え
     ko = 유형으로 분류
     lt = Rikiuoti pagal rūšį
     lv = Kārtot pēc tipa
@@ -27523,7 +27523,7 @@
     hu = Távolság szerint
     id = Urutkan per jarak
     it = Ordina per distanza
-    ja = 距離で並び替え
+    ja = 距離で並べ替え
     ko = 거리로 분류
     lt = Rikiuoti pagal atstumą
     lv = Kārtot pēc attāluma
@@ -27569,7 +27569,7 @@
     hu = Dátum szerint
     id = Urutkan per tanggal
     it = Ordina per data
-    ja = 日付で並び替え
+    ja = 日付で並べ替え
     ko = 날짜로 분류
     lt = Rikiuoti pagal datą
     lv = Kārtot pēc datuma
@@ -27616,7 +27616,7 @@
     hu = Rendezés név szerint
     id = Urutkan berdasarkan nama
     it = Ordina per nome
-    ja = 名前でソートする
+    ja = 名前で並べ替え
     ko = 이름별로 정렬
     lt = Rūšiuoti pagal pavadinimą
     lv = Kārtot pēc nosaukuma

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -875,14 +875,14 @@
 "carplay_roundabout_exit" = "第%@出口";
 
 /* max. 10 symbols, both iOS and Android */
-"sort" = "並び替え中…";
+"sort" = "並べ替え…";
 
 /* iOS */
-"sort_default" = "デフォルトで並び替え";
-"sort_type" = "タイプで並び替え";
-"sort_distance" = "距離で並び替え";
-"sort_date" = "日付で並び替え";
-"sort_name" = "名前でソートする";
+"sort_default" = "デフォルトで並べ替え";
+"sort_type" = "タイプで並べ替え";
+"sort_distance" = "距離で並べ替え";
+"sort_date" = "日付で並べ替え";
+"sort_name" = "名前で並べ替え";
 "week_ago_sorttype" = "1週間前";
 "month_ago_sorttype" = "1ケ月前";
 "moremonth_ago_sorttype" = "1ケ月以上前";


### PR DESCRIPTION
This is a retry of #10309.

translations of "sort" into more natural Japanese / sortの訳をより自然な日本語に

"並び替え中…" means ”we are in the process of sorting at this very moment". But it seems to indicate here "you can change the order from this menu".
It is that "ソート" make sense too (the same meaning), but adapted it to the surroundings.
/ 「並び替え中…」とすると「今まさに並び替えの動作の最中である」という意味になります。ですが、ここは並べ替えができるメニューが選べる、という意味だと思います。 また、"ソート"でも通じますが、周りが「並べ替え」とあるのでそちらに合わせます。

（Sorry. Only in Japanese from here on.）
「並び替え」と「並べ替え」では主語が違います。

- **リストが**並ぶ
- **私が**リストを並べる

ここでは「私がメニューを選んでリストを並べる」とした方が自然と思いましたので、「並び替え」から「並べ替え」に変更しています。


