### PR TITLE
[ios] Fix search count calculation for `?edits` debug command

### DIFF
--- a/iphone/Maps/Core/Search/MWMSearch.mm
+++ b/iphone/Maps/Core/Search/MWMSearch.mm
@@ -91,7 +91,7 @@ using Observers = NSHashTable<Observer>;
   search::ViewportSearchParams params{
     m_query, m_locale, {} /* default timeout */, m_isCategory,
     // m_onStarted
-    [self] { self.searchCount += 1; },
+    {},
     // m_onCompleted
     [self](search::Results results)
     {
@@ -99,7 +99,6 @@ using Observers = NSHashTable<Observer>;
         return;
       if (!results.IsEndedCancelled())
         self->m_viewportResults = std::move(results);
-      self.searchCount -= 1;
     }
   };
 


### PR DESCRIPTION
Closes #10544

### Bug description
During the searching, the `searchCount` tracks the progress and notifies the observers (when 0 then completed). It crashes in debug when less than 0.

When the `?edits` command is typed into the search field the `searchInViewport`'s  `m_onStarted` callback is called, but `m_onStarted` **is not**  executed at all (in the core). It produces a data race in the `searchCount` and breaks the UI updates for this debug command.

https://github.com/organicmaps/organicmaps/blob/251c2022c855f11a33a0d7ed3e868566c0d1d9df/map/framework.cpp#L2793-L2822

The calling of the `m_onStarted` will not help because it is executed asynchronously as a separate UI task, is also produces a data race (when the count is <0).

### Solution
Since the `searchEverywhere` and `searchInViewport` are called simultaneously while typing the query in iOS, there is no reason to track the `searchInViewport` searches and increment the count. Only the `searchEverywhere` is enough because it is responsible for the UI updates. `searchInViewport` is not affecting the platform UI at all - it's just showing the marks on the map.

<img width="350" alt="image" src="https://github.com/user-attachments/assets/67aa68db-0154-4217-b588-814d11e29d38" />

![Simulator Screen Recording - iPhone 16 Pro - 2025-05-20 at 16 35 11](https://github.com/user-attachments/assets/fd06cf80-8a3c-4286-a4f7-76dd82acd3e6)
