### PR TITLE
[Generator][Indexer][Android] Display route refs for bus stops

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -1659,6 +1659,16 @@ Java_app_organicmaps_Framework_nativeGetActiveObjectFormattedCuisine(JNIEnv * en
   return jni::ToJavaString(env, g_framework->GetPlacePageInfo().FormatCuisines());
 }
 
+JNIEXPORT jstring JNICALL
+Java_app_organicmaps_Framework_nativeGetActiveObjectFormattedRouteRefs(JNIEnv * env, jclass)
+{
+  ::Framework * frm = g_framework->NativeFramework();
+  if (!frm->HasPlacePageInfo())
+    return {};
+
+  return jni::ToJavaString(env, g_framework->GetPlacePageInfo().FormatRouteRefs());
+}
+
 JNIEXPORT void JNICALL
 Java_app_organicmaps_Framework_nativeSetVisibleRect(JNIEnv * env, jclass, jint left, jint top, jint right, jint bottom)
 {

--- a/android/app/src/main/java/app/organicmaps/Framework.java
+++ b/android/app/src/main/java/app/organicmaps/Framework.java
@@ -302,6 +302,8 @@ public class Framework
 
   public static native String nativeGetActiveObjectFormattedCuisine();
 
+  public static native String nativeGetActiveObjectFormattedRouteRefs();
+
   public static native void nativeSetVisibleRect(int left, int top, int right, int bottom);
 
   // Navigation.

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/Metadata.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/Metadata.java
@@ -67,7 +67,8 @@ public class Metadata implements Parcelable
     FMD_WEBSITE_MENU(46),
     FMD_SELF_SERVICE(47),
     FMD_OUTDOOR_SEATING(48),
-    FMD_NETWORK(49);
+    FMD_NETWORK(49),
+    FMD_ROUTE_REF(50);
     private final int mMetaType;
 
     MetadataType(int metadataType)

--- a/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
@@ -130,6 +130,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
 
   private TextInputLayout mInputHouseNumber;
   private TextInputLayout mInputBuildingLevels;
+  private TextInputLayout mInputRouteRef;
 
   private View mEmptyOpeningHours;
   private TextView mOpeningHours;
@@ -152,6 +153,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
   @Override
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState)
   {
+    super.onViewCreated(view, savedInstanceState);
     mParent = (EditorHostFragment) getParentFragment();
 
     initViews(view);
@@ -199,6 +201,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
     String selfServiceMetadata = Editor.nativeGetMetadata(Metadata.MetadataType.FMD_SELF_SERVICE.toInt());
     mSelfService.setText(Utils.getTagValueLocalized(view.getContext(), "self_service", selfServiceMetadata));
     initMetadataEntry(Metadata.MetadataType.FMD_OPERATOR, 0);
+    initMetadataEntry(Metadata.MetadataType.FMD_ROUTE_REF, R.string.error_enter_correct_route_ref);
     mWifi.setChecked(Editor.nativeHasWifi());
     // TODO Reimplement this to avoid https://github.com/organicmaps/organicmaps/issues/9049
     //mOutdoorSeating.setChecked(Editor.nativeGetSwitchInput(Metadata.MetadataType.FMD_OUTDOOR_SEATING.toInt(),"yes"));
@@ -456,6 +459,8 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
             R.drawable.ic_line_white, R.string.editor_line_social_network, InputType.TYPE_TEXT_VARIATION_URI);
     View operatorBlock = initBlock(view, Metadata.MetadataType.FMD_OPERATOR, R.id.block_operator,
             R.drawable.ic_operator, R.string.editor_operator, 0);
+    View routeRefBlock = initBlock(view, Metadata.MetadataType.FMD_ROUTE_REF, R.id.block_route_ref,
+            R.drawable.ic_category_bus, R.string.route_ref, 0);
 
     View blockCuisine = view.findViewById(R.id.block_cuisine);
     blockCuisine.setOnClickListener(this);
@@ -498,6 +503,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
     mDetailsBlocks.put(Metadata.MetadataType.FMD_WEBSITE_MENU, websiteMenuBlock);
     mDetailsBlocks.put(Metadata.MetadataType.FMD_EMAIL, emailBlock);
     mDetailsBlocks.put(Metadata.MetadataType.FMD_OPERATOR, operatorBlock);
