### PR TITLE
Fix unintended coupling of 3D settings in Settings page session (#10581)

### DIFF
--- a/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
@@ -317,7 +317,9 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment implements La
     disableOrEnable3DBuildingsForPowerMode(powerManagementValue);
 
     pref.setOnPreferenceChangeListener((preference, newValue) -> {
-      Framework.nativeSet3dMode(_3d.enabled, (Boolean)newValue);
+      Framework.Params3dMode current = new Framework.Params3dMode();
+      Framework.nativeGet3dMode(current);
+      Framework.nativeSet3dMode(current.enabled, (Boolean)newValue);
       return true;
     });
   }
@@ -356,7 +358,9 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment implements La
     pref.setChecked(_3d.enabled);
 
     pref.setOnPreferenceChangeListener((preference, newValue) -> {
-      Framework.nativeSet3dMode((Boolean) newValue, _3d.buildings);
+      Framework.Params3dMode current = new Framework.Params3dMode();
+      Framework.nativeGet3dMode(current);
+      Framework.nativeSet3dMode((Boolean) newValue, current.buildings);
       return true;
     });
   }


### PR DESCRIPTION
Issue:
The "3D buildings" and "Perspective view" settings are coupled per Settings page session so that if one is changed, it overwrites any changes made on the other compared to what the values were when the Settings page was entered.

Fix:
made changes to preference change listener to get the current 3D mode state at the time of the change
This was done by creating a fresh Params3dMode object inside the listener to hold the current state, rather than relying on a previously fetched final object.