### PR TITLE
[map] Show track's place page screen on save route automatically

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1775,7 +1775,8 @@ bool Framework::IsTrackRecordingEnabled() const
 
 void Framework::SaveRoute()
 {
-  m_routingManager.SaveRoute();
+  auto const trackId = m_routingManager.SaveRoute();
+  ShowTrack(trackId);
 }
 
 void Framework::OnUpdateGpsTrackPointsCallback(vector<pair<size_t, location::GpsInfo>> && toAdd,

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1098,7 +1098,7 @@ static std::string GetNameFromPoint(RouteMarkData const & rmd)
   return rmd.m_title;
 }
 
-void RoutingManager::SaveRoute()
+kml::TrackId RoutingManager::SaveRoute()
 {
   auto points = GetRoutePolyline().GetPolyline().GetPoints();
   auto const routePoints = GetRoutePoints();
@@ -1109,7 +1109,7 @@ void RoutingManager::SaveRoute()
       std::unique(points.begin(), points.end(), [](const m2::PointD & p1, const m2::PointD & p2) { return AlmostEqualAbs(p1, p2, kMwmPointAccuracy); }),
       points.end());
 
-  m_bmManager->SaveRoute(points, from, to);
+  return m_bmManager->SaveRoute(points, from, to);
 }
 
 bool RoutingManager::DisableFollowMode()

--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -142,7 +142,7 @@ public:
   // This method was added because we do not want to break the behaviour that is familiar to our
   // users.
   bool DisableFollowMode();
-  void SaveRoute();
+  kml::TrackId SaveRoute();
 
   void SetRouteBuildingListener(RouteBuildingCallback const & buildingCallback)
   {


### PR DESCRIPTION
It will help the user to save the track to the right place, set color and name without searching for the track in the bookmarks screen.
Only a zoom for the track selection should be [fixed](https://github.com/organicmaps/organicmaps/issues/10757).

![Simulator Screen Recording - iPhone 16 Pro - 2025-06-20 at 17 06 03](https://github.com/user-attachments/assets/6806bda6-d29b-4ba2-a584-106e63778abe)
