### PR TITLE
[ios] Fix track selection point updates on every new tap

### DIFF
--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageTrackData+Core.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageTrackData+Core.h
@@ -6,7 +6,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PlacePageTrackData (Core)
 
-- (instancetype)initWithTrack:(Track const &)track;
+- (instancetype)initWithTrack:(Track const &)track
+         onActivePointChanged:(MWMVoidBlock)onActivePointChangedHandler;
 
 @end
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageTrackData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageTrackData.h
@@ -12,8 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) MWMMarkGroupID groupId;
 @property(nonatomic, readwrite, nonnull) TrackInfo * trackInfo;
 @property(nonatomic, readwrite, nullable) ElevationProfileData * elevationProfileData;
-@property(nonatomic, readonly) double activePoint;
-@property(nonatomic, readonly) double myPosition;
+@property(nonatomic, readonly) double activePointDistance;
+@property(nonatomic, readonly) double myPositionDistance;
 @property(nonatomic) MWMVoidBlock onActivePointChangedHandler;
 
 - (instancetype)initWithTrackInfo:(TrackInfo *)trackInfo

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageTrackData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageTrackData.h
@@ -12,8 +12,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) MWMMarkGroupID groupId;
 @property(nonatomic, readwrite, nonnull) TrackInfo * trackInfo;
 @property(nonatomic, readwrite, nullable) ElevationProfileData * elevationProfileData;
+@property(nonatomic, readonly) double activePoint;
+@property(nonatomic, readonly) double myPosition;
+@property(nonatomic) MWMVoidBlock onActivePointChangedHandler;
 
-- (instancetype)initWithTrackInfo:(TrackInfo * _Nonnull)trackInfo elevationInfo:(ElevationProfileData * _Nullable)elevationInfo;
+- (instancetype)initWithTrackInfo:(TrackInfo *)trackInfo
+                    elevationInfo:(ElevationProfileData * _Nullable)elevationInfo
+             onActivePointChanged:(MWMVoidBlock)onActivePointChangedHandler;
+
+- (void)updateActivePointDistance:(double)distance;
 
 @end
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageTrackData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageTrackData.mm
@@ -4,7 +4,7 @@
 
 @interface PlacePageTrackData ()
 
-@property(nonatomic, readwrite) double activePoint;
+@property(nonatomic, readwrite) double activePointDistance;
 
 @end
 
@@ -23,7 +23,7 @@
 }
 
 - (void)updateActivePointDistance:(double)distance {
-  self.activePoint = distance;
+  self.activePointDistance = distance;
   if (self.onActivePointChangedHandler)
     self.onActivePointChangedHandler();
 }
@@ -40,8 +40,8 @@
     _trackInfo = [[TrackInfo alloc] initWithTrackStatistics:track.GetStatistics()];
 
     auto const & bm = GetFramework().GetBookmarkManager();
-    _activePoint = bm.GetElevationActivePoint(_trackId);
-    _myPosition = bm.GetElevationMyPosition(_trackId);
+    _activePointDistance = bm.GetElevationActivePoint(_trackId);
+    _myPositionDistance = bm.GetElevationMyPosition(_trackId);
     _onActivePointChangedHandler = onActivePointChangedHandler;
 
     auto const & elevationInfo = track.GetElevationInfo();

--- a/iphone/CoreApi/CoreApi/PlacePageData/ElevationProfile/ElevationProfileData+Core.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/ElevationProfile/ElevationProfileData+Core.h
@@ -8,9 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ElevationProfileData (Core)
 
 - (instancetype)initWithTrackId:(MWMTrackID)trackId
-                  elevationInfo:(ElevationInfo const &)elevationInfo
-                    activePoint:(double)activePoint
-                     myPosition:(double)myPosition;
+                  elevationInfo:(ElevationInfo const &)elevationInfo;
 - (instancetype)initWithElevationInfo:(ElevationInfo const &)elevationInfo;
 
 @end