+    mDetailsBlocks.put(Metadata.MetadataType.FMD_ROUTE_REF, routeRefBlock);
 
     mSocialMediaBlocks.put(Metadata.MetadataType.FMD_CONTACT_FACEBOOK, facebookContactBlock);
     mSocialMediaBlocks.put(Metadata.MetadataType.FMD_CONTACT_INSTAGRAM, instagramContactBlock);

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -119,6 +119,8 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
   private TextView mTvOutdoorSeating;
   private View mEntrance;
   private TextView mTvEntrance;
+  private View mRouteRef;
+  private TextView mTvRouteRef;
   private View mEditPlace;
   private View mAddOrganisation;
   private View mAddPlace;
@@ -273,6 +275,9 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     mTvCuisine = mFrame.findViewById(R.id.tv__place_cuisine);
     mEntrance = mFrame.findViewById(R.id.ll__place_entrance);
     mTvEntrance = mEntrance.findViewById(R.id.tv__place_entrance);
+    mRouteRef = mFrame.findViewById(R.id.ll__place_route_ref);
+    mRouteRef.setOnClickListener(this);
+    mTvRouteRef = mFrame.findViewById(R.id.tv__place_route_ref);
     mEditPlace = mFrame.findViewById(R.id.ll__place_editor);
     mEditPlace.setOnClickListener(this);
     mAddOrganisation = mFrame.findViewById(R.id.ll__add_organisation);
@@ -469,7 +474,8 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     final String outdoorSeating = mMapObject.getMetadata(Metadata.MetadataType.FMD_OUTDOOR_SEATING);
     refreshMetadataOrHide(outdoorSeating.equals("yes") ? getString(R.string.outdoor_seating) : "", mOutdoorSeating, mTvOutdoorSeating);
 
