### PR TITLE
[android] Fixes crosshair jump when adding POI

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -734,6 +734,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
   private void showPositionChooser(ChoosePositionMode mode, boolean isBusiness, boolean applyPosition)
   {
     closeFloatingToolbarsAndPanels(false);
+    int width = mMapFragment.getView().getWidth();
+    int height = mMapFragment.getView().getHeight();
+    Framework.nativeSetVisibleRect(0, 0, width, height);
     UiUtils.show(mPointChooser);
     mMapButtonsViewModel.setButtonsHidden(true);
     ChoosePositionMode.set(mode, isBusiness, applyPosition);
@@ -746,6 +749,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     ChoosePositionMode mode = ChoosePositionMode.get();
     ChoosePositionMode.set(ChoosePositionMode.None, false, false);
     mMapButtonsViewModel.setButtonsHidden(false);
+    Framework.nativeDeactivatePopup();
     refreshLightStatusBar();
     if (mode == ChoosePositionMode.Api)
       finish();

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
@@ -31,6 +31,7 @@ import app.organicmaps.bookmarks.data.MapObject;
 import app.organicmaps.bookmarks.data.RoadWarningMarkType;
 import app.organicmaps.intent.Factory;
 import app.organicmaps.routing.RoutingController;
+import app.organicmaps.sdk.ChoosePositionMode;
 import app.organicmaps.settings.RoadType;
 import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.UiUtils;
@@ -225,7 +226,9 @@ public class PlacePageController extends Fragment implements
 
   private void onHiddenInternal()
   {
-    Framework.nativeDeactivatePopup();
+    if (ChoosePositionMode.get() == ChoosePositionMode.None) {
+      Framework.nativeDeactivatePopup();
+    }
     PlacePageUtils.updateMapViewport(mCoordinator, mDistanceToTop, mViewportMinHeight);
     resetPlacePageHeightBounds();
     removePlacePageFragments();


### PR DESCRIPTION
- Fixes : [#9122](https://git.omaps.dev/organicmaps/organicmaps/issues/9122) [#453](https://git.omaps.dev/organicmaps/organicmaps/issues/453)

- Kept the chosen point marker so that user can clearly see selected point.


https://github.com/user-attachments/assets/51187e9f-a5e5-469c-9e9d-464a42d0d051


https://github.com/user-attachments/assets/6f1a5048-726b-43d8-900b-f52c981c81d5

