### PR TITLE
[ios] Disable elevation chart interaction when the chart data is empty

### DIFF
--- a/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfilePresenter.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfilePresenter.swift
@@ -80,10 +80,13 @@ extension ElevationProfilePresenter: ElevationProfilePresenterProtocol {
 
     let kMinPointsToDraw = 3
     guard let profileData, let chartData, chartData.points.count >= kMinPointsToDraw else {
+      view?.userInteractionEnabled = false
       return
     }
+
     view?.setChartData(ChartPresentationData(chartData, formatter: formatter))
     view?.reloadDescription()
+    view?.userInteractionEnabled = true
 
     guard !profileData.isTrackRecording else {
       view?.isChartViewInfoHidden = true

--- a/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfileViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfileViewController.swift
@@ -3,6 +3,7 @@ import Chart
 protocol ElevationProfileViewProtocol: AnyObject {
   var presenter: ElevationProfilePresenterProtocol?  { get set }
 
+  var userInteractionEnabled: Bool { get set }
   var isChartViewHidden: Bool { get set }
   var isChartViewInfoHidden: Bool { get set }
 
@@ -116,6 +117,12 @@ final class ElevationProfileViewController: UIViewController {
 // MARK: - ElevationProfileViewProtocol
 
 extension ElevationProfileViewController: ElevationProfileViewProtocol {
+
+  var userInteractionEnabled: Bool {
+    get { chartView.isUserInteractionEnabled }
+    set { chartView.isUserInteractionEnabled = newValue }
+  }
+
   var isChartViewHidden: Bool {
     get { chartView.isHidden }
     set {


### PR DESCRIPTION
When the track recording elevation info data is empty (less than 3 point) and the user start interacting with the chart it fail.
This PR fixed it.