-//    showTaxiOffer(mapObject);
+    // showTaxiOffer(mapObject);
+    refreshMetadataOrHide(Framework.nativeGetActiveObjectFormattedRouteRefs(), mRouteRef, mTvRouteRef);
 
     if (RoutingController.get().isNavigating() || RoutingController.get().isPlanning())
     {

--- a/android/app/src/main/res/drawable/ic_category_bus.xml
+++ b/android/app/src/main/res/drawable/ic_category_bus.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="
+            M18,11H6V6H18
+            M16.5,17A1.5,1.5 0 0,1 15,15.5
+            A1.5,1.5 0 0,1 16.5,14
+            A1.5,1.5 0 0,1 18,15.5
+            A1.5,1.5 0 0,1 16.5,17
+            M7.5,17A1.5,1.5 0 0,1 6,15.5
+            A1.5,1.5 0 0,1 7.5,14
+            A1.5,1.5 0 0,1 9,15.5
+            A1.5,1.5 0 0,1 7.5,17
+            M4,16C4,16.88 4.39,17.67 5,18.22V20
+            A1,1 0 0,0 6,21H7
+            A1,1 0 0,0 8,20V19H16V20
+            A1,1 0 0,0 17,21H18
+            A1,1 0 0,0 19,20V18.22
+            C19.61,17.67 20,16.88 20,16V6
+            C20,2.5 16.42,2 12,2
+            C7.58,2 4,2.5 4,6V16Z" />
+</vector>

--- a/android/app/src/main/res/layout/fragment_editor.xml
+++ b/android/app/src/main/res/layout/fragment_editor.xml
@@ -187,6 +187,10 @@
           layout="@layout/item_editor_input"/>
 
         <include
+          android:id="@+id/block_route_ref"
+          layout="@layout/item_editor_input"/>
+          
+        <include
           android:id="@+id/block_website"
           layout="@layout/item_editor_input"/>
 

--- a/android/app/src/main/res/layout/place_page_details.xml
+++ b/android/app/src/main/res/layout/place_page_details.xml
@@ -66,6 +66,8 @@
 
     <include layout="@layout/place_page_outdoor_seating"/>
 
+    <include layout="@layout/place_page_route_ref"/>
+
     <!-- ToDo: Address is missing compared with iOS. It's shown in title but anyway .. -->
 
     <include layout="@layout/place_page_latlon"/>

--- a/android/app/src/main/res/layout/place_page_route_ref.xml
+++ b/android/app/src/main/res/layout/place_page_route_ref.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:id="@+id/ll__place_route_ref"
+  style="@style/PlacePageItemFrame"
+  android:tag="route_ref"
+  tools:background="#40FF00FF"
+  tools:visibility="visible">
+
+  <ImageView
+    android:id="@+id/iv__place_route_ref"
+    style="@style/PlacePageMetadataIcon"
+    app:srcCompat="@drawable/ic_category_bus" />
+
+  <TextView
+    android:id="@+id/tv__place_route_ref"
+    android:textAlignment="viewStart"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textAppearance="@style/MwmTextAppearance.PlacePage"
+    tools:text="Route references"/>
+
+</LinearLayout> 

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -839,4 +839,8 @@
     <string name="uri_open_location_failed">Nenhuma aplicação instalada que possa abrir a localização</string>
     <!-- preference string for using auto theme only in navigation mode -->
     <string name="nav_auto">Auto na navegação</string>
+    <!-- Route reference label in editor -->
+    <string name="route_ref">Linhas de autocarro</string>
+    <string name="route_ref_hint">A;B;C;D (linhas de autocarro separadas por ponto e vírgula)</string>
+    <string name="error_enter_correct_route_ref">Por favor, introduza linhas de autocarro válidas separadas por ponto e vírgula (e.g. A1;B2;C3)</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -921,4 +921,8 @@
     <string name="uri_open_location_failed">No app installed that can open the location</string>
     <!-- preference string for using auto theme only in navigation mode -->
     <string name="nav_auto">Auto in navigation</string>
+    <!-- Route reference label in editor -->
+    <string name="route_ref">Bus lines</string>
+    <string name="route_ref_hint">A;B;C;D (semicolon-separated bus lines)</string>
+    <string name="error_enter_correct_route_ref">Please enter valid bus lines separated by semicolons (e.g. A1;B2;C3)</string>
 </resources>

--- a/android/app/src/main/res/values/types_strings.xml
+++ b/android/app/src/main/res/values/types_strings.xml
@@ -1129,6 +1129,7 @@
     <string name="type.railway.tram.tunnel">Tram Line Tunnel</string>
     <string name="type.railway.tram_stop">Tram Stop</string>
     <string name="type.route">Route</string>
+    <string name="type.route.ref">Route Ref</string>
     <string name="type.route.ferry">Ferry</string>
     <string name="type.route.shuttle_train">route-shuttle_train</string>
     <string name="type.shop">Shop</string>

--- a/data/editor.config
+++ b/data/editor.config
@@ -90,6 +90,10 @@
       <field name="contact_line">
         <tag k="contact:line" />
       </field>
+      <field name="route_ref">
+        <tag k="ref" />
+        <value type="string" many="yes" />
+      </field>
       <field name="outdoor_seating">
         <tag k="outdoor_seating" />
         <value type="list">
@@ -184,6 +188,7 @@
         <field_ref name="contact_twitter" />
         <field_ref name="contact_vk" />
         <field_ref name="contact_line" />
+        <field_ref name="route_ref" />
       </field_group>
       <field_group name="poi_internet">
         <field_ref name="name" />
@@ -550,6 +555,7 @@
       </type>
       <type id="highway-bus_stop">
         <include field="name" />
+        <include field="route_ref" />
       </type>
       <type id="historic-archaeological_site" group="historic">
         <include group="poi" />

--- a/editor/editor_config.cpp
+++ b/editor/editor_config.cpp
@@ -43,7 +43,9 @@ static std::unordered_map<std::string, EType> const kNamesToFMD = {
     {"drive_through", EType::FMD_DRIVE_THROUGH},
     {"website_menu", EType::FMD_WEBSITE_MENU},
     {"self_service", EType::FMD_SELF_SERVICE},
-    {"outdoor_seating", EType::FMD_OUTDOOR_SEATING}
+    {"outdoor_seating", EType::FMD_OUTDOOR_SEATING},
+    {"route_ref", EType::FMD_ROUTE_REF}
+    
     /// @todo Add description?
 };
 

--- a/feature_list/feature_list.cpp
+++ b/feature_list/feature_list.cpp
@@ -269,6 +269,7 @@ public:
     string const wikipedia(meta.Get(feature::Metadata::FMD_WIKIPEDIA));
     string const wikimedia_commons(meta.Get(feature::Metadata::FMD_WIKIMEDIA_COMMONS));
     string const floor(meta.Get(feature::Metadata::FMD_LEVEL));
+    string const route_ref(meta.Get(feature::Metadata::FMD_ROUTE_REF));
     string const fee = category.ends_with("-fee") ? "yes" : "";
     string const atm = HasAtm(f) ? "yes" : "";
 
@@ -276,7 +277,7 @@ public:
         osmId,             uid,             lat,           lon,       mwmName, category,     name,    std::string(city),
         addrStreet,        addrHouse,       phone,         website,   stars,   std::string(metaOperator), internet,
         denomination,      wheelchair,      opening_hours, wikipedia, floor,   fee,          atm,     contact_facebook,
-        contact_instagram, contact_twitter, contact_vk,    contact_line, wikimedia_commons};
+        contact_instagram, contact_twitter, contact_vk,    contact_line, wikimedia_commons, route_ref};
 
     AppendNames(f, columns);
     PrintAsCSV(columns, ';', cout);
