### PR TITLE
[ios] Fix PlacePage layout for the iPad in SplitView mode

### DIFF
--- a/iphone/Maps/Categories/UIViewController+alternative.swift
+++ b/iphone/Maps/Categories/UIViewController+alternative.swift
@@ -1,9 +1,9 @@
 extension UIViewController {
   func alternativeSizeClass<T>(iPhone: @autoclosure () -> T, iPad: @autoclosure () -> T) -> T {
-    isIPad ? iPad() : iPhone()
+    isiPad ? iPad() : iPhone()
   }
 
   func alternativeSizeClass(iPhone: () -> Void, iPad: () -> Void) {
-    isIPad ? iPad() : iPhone()
+    isiPad ? iPad() : iPhone()
   }
 }

--- a/iphone/Maps/Categories/UIViewController+alternative.swift
+++ b/iphone/Maps/Categories/UIViewController+alternative.swift
@@ -1,16 +1,9 @@
 extension UIViewController {
   func alternativeSizeClass<T>(iPhone: @autoclosure () -> T, iPad: @autoclosure () -> T) -> T {
-    if traitCollection.verticalSizeClass == .regular && traitCollection.horizontalSizeClass == .regular {
-      return iPad()
-    }
-    return iPhone()
+    isIPad ? iPad() : iPhone()
   }
 
   func alternativeSizeClass(iPhone: () -> Void, iPad: () -> Void) {
-    if traitCollection.verticalSizeClass == .regular && traitCollection.horizontalSizeClass == .regular {
-      iPad()
-    } else {
-      iPhone()
-    }
+    isIPad ? iPad() : iPhone()
   }
 }

--- a/iphone/Maps/Common/Common.swift
+++ b/iphone/Maps/Common/Common.swift
@@ -1,10 +1,15 @@
 import Foundation
 
-var isIPad: Bool { return UI_USER_INTERFACE_IDIOM() == .pad }
+var isIPad: Bool {
+  if #available(iOS 14.0, *), ProcessInfo.processInfo.isiOSAppOnMac {
+    return true
+  }
+  return UIDevice.current.userInterfaceIdiom == .pad
+}
 
 func L(_ key: String) -> String { return NSLocalizedString(key, comment: "") }
 
-func alternative<T>(iPhone: T, iPad: T) -> T { return isIPad ? iPad : iPhone }
+func alternative<T>(iPhone: T, iPad: T) -> T { isIPad ? iPad : iPhone }
 
 func iPadSpecific(_ f: () -> Void) {
   if isIPad {

--- a/iphone/Maps/Common/Common.swift
+++ b/iphone/Maps/Common/Common.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-var isIPad: Bool {
+var isiPad: Bool {
   if #available(iOS 14.0, *), ProcessInfo.processInfo.isiOSAppOnMac {
     return true
   }
@@ -9,16 +9,16 @@ var isIPad: Bool {
 
 func L(_ key: String) -> String { return NSLocalizedString(key, comment: "") }
 
-func alternative<T>(iPhone: T, iPad: T) -> T { isIPad ? iPad : iPhone }
+func alternative<T>(iPhone: T, iPad: T) -> T { isiPad ? iPad : iPhone }
 
 func iPadSpecific(_ f: () -> Void) {
-  if isIPad {
+  if isiPad {
     f()
   }
 }
 
 func iPhoneSpecific(_ f: () -> Void) {
-  if !isIPad {
+  if !isiPad {
     f()
   }
 }

--- a/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
@@ -452,7 +452,7 @@ extension GlobalStyleSheet: IStyleSheet {
         s.shadowRadius = 6
         s.cornerRadius = .modalSheet
         s.clip = false
-        s.maskedCorners = isIPad ? [] : [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        s.maskedCorners = isiPad ? [] : [.layerMinXMinYCorner, .layerMaxXMinYCorner]
       }
     case .modalSheetContent:
       return .addFrom(Self.modalSheetBackground) { s in

--- a/iphone/Maps/Core/Theme/PlacePageStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/PlacePageStyleSheet.swift
@@ -125,7 +125,7 @@ extension PlacePageStyleSheet: IStyleSheet {
     case .ppBackgroundView:
       return .addFrom(GlobalStyleSheet.modalSheetBackground) { s in
         s.backgroundColor = colors.pressBackground
-        s.maskedCorners = isIPad ? CACornerMask.all : [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        s.maskedCorners = isiPad ? CACornerMask.all : [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         s.clip = false
       }
     case .ppView:

--- a/iphone/Maps/Tests/UI/SearchOnMapTests/SearchOnMapTests.swift
+++ b/iphone/Maps/Tests/UI/SearchOnMapTests/SearchOnMapTests.swift
@@ -130,7 +130,7 @@ final class SearchOnMapTests: XCTestCase {
     searchManager.results = results
 
     interactor.handle(.didSelectResult(results[0], withQuery: query))
-    if isIPad {
+    if isiPad {
       XCTAssertEqual(currentState, .searching)
       XCTAssertEqual(view.viewModel.presentationStep, .fullScreen)
     } else {
@@ -145,7 +145,7 @@ final class SearchOnMapTests: XCTestCase {
 
     interactor.handle(.didSelectPlaceOnMap)
 
-    if isIPad {
+    if isiPad {
       XCTAssertNotEqual(view.viewModel.presentationStep, .hidden)
     } else {
       XCTAssertEqual(view.viewModel.presentationStep, .hidden)
@@ -163,7 +163,7 @@ final class SearchOnMapTests: XCTestCase {
     searchManager.results = results
 
     interactor.handle(.didSelectResult(results[0], withQuery: query))
-    if isIPad {
+    if isiPad {
       XCTAssertEqual(currentState, .searching)
       XCTAssertEqual(view.viewModel.presentationStep, .fullScreen)
     } else {

--- a/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapInteractor.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapInteractor.swift
@@ -48,7 +48,7 @@ final class SearchOnMapInteractor: NSObject {
     case .didSelectResult(let result, let query):
       return processSelectedResult(result, query: query)
     case .didSelectPlaceOnMap:
-      return isIPad ? .none : .setSearchScreenHidden(true)
+      return isiPad ? .none : .setSearchScreenHidden(true)
     case .didDeselectPlaceOnMap:
       return deselectPlaceOnMap()
     case .didStartDraggingMap:
@@ -113,7 +113,7 @@ final class SearchOnMapInteractor: NSObject {
       @unknown default:
         fatalError("Unsupported routingTooltipSearch")
       }
-      return isIPad ? .none : .setSearchScreenHidden(true)
+      return isiPad ? .none : .setSearchScreenHidden(true)
     case .suggestion:
       let suggestionQuery = SearchQuery(result.suggestion,
                                         locale: query.locale,


### PR DESCRIPTION
Im not sure that this PR should close the https://github.com/organicmaps/organicmaps/issues/8404 because it is related only to the last comment: https://github.com/organicmaps/organicmaps/issues/8404#issuecomment-2913883463.

The logic of the decision of whether the device is iPad or not was not correct in the `alternativeSizeClass` methods - it should not rely on hor and vert size classes. Because iPad in `SplitView` mode can have compact horizontal size class (in 1/2 or 1/3- depends on device), this breaks the layout logic. Only in the fullscreen mode iPad will have [both regular](https://developer.apple.com/design/human-interface-guidelines/layout#iOS-iPadOS-device-size-classes).

(Sorry for the vertical GIF)
![Simulator Screen Recording - iPad (9th generation) - 2025-05-28 at 20 39 52](https://github.com/user-attachments/assets/e7bf59e4-1b8a-482f-84d0-03fcc4e04a3c)


