### PR TITLE
[core] [map] Clear the gps tracker on save

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1752,6 +1752,7 @@ void Framework::StopTrackRecording()
 void Framework::SaveTrackRecordingWithName(std::string const & name)
 {
   GetBookmarkManager().SaveTrackRecording(name);
+  GpsTracker::Instance().Clear();
   if (m_drapeEngine)
     m_drapeEngine->ClearGpsTrackPoints();
 }

--- a/map/gps_tracker.cpp
+++ b/map/gps_tracker.cpp
@@ -60,6 +60,11 @@ void GpsTracker::SetEnabled(bool enabled)
     m_track.Clear();
 }
 
+void GpsTracker::Clear()
+{
+  m_track.Clear();
+}
+
 bool GpsTracker::IsEnabled() const
 {
   return m_enabled;

--- a/map/gps_tracker.hpp
+++ b/map/gps_tracker.hpp
@@ -14,6 +14,7 @@ public:
 
   bool IsEnabled() const;
   void SetEnabled(bool enabled);
+  void Clear();
 
   bool IsEmpty() const;
   size_t GetTrackSize() const;


### PR DESCRIPTION
Clears the gps tracker after Saving to free up the memory until the next recording is started. 
In the previous implementation the data will stay in the memory `forever` until the next recording is started(it may be even months of unnecessary memory consumption).