@@ -290,7 +291,7 @@ void PrintHeader()
                             "phone",           "website",      "cuisines",   "stars",            "operator",
                             "internet",        "denomination", "wheelchair", "opening_hours",    "wikipedia",
                             "floor",           "fee",          "atm",        "contact_facebook", "contact_instagram",
-                            "contact_twitter", "contact_vk",   "contact_line", "wikimedia_commons"};
+                            "contact_twitter", "contact_vk",   "contact_line", "wikimedia_commons", "route_ref"};
   // Append all supported name languages in order.
   for (uint8_t idx = 1; idx < kLangCount; idx++)
     columns.push_back("name_" + string(StringUtf8Multilang::GetLangByCode(idx)));

--- a/generator/generator_tests/metadata_parser_test.cpp
+++ b/generator/generator_tests/metadata_parser_test.cpp
@@ -663,3 +663,24 @@ UNIT_TEST(Metadata_ValidateAndFormat_url)
   for (auto const& [input, output] : kTests)
     TEST_EQUAL(tp.ValidateAndFormat_url(input), output, ());
 }
+
+UNIT_TEST(Metadata_ValidateAndFormat_route_ref)
+{
+  FeatureBuilderParams params;
+  MetadataTagProcessorImpl tp(params);
+  Metadata & md = params.GetMetadata();
+
+  // Should accept a typical value
+  tp("route_ref", "530;123;203");
+  TEST_EQUAL(md.Get(Metadata::FMD_ROUTE_REF), "530;123;203", ());
+  md.Drop(Metadata::FMD_ROUTE_REF);
+
+  // Should accept a single value
+  tp("route_ref", "702");
+  TEST_EQUAL(md.Get(Metadata::FMD_ROUTE_REF), "702", ());
+  md.Drop(Metadata::FMD_ROUTE_REF);
+
+  // Should ignore empty value
+  tp("route_ref", "");
+  TEST(md.Empty(), ());
+}

--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -472,6 +472,10 @@ std::string MetadataTagProcessorImpl::ValidateAndFormat_duration(std::string con
   return format(hours);
 }
 
+std::string MetadataTagProcessorImpl::ValidateAndFormat_route_ref(std::string const & v)
+{
+  return v;
+}
 
 MetadataTagProcessor::~MetadataTagProcessor()
 {
@@ -566,6 +570,7 @@ void MetadataTagProcessor::operator()(std::string const & k, std::string const &
   case Metadata::FMD_SELF_SERVICE: valid = ValidateAndFormat_self_service(v); break;
   case Metadata::FMD_OUTDOOR_SEATING: valid = ValidateAndFormat_outdoor_seating(v); break;
   case Metadata::FMD_NETWORK: valid = ValidateAndFormat_operator(v); break;
+  case Metadata::FMD_ROUTE_REF: valid = ValidateAndFormat_route_ref(v); break;
   // Metadata types we do not get from OSM.
   case Metadata::FMD_CUISINE:
   case Metadata::FMD_DESCRIPTION:   // processed separately

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -40,6 +40,7 @@ struct MetadataTagProcessorImpl
   static std::string ValidateAndFormat_drive_through(std::string v);
   static std::string ValidateAndFormat_self_service(std::string v);
   static std::string ValidateAndFormat_outdoor_seating(std::string v);
+  static std::string ValidateAndFormat_route_ref(std::string const & v);
 
 protected:
   FeatureBuilderParams & m_params;

--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -268,6 +268,7 @@ bool EditableMapObject::IsValidMetadata(MetadataID type, std::string const & val
   case MetadataID::FMD_POSTCODE: return ValidatePostCode(value);
   case MetadataID::FMD_PHONE_NUMBER: return ValidatePhoneList(value);
   case MetadataID::FMD_EMAIL: return ValidateEmail(value);
+  case MetadataID::FMD_ROUTE_REF: return ValidateRouteRef(value);
 
   default: return true;
   }
@@ -576,6 +577,40 @@ bool EditableMapObject::ValidateName(string const & name)
     if (excludedSymbols.find(ch) != std::u32string_view::npos)
       return false;
   }
+  return true;
+}
+
+bool EditableMapObject::ValidateRouteRef(string const & routeRef)
+{
+  if (routeRef.empty())
+    return true;
+
+  auto const tokens = strings::Tokenize(routeRef, ";");
+  if (tokens.empty())
+    return false;
+
+  for (auto const & token : tokens)
+  {
+    string_view trimmed = token;
+    strings::Trim(trimmed);
+    if (trimmed.empty())
+      return false;
+    
+    for (char c : trimmed)
+    {
+      if (std::isalnum(c))
+        continue;
+        
+      // Allow common route reference symbols
+      if (c == '/' || c == '-' || c == ' ' || c == '.' || 
+          c == '(' || c == ')' || c == '[' || c == ']' ||
+          c == ':' || c == '+' || c == '&')
+        continue;
+        
+      return false;
+    }
+  }
+
   return true;
 }
 

