### PR TITLE
[android][editor] Keep the last background unique osm upload work to avoid duplicates

### DIFF
--- a/android/app/src/main/java/app/organicmaps/background/OsmUploadWork.java
+++ b/android/app/src/main/java/app/organicmaps/background/OsmUploadWork.java
@@ -4,10 +4,10 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.work.Constraints;
+import androidx.work.ExistingWorkPolicy;
 import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
-import androidx.work.WorkRequest;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 import app.organicmaps.MwmApplication;
@@ -37,8 +37,8 @@ public class OsmUploadWork extends Worker
     if (Editor.nativeHasSomethingToUpload() && OsmOAuth.isAuthorized(context))
     {
       final Constraints c = new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build();
-      final WorkRequest wr = new OneTimeWorkRequest.Builder(OsmUploadWork.class).setConstraints(c).build();
-      WorkManager.getInstance(context).enqueue(wr);
+      final OneTimeWorkRequest wr = new OneTimeWorkRequest.Builder(OsmUploadWork.class).setConstraints(c).build();
+      WorkManager.getInstance(context).beginUniqueWork("UploadOsmChanges", ExistingWorkPolicy.KEEP, wr).enqueue();
     }
   }
 


### PR DESCRIPTION
May resolve duplicate notes uploading for Android mentioned in #2071

Keeps only one unit of work active by dropping the next one.

> enqueueUniqueWork
Added in [1.0.0](https://developer.android.com/jetpack/androidx/releases/work#1.0.0)

> public @[NonNull](https://developer.android.com/reference/androidx/annotation/NonNull) [Operation](https://developer.android.com/reference/androidx/work/Operation) [enqueueUniqueWork](https://developer.android.com/reference/androidx/work/WorkManager#enqueueUniqueWork(kotlin.String,androidx.work.ExistingWorkPolicy,androidx.work.OneTimeWorkRequest))(
    @[NonNull](https://developer.android.com/reference/androidx/annotation/NonNull) [String](https://developer.android.com/reference/java/lang/String.html) uniqueWorkName,
    @[NonNull](https://developer.android.com/reference/androidx/annotation/NonNull) [ExistingWorkPolicy](https://developer.android.com/reference/androidx/work/ExistingWorkPolicy) existingWorkPolicy,
    @[NonNull](https://developer.android.com/reference/androidx/annotation/NonNull) [OneTimeWorkRequest](https://developer.android.com/reference/androidx/work/OneTimeWorkRequest) request
)

> This method allows you to enqueue work requests to a uniquely-named [WorkContinuation](https://developer.android.com/reference/androidx/work/WorkContinuation), where only one continuation of a particular name can be active at a time. For example, you may only want one sync operation to be active. If there is one pending, you can choose to let it run or replace it with your new work.

> The uniqueWorkName uniquely identifies this [WorkContinuation](https://developer.android.com/reference/androidx/work/WorkContinuation).


> KEEP

> [ExistingWorkPolicy](https://developer.android.com/reference/androidx/work/ExistingWorkPolicy) [ExistingWorkPolicy.KEEP](https://developer.android.com/reference/androidx/work/ExistingWorkPolicy#KEEP)

> If there is existing pending (uncompleted) work with the same unique name, do nothing. Otherwise, insert the newly-specified work.