### PR TITLE
increse touch area of position chooser done button

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/AdvancedTimetableFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/AdvancedTimetableFragment.java
@@ -29,7 +29,7 @@ public class AdvancedTimetableFragment extends BaseMwmFragment
   private TextInputEditText mInput;
   private WebView mExample;
   private TextView mExamplesTitle;
-  private static ImageView mSaveButton;
+  private static TextView mSaveButton;
   @Nullable
   private String mInitTimetables;
   @Nullable

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/EditBookmarkFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/EditBookmarkFragment.java
@@ -207,17 +207,17 @@ public class EditBookmarkFragment extends BaseMwmDialogFragment implements View.
 
     ViewCompat.setOnApplyWindowInsetsListener(toolbar, PaddingInsetsListener.excludeBottom());
 
-    final ImageView imageView = toolbar.findViewById(R.id.save);
+    final TextView textView = toolbar.findViewById(R.id.save);
     switch (mType)
     {
       case TYPE_BOOKMARK ->
       {
-        imageView.setOnClickListener(v -> saveBookmark());
+        textView.setOnClickListener(v -> saveBookmark());
         toolbar.setTitle(R.string.placepage_edit_bookmark_button);
       }
       case TYPE_TRACK ->
       {
-        imageView.setOnClickListener(v -> saveTrack());
+        textView.setOnClickListener(v -> saveTrack());
         toolbar.setTitle(R.string.edit_track);
       }
     }

--- a/android/app/src/main/res/layout/fragment_edit_bookmark.xml
+++ b/android/app/src/main/res/layout/fragment_edit_bookmark.xml
@@ -11,17 +11,17 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:theme="@style/MwmWidget.ToolbarTheme">
-
-      <ImageView
-        app:tint="@color/image_view"
-        android:id="@+id/save"
-        app:srcCompat="@drawable/ic_done"
-        android:layout_width="?actionBarSize"
-        android:layout_height="?actionBarSize"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:layout_gravity="end|center_vertical"
-        android:scaleType="centerInside"
-        android:contentDescription="@string/save" />
+    <TextView
+      android:id="@+id/save"
+      android:layout_width="wrap_content"
+      android:layout_height="match_parent"
+      android:layout_gravity="end"
+      android:background="?attr/selectableItemBackgroundBorderless"
+      android:contentDescription="@string/save"
+      android:gravity="center_vertical"
+      android:padding="@dimen/margin_base"
+      android:text="@string/save"
+      android:textAppearance="@style/MwmTextAppearance.Body1" />
   </androidx.appcompat.widget.Toolbar>
   <FrameLayout
     style="@style/MwmWidget.FrameLayout.Elevation"

--- a/android/app/src/main/res/layout/fragment_editor_host.xml
+++ b/android/app/src/main/res/layout/fragment_editor_host.xml
@@ -28,15 +28,15 @@
         app:layout_constraintStart_toStartOf="parent"
         android:layout_marginEnd="?actionBarSize"
         tools:visibility="gone" />
-
-      <ImageView
-        app:tint="@color/image_view"
+      <TextView
         android:id="@+id/save"
-        android:layout_width="?actionBarSize"
-        android:layout_height="?actionBarSize"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:padding="@dimen/margin_base"
+        android:text="@string/save"
+        android:gravity="center"
         android:background="?selectableItemBackgroundBorderless"
-        android:scaleType="centerInside"
-        app:srcCompat="@drawable/ic_done"
+        android:textAppearance="@style/MwmTextAppearance.Body1"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>

--- a/android/app/src/main/res/layout/position_chooser.xml
+++ b/android/app/src/main/res/layout/position_chooser.xml
@@ -17,8 +17,7 @@
     <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:orientation="horizontal"
-      android:padding="@dimen/margin_half">
+      android:orientation="horizontal">
 
       <TextView
         android:id="@+id/title"
@@ -26,17 +25,17 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:text="@string/editor_add_select_location"
+        android:layout_margin="@dimen/margin_half"
         android:textAppearance="@style/MwmTextAppearance.Toolbar.Title"/>
-
-      <ImageView
-        app:tint="@color/image_view"
+      <TextView
         android:id="@+id/done"
-        app:srcCompat="@drawable/ic_done"
+        android:text="@string/done"
+        android:layout_height="match_parent"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:paddingHorizontal="@dimen/margin_base"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:layout_gravity="end"
-        android:scaleType="centerInside"
+        android:textAppearance="@style/MwmTextAppearance.Body1"
         android:contentDescription="@string/done" />
 
     </LinearLayout>

--- a/android/app/src/main/res/menu/menu_done.xml
+++ b/android/app/src/main/res/menu/menu_done.xml
@@ -5,6 +5,5 @@
   <item
     app:showAsAction="always"
     android:id="@+id/done"
-    android:title="@string/done"
-    android:icon="@drawable/ic_done"/>
+    android:title="@string/save" />
 </menu>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android">
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
 
   <style name="MwmWidget"/>
 
@@ -130,6 +130,10 @@
     <item name="titleTextAppearance">@style/MwmTextAppearance.Toolbar.Title</item>
   </style>
 
+  <style name="AppTheme.Widget.ActionButton" parent="@style/Widget.AppCompat.ActionButton">
+    <item name="textAllCaps">false</item>
+  </style>
+
   <style name="MwmWidget.ToolbarStyle.Light">
     <item name="android:titleTextAppearance">@style/MwmTextAppearance.Toolbar.Title.Light</item>
     <item name="titleTextAppearance">@style/MwmTextAppearance.Toolbar.Title.Light</item>
@@ -143,6 +147,8 @@
     <item name="android:gravity">center_vertical</item>
     <item name="colorAccent">@android:color/white</item>
     <item name="iconTint">@color/white_primary</item>
+    <item name="actionButtonStyle">@style/AppTheme.Widget.ActionButton</item>
+    <item name="actionMenuTextAppearance">@style/MwmTextAppearance.Body1</item>
   </style>
 
   <style name="MwmWidget.ToolbarTheme.Light" parent="MwmWidget.ToolbarTheme">


### PR DESCRIPTION
Changes tick icon to done/save text view and increases touch area of done button of toolbar as metioned  [here](https://github.com/organicmaps/organicmaps/pull/9697#issuecomment-2957127534) and few more pages too.

<img src="https://github.com/user-attachments/assets/70af0183-adc7-439a-afd8-dff7fc25553a" width="200">
<img src="https://github.com/user-attachments/assets/257d02e9-7d50-404b-a4d4-841f0b747589" width="200">
<img src="https://github.com/user-attachments/assets/a4ce1737-49ea-4222-9db0-286f4bd5d62e" width="200">


