### PR TITLE
[Android] transparent navbar light mode

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.graphics.Color;
 import android.location.Location;
 import android.net.Uri;
 import android.os.Build;
@@ -17,6 +18,7 @@ import android.text.method.LinkMovementMethod;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.Window;
 import android.view.WindowManager;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -509,6 +511,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
     final boolean newUiModeIsCarDisconnected = mLastUiMode == Configuration.UI_MODE_TYPE_CAR && newUiMode == Configuration.UI_MODE_TYPE_NORMAL;
     mLastUiMode = newUiMode;
 
+    if (!newUiModeIsCarConnected && !newUiModeIsCarDisconnected)
+    {
+      makeNavigationBarTransparentInLightMode();
+    }
+
     if (newUiModeIsCarConnected || newUiModeIsCarDisconnected)
       return;
     recreate();
@@ -527,6 +534,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
 
     setContentView(R.layout.activity_map);
+    makeNavigationBarTransparentInLightMode();
 
     mPlacePageViewModel = new ViewModelProvider(this).get(PlacePageViewModel.class);
     mMapButtonsViewModel = new ViewModelProvider(this).get(MapButtonsViewModel.class);
@@ -1100,6 +1108,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     ThemeSwitcher.INSTANCE.restart(isMapRendererActive());
     refreshSearchToolbar();
     setFullscreen(isFullscreen());
+    makeNavigationBarTransparentInLightMode();
     if (Framework.nativeGetChoosePositionMode() != Framework.ChoosePositionMode.NONE)
     {
       UiUtils.show(mPointChooser);
@@ -2470,5 +2479,36 @@ public class MwmActivity extends BaseMwmFragmentActivity
     Logger.d(TAG, "trim memory, level = " + level);
     if (level >= TRIM_MEMORY_RUNNING_LOW)
       Framework.nativeMemoryWarning();
+  }
+
+  private void makeNavigationBarTransparentInLightMode() {
+      boolean isLightMode = (getResources().getConfiguration().uiMode &
+              Configuration.UI_MODE_NIGHT_MASK) ==
+              Configuration.UI_MODE_NIGHT_NO;
+
+      if (isLightMode)
+      {
+        Window window = getWindow();
+
+        window.setNavigationBarColor(Color.TRANSPARENT);
+
+        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+
+        int flags = window.getDecorView().getSystemUiVisibility();
+
+        flags |= View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1)
+        {
+          flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+        }
+
+        window.getDecorView().setSystemUiVisibility(flags);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+        {
+          window.setNavigationBarContrastEnforced(false);
+        }
+      }
   }
 }


### PR DESCRIPTION
<h3>[android] Make navigation bar transparent in light mode</h3>

<p>Add functionality to make the navigation bar fully transparent when the
app is in light mode. This improves the map view by allowing it to
extend beneath the navigation bar for a more immersive experience.</p>

<p>Implementation includes clearing translucency flags and adding necessary
system UI flags to ensure proper transparency. Also handles proper
configuration changes and maintains transparency when returning from
fullscreen mode.</p>

<p>The transparency is only applied in light mode to maintain readability
of navigation buttons, with appropriate contrast settings for different
Android API levels.</p>

<img src="https://github.com/user-attachments/assets/9d72fae3-6585-4a64-a9ae-dc7fd3b71e80" alt="Screenshot showing transparent navigation bar in light mode" width="280" />

<p><strong>Fixes:</strong> #10393</p>