### PR TITLE
[ios] fix Placeholder view animation

### DIFF
--- a/iphone/Maps/UI/Search/SearchOnMap/PlaceholderView.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/PlaceholderView.swift
@@ -109,7 +109,9 @@ final class PlaceholderView: UIView {
     let offset = keyboardHeight > 0 ? max(bounds.height / 2 - keyboardHeight, minOffsetFromTheKeyboardTop + stackView.frame.height) : containerModalYTranslation / 2
     let maxOffset = bounds.height / 2 - maxOffsetFromTheTop
     centerYConstraint.constant = -min(offset, maxOffset)
-    layoutIfNeeded()
+    UIView.animate(withDuration: kDefaultAnimationDuration, delay: .zero, options: [.beginFromCurrentState, .curveEaseOut]) {
+      self.layoutIfNeeded()
+    }
   }
 }
 


### PR DESCRIPTION
The placeholder view animation on the search screen jumps on the modal presentation step changes.
This PR fix it.

### Before/After
#### Normal speed
![Simulator Screen Recording - iPhone 16 Pro - 2025-05-16 at 12 38 17](https://github.com/user-attachments/assets/1b1016c7-e7a0-4daf-a080-3a3c76ba4b0e)
![Simulator Screen Recording - iPhone 16 Pro - 2025-05-16 at 12 37 55](https://github.com/user-attachments/assets/48e5d5e2-bd0e-458a-b18e-1231da4535bc)

#### Slowmo
![Simulator Screen Recording - iPhone 16 Pro - 2025-05-16 at 12 38 29](https://github.com/user-attachments/assets/25ddf108-ccde-424c-be29-0ea8f16fe627)
![Simulator Screen Recording - iPhone 16 Pro - 2025-05-16 at 12 37 44](https://github.com/user-attachments/assets/95fbd6aa-4ce8-47f6-a5dc-90bc99fb5fa0)
