### PR TITLE
[android] Fixed crash when creating RoutePointInfo from JNI.

### DIFF
--- a/android/app/src/main/java/app/organicmaps/sdk/routing/RoutePointInfo.java
+++ b/android/app/src/main/java/app/organicmaps/sdk/routing/RoutePointInfo.java
@@ -30,6 +30,21 @@ public final class RoutePointInfo implements Parcelable
 
   public final int mIntermediateIndex;
 
+  // Called from JNI.
+  @Keep
+  public RoutePointInfo(int markType, int intermediateIndex)
+  {
+    switch (markType)
+    {
+      case 0: mMarkType = RouteMarkType.Start; break;
+      case 1: mMarkType = RouteMarkType.Intermediate; break;
+      case 2: mMarkType = RouteMarkType.Finish; break;
+      default: throw new IllegalArgumentException("Mark type is not valid = " + markType);
+    }
+
+    mIntermediateIndex = intermediateIndex;
+  }
+
   private RoutePointInfo(@NonNull RouteMarkType markType, int intermediateIndex)
   {
     mMarkType = markType;


### PR DESCRIPTION
- Build route
- Select start/intermediate/end point.
- Crash