--- a/indexer/editable_map_object.hpp
+++ b/indexer/editable_map_object.hpp
@@ -129,6 +129,7 @@ public:
   static bool ValidateEmail(std::string const & email);
   static bool ValidateLevel(std::string const & level);
   static bool ValidateName(std::string const & name);
+  static bool ValidateRouteRef(std::string const & routeRef);
 
   /// Journal that stores changes to map object
   EditJournal const & GetJournal() const;

--- a/indexer/feature_meta.cpp
+++ b/indexer/feature_meta.cpp
@@ -154,6 +154,8 @@ bool Metadata::TypeFromString(string_view k, Metadata::EType & outType)
     outType = Metadata::FMD_OUTDOOR_SEATING;
   else if (k == "network")
     outType = Metadata::FMD_NETWORK;
+  else if (k == "route_ref")
+    outType = Metadata::FMD_ROUTE_REF;
   else
     return false;
 
@@ -277,6 +279,7 @@ string ToString(Metadata::EType type)
   case Metadata::FMD_SELF_SERVICE: return "self_service";
   case Metadata::FMD_OUTDOOR_SEATING: return "outdoor_seating";
   case Metadata::FMD_NETWORK: return "network";
+  case Metadata::FMD_ROUTE_REF: return "route_ref";
   case Metadata::FMD_COUNT: CHECK(false, ("FMD_COUNT can not be used as a type."));
   };
 

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -155,6 +155,7 @@ public:
     FMD_SELF_SERVICE = 47,
     FMD_OUTDOOR_SEATING = 48,
     FMD_NETWORK = 49,
+    FMD_ROUTE_REF = 50,
     FMD_COUNT
   };
 

--- a/indexer/indexer_tests/editable_map_object_test.cpp
+++ b/indexer/indexer_tests/editable_map_object_test.cpp
@@ -542,4 +542,49 @@ UNIT_TEST(EditableMapObject_GetLocalizedAllTypes)
   }
 }
 
