### PR TITLE
[routing] Make 'auto reordering of intermediate stops' optional

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -1565,7 +1565,8 @@ Java_app_organicmaps_Framework_nativeAddRoutePoint(JNIEnv * env, jclass, jstring
                                                        jstring subtitle, jint markType,
                                                        jint intermediateIndex,
                                                        jboolean isMyPosition,
-                                                       jdouble lat, jdouble lon)
+                                                       jdouble lat, jdouble lon,
+                                                       jboolean reorderIntermediatePoints)
 {
   RouteMarkData data;
   data.m_title = jni::ToNativeString(env, title);
@@ -1575,7 +1576,7 @@ Java_app_organicmaps_Framework_nativeAddRoutePoint(JNIEnv * env, jclass, jstring
   data.m_isMyPosition = static_cast<bool>(isMyPosition);
   data.m_position = m2::PointD(mercator::FromLatLon(lat, lon));
 
-  frm()->GetRoutingManager().AddRoutePoint(std::move(data));
+  frm()->GetRoutingManager().AddRoutePoint(std::move(data), reorderIntermediatePoints);
 }
 
 JNIEXPORT void JNICALL

--- a/android/app/src/main/java/app/organicmaps/Framework.java
+++ b/android/app/src/main/java/app/organicmaps/Framework.java
@@ -335,15 +335,21 @@ public class Framework
 
   public static void addRoutePoint(RouteMarkData point)
   {
+    addRoutePoint(point, true);
+  }
+
+  public static void addRoutePoint(RouteMarkData point, boolean reorderIntermediatePoints)
+  {
     Framework.nativeAddRoutePoint(point.mTitle, point.mSubtitle, point.mPointType,
                                   point.mIntermediateIndex, point.mIsMyPosition,
-                                  point.mLat, point.mLon);
+                                  point.mLat, point.mLon, reorderIntermediatePoints);
   }
 
   public static native void nativeAddRoutePoint(String title, String subtitle,
                                                 @RoutePointInfo.RouteMarkType int markType,
                                                 int intermediateIndex, boolean isMyPosition,
-                                                double lat, double lon);
+                                                double lat, double lon,
+                                                boolean reorderIntermediatePoints);
 
   public static native void nativeRemoveRoutePoints();
 

--- a/android/app/src/main/java/app/organicmaps/routing/ManageRouteBottomSheet.java
+++ b/android/app/src/main/java/app/organicmaps/routing/ManageRouteBottomSheet.java
@@ -140,42 +140,9 @@ public class ManageRouteBottomSheet extends BottomSheetDialogFragment
       // Secondly, add the starting point.
       Framework.addRoutePoint(newRoutePoints.get(0));
 
-      // And then, add all intermediate points.
+      // And then, add all intermediate points (with no reordering).
       for (int pos = 1; pos < newRoutePoints.size() - 1; pos++)
-        Framework.addRoutePoint(newRoutePoints.get(pos));
-
-      // Intermediate route points are added sorted by distance.
-      // We have to make sure that they follow the requested order.
-      RouteMarkData[] finalRoutePoints = Framework.nativeGetRoutePoints();
-
-      for (int first = 1; first < newRoutePoints.size() - 1; first++)
-      {
-        int secondIndex = -1;
-
-        for (int second = first; second < newRoutePoints.size() - 1; second++)
-        {
-          if (finalRoutePoints[first].equals(newRoutePoints.get(second)))
-          {
-            secondIndex = second;
-            break;
-          }
-        }
-
-        if (secondIndex < 0)
-        {
-          // Something went bad. Intermediate point not found in the route points.
-          break;
-        }
-
-        if (first != secondIndex)
-        {
-          // Intermediate point needs to be moved.
-          Framework.nativeMoveRoutePoint(secondIndex, first);
-
-          // Refresh final route points.
-          finalRoutePoints = Framework.nativeGetRoutePoints();
-        }
-      }
+        Framework.addRoutePoint(newRoutePoints.get(pos), false);
 
       // Launch route planning.
       RoutingController.get().launchPlanning();

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingController.java
@@ -777,7 +777,8 @@ public class RoutingController
     Framework.nativeAddRoutePoint(description.first /* title */, description.second /* subtitle */,
                                   type, 0 /* intermediateIndex */,
                                   point.isMyPosition(),
-                                  point.getLat(), point.getLon());
+                                  point.getLat(), point.getLon(),
+                                  true /* reorderIntermediatePoints */);
   }
 
   @NonNull

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -841,7 +841,7 @@ bool RoutingManager::CouldAddIntermediatePoint() const
     < RoutePointsLayout::kMaxIntermediatePointsCount + 2;
 }
 
-void RoutingManager::AddRoutePoint(RouteMarkData && markData)
+void RoutingManager::AddRoutePoint(RouteMarkData && markData, bool reorderIntermediatePoints)
 {
   ASSERT(m_bmManager != nullptr, ());
   RoutePointsLayout routePoints(*m_bmManager);
@@ -859,7 +859,9 @@ void RoutingManager::AddRoutePoint(RouteMarkData && markData)
 
   markData.m_isVisible = !markData.m_isMyPosition;
   routePoints.AddRoutePoint(std::move(markData));
-  ReorderIntermediatePoints();
+
+  if (reorderIntermediatePoints)
+    ReorderIntermediatePoints();
 }
 
 void RoutingManager::ContinueRouteToPoint(RouteMarkData && markData)

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -226,7 +226,7 @@ public:
   /// will not return previous data, only newer.
   void GenerateNotifications(std::vector<std::string> & notifications, bool announceStreets);
 
-  void AddRoutePoint(RouteMarkData && markData);
+  void AddRoutePoint(RouteMarkData && markData, bool reorderIntermediatePoints = true);
   void ContinueRouteToPoint(RouteMarkData && markData);
   std::vector<RouteMarkData> GetRoutePoints() const;
   size_t GetRoutePointsCount() const;


### PR DESCRIPTION
This PR makes optional the 'auto reordering of intermediate stops' which is called in the native code when a route point is added.

This change allows the removal of extra code in [PR 10151](https://github.com/organicmaps/organicmaps/pull/10151) for the manage route functionality in Android.