### PR TITLE
Fix crash on Android 5 and 6 when PP type field (subtitle) has unicode > 0xFFFF

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/UserMarkHelper.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/UserMarkHelper.cpp
@@ -76,7 +76,7 @@ jobject CreateMapObject(JNIEnv * env, place_page::Info const & info, int mapObje
                           (jint)fID.m_index));
   jni::TScopedLocalRef jTitle(env, jni::ToJavaString(env, info.GetTitle()));
   jni::TScopedLocalRef jSecondaryTitle(env, jni::ToJavaString(env, info.GetSecondaryTitle()));
-  jni::TScopedLocalRef jSubtitle(env, jni::ToJavaString(env, info.GetSubtitle()));
+  jni::TScopedLocalRef jSubtitle(env, jni::ToJavaStringWithSupplementalCharsFix(env, info.GetSubtitle()));
   jni::TScopedLocalRef jAddress(env, jni::ToJavaString(env, info.GetSecondarySubtitle()));
   jni::TScopedLocalRef jApiId(env, jni::ToJavaString(env, parseApi ? info.GetApiUrl() : ""));
   jni::TScopedLocalRef jWikiDescription(env, jni::ToJavaString(env, info.GetWikiDescription()));
@@ -120,7 +120,7 @@ jobject CreateBookmark(JNIEnv *env, const place_page::Info &info,
                               (jlong)info.GetID().GetMwmVersion(), (jint)info.GetID().m_index));
   jni::TScopedLocalRef jTitle(env, jni::ToJavaString(env, info.GetTitle()));
   jni::TScopedLocalRef jSecondaryTitle(env, jni::ToJavaString(env, info.GetSecondaryTitle()));
-  jni::TScopedLocalRef jSubtitle(env, jni::ToJavaString(env, info.GetSubtitle()));
+  jni::TScopedLocalRef jSubtitle(env, jni::ToJavaStringWithSupplementalCharsFix(env, info.GetSubtitle()));
   jni::TScopedLocalRef jAddress(env, jni::ToJavaString(env, info.GetSecondarySubtitle()));
   jni::TScopedLocalRef jWikiDescription(env, jni::ToJavaString(env, info.GetWikiDescription()));
   jobject mapObject = env->NewObject(

--- a/android/app/src/main/cpp/app/organicmaps/core/jni_helper.hpp
+++ b/android/app/src/main/cpp/app/organicmaps/core/jni_helper.hpp
@@ -55,6 +55,9 @@ inline jstring ToJavaString(JNIEnv * env, std::string_view sv)
   return ToJavaString(env, std::string(sv).c_str());
 }
 
+// Remove after dropping Android 5 and 6 support.
+jstring ToJavaStringWithSupplementalCharsFix(JNIEnv * env, std::string const & s);
+
 jclass GetStringClass(JNIEnv * env);
 char const * GetStringClassName();
 


### PR DESCRIPTION
Fixes #9624 thanks to @batterydotac

Now it doesn't crash, but WiFi emoji is missing in the font, so it can be fixed separately. Note that other emoji (atm, toilet, accessibility) are displayed properly.

What I don't understand is: why the title without this conversion works, but only subtitle where types are displayed crashes? CC @hb0nd 

![grafik](https://github.com/user-attachments/assets/a2b03a75-023f-4b94-8395-31596cb4212d)

CC @hemanggs 