--- a/iphone/CoreApi/CoreApi/PlacePageData/ElevationProfile/ElevationProfileData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/ElevationProfile/ElevationProfileData.h
@@ -16,8 +16,6 @@ typedef NS_ENUM(NSInteger, ElevationDifficulty) {
 @property(nonatomic, readonly) BOOL isTrackRecording;
 @property(nonatomic, readonly) ElevationDifficulty difficulty;
 @property(nonatomic, readonly) NSArray<ElevationHeightPoint *> * points;
-@property(nonatomic, readonly) double activePoint;
-@property(nonatomic, readonly) double myPosition;
 
 @end
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/ElevationProfile/ElevationProfileData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/ElevationProfile/ElevationProfileData.mm
@@ -23,16 +23,12 @@ static ElevationDifficulty convertDifficulty(uint8_t difficulty) {
 @implementation ElevationProfileData (Core)
 
 - (instancetype)initWithTrackId:(MWMTrackID)trackId
-                  elevationInfo:(ElevationInfo const &)elevationInfo
-                    activePoint:(double)activePoint
-                     myPosition:(double)myPosition {
+                  elevationInfo:(ElevationInfo const &)elevationInfo {
   self = [super init];
   if (self) {
     _trackId = trackId;
     _difficulty = convertDifficulty(elevationInfo.GetDifficulty());
     _points = [ElevationProfileData pointsFromElevationInfo:elevationInfo];
-    _activePoint = activePoint;
-    _myPosition = myPosition;
     _isTrackRecording = false;
   }
   return self;

--- a/iphone/CoreApi/CoreApi/PlacePageData/PlacePageData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/PlacePageData.mm
@@ -119,7 +119,7 @@ static PlacePageRoadType convertRoadType(RoadWarningMarkType roadType) {
   if (!self || !rawData().IsTrack())
     return;
   auto const & trackInfo = GetFramework().GetBookmarkManager().GetTrackSelectionInfo(rawData().GetTrackId());
-  auto latlon = mercator::ToLatLon(trackInfo.m_trackPoint);
+  auto const latlon = mercator::ToLatLon(trackInfo.m_trackPoint);
   _locationCoordinate = CLLocationCoordinate2DMake(latlon.m_lat, latlon.m_lon);
   self.previewData = [[PlacePagePreviewData alloc] initWithRawData:rawData()];
 }

--- a/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfileBuilder.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfileBuilder.swift
@@ -1,13 +1,11 @@
 import CoreApi
 
 class ElevationProfileBuilder {
-  static func build(trackInfo: TrackInfo,
-                    elevationProfileData: ElevationProfileData?,
+  static func build(trackData: PlacePageTrackData,
                     delegate: ElevationProfileViewControllerDelegate?) -> ElevationProfileViewController {
     let viewController = ElevationProfileViewController();
     let presenter = ElevationProfilePresenter(view: viewController,
-                                              trackInfo: trackInfo,
-                                              profileData: elevationProfileData,
+                                              trackData: trackData,
                                               delegate: delegate)
     viewController.presenter = presenter
     return viewController

--- a/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfilePresenter.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfilePresenter.swift
@@ -1,10 +1,14 @@
 import Chart
 import CoreApi
 
-protocol ElevationProfilePresenterProtocol: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
-  func configure()
-  func update(trackInfo: TrackInfo, profileData: ElevationProfileData?)
+protocol TrackActivePointPresenter: AnyObject {
+  func updateActivePoint(_ distance: Double)
+  func updateMyPosition(_ distance: Double)
+}
 
+protocol ElevationProfilePresenterProtocol: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, TrackActivePointPresenter {
+  func configure()
+  func update(with trackData: PlacePageTrackData)
   func onDifficultyButtonPressed()
   func onSelectedPointChanged(_ point: CGFloat)
 }
@@ -22,8 +26,7 @@ fileprivate struct DescriptionsViewModel {
 
 final class ElevationProfilePresenter: NSObject {
   private weak var view: ElevationProfileViewProtocol?
-  private var trackInfo: TrackInfo
-  private var profileData: ElevationProfileData?
+  private var trackData: PlacePageTrackData
   private let delegate: ElevationProfileViewControllerDelegate?
   private let bookmarkManager: BookmarksManager = .shared()
 
@@ -33,19 +36,17 @@ final class ElevationProfilePresenter: NSObject {
   private let formatter: ElevationProfileFormatter
 
   init(view: ElevationProfileViewProtocol,
-       trackInfo: TrackInfo,
-       profileData: ElevationProfileData?,
+       trackData: PlacePageTrackData,
        formatter: ElevationProfileFormatter = ElevationProfileFormatter(),
        delegate: ElevationProfileViewControllerDelegate?) {
     self.view = view
     self.delegate = delegate
     self.formatter = formatter
-    self.trackInfo = trackInfo
-    self.profileData = profileData
-    if let profileData {
+    self.trackData = trackData
+    if let profileData = trackData.elevationProfileData {
       self.chartData = ElevationProfileChartData(profileData)
     }
-    self.descriptionModels = Self.descriptionModels(for: trackInfo)
+    self.descriptionModels = Self.descriptionModels(for: trackData.trackInfo)
   }
 
   private static func descriptionModels(for trackInfo: TrackInfo) -> [DescriptionsViewModel] {
@@ -56,30 +57,37 @@ final class ElevationProfilePresenter: NSObject {
       DescriptionsViewModel(title: L("elevation_profile_min_elevation"), value: trackInfo.minElevation, imageName: "ic_em_min_attitude_24")
     ]
   }
-
-  deinit {
-    bookmarkManager.resetElevationActivePointChanged()
-    bookmarkManager.resetElevationMyPositionChanged()
-  }
 }
 
 extension ElevationProfilePresenter: ElevationProfilePresenterProtocol {
-  func update(trackInfo: TrackInfo, profileData: ElevationProfileData?) {
-    self.profileData = profileData
-    if let profileData {
+  func update(with trackData: PlacePageTrackData) {
+    self.trackData = trackData
+    if let profileData = trackData.elevationProfileData {
       self.chartData = ElevationProfileChartData(profileData)
     } else {
       self.chartData = nil
     }
-    descriptionModels = Self.descriptionModels(for: trackInfo)
+    descriptionModels = Self.descriptionModels(for: trackData.trackInfo)
     configure()
+  }
+
+  func updateActivePoint(_ distance: Double) {
+    guard let view, !view.isChartViewInfoHidden else { return }
+    view.setActivePoint(distance)
+  }
+
+  func updateMyPosition(_ distance: Double) {
+    guard let view, !view.isChartViewInfoHidden else { return }
+    view.setMyPosition(distance)
   }
 
   func configure() {
     view?.isChartViewHidden = false
 
     let kMinPointsToDraw = 3
-    guard let profileData, let chartData, chartData.points.count >= kMinPointsToDraw else {
+    guard let profileData = trackData.elevationProfileData,
+          let chartData,
+          chartData.points.count >= kMinPointsToDraw else {
       view?.userInteractionEnabled = false
       return
     }
@@ -93,14 +101,8 @@ extension ElevationProfilePresenter: ElevationProfilePresenterProtocol {
       return
     }
 
-    view?.setActivePoint(profileData.activePoint)
-    view?.setMyPosition(profileData.myPosition)
-    bookmarkManager.setElevationActivePointChanged(profileData.trackId) { [weak self] distance in
-      self?.view?.setActivePoint(distance)
-    }
-    bookmarkManager.setElevationMyPositionChanged(profileData.trackId) { [weak self] distance in
-      self?.view?.setMyPosition(distance)
-    }
+    view?.setActivePoint(trackData.activePoint)
+    view?.setMyPosition(trackData.myPosition)
   }
 
   func onDifficultyButtonPressed() {

--- a/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfilePresenter.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfilePresenter.swift
@@ -2,8 +2,8 @@ import Chart
 import CoreApi
 
 protocol TrackActivePointPresenter: AnyObject {
-  func updateActivePoint(_ distance: Double)
-  func updateMyPosition(_ distance: Double)
+  func updateActivePointDistance(_ distance: Double)
+  func updateMyPositionDistance(_ distance: Double)
 }
 
 protocol ElevationProfilePresenterProtocol: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, TrackActivePointPresenter {
@@ -71,14 +71,14 @@ extension ElevationProfilePresenter: ElevationProfilePresenterProtocol {
     configure()
   }
 
-  func updateActivePoint(_ distance: Double) {
+  func updateActivePointDistance(_ distance: Double) {
     guard let view, !view.isChartViewInfoHidden else { return }
-    view.setActivePoint(distance)
+    view.setActivePointDistance(distance)
   }
 
-  func updateMyPosition(_ distance: Double) {
+  func updateMyPositionDistance(_ distance: Double) {
     guard let view, !view.isChartViewInfoHidden else { return }
-    view.setMyPosition(distance)
+    view.setMyPositionDistance(distance)
   }
 
   func configure() {
@@ -101,8 +101,8 @@ extension ElevationProfilePresenter: ElevationProfilePresenterProtocol {
       return
     }
 
-    view?.setActivePoint(trackData.activePoint)
-    view?.setMyPosition(trackData.myPosition)
+    view?.setActivePointDistance(trackData.activePointDistance)
+    view?.setMyPositionDistance(trackData.myPositionDistance)
   }
 
   func onDifficultyButtonPressed() {

--- a/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfileViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfileViewController.swift
@@ -8,8 +8,8 @@ protocol ElevationProfileViewProtocol: AnyObject {
   var isChartViewInfoHidden: Bool { get set }
 
   func setChartData(_ data: ChartPresentationData)
-  func setActivePoint(_ distance: Double)
-  func setMyPosition(_ distance: Double)
+  func setActivePointDistance(_ distance: Double)
+  func setMyPositionDistance(_ distance: Double)
   func reloadDescription()
 }
 
@@ -143,11 +143,11 @@ extension ElevationProfileViewController: ElevationProfileViewProtocol {
     chartView.chartData = data
   }
 
-  func setActivePoint(_ distance: Double) {
+  func setActivePointDistance(_ distance: Double) {
     chartView.setSelectedPoint(distance)
   }
 
-  func setMyPosition(_ distance: Double) {
+  func setMyPositionDistance(_ distance: Double) {
     chartView.myPosition = distance
   }
 

--- a/iphone/Maps/UI/PlacePage/PlacePageBuilder.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageBuilder.swift
@@ -13,7 +13,9 @@
     case .POI, .bookmark:
       layout = PlacePageCommonLayout(interactor: interactor, storyboard: storyboard, data: data)
     case .track:
-      layout = PlacePageTrackLayout(interactor: interactor, storyboard: storyboard, data: data)
+      let trackLayout = PlacePageTrackLayout(interactor: interactor, storyboard: storyboard, data: data)
+      interactor.trackActivePointPresenter = trackLayout.elevationMapViewController?.presenter
+      layout = trackLayout
     case .trackRecording:
       layout = PlacePageTrackRecordingLayout(interactor: interactor, storyboard: storyboard, data: data)
     @unknown default:
@@ -38,7 +40,9 @@
     case .POI, .bookmark:
       layout = PlacePageCommonLayout(interactor: interactor, storyboard: storyboard, data: data)
     case .track:
-      layout = PlacePageTrackLayout(interactor: interactor, storyboard: storyboard, data: data)
+      let trackLayout = PlacePageTrackLayout(interactor: interactor, storyboard: storyboard, data: data)
+      interactor.trackActivePointPresenter = trackLayout.elevationMapViewController?.presenter
+      layout = trackLayout
     case .trackRecording:
       layout = PlacePageTrackRecordingLayout(interactor: interactor, storyboard: storyboard, data: data)
     @unknown default:

--- a/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
@@ -56,16 +56,16 @@ class PlacePageInteractor: NSObject {
   private func subscribeOnTrackActivePointUpdates() {
     guard placePageData.objectType == .track, let trackData = placePageData.trackData else { return }
     bookmarksManager.setElevationActivePointChanged(trackData.trackId) { [weak self] distance in
-      self?.trackActivePointPresenter?.updateActivePoint(distance)
+      self?.trackActivePointPresenter?.updateActivePointDistance(distance)
       trackData.updateActivePointDistance(distance)
     }
     bookmarksManager.setElevationMyPositionChanged(trackData.trackId) { [weak self] distance in
-      self?.trackActivePointPresenter?.updateMyPosition(distance)
+      self?.trackActivePointPresenter?.updateMyPositionDistance(distance)
     }
   }
 
   private func unsubscribeFromTrackActivePointUpdates() {
-    guard placePageData.objectType == .track, let trackData = placePageData.trackData else { return }
+    guard placePageData.trackData?.onActivePointChangedHandler != nil else { return }
     bookmarksManager.resetElevationActivePointChanged()
     bookmarksManager.resetElevationMyPositionChanged()
   }

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageTrackLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageTrackLayout.swift
@@ -43,13 +43,10 @@ class PlacePageTrackLayout: IPlacePageLayout {
   }()
 
   lazy var elevationMapViewController: ElevationProfileViewController? = {
-    guard trackData.trackInfo.hasElevationInfo,
-          let elevationProfileData = trackData.elevationProfileData else {
+    guard trackData.trackInfo.hasElevationInfo, trackData.elevationProfileData != nil else {
       return nil
     }
-    return ElevationProfileBuilder.build(trackInfo: trackData.trackInfo,
-                                         elevationProfileData: elevationProfileData,
-                                         delegate: interactor)
+    return ElevationProfileBuilder.build(trackData: trackData, delegate: interactor)
   }()
 
   lazy var actionBarViewController: ActionBarViewController = {

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageTrackRecordingLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageTrackRecordingLayout.swift
@@ -39,8 +39,7 @@ final class PlacePageTrackRecordingLayout: IPlacePageLayout {
     guard let trackData = placePageData.trackData else {
       return nil
     }
-    return ElevationProfileBuilder.build(trackInfo: trackData.trackInfo,
-                                         elevationProfileData: trackData.elevationProfileData,
+    return ElevationProfileBuilder.build(trackData: trackData,
                                          delegate: interactor)
   }()
 
@@ -86,9 +85,9 @@ final class PlacePageTrackRecordingLayout: IPlacePageLayout {
 
 private extension PlacePageTrackRecordingLayout {
   func updateTrackRecordingRelatedSections() {
-    guard let elevationProfileViewController, let trackInfo = placePageData.trackData?.trackInfo else { return }
+    guard let elevationProfileViewController, let trackData = placePageData.trackData else { return }
     headerViewController.setTitle(placePageData.previewData.title, secondaryTitle: nil)
-    elevationProfileViewController.presenter?.update(trackInfo: trackInfo, profileData: placePageData.trackData?.elevationProfileData)
+    elevationProfileViewController.presenter?.update(with: trackData)
     presenter?.layoutIfNeeded()
   }
 }


### PR DESCRIPTION
## Bug description
When a user selects a point on a track, the coordinates are stored in the PP (Place Page) data. However, these coordinates are not updated upon subsequent selections. As a result, the “Route to/from” buttons always use the coordinates of the initially selected point, breaking their expected behavior.

## Solution
The coordinates of the selected track point are now updated on every new tap on the Track or while dragging in the Elevation chart. This ensures the “Route to/from” buttons always use the most recent selection. Key changes include:
	1.	`Active point` and `My position` have been moved from the `Elevation profile` to `PlacePageTrackData`, as they represent track-wide state, not just data relevant to the chart.
	2.	Subscription to active point updates has been moved from the `Elevation profile` to the `PlacePagePresenter` for the same reason as above.
	3.	`onActivePointChanged` callback has been added to notify when the active point changes. It allows to incapsulate the active point updating logic inside the place page data.
	4.	When the callback is triggered, `PlacePageTrackData` fetches the new coordinates from the core and updates its internal state. These updated coordinates are then used by the “Route to/from” buttons.

This fix does not affect the TrackRecording since there are no active point selections.

## Results
![Simulator Screen Recording - iPhone 16 Pro - 2025-06-18 at 19 14 27](https://github.com/user-attachments/assets/048cd6ab-e6fb-40fb-90d2-74a2c5877558)

![Simulator Screen Recording - iPhone 16 Pro - 2025-06-18 at 18 06 21](https://github.com/user-attachments/assets/484177dc-4291-42da-9a7e-adfeb5e7f1a2)

