### PR TITLE
[android] Don't set subway routing mode when layer active

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -77,7 +77,6 @@ import app.organicmaps.maplayer.MapButtonsViewModel;
 import app.organicmaps.maplayer.ToggleMapLayerFragment;
 import app.organicmaps.maplayer.isolines.IsolinesManager;
 import app.organicmaps.maplayer.isolines.IsolinesState;
-import app.organicmaps.maplayer.subway.SubwayManager;
 import app.organicmaps.routing.NavigationController;
 import app.organicmaps.routing.NavigationService;
 import app.organicmaps.routing.RoutePointInfo;
@@ -1663,12 +1662,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
 
     mRoutingPlanInplaceController.showDrivingOptionView();
-  }
-
-  @Override
-  public boolean isSubwayEnabled()
-  {
-    return SubwayManager.from(this).isEnabled();
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/intent/Factory.java
+++ b/android/app/src/main/java/app/organicmaps/intent/Factory.java
@@ -99,7 +99,7 @@ public class Factory
           RoutingController.get().prepare(MapObject.createMapObject(FeatureId.EMPTY, MapObject.API_POINT,
                                                                     from.mName, "", from.mLat, from.mLon),
                                           MapObject.createMapObject(FeatureId.EMPTY, MapObject.API_POINT,
-                                                                    to.mName, "", to.mLat, to.mLon), true);
+                                                                    to.mName, "", to.mLat, to.mLon));
           return true;
         case RequestType.SEARCH:
         {

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingController.java
@@ -60,7 +60,7 @@ public class RoutingController
     default void onResetToPlanningState() {}
     default void onBuiltRoute() {}
     default void onDrivingOptionsWarning() {}
-    default boolean isSubwayEnabled() { return false; }
+
     default void onCommonBuildError(int lastResultCode, @NonNull String[] lastMissingMaps) {}
     default void onDrivingOptionsBuildError() {}
 
@@ -333,43 +333,21 @@ public class RoutingController
   {
     setState(State.NONE);
     setBuildState(BuildState.NONE);
-    prepare(getStartPoint(), getEndPoint(), false);
+    prepare(getStartPoint(), getEndPoint());
   }
 
   public void prepare(@Nullable MapObject startPoint, @Nullable MapObject endPoint)
   {
-    prepare(startPoint, endPoint, false);
-  }
-
-  public void prepare(@Nullable MapObject startPoint, @Nullable MapObject endPoint, boolean fromApi)
-  {
     Logger.d(TAG, "prepare (" + (endPoint == null ? "route)" : "p2p)"));
-    initLastRouteType(startPoint, endPoint, fromApi);
+    initLastRouteType(startPoint, endPoint);
     prepare(startPoint, endPoint, mLastRouterType);
   }
 
-  private void initLastRouteType(@Nullable MapObject startPoint, @Nullable MapObject endPoint,
-                                 boolean fromApi)
+  private void initLastRouteType(@Nullable MapObject startPoint, @Nullable MapObject endPoint)
   {
-    if (shouldForceTransitRoute(fromApi))
-    {
-      mLastRouterType = Framework.ROUTER_TYPE_TRANSIT;
-      return;
-    }
-
     if (startPoint != null && endPoint != null)
       mLastRouterType = Framework.nativeGetBestRouter(startPoint.getLat(), startPoint.getLon(),
                                                       endPoint.getLat(), endPoint.getLon());
-  }
-
-  private boolean isSubwayEnabled()
-  {
-    return mContainer != null && mContainer.isSubwayEnabled();
-  }
-
-  private boolean shouldForceTransitRoute(boolean fromApi)
-  {
-    return mState == State.NONE && isSubwayEnabled() && !fromApi;
   }
 
   public void prepare(final @Nullable MapObject startPoint, final @Nullable MapObject endPoint,


### PR DESCRIPTION
Companion to https://github.com/organicmaps/organicmaps/pull/8431

Removes setting the routing mode to subway when the subway layer is active. Many people have been confused by this, and others would like to keep the subway layer on permanently, but still use the app as normal (https://github.com/organicmaps/organicmaps/issues/9565).

(the old behaviour also set the mLastRouterType to subway, so even if you disabled the layer, the next route you started would still be in subway routing mode) 