### PR TITLE
[map] Fix zoom on selected/saved track

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -904,7 +904,7 @@ void Framework::ShowTrack(kml::TrackId trackId)
   es.SetIsVisible(track->GetGroupId(), true /* visible */);
 
   if (m_drapeEngine)
-    m_drapeEngine->SetModelViewCenter(rect.Center(), scales::GetScaleLevel(rect), true /* isAnim */, true /* trackVisibleViewport */);
+    m_drapeEngine->SetModelViewRect(rect, true, scales::GetScaleLevel(rect), true /* isAnim */, true /* trackVisibleViewport */);
 
   ActivateMapSelection();
 }


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/10757

This is the 1st attempt to fix the track selection zoom level. The `SetModelViewCenter` appears not to be suitable for the tracks.

There are some questions:
1. Should we bring back the viewport on deselecting the track? It seems logical and the bookmarks has the same behaviour.
2. Should we update the viewport when the PP is fully opened (2nd iteration) and update the zoom level accordingly (see how the bookmarks are zoomed)? Because the PP takes a lot of space (almost half of the screen). So maybe a little track cropping is ok?

![Simulator Screen Recording - iPhone 16 Pro - 2025-06-20 at 17 47 38](https://github.com/user-attachments/assets/0c588adc-11e6-4522-a69f-2b742c7bb99d)
![Simulator Screen Recording - iPhone 16 Pro - 2025-06-20 at 17 48 32](https://github.com/user-attachments/assets/fc46b510-ddf5-4caa-9d67-072d71dae791)
