### PR TITLE
[ios] update side buttons animation

### DIFF
--- a/iphone/Maps/Classes/CustomViews/MapViewControls/SideButtons/MWMSideButtonsView.mm
+++ b/iphone/Maps/Classes/CustomViews/MapViewControls/SideButtons/MWMSideButtonsView.mm
@@ -59,25 +59,28 @@ CGFloat const kButtonsBottomOffset = 6;
 
 - (void)layoutYPosition {
   CGFloat const centerShift = (self.height - self.zoomIn.midY - self.zoomOut.midY) / 2;
-  self.midY = centerShift + self.superview.height / 2;
-  if (self.maxY > self.bottomBound)
-    self.maxY = self.bottomBound;
+  [UIView animateWithDuration:kDefaultAnimationDuration
+                   animations:^{
+    self.midY = centerShift + self.superview.height / 2;
+    if (self.maxY > self.bottomBound)
+      self.maxY = self.bottomBound;
+  }];
 }
 
 - (void)fadeZoomButtonsShow:(BOOL)show {
   CGFloat const alpha = show ? 1.0 : 0.0;
   [UIView animateWithDuration:kDefaultAnimationDuration
                    animations:^{
-                     self.zoomIn.alpha = alpha;
-                     self.zoomOut.alpha = alpha;
-                   }];
+    self.zoomIn.alpha = alpha;
+    self.zoomOut.alpha = alpha;
+  }];
 }
 
 - (void)fadeLocationButtonShow:(BOOL)show {
   [UIView animateWithDuration:kDefaultAnimationDuration
                    animations:^{
-                     self.location.alpha = show ? 1.0 : 0.0;
-                   }];
+    self.location.alpha = show ? 1.0 : 0.0;
+  }];
 }
 
 // Show/hide zoom and location buttons depending on available vertical space.

--- a/iphone/Maps/Classes/CustomViews/MapViewControls/TrafficButton/MWMTrafficButtonViewController.mm
+++ b/iphone/Maps/Classes/CustomViews/MapViewControls/TrafficButton/MWMTrafficButtonViewController.mm
@@ -86,11 +86,13 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
 - (void)refreshLayout {
   dispatch_async(dispatch_get_main_queue(), ^{
     auto const availableArea = self.availableArea;
-    auto const leftOffset = self.hidden ? -self.view.width : availableArea.origin.x + kViewControlsOffsetToBounds;
+    auto const fitInAvailableArea = CGRectGetMaxY(self.view.frame) < CGRectGetMaxY(availableArea) + kTopOffset;
+    auto const shouldHide = self.hidden || !fitInAvailableArea;
+    auto const leftOffset = shouldHide ? -self.view.width : availableArea.origin.x + kViewControlsOffsetToBounds;
     [self.view.superview animateConstraintsWithAnimations:^{
       self.topOffset.constant = availableArea.origin.y + kTopOffset;
       self.leftOffset.constant = leftOffset;
-      self.view.alpha = self.hidden ? 0 : 1;
+      self.view.alpha = shouldHide ? 0 : 1;
     }];
   });
 }
@@ -195,8 +197,6 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
   if (CGRectEqualToRect(controller.availableArea, frame))
     return;
   controller.availableArea = frame;
-  BOOL isHidden = frame.origin.y + frame.size.height < controller.view.origin.y + controller.view.height + kTopOffset;
-  [MapViewController.sharedController.controlsManager setTrafficButtonHidden:isHidden];
   [controller refreshLayout];
 }
 

--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -763,9 +763,6 @@ NSString *const kSettingsSegue = @"Map2Settings";
 - (void)setPlacePageTopBound:(CGFloat)bound duration:(double)duration {
   self.visibleAreaBottom.constant = bound;
   self.sideButtonsAreaBottom.constant = bound;
-  [UIView animateWithDuration:duration delay:0 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
-    [self.view layoutIfNeeded];
-  } completion:nil];
 }
 
 + (void)setViewport:(double)lat lon:(double)lon zoomLevel:(int)zoomLevel {


### PR DESCRIPTION
The old implementation was rigidly tied to the place page top bound. It breaks the side buttons (zoom, location) hiding/showing animation when the PP is expanded. 

Now the side buttons follow the PP top edge with animation softly without rigidity and disappear animated when they are out of bounds.

Also, the `Layers` button now disappears when it does not fit in the available space.


![Simulator Screen Recording - iPhone 16 Pro - 2025-05-22 at 20 16 55](https://github.com/user-attachments/assets/77ff6de5-1bfc-431f-89dc-caa3a2d47711)
![Simulator Screen Recording - iPhone 16 Pro - 2025-05-22 at 20 17 15](https://github.com/user-attachments/assets/3a6bca71-34eb-4852-a4f8-f23589fb41db)
