### PR TITLE
[android] Adds delay to inset application on API 29 and lower

### DIFF
--- a/android/app/src/main/java/app/organicmaps/maplayer/MapButtonsController.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/MapButtonsController.java
@@ -424,7 +424,8 @@ public class MapButtonsController extends Fragment
         .build();
     ViewCompat.setOnApplyWindowInsetsListener(mFrame, insetsListener);
     // Fixes insets on older Androids and with a search opened via API on all Androids.
-    mFrame.post(() -> ViewCompat.requestApplyInsets(mFrame));
+    if (mFrame.hasWindowFocus())
+      ViewCompat.requestApplyInsets(mFrame);
   }
 
   @Override


### PR DESCRIPTION
Fixes : #10739

- Thanks to @pastk  for pointing out.

- The issue seems to be with race condition between application of inset and closing animation of keyboard screen , adding a slight delay fixes it ( 1000ms is enough , it went to 1200 ms on some outliers though) 

- Weirdly the i only found this issue on android 10  and not on android 5 , to be safe i have applied delay to android 10 and below.

- #10600 works as expected



CC @biodranik 