### PR TITLE
[android] Fix crash when print log with emoji on Android 5 and 6

### DIFF
--- a/drape/glyph_manager.cpp
+++ b/drape/glyph_manager.cpp
@@ -663,8 +663,10 @@ text::TextMetrics GlyphManager::ShapeText(std::string_view utf8, int fontPixelHe
     } while (u32CharacterIter != end);
   }
 
+  // Uncomment utf8 printing for debugging if necessary. It crashes JNI with non-modified UTF-8 strings on Android 5 and 6.
+  // See https://github.com/organicmaps/organicmaps/issues/10685
   if (allGlyphs.m_glyphs.empty())
-    LOG(LWARNING, ("No glyphs were found in all fonts for string", utf8));
+    LOG(LWARNING, ("No glyphs were found in all fonts for string with characters in warnings above"/*, utf8*/));
 
   // Empirically measured, may need more tuning.
   size_t constexpr kMaxCacheSize = 50000;


### PR DESCRIPTION
A warning with the missing Unicode character code is displayed before this line, so there's no need to print the original string in full.

Fixes #10685

Grapes emoji are also popular in OpenStreetMap.org:

https://www.openstreetmap.org/node/427043258

https://www.openstreetmap.org/node/508567791

https://www.openstreetmap.org/node/807055352

https://www.openstreetmap.org/node/2721676230

https://www.openstreetmap.org/node/4785410399

https://www.openstreetmap.org/node/7775622442

https://www.openstreetmap.org/node/8525518430

https://www.openstreetmap.org/node/9967572810

https://www.openstreetmap.org/node/10900386710

https://www.openstreetmap.org/node/10935098949

https://www.openstreetmap.org/node/11134771875

https://www.openstreetmap.org/node/11220327798

https://www.openstreetmap.org/node/11724569398

https://www.openstreetmap.org/node/12134584501

https://www.openstreetmap.org/node/12422645813

https://www.openstreetmap.org/node/12895460915

https://www.openstreetmap.org/node/12895522552

https://www.openstreetmap.org/node/12895565448

https://www.openstreetmap.org/node/12895565451

https://www.openstreetmap.org/node/12895544955

https://www.openstreetmap.org/node/12895601124

https://www.openstreetmap.org/relation/13708110