### PR TITLE
[ios] Fully expand the track PP when opened

### DIFF
--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageTrackLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageTrackLayout.swift
@@ -104,9 +104,6 @@ class PlacePageTrackLayout: IPlacePageLayout {
     }
     let previewFrame = scrollView.convert(previewView.bounds, from: previewView)
     steps.append(.preview(previewFrame.maxY - scrollHeight))
-    if !compact {
-      steps.append(.expanded(-scrollHeight * 0.55))
-    }
     steps.append(.full(0))
     return steps
   }


### PR DESCRIPTION
The track PP will be fully expanded for now to allow user to see all of the info + elevation data

![Simulator Screen Recording - iPhone 16 Pro - 2025-05-22 at 18 24 14](https://github.com/user-attachments/assets/b3e14013-24d5-4e2f-afe8-d183cd2590e6)
