### PR TITLE
[ios] Refactor Toast class and improve toast message style

### DIFF
--- a/iphone/Maps/Classes/CustomViews/MapViewControls/SideButtons/MWMSideButtons.mm
+++ b/iphone/Maps/Classes/CustomViews/MapViewControls/SideButtons/MWMSideButtons.mm
@@ -141,7 +141,7 @@ NSString * const kUDDidShowLongTapToShowSideButtonsToast = @"kUDDidShowLongTapTo
 - (void)setHidden:(BOOL)hidden 
 {
   if (!self.hidden && hidden)
-    [[MWMToast toastWithText:L(@"long_tap_toast")] show];
+    [Toast showWithText:L(@"long_tap_toast")];
 
   return [self.sideView setHidden:hidden animated:YES];
 }

--- a/iphone/Maps/Classes/CustomViews/MapViewControls/TrafficButton/MWMTrafficButtonViewController.mm
+++ b/iphone/Maps/Classes/CustomViews/MapViewControls/TrafficButton/MWMTrafficButtonViewController.mm
@@ -65,7 +65,7 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
 
 - (void)viewWillDisappear:(BOOL)animated {
   [super viewWillDisappear:animated];
-  [MWMToast hideAll];
+  [Toast hideAll];
 }
 
 - (void)configLayout {
@@ -115,7 +115,7 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
       break;
     case MWMMapOverlayTrafficStateNoData:
       btn.imageName = @"btn_traffic_on";
-      [[MWMToast toastWithText:L(@"traffic_data_unavailable")] show];
+      [Toast showWithText:L(@"traffic_data_unavailable")];
       break;
     case MWMMapOverlayTrafficStateNetworkError:
       [MWMMapOverlayManager setTrafficEnabled:NO];
@@ -123,11 +123,11 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
       break;
     case MWMMapOverlayTrafficStateExpiredData:
       btn.imageName = @"btn_traffic_outdated";
-      [[MWMToast toastWithText:L(@"traffic_update_maps_text")] show];
+      [Toast showWithText:L(@"traffic_update_maps_text")];
       break;
     case MWMMapOverlayTrafficStateExpiredApp:
       btn.imageName = @"btn_traffic_outdated";
-      [[MWMToast toastWithText:L(@"traffic_update_app_message")] show];
+      [Toast showWithText:L(@"traffic_update_app_message")];
       break;
   }
 }
@@ -138,7 +138,7 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
       break;
     case MWMMapOverlayIsolinesStateEnabled:
       if (![MWMMapOverlayManager isolinesVisible])
-        [[MWMToast toastWithText:L(@"isolines_toast_zooms_1_10")] show];
+        [Toast showWithText:L(@"isolines_toast_zooms_1_10")];
       break;
     case MWMMapOverlayIsolinesStateExpiredData:
       [MWMAlertViewController.activeAlertController presentInfoAlert:L(@"isolines_activation_error_dialog")];
