### PR TITLE
[android] Fix jump of current location point

### DIFF
--- a/android/app/src/main/java/app/organicmaps/location/LocationHelper.java
+++ b/android/app/src/main/java/app/organicmaps/location/LocationHelper.java
@@ -213,7 +213,7 @@ public class LocationHelper implements BaseLocationProvider.Listener
 
     if (mSavedLocation != null)
     {
-      if (!LocationUtils.isFromFusedProvider(location) && !LocationUtils.isLocationBetterThanLast(location, mSavedLocation))
+      if (!LocationUtils.isLocationBetterThanLast(location, mSavedLocation))
       {
         Logger.d(TAG, "The new " + location + " is worse than the last " + mSavedLocation);
         return;

--- a/android/app/src/main/java/app/organicmaps/util/LocationUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/LocationUtils.java
@@ -14,14 +14,11 @@ import android.view.Surface;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 
-import java.util.Objects;
-
 public class LocationUtils
 {
   private LocationUtils() {}
 
   private static final double DEFAULT_SPEED_MPS = 5;
-  private static final float THRESHOLD_DISTNACE_METERS = 3; //meters
   public static final String FUSED_PROVIDER = "fused";
 
   /**
@@ -87,8 +84,7 @@ public class LocationUtils
 
   public static boolean isLocationBetterThanLast(@NonNull Location newLocation, @NonNull Location lastLocation)
   {
-    //if provider is changing but distance between the two co-ords are less than threshold then discard
-    if (!Objects.equals(lastLocation.getProvider(), newLocation.getProvider()) && lastLocation.distanceTo(newLocation) < THRESHOLD_DISTNACE_METERS)
+    if (newLocation.getElapsedRealtimeNanos() < lastLocation.getElapsedRealtimeNanos())
       return false;
 
     // As described in isAccuracySatisfied, GPS may have zero accuracy "for some reasons".

--- a/android/app/src/main/java/app/organicmaps/util/LocationUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/LocationUtils.java
@@ -14,11 +14,14 @@ import android.view.Surface;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 
+import java.util.Objects;
+
 public class LocationUtils
 {
   private LocationUtils() {}
 
   private static final double DEFAULT_SPEED_MPS = 5;
+  private static final float THRESHOLD_DISTNACE_METERS = 3; //meters
   public static final String FUSED_PROVIDER = "fused";
 
   /**
@@ -84,6 +87,10 @@ public class LocationUtils
 
   public static boolean isLocationBetterThanLast(@NonNull Location newLocation, @NonNull Location lastLocation)
   {
+    //if provider is changing but distance between the two co-ords are less than threshold then discard
+    if (!Objects.equals(lastLocation.getProvider(), newLocation.getProvider()) && lastLocation.distanceTo(newLocation) < THRESHOLD_DISTNACE_METERS)
+      return false;
+
     // As described in isAccuracySatisfied, GPS may have zero accuracy "for some reasons".
     if (isFromGpsProvider(lastLocation) && lastLocation.getAccuracy() == 0.0f)
       return true;


### PR DESCRIPTION
partially fixes #10128
fixes #9054 #6270 

The current logic filters out all the location updates from all the providers except the fused location provider. Which results in a jumps in location arrow. Better solution is pass all the location updates (including fused location) through filter and the choose the precise one. 

We cannot solely rely on fused as well since some OS have issues with it. Check out this [comment](https://github.com/organicmaps/organicmaps/blob/master/android/app/src/main/java/app/organicmaps/location/AndroidNativeProvider.java#L92)

Note - Since multiple providers are there so flickering can still be seen but it is minimized due to checks. For total removal either we have to rely on single provider of we need to improve the filter.