### PR TITLE
[drape] Fix initialization of struct

### DIFF
--- a/drape/vulkan/vulkan_context_factory.cpp
+++ b/drape/vulkan/vulkan_context_factory.cpp
@@ -218,7 +218,7 @@ VulkanContextFactory::VulkanContextFactory(uint32_t appVersionCode, int sdkVersi
   if (!availableFeatures.wideLines)
     LOG(LWARNING, ("Widelines Vulkan feature is not supported."));
 
-  VkPhysicalDeviceFeatures enabledFeatures;
+  VkPhysicalDeviceFeatures enabledFeatures = {};
   enabledFeatures.wideLines = availableFeatures.wideLines;
 
   VkDeviceCreateInfo deviceCreateInfo = {};


### PR DESCRIPTION
Fix initialization of `VkPhysicalDeviceFeatures` struct, after compilation warning removal in [PR #10388](https://github.com/organicmaps/organicmaps/pull/10388).