### PR TITLE
[android] Fix crash upon deleting a POI via the Editor

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -3407,6 +3407,9 @@ bool Framework::ShouldShowProducts() const
   if (!m_usageStats.IsLoyalUser())
     return false;
 
+  if (!HasPlacePageInfo()) // happens after the POI is deleted via the editor
+    return false;
+
   if (!storage::IsPointCoveredByDownloadedMaps(GetCurrentPlacePageInfo().GetMercator(), m_storage, *m_infoGetter))
     return false;
 


### PR DESCRIPTION
Fixes #10211 

Made it so that `Framework::ShouldShowProducts()` doesn't attempt to invoke `Framework::GetCurrentPlacePageInfo()` without first ensuring the `HasPlacePageInfo()` check passes, which would otherwise lead to a crash.