### PR TITLE
[ios] Skip search query history duplications

### DIFF
--- a/iphone/Maps/Core/Search/MWMSearch.h
+++ b/iphone/Maps/Core/Search/MWMSearch.h
@@ -6,6 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSUInteger, SearchTextSource) {
   SearchTextSourceTypedText,
   SearchTextSourceCategory,
+  SearchTextSourceHistory,
   SearchTextSourceSuggestion,
   SearchTextSourceDeeplink
 };

--- a/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapInteractor.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapInteractor.swift
@@ -81,7 +81,9 @@ final class SearchOnMapInteractor: NSObject {
 
   private func processSelectedText(_ query: SearchQuery) -> SearchOnMap.Response {
     isUpdatesDisabled = false
-    searchManager.save(query)
+    if query.source != .history {
+      searchManager.save(query)
+    }
     searchManager.searchQuery(query)
     showResultsOnMap = true
     return .selectQuery(query)

--- a/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapPresenter.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapPresenter.swift
@@ -82,7 +82,7 @@ final class SearchOnMapPresenter {
       switch query.source {
       case .typedText, .suggestion:
         viewModel.isTyping = true
-      case .category, .deeplink:
+      case .category, .history, .deeplink:
         viewModel.isTyping = false
         viewModel.presentationStep = isRouting ? .hidden : .halfScreen
       @unknown default:

--- a/iphone/Maps/UI/Search/Tabs/SearchTabViewController.swift
+++ b/iphone/Maps/UI/Search/Tabs/SearchTabViewController.swift
@@ -80,7 +80,7 @@ extension SearchTabViewController: SearchCategoriesViewControllerDelegate {
 extension SearchTabViewController: SearchHistoryViewControllerDelegate {
   func searchHistoryViewController(_ viewController: SearchHistoryViewController,
                                    didSelect query: String) {
-    let query = SearchQuery(query.trimmingCharacters(in: .whitespacesAndNewlines) + " ", source: .suggestion)
+    let query = SearchQuery(query.trimmingCharacters(in: .whitespacesAndNewlines) + " ", source: .history)
     delegate?.searchTabController(self, didSearch: query)
   }
 }


### PR DESCRIPTION
### Bug description
When the user types the "Cafe" in the search field,  and pres Save, it will be saved with a keyboard language defined locale (for example `en-EN`). Then, if the user selects it from the search history the `App info locale` will be used (`en-BY`). It produces savings of the 2 objects in the history with the different locales.

### Fix
The `history` query source is added. For this source, the query saving is skipped.