+UNIT_TEST(EditableMapObject_ValidateRouteRef)
+{
+  // Valid cases
+  TEST(EditableMapObject::ValidateRouteRef("530;123;203"), ());
+  TEST(EditableMapObject::ValidateRouteRef("A1;B2;C3"), ());
+  TEST(EditableMapObject::ValidateRouteRef("M1/A1"), ());
+  TEST(EditableMapObject::ValidateRouteRef("(A1)"), ());
+  TEST(EditableMapObject::ValidateRouteRef(""), ());
+  
+  // Invalid cases
+  TEST(!EditableMapObject::ValidateRouteRef("530;;123"), ()); // Empty token
+  TEST(!EditableMapObject::ValidateRouteRef("530; ;123"), ()); // Space-only token
+  TEST(!EditableMapObject::ValidateRouteRef("530#123"), ()); // Invalid character
+  TEST(!EditableMapObject::ValidateRouteRef("530;123;"), ()); // Trailing semicolon
+  TEST(!EditableMapObject::ValidateRouteRef(";530;123"), ()); // Leading semicolon
+}
+
+UNIT_TEST(EditableMapObject_RouteRefJournal)
+{
+  EditableMapObject emo;
+  
+  emo.SetMetadata(MetadataID::FMD_ROUTE_REF, "A1;B2");
+  TEST_EQUAL(emo.GetMetadata(MetadataID::FMD_ROUTE_REF), "A1;B2", ());
+  
+  emo.SetMetadata(MetadataID::FMD_ROUTE_REF, "C3;D4");
+  TEST_EQUAL(emo.GetMetadata(MetadataID::FMD_ROUTE_REF), "C3;D4", ());
+  
+  emo.SetMetadata(MetadataID::FMD_ROUTE_REF, "");
+  TEST_EQUAL(emo.GetMetadata(MetadataID::FMD_ROUTE_REF), "", ());
+}
+
+UNIT_TEST(EditableMapObject_RouteRefFormatting)
+{
+  EditableMapObject emo;
+  
+  emo.SetMetadata(MetadataID::FMD_ROUTE_REF, "A1;B2;C3");
+  TEST_EQUAL(emo.FormatRouteRefs(), "A1, B2, C3", ());
+  
+  emo.SetMetadata(MetadataID::FMD_ROUTE_REF, "A1");
+  TEST_EQUAL(emo.FormatRouteRefs(), "A1", ());
+  
+  emo.SetMetadata(MetadataID::FMD_ROUTE_REF, "");
+  TEST_EQUAL(emo.FormatRouteRefs(), "", ());
+}
+
 } // namespace editable_map_object_test

--- a/indexer/indexer_tests/feature_metadata_test.cpp
+++ b/indexer/indexer_tests/feature_metadata_test.cpp
@@ -132,4 +132,23 @@ UNIT_TEST(Feature_Metadata_Print)
 
   TEST_EQUAL(DebugPrint(m), "Metadata [description=" + DebugPrint(s) + "]", ());
 }
+
+UNIT_TEST(Feature_Metadata_RouteRef)
+{
+  Metadata m;
+  EType const type = EType::FMD_ROUTE_REF;
+
+  TEST_EQUAL(m.Get(type), "", ());
+
+  std::string const kRouteRef = "530;123;203";
+  m.Set(type, kRouteRef);
+  TEST_EQUAL(m.Get(type), kRouteRef, ());
+
+  std::string const kNewRouteRef = "702";
+  m.Set(type, kNewRouteRef);
+  TEST_EQUAL(m.Get(type), kNewRouteRef, ());
+
+  m.Set(type, "");
+  TEST_EQUAL(m.Get(type), "", ());
+}
 } // namespace feature_metadata_test

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -204,6 +204,16 @@ string MapObject::FormatRoadShields() const
   return strings::JoinStrings(m_roadShields, feature::kFieldsSeparator);
 }
 
+string MapObject::FormatRouteRefs() const
+{
+  auto const routeRef = m_metadata.Get(MetadataID::FMD_ROUTE_REF);
+  auto tokens = strings::Tokenize(routeRef, ";");
+  // Tokenize returns string_view, so we convert it to string using vector constructor
+  vector<string> stringTokens(tokens.begin(), tokens.end());
+  return strings::JoinStrings(stringTokens, feature::kFieldsSeparator);
+}
+
+
 int MapObject::GetStars() const
 {
   uint8_t count = 0;

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -80,6 +80,8 @@ public:
 
   std::string FormatRoadShields() const;
 
+  std::string FormatRouteRefs() const;
+
   std::string_view GetOpeningHours() const;
   feature::Internet GetInternet() const;
   int GetStars() const;


### PR DESCRIPTION
Currently, bus/trolleybus/tramway stops do not display any information about the lines that use it. We found that OSM has a bus stop field called "route_ref", listing all bus lines that pass on that specific stop.
<img src="https://github.com/user-attachments/assets/82b21b9c-82de-4d3a-8f2e-4a4fa0719e30" width="200"/>
While working on this implementation, we got to the conclusion that the "route_ref" field is not as common as we'd wish. To face this, we present a solution where users can also edit the field regarding bus lines on a bus stop and add lines on stops that do not use "route_ref". 
<img src="https://github.com/user-attachments/assets/eaa8d3cd-5f11-4914-ba4d-61ba95e17c1f" width="200"/>
Another possible solution would be to use bus stop relations to parse this data - something that can be explored in the future, but would involve parsing those relations, thus adding more data to the .mwm files.
This feature is also related to the issue #2175.

