### PR TITLE
[ios] remove spacing and separator from the Track recording Place page

### DIFF
--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/IPlacePageLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/IPlacePageLayout.swift
@@ -28,6 +28,11 @@ protocol IPlacePageLayout: AnyObject {
   var bodyViewControllers: [UIViewController] { get }
   var actionBar: ActionBarViewController? { get }
   var navigationBar: UIViewController? { get }
+  var sectionSpacing: CGFloat { get }
 
   func calculateSteps(inScrollView scrollView: UIScrollView, compact: Bool) -> [PlacePageState]
+}
+
+extension IPlacePageLayout {
+  var sectionSpacing: CGFloat { return 24.0 }
 }

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageTrackRecordingLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageTrackRecordingLayout.swift
@@ -53,6 +53,8 @@ final class PlacePageTrackRecordingLayout: IPlacePageLayout {
     return vc
   }()
 
+  var sectionSpacing: CGFloat { 0.0 }
+
   init(interactor: PlacePageInteractor, storyboard: UIStoryboard, data: PlacePageData) {
     self.interactor = interactor
     self.storyboard = storyboard

--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -176,8 +176,10 @@ final class PlacePageScrollView: UIScrollView {
   private func setupLayout(_ layout: IPlacePageLayout) {
     setLayout(layout)
 
-    fillHeader(with: layout.headerViewControllers)
-    fillBody(with: layout.bodyViewControllers)
+    let showSeparator = layout.sectionSpacing > 0
+    stackView.spacing = layout.sectionSpacing
+    fillHeader(with: layout.headerViewControllers, showSeparator: showSeparator)
+    fillBody(with: layout.bodyViewControllers, showSeparator: showSeparator)
 
     beginDragging = false
     if let actionBar = layout.actionBar {
@@ -188,23 +190,27 @@ final class PlacePageScrollView: UIScrollView {
     }
   }
 
-  private func fillHeader(with viewControllers: [UIViewController]) {
+  private func fillHeader(with viewControllers: [UIViewController], showSeparator: Bool = true) {
     viewControllers.forEach { [self] viewController in
       if !stackView.arrangedSubviews.contains(headerStackView) {
         stackView.addArrangedSubview(headerStackView)
       }
       headerStackView.addArrangedSubview(viewController.view)
     }
-    headerStackView.addSeparator(.bottom)
+    if showSeparator {
+      headerStackView.addSeparator(.bottom)
+    }
   }
 
-  private func fillBody(with viewControllers: [UIViewController]) {
+  private func fillBody(with viewControllers: [UIViewController], showSeparator: Bool = true) {
     viewControllers.forEach { [self] viewController in
       addChild(viewController)
       stackView.addArrangedSubview(viewController.view)
       viewController.didMove(toParent: self)
-      viewController.view.addSeparator(.top)
-      viewController.view.addSeparator(.bottom)
+      if showSeparator {
+        viewController.view.addSeparator(.top)
+        viewController.view.addSeparator(.bottom)
+      }
     }
   }
 


### PR DESCRIPTION
This PR removes the **spacing** and **separator** between the header and track's data info body for Track Recording Place page to decrease its space and slightly improve visual style to not split the data visually.

Before/After:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/671a7794-872b-4340-b969-12f8f057d4fa" /> <img width="350" alt="image" src="https://github.com/user-attachments/assets/6d22364c-4649-4947-88eb-8f3de12a33a2" />
