### PR TITLE
[ios] Increase search screen top inset from the safe area

### DIFF
--- a/iphone/Maps/UI/Search/SearchOnMap/Presentation/ModalPresentationStep.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/Presentation/ModalPresentationStep.swift
@@ -9,9 +9,8 @@ extension ModalPresentationStep {
   private enum Constants {
     static let iPadWidth: CGFloat = 350
     static let compactHeightOffset: CGFloat = 120
-    static let fullScreenHeightFactorPortrait: CGFloat = 0.1
     static let halfScreenHeightFactorPortrait: CGFloat = 0.55
-    static let landscapeTopInset: CGFloat = 10
+    static let topInset: CGFloat = 8
   }
 
   var upper: ModalPresentationStep {
@@ -73,7 +72,7 @@ extension ModalPresentationStep {
     if isPortraitOrientation {
       switch self {
       case .fullScreen:
-        frame.origin.y = containerSize.height * Constants.fullScreenHeightFactorPortrait
+        frame.origin.y = safeAreaInsets.top + Constants.topInset
       case .halfScreen:
         frame.origin.y = containerSize.height * Constants.halfScreenHeightFactorPortrait
       case .compact:
@@ -86,7 +85,7 @@ extension ModalPresentationStep {
       frame.origin.x = safeAreaInsets.left
       switch self {
       case .fullScreen:
-        frame.origin.y = Constants.landscapeTopInset
+        frame.origin.y = Constants.topInset
       case .halfScreen, .compact:
         frame.origin.y = containerSize.height - Constants.compactHeightOffset
       case .hidden:


### PR DESCRIPTION
Now the top inset is `8 + safe area`

Before / After
<img width="350" alt="image" src="https://github.com/user-attachments/assets/55f93b7e-f858-4894-9586-0f395307924a" /><img width="350" alt="image" src="https://github.com/user-attachments/assets/4b2a4af6-e5a5-4b28-8faf-c6bbe54a8e33" />

It doesn't affect landscape iPhone and the iPad
before
<img width="600" alt="image" src="https://github.com/user-attachments/assets/3cb84562-42df-4194-9489-96fddeb4e0eb" />
after
<img width="600" alt="image" src="https://github.com/user-attachments/assets/34491b95-e9c2-4f13-8721-de6017e00d83" />
