### PR TITLE
[ios] Fix route building error while searching when current location is none

### DIFF
--- a/iphone/Maps/Core/Search/SearchResult.mm
+++ b/iphone/Maps/Core/Search/SearchResult.mm
@@ -36,16 +36,16 @@
     if (result.IsSuggest())
       _suggestion = @(result.GetSuggestionString().c_str());
 
+    auto const & pivot = result.GetFeatureCenter();
+    _point = CGPointMake(pivot.x, pivot.y);
+    auto const location = mercator::ToLatLon(pivot);
+    _coordinate = CLLocationCoordinate2DMake(location.m_lat, location.m_lon);
+
     CLLocation * lastLocation = [MWMLocationManager lastLocation];
     if (lastLocation && result.HasPoint()) {
       double distanceInMeters = mercator::DistanceOnEarth(lastLocation.mercator, result.GetFeatureCenter());
       std::string distanceStr = platform::Distance::CreateFormatted(distanceInMeters).ToString();
       _distanceText = @(distanceStr.c_str());
-
-      auto const & pivot = result.GetFeatureCenter();
-      _point = CGPointMake(pivot.x, pivot.y);
-      auto const location = mercator::ToLatLon(pivot);
-      _coordinate = CLLocationCoordinate2DMake(location.m_lat, location.m_lon);
     } else {
       _distanceText = nil;
     }

--- a/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapInteractor.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapInteractor.swift
@@ -96,24 +96,24 @@ final class SearchOnMapInteractor: NSObject {
         searchManager.showResult(at: result.index)
       case .start:
         let point = MWMRoutePoint(cgPoint: result.point,
-                               title: result.titleText,
-                               subtitle: result.addressText,
-                               type: .start,
-                               intermediateIndex: 0)
+                                  title: result.titleText,
+                                  subtitle: result.addressText,
+                                  type: .start,
+                                  intermediateIndex: 0)
         routeManager.build(from: point, bestRouter: false)
       case .finish:
         let point = MWMRoutePoint(cgPoint: result.point,
-                               title: result.titleText,
-                               subtitle: result.addressText,
-                               type: .finish,
-                               intermediateIndex: 0)
+                                  title: result.titleText,
+                                  subtitle: result.addressText,
+                                  type: .finish,
+                                  intermediateIndex: 0)
         routeManager.build(to: point, bestRouter: false)
       @unknown default:
         fatalError("Unsupported routingTooltipSearch")
       }
       return isIPad ? .none : .setSearchScreenHidden(true)
     case .suggestion:
-      var suggestionQuery = SearchQuery(result.suggestion,
+      let suggestionQuery = SearchQuery(result.suggestion,
                                         locale: query.locale,
                                         source: result.isPureSuggest ? .suggestion : .typedText)
       searchManager.searchQuery(suggestionQuery)


### PR DESCRIPTION
Fixes issue https://github.com/organicmaps/organicmaps/issues/10606

When there is no current location found, the `SearchResult` model skips the feature coordinates. It is incorrect behaviour - the coords should be fetched in all cases.

![Simulator Screen Recording - iPhone 16 Pro - 2025-05-26 at 17 24 11](https://github.com/user-attachments/assets/2a87399e-f340-495d-836d-f73e8c976051)
