### PR TITLE
[ios] Make MWMSearchFrameworkHelper methods `class` instead of `instance`

### DIFF
--- a/iphone/CoreApi/CoreApi/Search/MWMSearchFrameworkHelper.h
+++ b/iphone/CoreApi/CoreApi/Search/MWMSearchFrameworkHelper.h
@@ -4,11 +4,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MWMSearchFrameworkHelper : NSObject
 
-- (NSArray<NSString *> *)searchCategories;
++ (NSArray<NSString *> *)searchCategories;
 
-- (BOOL)isSearchHistoryEmpty;
-- (NSArray<NSString *> *)lastSearchQueries;
-- (void)clearSearchHistory;
++ (BOOL)isSearchHistoryEmpty;
++ (NSArray<NSString *> *)lastSearchQueries;
++ (void)clearSearchHistory;
 
 @end
 

--- a/iphone/CoreApi/CoreApi/Search/MWMSearchFrameworkHelper.mm
+++ b/iphone/CoreApi/CoreApi/Search/MWMSearchFrameworkHelper.mm
@@ -6,34 +6,30 @@
 
 @implementation MWMSearchFrameworkHelper
 
-- (NSArray<NSString *> *)searchCategories
++ (NSArray<NSString *> *)searchCategories
 {
   NSMutableArray * result = [NSMutableArray array];
   auto const & categories = GetFramework().GetDisplayedCategories().GetKeys();
   for (auto const & item : categories)
-  {
     [result addObject:@(item.c_str())];
-  }
   return [result copy];
 }
 
-- (BOOL)isSearchHistoryEmpty
++ (BOOL)isSearchHistoryEmpty
 {
   return GetFramework().GetSearchAPI().GetLastSearchQueries().empty();
 }
 
-- (NSArray<NSString *> *)lastSearchQueries
++ (NSArray<NSString *> *)lastSearchQueries
 {
   NSMutableArray * result = [NSMutableArray array];
   auto const & queries = GetFramework().GetSearchAPI().GetLastSearchQueries();
   for (auto const & item : queries)
-  {
     [result addObject:@(item.second.c_str())];
-  }
   return [result copy];
 }
 
-- (void)clearSearchHistory
++ (void)clearSearchHistory
 {
   GetFramework().GetSearchAPI().ClearSearchHistory();
 }

--- a/iphone/Maps/UI/Search/Tabs/CategoriesTab/SearchCategoriesViewController.swift
+++ b/iphone/Maps/UI/Search/Tabs/CategoriesTab/SearchCategoriesViewController.swift
@@ -7,7 +7,7 @@ final class SearchCategoriesViewController: MWMTableViewController {
   private weak var delegate: SearchCategoriesViewControllerDelegate?
   private let categories: [String]
 
-  init(frameworkHelper: MWMSearchFrameworkHelper, delegate: SearchCategoriesViewControllerDelegate?) {
+  init(frameworkHelper: MWMSearchFrameworkHelper.Type, delegate: SearchCategoriesViewControllerDelegate?) {
     self.delegate = delegate
     categories = frameworkHelper.searchCategories()
     super.init(nibName: nil, bundle: nil)

--- a/iphone/Maps/UI/Search/Tabs/HistoryTab/SearchHistoryViewController.swift
+++ b/iphone/Maps/UI/Search/Tabs/HistoryTab/SearchHistoryViewController.swift
@@ -6,14 +6,14 @@ protocol SearchHistoryViewControllerDelegate: SearchOnMapScrollViewDelegate {
 final class SearchHistoryViewController: MWMViewController {
   private weak var delegate: SearchHistoryViewControllerDelegate?
   private var lastQueries: [String] = []
-  private let frameworkHelper: MWMSearchFrameworkHelper
+  private let frameworkHelper: MWMSearchFrameworkHelper.Type
   private let emptyHistoryView = PlaceholderView(title: L("search_history_title"),
                                                  subtitle: L("search_history_text"))
 
   private let tableView = UITableView()
 
   // MARK: - Init
-  init(frameworkHelper: MWMSearchFrameworkHelper, delegate: SearchHistoryViewControllerDelegate?) {
+  init(frameworkHelper: MWMSearchFrameworkHelper.Type, delegate: SearchHistoryViewControllerDelegate?) {
     self.delegate = delegate
     self.frameworkHelper = frameworkHelper
     super.init(nibName: nil, bundle: nil)

--- a/iphone/Maps/UI/Search/Tabs/SearchTabViewController.swift
+++ b/iphone/Maps/UI/Search/Tabs/SearchTabViewController.swift
@@ -13,10 +13,8 @@ final class SearchTabViewController: TabViewController {
   private static let selectedIndexKey = "SearchTabViewController_selectedIndexKey"
   @objc weak var delegate: SearchTabViewControllerDelegate?
   
-  private lazy var frameworkHelper: MWMSearchFrameworkHelper = {
-    return MWMSearchFrameworkHelper()
-  }()
-  
+  private var frameworkHelper = MWMSearchFrameworkHelper.self
+
   private var activeTab: SearchActiveTab = SearchActiveTab.init(rawValue:
     UserDefaults.standard.integer(forKey: SearchTabViewController.selectedIndexKey)) ?? .categories {
     didSet {


### PR DESCRIPTION
There is no any stored property in this manager so there is no reason to create it's instance.