### PR TITLE
[android] Fix IllegalStateException in destroySurface method.

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MapFragment.java
+++ b/android/app/src/main/java/app/organicmaps/MapFragment.java
@@ -41,9 +41,9 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
     mMap.updateMyPositionRoutingOffset(offsetY);
   }
 
-  public void destroySurface()
+  public void destroySurface(boolean activityIsChangingConfigurations)
   {
-      mMap.onSurfaceDestroyed(true, isAdded());
+    mMap.onSurfaceDestroyed(activityIsChangingConfigurations, isAdded());
   }
 
   public boolean isContextCreated()

--- a/android/app/src/main/java/app/organicmaps/MapFragment.java
+++ b/android/app/src/main/java/app/organicmaps/MapFragment.java
@@ -43,7 +43,6 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
 
   public void destroySurface()
   {
-    if (getActivity() != null)
       mMap.onSurfaceDestroyed(true, isAdded());
   }
 

--- a/android/app/src/main/java/app/organicmaps/MapFragment.java
+++ b/android/app/src/main/java/app/organicmaps/MapFragment.java
@@ -44,7 +44,7 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
   public void destroySurface()
   {
     if (getActivity() != null)
-      mMap.onSurfaceDestroyed(getActivity().isChangingConfigurations(), isAdded());
+      mMap.onSurfaceDestroyed(true, isAdded());
   }
 
   public boolean isContextCreated()

--- a/android/app/src/main/java/app/organicmaps/MapFragment.java
+++ b/android/app/src/main/java/app/organicmaps/MapFragment.java
@@ -43,7 +43,8 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
 
   public void destroySurface()
   {
-    mMap.onSurfaceDestroyed(requireActivity().isChangingConfigurations(), isAdded());
+    if (getActivity() != null)
+      mMap.onSurfaceDestroyed(getActivity().isChangingConfigurations(), isAdded());
   }
 
   public boolean isContextCreated()

--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1113,7 +1113,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     // Explicitly destroy surface before activity recreation.
     if (mMapFragment != null)
-      mMapFragment.destroySurface();
+      mMapFragment.destroySurface(true);
     super.recreate();
   }
 


### PR DESCRIPTION
- Fixes #9819 

# Changes:

  - Changed `requireActivity()` method to `getActivity()`.
  - Added a check to ensure it's not null.