### PR TITLE
[ios] Fix `stop track recording` button action

### DIFF
--- a/iphone/Maps/UI/BottomMenu/Menu/BottomMenuInteractor.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/BottomMenuInteractor.swift
@@ -77,14 +77,15 @@ extension BottomMenuInteractor: BottomMenuInteractorProtocol {
 
   func toggleTrackRecording() {
     close()
+    let mapViewController = MapViewController.shared()!
     switch trackRecorder.recordingState {
     case .active:
-      break
+      mapViewController.showTrackRecordingPlacePage()
     case .inactive:
       trackRecorder.start { result in
         switch result {
         case .success:
-          MapViewController.shared()?.showTrackRecordingPlacePage()
+          mapViewController.showTrackRecordingPlacePage()
         case .failure:
           break
         }


### PR DESCRIPTION
Hotfix for the issue caused by the #9942 - the stop track recording button doesnt stop the TR.
Now it shows the TR place page screen.

![Simulator Screen Recording - iPhone 16 Pro - 2025-06-16 at 11 52 06](https://github.com/user-attachments/assets/b15d1d55-b3ec-42d2-af28-28e7ba23ab0d)

