### PR TITLE
[ios] Remove green background from the Search screen header

### DIFF
--- a/iphone/Maps/Categories/UIView+AddSeparator.swift
+++ b/iphone/Maps/Categories/UIView+AddSeparator.swift
@@ -4,9 +4,10 @@ extension UIView {
     case bottom
   }
 
+  @discardableResult
   func addSeparator(_ position: SeparatorPosition = .top,
                     thickness: CGFloat = 1.0,
-                    insets: UIEdgeInsets = .zero) {
+                    insets: UIEdgeInsets = .zero) -> UIView {
     let lineView = UIView()
     lineView.setStyleAndApply(.divider)
     lineView.isUserInteractionEnabled = false
@@ -24,5 +25,6 @@ extension UIView {
     case .bottom:
       lineView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -insets.bottom).isActive = true
     }
+    return lineView
   }
 }

--- a/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
@@ -4,6 +4,7 @@ enum GlobalStyleSheet: String, CaseIterable {
   case tableViewCell = "MWMTableViewCell"
   case defaultTableViewCell
   case tableViewHeaderFooterView = "TableViewHeaderFooterView"
+  case defaultSearchBar
   case searchBar = "SearchBar"
   case navigationBar = "NavigationBar"
   case navigationBarItem = "NavigationBarItem"
@@ -94,6 +95,14 @@ extension GlobalStyleSheet: IStyleSheet {
       return .add { s in
         s.font = fonts.medium14
         s.fontColor = colors.blackSecondaryText
+      }
+    case .defaultSearchBar:
+      return .add { s in
+        s.backgroundColor = colors.pressBackground
+        s.barTintColor = colors.clear
+        s.fontColor = colors.blackPrimaryText
+        s.fontColorDetailed = UIColor.white
+        s.tintColor = colors.blackSecondaryText
       }
     case .searchBar:
       return .add { s in
@@ -224,10 +233,11 @@ extension GlobalStyleSheet: IStyleSheet {
       }
     case .tabView:
       return .add { s in
-        s.backgroundColor = colors.pressBackground
-        s.barTintColor = colors.primary
-        s.tintColor = colors.white
-        s.fontColor = colors.whitePrimaryText
+        s.backgroundColor = colors.white
+        s.barTintColor = colors.white
+        s.tintColor = colors.linkBlue
+        s.fontColor = colors.blackSecondaryText
+        s.fontColorHighlighted = colors.linkBlue
         s.font = fonts.medium14
       }
     case .dialogView:

--- a/iphone/Maps/Core/Theme/Renderers/TabViewRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/TabViewRenderer.swift
@@ -21,8 +21,12 @@ class TabViewRenderer {
     if let tintColor = style.tintColor {
       control.tintColor = tintColor
     }
+    if let font = style.font, let fontColor = style.fontColorHighlighted {
+      control.selectedHeaderTextAttributes = [.foregroundColor: fontColor,
+                                      .font: font]
+    }
     if let font = style.font, let fontColor = style.fontColor {
-      control.headerTextAttributes = [.foregroundColor: fontColor,
+      control.deselectedHeaderTextAttributes = [.foregroundColor: fontColor,
                                       .font: font]
     }
   }

--- a/iphone/Maps/Core/Theme/SearchStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/SearchStyleSheet.swift
@@ -18,8 +18,8 @@ extension SearchStyleSheet: IStyleSheet {
       }
     case .searchCancelButton:
       return .add { s in
-        s.fontColor = colors.whitePrimaryText
-        s.fontColorHighlighted = colors.whitePrimaryTextHighlighted
+        s.fontColor = colors.linkBlue
+        s.fontColorHighlighted = colors.linkBlueHighlighted
         s.font = fonts.regular17
         s.backgroundColor = .clear
       }

--- a/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapHeaderView.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapHeaderView.swift
@@ -24,6 +24,7 @@ final class SearchOnMapHeaderView: UIView {
   private let searchBar = UISearchBar()
   private let cancelButton = UIButton()
   private let cancelContainer = UIView()
+  private var separator: UIView?
 
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -37,7 +38,7 @@ final class SearchOnMapHeaderView: UIView {
   }
 
   private func setupView() {
-    setStyle(.primaryBackground)
+    setStyle(.background)
 
     setupGrabberView()
     setupGrabberTapHandlerView()
@@ -61,6 +62,7 @@ final class SearchOnMapHeaderView: UIView {
   }
 
   private func setupSearchBar() {
+    searchBar.setStyle(.defaultSearchBar)
     searchBar.placeholder = L("search")
     searchBar.showsCancelButton = false
     if #available(iOS 13.0, *) {
@@ -71,7 +73,7 @@ final class SearchOnMapHeaderView: UIView {
   }
 
   private func setupCancelButton() {
-    cancelContainer.setStyle(.primaryBackground)
+    cancelContainer.setStyle(.background)
     cancelButton.setStyle(.searchCancelButton)
     cancelButton.setTitle(L("cancel"), for: .normal)
     cancelButton.addTarget(self, action: #selector(cancelButtonDidTap), for: .touchUpInside)
@@ -83,6 +85,7 @@ final class SearchOnMapHeaderView: UIView {
     addSubview(searchBar)
     addSubview(cancelContainer)
     cancelContainer.addSubview(cancelButton)
+    separator = addSeparator(.bottom)
 
     grabberView.translatesAutoresizingMaskIntoConstraints = false
     grabberTapHandlerView.translatesAutoresizingMaskIntoConstraints = false
@@ -141,5 +144,9 @@ final class SearchOnMapHeaderView: UIView {
 
   var searchText: SearchOnMap.SearchText {
     SearchOnMap.SearchText(searchBar.text ?? "", locale: searchBar.textInputMode?.primaryLanguage)
+  }
+
+  func setSeparatorHidden(_ hidden: Bool) {
+    separator?.isHidden = hidden
   }
 }

--- a/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapViewController.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapViewController.swift
@@ -168,8 +168,8 @@ final class SearchOnMapViewController: UIViewController {
     }
     view.addSubview(availableAreaView)
     availableAreaView.addSubview(contentView)
-    contentView.addSubview(headerView)
     contentView.addSubview(searchResultsView)
+    contentView.addSubview(headerView)
 
     contentView.translatesAutoresizingMaskIntoConstraints = false
     headerView.translatesAutoresizingMaskIntoConstraints = false
@@ -310,6 +310,7 @@ final class SearchOnMapViewController: UIViewController {
     case .searching:
       break
     }
+    headerView.setSeparatorHidden(content == .historyAndCategory)
     showView(viewToShow(for: content))
   }
 


### PR DESCRIPTION
Closes #10562 

1. green background is removed
2. tab view shadow is replaced with the separator

before/after
<img width="350" alt="image" src="https://github.com/user-attachments/assets/7fb80904-98d5-4786-9013-a80ebd53e629" />  <img width="350" alt="image" src="https://github.com/user-attachments/assets/b18777f2-685f-4a07-9375-2088841350fd" />


<img width="350" alt="image" src="https://github.com/user-attachments/assets/8742ef83-433d-46c0-90ce-80ebdc7b179d" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/776959f7-e72c-41a1-be47-e82d7eb3bb74" />
