### PR TITLE
[ios] Fix search infinity loading

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
@@ -145,6 +145,8 @@ NSString *const kNavigationControlViewXibName = @"NavigationControlView";
 
 - (void)statePrepare {
   self.navigationInfoView.state = MWMNavigationInfoViewStatePrepare;
+  if (self.searchManager.isSearching)
+    [self.navigationInfoView setSearchState:NavigationSearchState::MinimizedSearch animated:YES];
   auto routePreview = self.routePreview;
   [routePreview addToView:self.ownerView];
   [routePreview statePrepare];
@@ -252,7 +254,8 @@ NSString *const kNavigationControlViewXibName = @"NavigationControlView";
       break;
     case SearchOnMapStateHidden:
     case SearchOnMapStateSearching:
-      [self setMapSearch];
+      [self.navigationInfoView setSearchState:NavigationSearchState::MinimizedSearch animated:YES];
+      break;
   }
 }
 
@@ -347,10 +350,6 @@ NSString *const kNavigationControlViewXibName = @"NavigationControlView";
   if (!_entity)
     _entity = [[MWMNavigationDashboardEntity alloc] init];
   return _entity;
-}
-
-- (void)setMapSearch {
-  [_navigationInfoView setMapSearch];
 }
 
 #pragma mark - MWMRoutePreviewDelegate

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.h
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.h
@@ -29,8 +29,6 @@ typedef NS_ENUM(NSUInteger, MWMNavigationInfoViewState) {
 
 - (void)onNavigationInfoUpdated:(MWMNavigationDashboardEntity *)info;
 
-- (void)setMapSearch;
-
 - (void)updateToastView;
 
 @end

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.mm
@@ -100,9 +100,6 @@ BOOL defaultOrientation(CGSize const &size) {
 
 @implementation MWMNavigationInfoView
 
-- (void)setMapSearch {
-  [self setSearchState:NavigationSearchState::MinimizedSearch animated:YES];
-}
 - (void)updateToastView {
   // -S-F-L -> Start
   // -S-F+L -> Finish

--- a/iphone/Maps/Core/Search/MWMSearch.h
+++ b/iphone/Maps/Core/Search/MWMSearch.h
@@ -11,10 +11,17 @@ typedef NS_ENUM(NSUInteger, SearchTextSource) {
   SearchTextSourceDeeplink
 };
 
+typedef NS_ENUM(NSUInteger, SearchMode) {
+  SearchModeEverywhere,
+  SearchModeViewport,
+  SearchModeEverywhereAndViewport
+};
+
 @class SearchResult;
 @class SearchQuery;
 
 @protocol SearchManager
+
 + (void)addObserver:(id<MWMSearchObserver>)observer;
 + (void)removeObserver:(id<MWMSearchObserver>)observer;
 
@@ -22,8 +29,8 @@ typedef NS_ENUM(NSUInteger, SearchTextSource) {
 + (void)searchQuery:(SearchQuery *)query;
 
 + (void)showResultAtIndex:(NSUInteger)index;
-+ (void)showEverywhereSearchResultsOnMap;
-+ (void)showViewportSearchResultsOnMap;
++ (SearchMode)searchMode;
++ (void)setSearchMode:(SearchMode)mode;
 
 + (NSArray<SearchResult *> *)getResults;
 

--- a/iphone/Maps/Tests/UI/SearchOnMapTests/SearchOnMapTests.swift
+++ b/iphone/Maps/Tests/UI/SearchOnMapTests/SearchOnMapTests.swift
@@ -239,6 +239,23 @@ final class SearchOnMapTests: XCTestCase {
     XCTAssertEqual(view.viewModel.presentationStep, .halfScreen)
     XCTAssertEqual(view.viewModel.isTyping, false) // No typing when deeplink is used
   }
+
+  func test_GivenSearchIsActive_WhenPresentationStepUpdate_ThenUpdateSearchMode() {
+    interactor.handle(.openSearch)
+    XCTAssertEqual(searchManager.searchMode(), isiPad ? .everywhereAndViewport : .everywhere)
+
+    interactor.handle(.didUpdatePresentationStep(.halfScreen))
+    XCTAssertEqual(searchManager.searchMode(), .everywhereAndViewport)
+
+    interactor.handle(.didUpdatePresentationStep(.compact))
+    XCTAssertEqual(searchManager.searchMode(), .everywhereAndViewport)
+
+    interactor.handle(.didUpdatePresentationStep(.hidden))
+    XCTAssertEqual(searchManager.searchMode(), .viewport)
+
+    interactor.handle(.didUpdatePresentationStep(.fullScreen))
+    XCTAssertEqual(searchManager.searchMode(), isiPad ? .everywhereAndViewport : .everywhere)
+  }
 }
 
 // MARK: - Mocks
@@ -264,6 +281,7 @@ private class SearchManagerMock: SearchManager {
       }
     }
   }
+  private static var _searchMode: SearchMode = .everywhere
 
   static func add(_ observer: any MWMSearchObserver) {
     self.observers.addListener(observer)
@@ -276,10 +294,10 @@ private class SearchManagerMock: SearchManager {
   static func save(_ query: SearchQuery) {}
   static func searchQuery(_ query: SearchQuery) {}
   static func showResult(at index: UInt) {}
-  static func showEverywhereSearchResultsOnMap() {}
-  static func showViewportSearchResultsOnMap() {}
   static func clear() {}
   static func getResults() -> [SearchResult] { results.results }
+  static func searchMode() -> SearchMode { _searchMode }
+  static func setSearchMode(_ mode: SearchMode) { _searchMode = mode }
 }
 
 private extension SearchResult {

--- a/iphone/Maps/UI/Search/SearchOnMap/Presentation/ModalPresentationStepsController.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/Presentation/ModalPresentationStepsController.swift
@@ -77,7 +77,7 @@ final class ModalPresentationStepsController {
       }
 
       let animation: PresentationStepChangeAnimation = abs(velocity.y) > Constants.slowSwipeVelocity ? .slideAndBounce : .slide
-      setStep(nextStep, animation: animation, notifyAboutStepUpdate: true)
+      setStep(nextStep, animation: animation)
     default:
       break
     }
@@ -86,27 +86,23 @@ final class ModalPresentationStepsController {
   func setStep(_ step: ModalPresentationStep,
                completion: (() -> Void)? = nil) {
     guard currentStep != step else { return }
-    setStep(step, animation: .slide, notifyAboutStepUpdate: false, completion: completion)
+    setStep(step, animation: .slide, completion: completion)
   }
 
   private func setStep(_ step: ModalPresentationStep,
                        animation: PresentationStepChangeAnimation,
-                       notifyAboutStepUpdate: Bool = true,
                        completion: (() -> Void)? = nil) {
     guard let presentedView else { return }
     currentStep = step
     updateMaxAvailableFrame()
 
     let frame = frame(for: step)
+    didUpdateHandler?(.didUpdateStep(step))
     didUpdateHandler?(.didUpdateFrame(frame))
 
     ModalPresentationAnimator.animate(with: animation) {
       presentedView.frame = frame
-    } completion: { [weak self] _ in
-      guard let self else { return }
-      if notifyAboutStepUpdate {
-        self.didUpdateHandler?(.didUpdateStep(step))
-      }
+    } completion: { _ in
       completion?()
     }
   }


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/10561 and https://github.com/organicmaps/organicmaps/issues/10609

This PR:
1. Fixes the search modes switching by using the typed `SearchMode` that is tied to the presentation mode:
- When the screen is **fullscreen** on an iPhone, only the `search everywhere` will be triggered
- When the search is in the **"halfscreen" or compact** modes, both the search `everywhere` and `viewport` will be triggered.
- When the search is **hidden** only the `viewport` will be triggered.
- On the iPad, there are only 2 modes: **opened** ( `everywhere` + `viewport`) and **hidden** (`viewport`)

2. During the viewport updates, the new search will be triggered only when the previous search is finished to decrease the search payload and execute searches synchronously.