@@ -162,7 +162,7 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
   } else if ([MWMMapOverlayManager transitEnabled]) {
     btn.imageName = @"btn_subway_on";
     if ([MWMMapOverlayManager transitState] == MWMMapOverlayTransitStateNoData)
-      [[MWMToast toastWithText:L(@"subway_data_unavailable")] show];
+      [Toast showWithText:L(@"subway_data_unavailable")];
   } else if ([MWMMapOverlayManager isoLinesEnabled]) {
     btn.imageName = @"btn_isoMap_on";
     [self handleIsolinesState:[MWMMapOverlayManager isolinesState]];

--- a/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
@@ -23,7 +23,6 @@ enum GlobalStyleSheet: String, CaseIterable {
   case trackRecordingWidgetButton = "TrackRecordingWidgetButton"
   case blackOpaqueBackground = "BlackOpaqueBackground"
   case blueBackground = "BlueBackground"
-  case toastBackground = "ToastBackground"
   case fadeBackground = "FadeBackground"
   case errorBackground = "ErrorBackground"
   case blackStatusBarBackground = "BlackStatusBarBackground"
@@ -62,6 +61,8 @@ enum GlobalStyleSheet: String, CaseIterable {
   case grabber
   case modalSheetBackground
   case modalSheetContent
+  case toastBackground
+  case toastLabel
 }
 
 extension GlobalStyleSheet: IStyleSheet {
@@ -196,10 +197,6 @@ extension GlobalStyleSheet: IStyleSheet {
     case .blueBackground:
       return .add { s in
         s.backgroundColor = colors.linkBlue
-      }
-    case .toastBackground:
-      return .add { s in
-        s.backgroundColor = colors.toastBackground
       }
     case .fadeBackground:
       return .add { s in
@@ -451,6 +448,17 @@ extension GlobalStyleSheet: IStyleSheet {
       return .addFrom(Self.modalSheetBackground) { s in
         s.backgroundColor = colors.clear
         s.clip = true
+      }
+    case .toastBackground:
+      return .add { s in
+        s.cornerRadius = .modalSheet
+        s.clip = true
+      }
+    case .toastLabel:
+      return .add { s in
+        s.font = fonts.regular16
+        s.fontColor = colors.whitePrimaryText
+        s.textAlignment = .center
       }
     }
   }

--- a/iphone/Maps/Core/TrackRecorder/TrackRecordingManager.swift
+++ b/iphone/Maps/Core/TrackRecorder/TrackRecordingManager.swift
@@ -138,7 +138,7 @@ final class TrackRecordingManager: NSObject {
 
   private func stop(completion: (CompletionHandler)? = nil) {
     guard !trackRecorder.isTrackRecordingEmpty() else {
-      Toast.toast(withText: L("track_recording_toast_nothing_to_save")).show()
+      Toast.show(withText: L("track_recording_toast_nothing_to_save"))
       stopRecording(.withoutSaving, completion: completion)
       return
     }

--- a/iphone/Maps/UI/Editor/MWMEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/MWMEditorViewController.mm
@@ -256,7 +256,7 @@ void registerCellsForTableView(std::vector<MWMEditorCellID> const & cells, UITab
 
 - (void)showNotesQueuedToast
 {
-  [[MWMToast toastWithText:L(@"editor_edits_sent_message")] show];
+  [Toast showWithText:L(@"editor_edits_sent_message")];
 }
 
 #pragma mark - Headers

--- a/iphone/Maps/UI/Help/AboutController/AboutController.swift
+++ b/iphone/Maps/UI/Help/AboutController/AboutController.swift
@@ -346,7 +346,7 @@ private extension AboutController {
     UIPasteboard.general.string = content
     let message = String(format: L("copied_to_clipboard"), content)
     UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-    Toast.toast(withText: message).show(withAlignment: .bottom, pinToSafeArea: false)
+    Toast.show(withText: message, alignment: .bottom, pinToSafeArea: false)
   }
 }
 

--- a/iphone/Maps/UI/Help/AboutController/Views/DonationView.swift
+++ b/iphone/Maps/UI/Help/AboutController/Views/DonationView.swift
@@ -59,7 +59,7 @@ final class DonationView: UIView {
   }
 }
 
-private extension NSLayoutConstraint {
+extension NSLayoutConstraint {
   func withPriority(_ priority: UILayoutPriority) -> NSLayoutConstraint {
     self.priority = priority
     return self

--- a/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
@@ -129,7 +129,7 @@ extension PlacePageInteractor: PlacePageInfoViewControllerDelegate {
     UIPasteboard.general.string = content
     let message = String(format: L("copied_to_clipboard"), content)
     UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-    Toast.toast(withText: message).show(withAlignment: .bottom)
+    Toast.show(withText: message, alignment: .bottom)
   }
 
   func didPressOpenInApp(from sourceView: UIView) {

--- a/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
+++ b/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
@@ -254,12 +254,12 @@ static NSString * const kUDDidShowICloudSynchronizationEnablingAlert = @"kUDDidS
           break;
         }
         case MWMBookmarksShareStatusEmptyCategory:
-          [[MWMToast toastWithText:L(@"bookmarks_error_title_share_empty")] show];
+          [Toast showWithText:L(@"bookmarks_error_title_share_empty")];
           isEnabled(NO);
           break;
         case MWMBookmarksShareStatusArchiveError:
         case MWMBookmarksShareStatusFileError:
-          [[MWMToast toastWithText:L(@"dialog_routing_system_error")] show];
+          [Toast showWithText:L(@"dialog_routing_system_error")];
           isEnabled(NO);
           break;
       }


### PR DESCRIPTION
1. Update style: bigger fonts and insets to make toast more readable
2. Update background blur
3. Get rid of MWM prefix
4. Replace the `timer` with the `dispatch async after`. In this case, there is no need to create a whole timer for each toast message just to add a timeout.
5. Reorder Toast class methods for more readibility
6. Replace the instance  method `show` with a class `static show`. Because there is no need to call `show` every time: we do not have stored toast that will be shown in different places than created.

___
Before/Aftter
<img width="370" alt="image" src="https://github.com/user-attachments/assets/c91192f3-2f3a-4ddf-a573-c78f61efb0be" /> <img width="370" alt="image" src="https://github.com/user-attachments/assets/768e9117-1406-44a6-bc15-bfb8de9ac00f" /> 