### PR TITLE
Fix "About" dialog window flags on desktop.

### DIFF
--- a/qt/about.cpp
+++ b/qt/about.cpp
@@ -15,7 +15,8 @@
 #include <QtWidgets/QVBoxLayout>
 
 AboutDialog::AboutDialog(QWidget * parent)
-  : QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint)
+  : QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowMinimizeButtonHint |
+            Qt::WindowMaximizeButtonHint | Qt::WindowCloseButtonHint)
 {
   QIcon icon(":/ui/logo.png");
   setWindowIcon(icon);


### PR DESCRIPTION
On desktop, on Linux, when I open the "About" dialog, I can: 

1. Minimize the app by pressing "minimize" button in the dialog;
2. Maximisze the dialog;
3. Close the dialog.

When building the app on Windows, I can do neither of those things.

I suggest setting those Window flags explicitly to achieve same behaviour across platforms.