### PR TITLE
[strings] Change 'My position' to 'My location'

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmApplication.java
+++ b/android/app/src/main/java/app/organicmaps/MwmApplication.java
@@ -252,7 +252,7 @@ public class MwmApplication extends Application implements Application.ActivityL
     nativeAddLocalization("core_entrance", getString(R.string.core_entrance));
     nativeAddLocalization("core_exit", getString(R.string.core_exit));
     nativeAddLocalization("core_my_places", getString(R.string.core_my_places));
-    nativeAddLocalization("core_my_position", getString(R.string.core_my_position));
+    nativeAddLocalization("core_my_location", getString(R.string.core_my_location));
     nativeAddLocalization("core_placepage_unknown_place", getString(R.string.core_placepage_unknown_place));
     nativeAddLocalization("postal_code", getString(R.string.postal_code));
     nativeAddLocalization("wifi", getString(R.string.category_wifi));

--- a/android/app/src/main/java/app/organicmaps/routing/ManageRouteAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/routing/ManageRouteAdapter.java
@@ -97,7 +97,7 @@ public class ManageRouteAdapter extends RecyclerView.Adapter<ManageRouteAdapter.
     if (mRoutePoints.get(position).mIsMyPosition)
     {
       // My position point.
-      title = mContext.getString(R.string.core_my_position);
+      title = mContext.getString(R.string.core_my_location);
 
       if (mRoutePoints.get(position).mPointType != RoutePointInfo.ROUTE_MARK_START)
         subtitle = mRoutePoints.get(position).mTitle;

--- a/android/app/src/main/res/layout/item_search_my_position.xml
+++ b/android/app/src/main/res/layout/item_search_my_position.xml
@@ -2,5 +2,5 @@
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:app="http://schemas.android.com/apk/res-auto"
           style="@style/MwmWidget.TextView.Search"
-          android:text="@string/p2p_your_location"
+          android:text="@string/core_my_location"
           app:drawableStartCompat="@drawable/ic_search_my_position"/>

--- a/android/app/src/main/res/layout/map_buttons_myposition.xml
+++ b/android/app/src/main/res/layout/map_buttons_myposition.xml
@@ -3,4 +3,4 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:id="@+id/my_position"
   style="@style/MwmWidget.MapButton"
-  android:contentDescription="@string/core_my_position" />
+  android:contentDescription="@string/core_my_location"/>

--- a/android/app/src/main/res/values-af/strings.xml
+++ b/android/app/src/main/res/values-af/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">GB</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Myle</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">My posisie</string>
     <!-- Update maps later button text -->
     <string name="later">Later</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -400,7 +398,6 @@
     <string name="search_history_title">Soekgeskiedenis</string>
     <string name="search_history_text">Bekyk al u onlangse soektogte.</string>
     <string name="clear_search">Wis soekgeskiedenis</string>
-    <string name="p2p_your_location">U ligging</string>
     <string name="p2p_start">Begin</string>
     <string name="p2p_from_here">Roete vanaf</string>
     <string name="p2p_to_here">Roete na</string>

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">غيغابايت</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">الأميال</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">موقعي</string>
     <!-- Update maps later button text -->
     <string name="later">ًلاحقا</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -428,7 +426,6 @@
     <string name="clear_search">مسح سجل البحث</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">ويكيبيديا</string>
-    <string name="p2p_your_location">موقعك</string>
     <string name="p2p_start">ابدأ</string>
     <string name="p2p_from_here">الطريق من هنا</string>
     <string name="p2p_to_here">الطريق إلى</string>

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -18,8 +18,6 @@
     <string name="mb">MB</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Mil</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Ünvanım</string>
     <!-- Update maps later button text -->
     <string name="later">Daha sonra</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -414,7 +412,6 @@
     <string name="clear_search">Axtarış Tarixçəsini silin</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Vikipediya</string>
-    <string name="p2p_your_location">Məkanınız</string>
     <string name="p2p_start">Başla</string>
     <string name="p2p_from_here">Başlanğıc</string>
     <string name="p2p_to_here">Son dayanacaq</string>

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">ГБ</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Мілі</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Маё месцазнаходжанне</string>
     <!-- Update maps later button text -->
     <string name="later">Потым</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -410,7 +408,6 @@
     <string name="clear_search">Ачысціць гісторыю пошуку</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Вікіпедыя</string>
-    <string name="p2p_your_location">Ваша месцазнаходжанне</string>
     <string name="p2p_start">Пачаць</string>
     <string name="p2p_from_here">Адсюль</string>
     <string name="p2p_to_here">Дасюль</string>

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">ГБ</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Мили</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Мое местоположение</string>
     <!-- Update maps later button text -->
     <string name="later">По-късно</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -379,7 +377,6 @@
     <string name="search_history_title">История на търсенията</string>
     <string name="search_history_text">Преглед на последните търсения.</string>
     <string name="clear_search">Изчистване на историята на търсенията</string>
-    <string name="p2p_your_location">Вашето местоположение</string>
     <string name="p2p_start">Начало</string>
     <string name="p2p_from_here">Маршрут от</string>
     <string name="p2p_to_here">Маршрут към</string>

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Quilòmetres</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Milles</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">La meva posició</string>
     <!-- Update maps later button text -->
     <string name="later">Més tard</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -411,7 +409,6 @@
     <string name="clear_search">Buida l\'historial de cerques.</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Viquipèdia</string>
-    <string name="p2p_your_location">La vostra ubicació</string>
     <string name="p2p_start">Inicia</string>
     <string name="p2p_from_here">De</string>
     <string name="p2p_to_here">A</string>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilometry</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Míle</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Moje poloha</string>
     <!-- Update maps later button text -->
     <string name="later">Později</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -389,7 +387,6 @@
     <string name="search_history_title">Historie vyhledávání</string>
     <string name="search_history_text">Získejte rychlý přístup k hledaným výrazům.</string>
     <string name="clear_search">Vymazat historii vyhledávání</string>
-    <string name="p2p_your_location">Vaše umístění</string>
     <string name="p2p_start">Start</string>
     <string name="p2p_from_here">Trasa z</string>
     <string name="p2p_to_here">Trasa do</string>

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilometer</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Miles</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Min position</string>
     <!-- Update maps later button text -->
     <string name="later">Senere</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -381,7 +379,6 @@
     <string name="search_history_title">Søgehistorik</string>
     <string name="search_history_text">Se dine seneste søgninger.</string>
     <string name="clear_search">Ryd søgehistorik</string>
-    <string name="p2p_your_location">Din placering</string>
     <string name="p2p_start">Start</string>
     <string name="p2p_from_here">Rute fra</string>
     <string name="p2p_to_here">Rute til</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilometer</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Meilen</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Mein Standort</string>
     <!-- Update maps later button text -->
     <string name="later">Später</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -407,7 +405,6 @@
     <string name="search_history_title">Suchverlauf</string>
     <string name="search_history_text">Hier werden Ihre letzten Suchanfragen angezeigt.</string>
     <string name="clear_search">Suchverlauf löschen</string>
-    <string name="p2p_your_location">Ihr Standort</string>
     <string name="p2p_start">Start</string>
     <string name="p2p_from_here">Von</string>
     <string name="p2p_to_here">Nach</string>

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -17,8 +17,6 @@
     <string name="gb">GB</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Μίλια</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Η θέση μου</string>
     <!-- Update maps later button text -->
     <string name="later">Αργότερα</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -416,7 +414,6 @@
     <string name="clear_search">Εκκαθάριση ιστορικού αναζητήσεων</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Βικιπέδια</string>
-    <string name="p2p_your_location">Η τοποθεσία σας</string>
     <string name="p2p_start">Έναρξη</string>
     <string name="p2p_from_here">Διαδρομή από</string>
     <string name="p2p_to_here">Διαδρομή προς</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilómetros</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Millas</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Mi posición</string>
     <!-- Update maps later button text -->
     <string name="later">Luego</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -405,7 +403,6 @@
     <string name="clear_search">Eliminar el historial de búsqueda</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Wikipedia</string>
-    <string name="p2p_your_location">Su ubicación</string>
     <string name="p2p_start">Empezar</string>
     <string name="p2p_from_here">Ruta desde</string>
     <string name="p2p_to_here">Ruta hacia</string>

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilomeetrid</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Miilid</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Minu asukoht</string>
     <!-- Update maps later button text -->
     <string name="later">Hiljem</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -395,7 +393,6 @@
     <string name="clear_search">Kustuta otsinguajalugu</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Vikipeedia</string>
-    <string name="p2p_your_location">Sinu asukoht</string>
     <string name="p2p_start">Alusta</string>
     <string name="p2p_from_here">Teekond lähtekohast</string>
     <string name="p2p_to_here">Teekond sihtkohta</string>

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilometro</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Miliak</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Nire kokapena</string>
     <!-- Update maps later button text -->
     <string name="later">Geroago</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -412,7 +410,6 @@
     <string name="search_history_title">Bilaketa historia</string>
     <string name="search_history_text">Ikusi azken bilaketak.</string>
     <string name="clear_search">Garbitu bilaketa historia</string>
-    <string name="p2p_your_location">Zure kokapena</string>
     <string name="p2p_start">Hasi</string>
     <string name="p2p_from_here">Hemendik</string>
     <string name="p2p_to_here">Bidea hona</string>

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">گیگابایت</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">مایل</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">مکان من</string>
     <!-- Update maps later button text -->
     <string name="later">بعداً</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -381,7 +379,6 @@
     <string name="clear_search">پاک کردن سابقه جستجوها</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">ویکی پدیا</string>
-    <string name="p2p_your_location">موقعیت شما</string>
     <string name="p2p_start">شروع</string>
     <string name="p2p_from_here">مسیر از</string>
     <string name="p2p_to_here">مسیر به</string>

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">Gt</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Mailit</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Sijaintini</string>
     <!-- Update maps later button text -->
     <string name="later">Myöhemmin</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -412,7 +410,6 @@
     <string name="clear_search">Poista hakuhistoria</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Wikipedia</string>
-    <string name="p2p_your_location">Sijaintisi</string>
     <string name="p2p_start">Aloita</string>
     <string name="p2p_from_here">Lähtöpaikka</string>
     <string name="p2p_to_here">Reitin loppupiste</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">Go</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Miles</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Ma position</string>
     <!-- Update maps later button text -->
     <string name="later">Plus tard</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -418,7 +416,6 @@
     <string name="clear_search">Effacer l\'historique de recherche</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Wikipédia</string>
-    <string name="p2p_your_location">Votre emplacement</string>
     <string name="p2p_start">Démarrer</string>
     <string name="p2p_from_here">Depuis</string>
     <string name="p2p_to_here">Itinéraire vers</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">गीगाबाइट</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">मील</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">मेरा स्थान</string>
     <!-- Update maps later button text -->
     <string name="later">बाद में</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilométer</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Mérföld</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Saját helyzet</string>
     <!-- Update maps later button text -->
     <string name="later">Később</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -404,7 +402,6 @@
     <string name="search_history_title">Keresési előzmények</string>
     <string name="search_history_text">Legutóbbi keresések gyors elérése.</string>
     <string name="clear_search">A keresési előzmények törlése</string>
-    <string name="p2p_your_location">Az Ön helyzete</string>
     <string name="p2p_start">Indítás</string>
     <string name="p2p_from_here">Kiindulópont</string>
     <string name="p2p_to_here">Célpont</string>

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -18,8 +18,6 @@
     <string name="mb">MB</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Mil</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Posisi Saya</string>
     <!-- Update maps later button text -->
     <string name="later">Nanti</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -391,7 +389,6 @@
     <string name="search_history_title">Riwayat Pencarian</string>
     <string name="search_history_text">Akses kueri pencarian terbaru dengan cepat.</string>
     <string name="clear_search">Bersihkan riwayat pencarian</string>
-    <string name="p2p_your_location">Lokasi Anda</string>
     <string name="p2p_start">Mulai</string>
     <string name="p2p_from_here">Dari</string>
     <string name="p2p_to_here">Rute ke</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Chilometri</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Miglia</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">La mia posizione</string>
     <!-- Update maps later button text -->
     <string name="later">Più tardi</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -401,7 +399,6 @@
     <string name="clear_search">Cancella сronologia ricerche</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Wikipedia</string>
-    <string name="p2p_your_location">La tua posizione</string>
     <string name="p2p_start">Inizia</string>
     <string name="p2p_from_here">Parti da</string>
     <string name="p2p_to_here">Vai a</string>

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">ק\"מ</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">מייל</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">המיקום שלי</string>
     <!-- Update maps later button text -->
     <string name="later">מאוחר יותר</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -409,7 +407,6 @@
     <string name="clear_search">נקה היסטוריית חיפוש</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">ויקיפדיה</string>
-    <string name="p2p_your_location">המיקום שלך</string>
     <string name="p2p_start">צא לדרך</string>
     <string name="p2p_from_here">מסלול מכאן</string>
     <string name="p2p_to_here">מסלול לכאן</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">キロメートル</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">マイル</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">現在地</string>
     <!-- Update maps later button text -->
     <string name="later">後で</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -418,7 +416,6 @@
     <string name="read_in_wikipedia">ウィキペディア</string>
     <!-- Place Page link to Wikimedia Commons. -->
     <string name="wikimedia_commons">ウィキメディア・コモンズ</string>
-    <string name="p2p_your_location">現在位置</string>
     <string name="p2p_start">開始</string>
     <string name="p2p_from_here">出発地</string>
     <string name="p2p_to_here">目的地</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">킬로미터</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">마일</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">나의 위치</string>
     <!-- Update maps later button text -->
     <string name="later">나중에</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -385,7 +383,6 @@
     <string name="search_history_title">검색 기록</string>
     <string name="search_history_text">최근 검색 쿼리에 신속하게 액세스할 수 있습니다.</string>
     <string name="clear_search">이력 검색 지우기</string>
-    <string name="p2p_your_location">위치</string>
     <string name="p2p_start">시작</string>
     <string name="p2p_from_here">출발지</string>
     <string name="p2p_to_here">목적지</string>

--- a/android/app/src/main/res/values-lt/strings.xml
+++ b/android/app/src/main/res/values-lt/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">GB</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Mylios</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Mano vieta</string>
     <!-- Update maps later button text -->
     <string name="later">Vėliau</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -402,7 +400,6 @@
     <string name="read_in_wikipedia">Vikipedija</string>
     <!-- Place Page link to Wikimedia Commons. -->
     <string name="wikimedia_commons">Vikiteka</string>
-    <string name="p2p_your_location">Jūsų vieta</string>
     <string name="p2p_start">Pradėti</string>
     <string name="p2p_from_here">Maršrutas iš</string>
     <string name="p2p_to_here">Maršrutas į</string>

--- a/android/app/src/main/res/values-lv/strings.xml
+++ b/android/app/src/main/res/values-lv/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilometri</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Jūdzes</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Mana vieta</string>
     <!-- Update maps later button text -->
     <string name="later">Vēlāk</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -410,7 +408,6 @@
     <string name="clear_search">Notīrīt vēsturi</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Vikipēdija</string>
-    <string name="p2p_your_location">Jūsu atrašanās vieta</string>
     <string name="p2p_start">Sākt</string>
     <string name="p2p_from_here">Maršruts no</string>
     <string name="p2p_to_here">Kurp</string>

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">किलोमीटर</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">मैल</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">माझे स्थान</string>
     <!-- Update maps later button text -->
     <string name="later">नंतर</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -385,7 +383,6 @@
     <string name="clear_search">शोध इतिहास पुसून टाका</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">विकिपीडिया</string>
-    <string name="p2p_your_location">तुमचे स्थान</string>
     <string name="p2p_start">सुरू करा</string>
     <string name="p2p_from_here">पासून मार्ग</string>
     <string name="p2p_to_here">पर्यंतचा मार्ग</string>

--- a/android/app/src/main/res/values-mt/strings.xml
+++ b/android/app/src/main/res/values-mt/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilometri</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Mili</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Il-Pożizzjoni Kurrenti</string>
     <!-- Update maps later button text -->
     <string name="later">Aktar tard</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -18,8 +18,6 @@
     <string name="mb">MB</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Miles</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Min posisjon</string>
     <!-- Update maps later button text -->
     <string name="later">Senere</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -411,7 +409,6 @@
     <string name="search_history_title">Søkehistorikk</string>
     <string name="search_history_text">Vis de siste søkene raskt.</string>
     <string name="clear_search">Tøm søkehistorikk</string>
-    <string name="p2p_your_location">Din beliggenhet</string>
     <string name="p2p_start">Start</string>
     <string name="p2p_from_here">Fra</string>
     <string name="p2p_to_here">Rute til</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilometers</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Mijlen</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Mijn locatie</string>
     <!-- Update maps later button text -->
     <string name="later">Later</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -411,7 +409,6 @@
     <string name="search_history_title">Zoekgeschiedenis</string>
     <string name="search_history_text">Snel toegang tot recente zoekopdrachten.</string>
     <string name="clear_search">Wis zoekgeschiedenis</string>
-    <string name="p2p_your_location">Uw locatie</string>
     <string name="p2p_start">Start</string>
     <string name="p2p_from_here">Van</string>
     <string name="p2p_to_here">Route naar</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilometry</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Mile</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Moje położenie</string>
     <!-- Update maps later button text -->
     <string name="later">Później</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -415,7 +413,6 @@
     <string name="clear_search">Wyczyść historię wyszukiwania</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Wikipedia</string>
-    <string name="p2p_your_location">Twoja lokalizacja</string>
     <string name="p2p_start">Start</string>
     <string name="p2p_from_here">Trasa od</string>
     <string name="p2p_to_here">Trasa do</string>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Quilômetros</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Milhas</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Minha posição</string>
     <!-- Update maps later button text -->
     <string name="later">Mais tarde</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -381,7 +379,6 @@
     <string name="clear_search">Limpar histórico de pesquisa</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Wikipédia</string>
-    <string name="p2p_your_location">Localização atual</string>
     <string name="p2p_start">Iniciar</string>
     <string name="p2p_from_here">De</string>
     <string name="p2p_to_here">Para</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Quilómetros</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Milhas</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">A minha posição</string>
     <!-- Update maps later button text -->
     <string name="later">Mais tarde</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -401,7 +399,6 @@
     <string name="clear_search">Limpar histórico de pesquisas</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Wikipédia</string>
-    <string name="p2p_your_location">Localização atual</string>
     <string name="p2p_start">Iniciar</string>
     <string name="p2p_from_here">De</string>
     <string name="p2p_to_here">Itinerário para</string>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilometri</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Mile</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Poziția mea</string>
     <!-- Update maps later button text -->
     <string name="later">Mai târziu</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -399,7 +397,6 @@
     <string name="clear_search">Șterge istoricul căutărilor</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Wikipedia</string>
-    <string name="p2p_your_location">Poziția ta</string>
     <string name="p2p_start">Pornește</string>
     <string name="p2p_from_here">De la</string>
     <string name="p2p_to_here">La</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">ГБ</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Мили</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Мое местоположение</string>
     <!-- Update maps later button text -->
     <string name="later">Не сейчас</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -414,7 +412,6 @@
     <string name="clear_search">Очистить историю поиска</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Википедия</string>
-    <string name="p2p_your_location">Ваше местоположение</string>
     <string name="p2p_start">Начать</string>
     <string name="p2p_from_here">Отсюда</string>
     <string name="p2p_to_here">Сюда</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilometre</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Míle</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Moja poloha</string>
     <!-- Update maps later button text -->
     <string name="later">Neskôr</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -413,7 +411,6 @@
     <string name="clear_search">Vymazať históriu vyhľadávania</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Wikipédia</string>
-    <string name="p2p_your_location">Vaša poloha</string>
     <string name="p2p_start">Štart</string>
     <string name="p2p_from_here">Cesta z</string>
     <string name="p2p_to_here">Cesta do</string>

--- a/android/app/src/main/res/values-sr/strings.xml
+++ b/android/app/src/main/res/values-sr/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Колиметри</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Миље</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Моја позиција</string>
     <!-- Update maps later button text -->
     <string name="later">Касније</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -404,7 +402,6 @@
     <string name="read_in_wikipedia">Википедија</string>
     <!-- Place Page link to Wikimedia Commons. -->
     <string name="wikimedia_commons">Викимедијина остава</string>
-    <string name="p2p_your_location">Ваша локација</string>
     <string name="p2p_start">Крени</string>
     <string name="p2p_from_here">Рута од</string>
     <string name="p2p_to_here">Рута до</string>

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilometer</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Mile</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Min position</string>
     <!-- Update maps later button text -->
     <string name="later">Senare</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -388,7 +386,6 @@
     <string name="search_history_title">Sökhistorik</string>
     <string name="search_history_text">Se senaste sökningar.</string>
     <string name="clear_search">Rensa sökhistorik</string>
-    <string name="p2p_your_location">Din plats</string>
     <string name="p2p_start">Start</string>
     <string name="p2p_from_here">Rutt från</string>
     <string name="p2p_to_here">Rutt till</string>

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -18,8 +18,6 @@
     <string name="mb">MB</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">ไมล์</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">ตำแหน่งของฉัน</string>
     <!-- Update maps later button text -->
     <string name="later">ภายหลัง</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -392,7 +390,6 @@
     <string name="search_history_title">ประวัติการค้นหา</string>
     <string name="search_history_text">เข้าถึงคำถามที่ใช้ในการค้นหาเมื่อเร็ว ๆ นี้ได้อย่างรวดเร็ว</string>
     <string name="clear_search">ล้างการค้นหาประวัติ</string>
-    <string name="p2p_your_location">ตำแหน่งที่ตั้งของคุณ</string>
     <string name="p2p_start">เริ่มต้น</string>
     <string name="p2p_from_here">จาก</string>
     <string name="p2p_to_here">เส้นทางถึง</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -18,8 +18,6 @@
     <string name="mb">MB</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Mil</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Konumum</string>
     <!-- Update maps later button text -->
     <string name="later">Daha sonra</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -415,7 +413,6 @@
     <string name="clear_search">Arama Geçmişini Temizle</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Vikipedi</string>
-    <string name="p2p_your_location">Konumunuz</string>
     <string name="p2p_start">Başla</string>
     <string name="p2p_from_here">Başlangıç</string>
     <string name="p2p_to_here">Varış yeri</string>

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">ГБ</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Милі</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Моє місцезнаходження</string>
     <!-- Update maps later button text -->
     <string name="later">Не зараз</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -413,7 +411,6 @@
     <string name="clear_search">Очистити історію пошуку</string>
     <!-- Place Page link to Wikipedia article (if map object has it). -->
     <string name="read_in_wikipedia">Вікіпедія</string>
-    <string name="p2p_your_location">Ваше місцезнаходження</string>
     <string name="p2p_start">Почати рух</string>
     <string name="p2p_from_here">Звідси</string>
     <string name="p2p_to_here">Сюди</string>

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -16,8 +16,6 @@
     <string name="kilometres">Kilômét</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Dặm</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">Vị trí của Tôi</string>
     <!-- Update maps later button text -->
     <string name="later">Để sau</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -390,7 +388,6 @@
     <string name="search_history_title">Lịch sử tìm kiếm</string>
     <string name="search_history_text">Truy cập nhanh chóng đến câu hỏi tìm kiếm gần đây.</string>
     <string name="clear_search">Xóa Lịch sử Tìm kiếm</string>
-    <string name="p2p_your_location">Vị trí của bạn</string>
     <string name="p2p_start">Bắt đầu</string>
     <string name="p2p_from_here">Từ</string>
     <string name="p2p_to_here">Tuyến đến</string>

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">GB</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">英哩</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">我的位置</string>
     <!-- Update maps later button text -->
     <string name="later">以後再說</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -424,7 +422,6 @@
     <string name="read_in_wikipedia">維基百科</string>
     <!-- Place Page link to Wikimedia Commons. -->
     <string name="wikimedia_commons">維基共享資源</string>
-    <string name="p2p_your_location">您的位置</string>
     <string name="p2p_start">開始</string>
     <string name="p2p_from_here">從這裡出發</string>
     <string name="p2p_to_here">到這裡去</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -19,8 +19,6 @@
     <string name="gb">GB</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">英里</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">我的位置</string>
     <!-- Update maps later button text -->
     <string name="later">以后再说</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -424,7 +422,6 @@
     <string name="read_in_wikipedia">维基百科</string>
     <!-- Place Page link to Wikimedia Commons. -->
     <string name="wikimedia_commons">维基共享资源</string>
-    <string name="p2p_your_location">您的位置</string>
     <string name="p2p_start">开始</string>
     <string name="p2p_from_here">从这出发</string>
     <string name="p2p_to_here">到这去</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -19,8 +19,8 @@
     <string name="gb">GB</string>
     <!-- Choose measurement on first launch alert - choose imperial system button -->
     <string name="miles">Miles</string>
-    <!-- A text for current gps location point/arrow selected on the map -->
-    <string name="core_my_position">My Position</string>
+    <!-- A text for current gps location point/arrow -->
+    <string name="core_my_location">My location</string>
     <!-- Update maps later button text -->
     <string name="later">Later</string>
     <!-- View and button titles for accessibility, please also edit it in iphone/plist.txt -->
@@ -440,7 +440,6 @@
     <string name="read_in_wikipedia">Wikipedia</string>
     <!-- Place Page link to Wikimedia Commons. -->
     <string name="wikimedia_commons">Wikimedia Commons</string>
-    <string name="p2p_your_location">Your Location</string>
     <string name="p2p_start">Start</string>
     <string name="p2p_from_here">Route from</string>
     <string name="p2p_to_here">Route to</string>

--- a/iphone/Maps/Classes/MapsAppDelegate.mm
+++ b/iphone/Maps/Classes/MapsAppDelegate.mm
@@ -52,7 +52,7 @@ void InitLocalizedStrings() {
   f.AddString("core_entrance", L(@"core_entrance").UTF8String);
   f.AddString("core_exit", L(@"core_exit").UTF8String);
   f.AddString("core_my_places", L(@"core_my_places").UTF8String);
-  f.AddString("core_my_position", L(@"core_my_position").UTF8String);
+  f.AddString("core_my_location", L(@"core_my_location").UTF8String);
   f.AddString("core_placepage_unknown_place", L(@"core_placepage_unknown_place").UTF8String);
   f.AddString("postal_code", L(@"postal_code").UTF8String);
 }

--- a/iphone/Maps/Classes/Share/MWMShareActivityItem.mm
+++ b/iphone/Maps/Classes/Share/MWMShareActivityItem.mm
@@ -58,7 +58,7 @@ NSString * httpGe0Url(NSString * shortUrl)
   auto const title = ^NSString *(PlacePageData *data)
   {
     if (!data || data.isMyPosition)
-      return L(@"core_my_position");
+      return L(@"core_my_location");
     else if (data.previewData.title.length > 0)
       return data.previewData.title;
     else if (data.previewData.subtitle.length)
@@ -107,7 +107,7 @@ NSString * httpGe0Url(NSString * shortUrl)
 {
   LPLinkMetadata * metadata = [[LPLinkMetadata alloc] init];
   metadata.originalURL = [NSURL URLWithString:[self url:NO]];
-  metadata.title = self.isMyPosition ? L(@"core_my_position") : self.data.previewData.title;
+  metadata.title = self.isMyPosition ? L(@"core_my_location") : self.data.previewData.title;
   metadata.iconProvider = [[NSItemProvider alloc] initWithObject:[UIImage imageNamed:@"imgLogo"]];
   return metadata;
 }

--- a/iphone/Maps/LocalizedStrings/af.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/af.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Myle";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "My posisie";
-
 /* Update maps later button text */
 "later" = "Later";
 
@@ -480,7 +477,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "U ligging";
 "p2p_start" = "Begin";
 "p2p_from_here" = "Roete vanaf";
 "p2p_to_here" = "Roete na";

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "الأميال";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "موقعي";
-
 /* Update maps later button text */
 "later" = "ًلاحقا";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "موقعك";
 "p2p_start" = "ابدأ";
 "p2p_from_here" = "الطريق من هنا";
 "p2p_to_here" = "الطريق إلى";

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mil";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Ünvanım";
-
 /* Update maps later button text */
 "later" = "Daha sonra";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Məkanınız";
 "p2p_start" = "Başla";
 "p2p_from_here" = "Başlanğıc";
 "p2p_to_here" = "Son dayanacaq";

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Мілі";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Маё месцазнаходжанне";
-
 /* Update maps later button text */
 "later" = "Потым";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Ваша месцазнаходжанне";
 "p2p_start" = "Пачаць";
 "p2p_from_here" = "Адсюль";
 "p2p_to_here" = "Дасюль";

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Мили";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Мое местоположение";
-
 /* Update maps later button text */
 "later" = "По-късно";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Вашето местоположение";
 "p2p_start" = "Начало";
 "p2p_from_here" = "Маршрут от";
 "p2p_to_here" = "Маршрут към";

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Milles";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "La meva posició";
-
 /* Update maps later button text */
 "later" = "Més tard";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "La vostra ubicació";
 "p2p_start" = "Inicia";
 "p2p_from_here" = "De";
 "p2p_to_here" = "A";

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Míle";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Moje poloha";
-
 /* Update maps later button text */
 "later" = "Později";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Vaše umístění";
 "p2p_start" = "Start";
 "p2p_from_here" = "Trasa z";
 "p2p_to_here" = "Trasa do";

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miles";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Min position";
-
 /* Update maps later button text */
 "later" = "Senere";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Din placering";
 "p2p_start" = "Start";
 "p2p_from_here" = "Rute fra";
 "p2p_to_here" = "Rute til";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Meilen";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Mein Standort";
-
 /* Update maps later button text */
 "later" = "Später";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Ihr Standort";
 "p2p_start" = "Start";
 "p2p_from_here" = "Von";
 "p2p_to_here" = "Nach";

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Μίλια";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Η θέση μου";
-
 /* Update maps later button text */
 "later" = "Αργότερα";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Η τοποθεσία σας";
 "p2p_start" = "Έναρξη";
 "p2p_from_here" = "Διαδρομή από";
 "p2p_to_here" = "Διαδρομή προς";

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miles";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "My Position";
-
 /* Update maps later button text */
 "later" = "Later";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Your Location";
 "p2p_start" = "Start";
 "p2p_from_here" = "Route from";
 "p2p_to_here" = "Route to";

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -25,8 +25,8 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miles";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "My Position";
+/* A text for current gps location point/arrow */
+"core_my_location" = "My location";
 
 /* Update maps later button text */
 "later" = "Later";
@@ -488,7 +488,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Your Location";
 "p2p_start" = "Start";
 "p2p_from_here" = "Route from";
 "p2p_to_here" = "Route to";

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Millas";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Mi posición";
-
 /* Update maps later button text */
 "later" = "Luego";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Su ubicación";
 "p2p_start" = "Empezar";
 "p2p_from_here" = "Ruta desde";
 "p2p_to_here" = "Ruta hacia";

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Millas";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Mi posición";
-
 /* Update maps later button text */
 "later" = "Luego";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Su ubicación";
 "p2p_start" = "Empezar";
 "p2p_from_here" = "Ruta desde";
 "p2p_to_here" = "Ruta hacia";

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miilid";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Minu asukoht";
-
 /* Update maps later button text */
 "later" = "Hiljem";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Sinu asukoht";
 "p2p_start" = "Alusta";
 "p2p_from_here" = "Teekond lähtekohast";
 "p2p_to_here" = "Teekond sihtkohta";

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miliak";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Nire kokapena";
-
 /* Update maps later button text */
 "later" = "Geroago";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Zure kokapena";
 "p2p_start" = "Hasi";
 "p2p_from_here" = "Hemendik";
 "p2p_to_here" = "Bidea hona";

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "مایل";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "مکان من";
-
 /* Update maps later button text */
 "later" = "بعداً";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "موقعیت شما";
 "p2p_start" = "شروع";
 "p2p_from_here" = "مسیر از";
 "p2p_to_here" = "مسیر به";

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mailit";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Sijaintini";
-
 /* Update maps later button text */
 "later" = "Myöhemmin";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Sijaintisi";
 "p2p_start" = "Aloita";
 "p2p_from_here" = "Lähtöpaikka";
 "p2p_to_here" = "Reitin loppupiste";

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miles";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Ma position";
-
 /* Update maps later button text */
 "later" = "Plus tard";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Votre emplacement";
 "p2p_start" = "Démarrer";
 "p2p_from_here" = "Depuis";
 "p2p_to_here" = "Itinéraire vers";

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "מייל";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "המיקום שלי";
-
 /* Update maps later button text */
 "later" = "מאוחר יותר";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "המיקום שלך";
 "p2p_start" = "צא לדרך";
 "p2p_from_here" = "מסלול מכאן";
 "p2p_to_here" = "מסלול לכאן";

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "मील";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "मेरा स्थान";
-
 /* Update maps later button text */
 "later" = "बाद में";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Your Location";
 "p2p_start" = "जाएँ";
 "p2p_from_here" = "यहाँ से";
 "p2p_to_here" = "यहाँ तक";

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mérföld";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Saját helyzet";
-
 /* Update maps later button text */
 "later" = "Később";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Az Ön helyzete";
 "p2p_start" = "Indítás";
 "p2p_from_here" = "Kiindulópont";
 "p2p_to_here" = "Célpont";

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mil";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Posisi Saya";
-
 /* Update maps later button text */
 "later" = "Nanti";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Lokasi Anda";
 "p2p_start" = "Mulai";
 "p2p_from_here" = "Dari";
 "p2p_to_here" = "Rute ke";

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miglia";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "La mia posizione";
-
 /* Update maps later button text */
 "later" = "Più tardi";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "La tua posizione";
 "p2p_start" = "Inizia";
 "p2p_from_here" = "Parti da";
 "p2p_to_here" = "Vai a";

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "マイル";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "現在地";
-
 /* Update maps later button text */
 "later" = "後で";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "ウィキメディア・コモンズ";
-"p2p_your_location" = "現在位置";
 "p2p_start" = "開始";
 "p2p_from_here" = "出発地";
 "p2p_to_here" = "目的地";

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "마일";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "나의 위치";
-
 /* Update maps later button text */
 "later" = "나중에";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "위치";
 "p2p_start" = "시작";
 "p2p_from_here" = "출발지";
 "p2p_to_here" = "목적지";

--- a/iphone/Maps/LocalizedStrings/lt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/lt.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mylios";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Mano vieta";
-
 /* Update maps later button text */
 "later" = "Vėliau";
 
@@ -476,7 +473,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Vikiteka";
-"p2p_your_location" = "Jūsų vieta";
 "p2p_start" = "Pradėti";
 "p2p_from_here" = "Maršrutas iš";
 "p2p_to_here" = "Maršrutas į";

--- a/iphone/Maps/LocalizedStrings/lv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/lv.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Jūdzes";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Mana vieta";
-
 /* Update maps later button text */
 "later" = "Vēlāk";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Vikikrātuve";
-"p2p_your_location" = "Jūsu atrašanās vieta";
 "p2p_start" = "Sākt";
 "p2p_from_here" = "Maršruts no";
 "p2p_to_here" = "Kurp";

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "मैल";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "माझे स्थान";
-
 /* Update maps later button text */
 "later" = "नंतर";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "तुमचे स्थान";
 "p2p_start" = "सुरू करा";
 "p2p_from_here" = "पासून मार्ग";
 "p2p_to_here" = "पर्यंतचा मार्ग";

--- a/iphone/Maps/LocalizedStrings/mt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mt.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mili";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Il-Pożizzjoni Kurrenti";
-
 /* Update maps later button text */
 "later" = "Aktar tard";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miles";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Min posisjon";
-
 /* Update maps later button text */
 "later" = "Senere";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Din beliggenhet";
 "p2p_start" = "Start";
 "p2p_from_here" = "Fra";
 "p2p_to_here" = "Rute til";

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mijlen";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Mijn locatie";
-
 /* Update maps later button text */
 "later" = "Later";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Uw locatie";
 "p2p_start" = "Start";
 "p2p_from_here" = "Van";
 "p2p_to_here" = "Route naar";

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mile";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Moje położenie";
-
 /* Update maps later button text */
 "later" = "Później";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Twoja lokalizacja";
 "p2p_start" = "Start";
 "p2p_from_here" = "Trasa od";
 "p2p_to_here" = "Trasa do";

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Milhas";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Minha posição";
-
 /* Update maps later button text */
 "later" = "Mais tarde";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Localização atual";
 "p2p_start" = "Iniciar";
 "p2p_from_here" = "De";
 "p2p_to_here" = "Para";

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Milhas";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "A minha posição";
-
 /* Update maps later button text */
 "later" = "Mais tarde";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Localização atual";
 "p2p_start" = "Iniciar";
 "p2p_from_here" = "De";
 "p2p_to_here" = "Itinerário para";

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mile";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Poziția mea";
-
 /* Update maps later button text */
 "later" = "Mai târziu";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Poziția ta";
 "p2p_start" = "Pornește";
 "p2p_from_here" = "De la";
 "p2p_to_here" = "La";

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Мили";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Мое местоположение";
-
 /* Update maps later button text */
 "later" = "Не сейчас";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Ваше местоположение";
 "p2p_start" = "Начать";
 "p2p_from_here" = "Отсюда";
 "p2p_to_here" = "Сюда";

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Míle";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Moja poloha";
-
 /* Update maps later button text */
 "later" = "Neskôr";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Vaša poloha";
 "p2p_start" = "Štart";
 "p2p_from_here" = "Cesta z";
 "p2p_to_here" = "Cesta do";

--- a/iphone/Maps/LocalizedStrings/sr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sr.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Миље";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Моја позиција";
-
 /* Update maps later button text */
 "later" = "Касније";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Викимедијина остава";
-"p2p_your_location" = "Ваша локација";
 "p2p_start" = "Крени";
 "p2p_from_here" = "Рута од";
 "p2p_to_here" = "Рута до";

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mile";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Min position";
-
 /* Update maps later button text */
 "later" = "Senare";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Din plats";
 "p2p_start" = "Start";
 "p2p_from_here" = "Rutt från";
 "p2p_to_here" = "Rutt till";

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miles";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "My Position";
-
 /* Update maps later button text */
 "later" = "Later";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Your Location";
 "p2p_start" = "Start";
 "p2p_from_here" = "Route from";
 "p2p_to_here" = "Route to";

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "ไมล์";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "ตำแหน่งของฉัน";
-
 /* Update maps later button text */
 "later" = "ภายหลัง";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "ตำแหน่งที่ตั้งของคุณ";
 "p2p_start" = "เริ่มต้น";
 "p2p_from_here" = "จาก";
 "p2p_to_here" = "เส้นทางถึง";

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mil";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Konumum";
-
 /* Update maps later button text */
 "later" = "Daha sonra";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Konumunuz";
 "p2p_start" = "Başla";
 "p2p_from_here" = "Başlangıç";
 "p2p_to_here" = "Varış yeri";

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Милі";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Моє місцезнаходження";
-
 /* Update maps later button text */
 "later" = "Не зараз";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Ваше місцезнаходження";
 "p2p_start" = "Почати рух";
 "p2p_from_here" = "Звідси";
 "p2p_to_here" = "Сюди";

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Dặm";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "Vị trí của Tôi";
-
 /* Update maps later button text */
 "later" = "Để sau";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "Wikimedia Commons";
-"p2p_your_location" = "Vị trí của bạn";
 "p2p_start" = "Bắt đầu";
 "p2p_from_here" = "Từ";
 "p2p_to_here" = "Tuyến đến";

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "英里";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "我的位置";
-
 /* Update maps later button text */
 "later" = "以后再说";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "维基共享资源";
-"p2p_your_location" = "您的位置";
 "p2p_start" = "开始";
 "p2p_from_here" = "从这出发";
 "p2p_to_here" = "到这去";

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -21,9 +21,6 @@
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "英哩";
 
-/* A text for current gps location point/arrow selected on the map */
-"core_my_position" = "我的位置";
-
 /* Update maps later button text */
 "later" = "以後再說";
 
@@ -468,7 +465,6 @@
 
 /* Place Page link to Wikimedia Commons. */
 "wikimedia_commons" = "維基共享資源";
-"p2p_your_location" = "您的位置";
 "p2p_start" = "開始";
 "p2p_from_here" = "從這裡出發";
 "p2p_to_here" = "到這裡去";

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -316,7 +316,7 @@ Framework::Framework(FrameworkParams const & params, bool loadMaps)
   m_stringsBundle.SetDefaultString("core_exit", "Exit");
   m_stringsBundle.SetDefaultString("core_placepage_unknown_place", "Map Point");
   m_stringsBundle.SetDefaultString("core_my_places", "My Places");
-  m_stringsBundle.SetDefaultString("core_my_position", "My Position");
+  m_stringsBundle.SetDefaultString("core_my_location", "My location");
   m_stringsBundle.SetDefaultString("postal_code", "Postal Code");
 
   m_featuresFetcher.InitClassificator();
@@ -786,7 +786,7 @@ void Framework::FillMyPositionInfo(place_page::Info & info, place_page::BuildInf
   auto const position = GetCurrentPosition();
   CHECK(position, ());
   info.SetMercator(*position);
-  info.SetCustomName(m_stringsBundle.GetString("core_my_position"));
+  info.SetCustomName(m_stringsBundle.GetString("core_my_location"));
 
   UserMark const * mark = FindUserMarkInTapPosition(buildInfo);
   if (mark != nullptr && mark->GetMarkType() == UserMark::Type::ROUTING)


### PR DESCRIPTION
This PR changes the string "My position" to "My location" in different parts of the app.

This change was suggested in PR https://github.com/organicmaps/organicmaps/pull/10151#issuecomment-2686457704, related to the new functionality of "Manage Route" for Android.

This change impacts both iOS and Android versions.

The translation of the new string shall be handled using the 'brand' new Weblate way.