### PR TITLE
[android] Made the "Emulate bad storage" setting invisible by default.

### DIFF
--- a/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
@@ -230,6 +230,8 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment implements La
 
     if (!SharedPropertiesUtils.shouldShowEmulateBadStorageSetting(requireContext()))
       removePreference(getString(R.string.pref_settings_general), pref);
+    else
+      pref.setVisible(true);
   }
 
   private void initAutoZoomPrefsCallbacks()

--- a/android/app/src/main/res/xml/prefs_main.xml
+++ b/android/app/src/main/res/xml/prefs_main.xml
@@ -68,6 +68,7 @@
       android:title="@string/setting_emulate_bad_storage"
       app:singleLineTitle="false"
       android:defaultValue="false"
+      app:isPreferenceVisible="false"
       android:order="13"/>
     <ListPreference
       android:key="@string/pref_use_mobile_data"

--- a/android/app/src/main/res/xml/prefs_voice_instructions.xml
+++ b/android/app/src/main/res/xml/prefs_voice_instructions.xml
@@ -9,16 +9,20 @@
   <SwitchPreferenceCompat
       android:key="@string/pref_tts_street_names"
       android:title="@string/pref_tts_street_names_title"
+      app:isPreferenceVisible="false"
       android:summary="@string/pref_tts_street_names_description"
       android:defaultValue="false" />
   <ListPreference
       android:key="@string/pref_tts_language"
+      app:isPreferenceVisible="false"
       android:title="@string/pref_tts_language_title" />
   <SeekBarPreference
       android:key="@string/pref_tts_volume"
+      app:isPreferenceVisible="false"
       android:title="@string/volume" />
   <Preference
       android:key="@string/pref_tts_test_voice"
+      app:isPreferenceVisible="false"
       android:title="@string/pref_tts_test_voice_title" />
   <Preference
       android:key="@string/pref_tts_open_system_settings"


### PR DESCRIPTION
- Fixes issue #10366

# Changes:
- I have made the items listed below invisible by default.
- ## Items:
  1. `setting_emulate_bad_storage` in the file [prefs_main.xml](https://github.com/organicmaps/organicmaps/compare/master...DevarshVasani:organicmaps:visibility-change?expand=1#diff-e1683e1c09d15615e187204188064268330afaa421379f717aff1268780ec57d)
  2. `pref_tts_street_names`, `pref_tts_language`, `pref_tts_test_voice`, and `pref_tts_volume` in the file [prefs_voice_instructions.xml](https://github.com/organicmaps/organicmaps/compare/master...DevarshVasani:organicmaps:visibility-change?expand=1#diff-07cc0fdbc609740bad8ce1ce30b0f2871fad71aef2eac631d4671f5f335a6d9a)
