### PR TITLE
[Android][UI] Fixed missing newlines in bookmark description

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/Holders.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/Holders.java
@@ -477,7 +477,8 @@ public class Holders
                     ? category.getDescription()
                     : category.getAnnotation();
 
-      Spanned spannedDesc = Utils.fromHtml(desc);
+      String formattedDesc = desc.replace("\n", "<br>");
+      Spanned spannedDesc = Utils.fromHtml(formattedDesc);
       mDescText.setText(spannedDesc);
 
       UiUtils.showIf(!TextUtils.isEmpty(spannedDesc), mDescText);


### PR DESCRIPTION
Fixes #5873, which highlighted that the list description preview on Android did not retain line breaks in plain text.
I modified the String processing before parsing to account for line breaks.

Before:
![before_bugfix](https://github.com/user-attachments/assets/07bb32ec-bb61-4c78-b1bb-5c08499d8bf4)

After:
![after_bugfix](https://github.com/user-attachments/assets/35f22124-83cd-4811-932f-7c4404803501)