### PR TITLE
Modified button_with_progress.xml

### DIFF
--- a/android/app/src/main/res/layout/button_with_progress.xml
+++ b/android/app/src/main/res/layout/button_with_progress.xml
@@ -36,5 +36,6 @@
     android:layout_marginEnd="@dimen/margin_base_plus"
     android:layout_marginBottom="@dimen/margin_base_plus"
     android:text="@string/download"
+    android:textColor="#000000"
     android:textAppearance="@style/MwmTextAppearance.Body1" />
 </LinearLayout>


### PR DESCRIPTION
Hello,
I just discovered a color-related issue: the text on the "download" button is white, which results in insufficient color contrast. This makes it difficult to read and negatively impacts accessibility. Therefore, it should be changed to black.

before:
![29b](https://github.com/user-attachments/assets/2d5cd416-cfce-415d-aacc-b910237f5eb9)

after:
![29a](https://github.com/user-attachments/assets/7f66aa3a-56bc-4b5c-8484-3368c081775a)
