### PR TITLE
Create map object for all taps on same track

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2136,27 +2136,11 @@ void Framework::OnTapEvent(place_page::BuildInfo const & buildInfo)
   }
   else
   {
-    auto const prevTrackId = m_currentPlacePageInfo ? m_currentPlacePageInfo->GetTrackId()
-                                                    : kml::kInvalidTrackId;
     DeactivateHotelSearchMark();
-
     m_currentPlacePageInfo = placePageInfo;
 
     if (m_currentPlacePageInfo->GetTrackId() != kml::kInvalidTrackId)
-    {
-      if (m_currentPlacePageInfo->GetTrackId() == prevTrackId)
-      {
-        if (m_drapeEngine)
-        {
-          m_drapeEngine->SelectObject(df::SelectionShape::ESelectedObject::OBJECT_TRACK,
-                                      m_currentPlacePageInfo->GetMercator(), FeatureID(),
-                                      false /* isAnim */, false /* isGeometrySelectionAllowed */,
-                                      true /* isSelectionShapeVisible */);
-        }
-        return;
-      }
       GetBookmarkManager().UpdateElevationMyPosition(m_currentPlacePageInfo->GetTrackId());
-    }
 
     ActivateMapSelection();
   }


### PR DESCRIPTION
The current implementation in master does not create new map object after first tap on track that is, if a user clicks second or third time on the same selected track then only the visual mark on track will change but the place page data will stay outdated (like co-ordinates, route to, route from, save bookmark, directionAndAzimuth), all these will not change and will target to the first tapped point on the track. Also few necessary Listeners like onElevationActivePointChanged etc also get blocked.

This PR will enable updation of PP on every tap on track. And will enable proper updation of all the listeners as well.

required for  #10580 

**The iOS portion may require to put an extra check for same trackId before creating elevation graph.** 