### PR TITLE
[android] fix fullscreen exit on Route From

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -2144,7 +2144,10 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public void onRoutingStart()
   {
     if (!showStartPointNotice())
+    {
+      UiUtils.setFullscreen(this, false);
       return;
+    }
 
     if (!showRoutingDisclaimer())
       return;


### PR DESCRIPTION
Fixes #8915

When on fullscreen mode, after selecting "Route to", the app leaves fullscreen mode when initiating the navigation window. The same was not happening when navigating in "Route from" mode, and it was only possible to leave fullscreen mode after leaving the navigation window.

This commit fixes that bug, ensuring that the app leaves fullscreen mode when entering "Route from" navigation. Fullscreen mode can then be set again after exiting navigation.


Demonstration:
https://github.com/user-attachments/assets/0bbb4e50-4fcf-41b6-8dd7-4ae0a2e1a239

