### PR TITLE
[github] Use the latest Xcode 16.4 for checks and releases

### DIFF
--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -54,7 +54,7 @@ jobs:
           - os: macos-15
             cc: clang
             cxx: clang++
-            developer-dir: /Applications/Xcode_16.app/Contents/Developer
+            developer-dir: /Applications/Xcode_16.4.app/Contents/Developer
         exclude:
           - environment: { unity: OFF }
             cmake-build-type: Release

--- a/.github/workflows/ios-beta.yaml
+++ b/.github/workflows/ios-beta.yaml
@@ -35,7 +35,7 @@ jobs:
     name: Apple TestFlight
     runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
       LANG: en_US.UTF-8  # Fastlane complains that the terminal is using ASCII.
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8

--- a/.github/workflows/ios-check.yaml
+++ b/.github/workflows/ios-check.yaml
@@ -37,7 +37,7 @@ jobs:
     name: Build iOS
     runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
       LANG: en_US.UTF-8  # Fastlane complains that the terminal is using ASCII.
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8

--- a/.github/workflows/ios-release.yaml
+++ b/.github/workflows/ios-release.yaml
@@ -7,7 +7,7 @@ jobs:
     name: iOS Release
     runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
       LANG: en_US.UTF-8  # Fastlane complains that the terminal is using ASCII.
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8


### PR DESCRIPTION
Maybe it also fixes failing iOS simulator in tests: https://github.com/organicmaps/organicmaps/actions/runs/15712497453/job/44273930870?pr=10707

```
2025-06-17 17:01:21.368 xcodebuild[17534:68865] [MT] IDETestOperationsObserverDebug: 772.225 elapsed -- Testing started completed.
2025-06-17 17:01:21.369 xcodebuild[17534:68865] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
2025-06-17 17:01:21.369 xcodebuild[17534:68865] [MT] IDETestOperationsObserverDebug: 772.225 sec, +772.225 sec -- end
Testing failed:
	Organic Maps (Debug) (62880) encountered an error (Test runner never began executing tests after launching)

** TEST FAILED **
```