### PR TITLE
[map] Save points altitudes when saving route as a track

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -1297,7 +1297,7 @@ Java_app_organicmaps_Framework_nativeGetRouteFollowingInfo(JNIEnv * env, jclass)
 JNIEXPORT jobjectArray JNICALL
 Java_app_organicmaps_Framework_nativeGetRouteJunctionPoints(JNIEnv * env, jclass)
 {
-  vector<m2::PointD> junctionPoints;
+  vector<geometry::PointWithAltitude> junctionPoints;
   if (!frm()->GetRoutingManager().RoutingSession().GetRouteJunctionPoints(junctionPoints))
   {
     LOG(LWARNING, ("Can't get the route junction points"));

--- a/android/app/src/main/cpp/app/organicmaps/sdk/routing/JunctionInfo.hpp
+++ b/android/app/src/main/cpp/app/organicmaps/sdk/routing/JunctionInfo.hpp
@@ -2,19 +2,20 @@
 
 #include "app/organicmaps/core/jni_helper.hpp"
 
-#include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
 
 #include <vector>
 
-jobjectArray CreateJunctionInfoArray(JNIEnv * env, std::vector<m2::PointD> const & junctionPoints)
+jobjectArray CreateJunctionInfoArray(JNIEnv * env, std::vector<geometry::PointWithAltitude> const & junctionPoints)
 {
   static jclass const junctionClazz = jni::GetGlobalClassRef(env, "app/organicmaps/sdk/routing/JunctionInfo");
   // Java signature : JunctionInfo(double lat, double lon)
   static jmethodID const junctionConstructor = jni::GetConstructorID(env, junctionClazz, "(DD)V");
 
   return jni::ToJavaArray(env, junctionClazz, junctionPoints,
-                          [](JNIEnv * env, m2::PointD const & point)
+                          [](JNIEnv * env, geometry::PointWithAltitude const & pointWithAltitude)
                           {
+                            auto & point = pointWithAltitude.GetPoint();
                             return env->NewObject(junctionClazz, junctionConstructor, mercator::YToLat(point.y),
                                                   mercator::XToLon(point.x));
                           });

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -1183,6 +1183,8 @@ std::string BookmarkManager::GenerateSavedRouteName(std::string const & from, st
 
 kml::TrackId BookmarkManager::SaveRoute(std::vector<geometry::PointWithAltitude> const & points, std::string const & from, std::string const & to)
 {
+  CHECK(!points.empty(), ("Route points should not be empty"));
+
   kml::MultiGeometry geometry;
   geometry.m_lines.emplace_back();
   geometry.m_timestamps.emplace_back();

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -1181,7 +1181,7 @@ std::string BookmarkManager::GenerateSavedRouteName(std::string const & from, st
   return GenerateTrackRecordingName();
 }
 
-kml::TrackId BookmarkManager::SaveRoute(std::vector<m2::PointD> const & points, std::string const & from, std::string const & to)
+kml::TrackId BookmarkManager::SaveRoute(std::vector<geometry::PointWithAltitude> const & points, std::string const & from, std::string const & to)
 {
   kml::MultiGeometry geometry;
   geometry.m_lines.emplace_back();

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -435,7 +435,7 @@ public:
   std::string GenerateTrackRecordingName() const;
   dp::Color GenerateTrackRecordingColor() const;
 
-  kml::TrackId SaveRoute(std::vector<m2::PointD> const & points, std::string const & from, std::string const & to);
+  kml::TrackId SaveRoute(std::vector<geometry::PointWithAltitude> const & points, std::string const & from, std::string const & to);
 
 private:
   class MarksChangesTracker : public df::UserMarksProvider

--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -1644,12 +1644,12 @@ UNIT_CLASS_TEST(Runner, Bookmarks_TestSaveRoute)
 {
   BookmarkManager bmManager(BM_CALLBACKS);
   bmManager.EnableTestMode(true);
-  auto const points = {m2::PointD(0.0, 0.0), m2::PointD(0.001, 0.001)};
+  auto const points = {geometry::PointWithAltitude({0.0, 0.0}, 0.0), geometry::PointWithAltitude({0.001, 0.001}, 0.001)};
   auto const trackId = bmManager.SaveRoute(points, "London", "Paris");
   auto const * track = bmManager.GetTrack(trackId);
   TEST_EQUAL(track->GetName(), "London - Paris", ());
   auto const line = track->GetData().m_geometry.m_lines[0];
-  std::vector const expectedLine = {{geometry::PointWithAltitude(m2::PointD(0.0, 0.0)), geometry::PointWithAltitude(m2::PointD(0.001, 0.001))}};
+  std::vector const expectedLine = {{geometry::PointWithAltitude(m2::PointD(0.0, 0.0), 0.0), geometry::PointWithAltitude(m2::PointD(0.001, 0.001), 0.001)}};
   TEST_EQUAL(line, expectedLine, ());
 }
 

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -1100,37 +1100,26 @@ static std::string GetNameFromPoint(RouteMarkData const & rmd)
 
 kml::TrackId RoutingManager::SaveRoute()
 {
-  auto points = GetRoutePolyline().GetPolyline().GetPoints();
-  auto const pointsCount = points.size();
+  std::vector<geometry::PointWithAltitude> junctions;
+  RoutingSession().GetRouteJunctionPoints(junctions);
 
-  std::vector<geometry::PointWithAltitude> pointsWithAltitudes;
-  pointsWithAltitudes.reserve(pointsCount);
-
-  auto distancesAltitudes = std::make_shared<DistanceAltitude>();
-  if (GetRouteAltitudesAndDistancesM(*distancesAltitudes))
-  {
-    auto const & altitudes = distancesAltitudes->m_altitudes;
-    ASSERT_EQUAL(pointsCount, altitudes.size(), ());
-    for (size_t i = 0; i < pointsCount; ++i)
-      pointsWithAltitudes.emplace_back(points[i], altitudes[i]);
-  }
-  else
-  {
-    for (size_t i = 0; i < pointsCount; ++i)
-      pointsWithAltitudes.emplace_back(points[i]);
-  }
-
-  // remove equal sequential points
-  pointsWithAltitudes.erase(
-               std::unique(pointsWithAltitudes.begin(), pointsWithAltitudes.end(), [](const geometry::PointWithAltitude & p1, const geometry::PointWithAltitude & p2)
-                           { return AlmostEqualAbs(p1, p2, kMwmPointAccuracy); }),
-               pointsWithAltitudes.end());
+  junctions.erase(
+    std::unique(
+      junctions.begin(),
+      junctions.end(),
+      [](const geometry::PointWithAltitude & p1, const geometry::PointWithAltitude & p2)
+      {
+        return AlmostEqualAbs(p1, p2, kMwmPointAccuracy);
+      }
+    ),
+    junctions.end()
+  );
 
   auto const routePoints = GetRoutePoints();
   std::string const from = GetNameFromPoint(routePoints.front());
   std::string const to = GetNameFromPoint(routePoints.back());
 
-  return m_bmManager->SaveRoute(pointsWithAltitudes, from, to);
+  return m_bmManager->SaveRoute(junctions, from, to);
 }
 
 bool RoutingManager::DisableFollowMode()

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -801,7 +801,7 @@ bool RoutingSession::IsRouteValid() const
   return m_route && m_route->IsValid();
 }
 
-bool RoutingSession::GetRouteJunctionPoints(std::vector<m2::PointD> & routeJunctionPoints) const
+bool RoutingSession::GetRouteJunctionPoints(std::vector<geometry::PointWithAltitude> & routeJunctionPoints) const
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   ASSERT(m_route, ());
@@ -815,7 +815,7 @@ bool RoutingSession::GetRouteJunctionPoints(std::vector<m2::PointD> & routeJunct
   for (size_t i = 0; i < segments.size(); ++i)
   {
     auto const & junction = segments[i].GetJunction();
-    routeJunctionPoints.push_back(junction.GetPoint());
+    routeJunctionPoints.push_back(junction);
   }
 
   ASSERT_EQUAL(routeJunctionPoints.size(), routeJunctionPoints.size(), ());

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -94,9 +94,9 @@ public:
   bool GetRouteAltitudesAndDistancesM(std::vector<double> & routeSegDistanceM,
                                       geometry::Altitudes & routeAltitudesM) const;
 
-  /// \brief returns coordinates of route junctions.
+  /// \brief returns points of route junctions.
   /// \returns true if there is valid route information. If the route is not valid returns false.
-  bool GetRouteJunctionPoints(std::vector<m2::PointD> & routeJunctionPoints) const;
+  bool GetRouteJunctionPoints(std::vector<geometry::PointWithAltitude> & routeJunctionPoints) const;
 
   SessionState OnLocationPositionChanged(location::GpsInfo const & info);
   void GetRouteFollowingInfo(FollowingInfo & info) const;


### PR DESCRIPTION
Continues https://github.com/organicmaps/organicmaps/pull/10528

@biodranik @vng @cyber-toad I didn't find the possible situation when the `poins.count` and `altitudes.count` are not equal. Should we fail in this situation or it's better to make all altitudes = 0 (prev solution)?

The statistics differ because for the elevation chart, the road altitudes and distances are simplified (there are Simplify() method). IMO it's acceptable.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/d8f69150-01e5-41e8-aa8c-72769f48ff83" /> 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f08dcfec-beae-443a-98a5-ede1dc046fe0" />

![Simulator Screen Recording - iPhone 16 Pro - 2025-06-20 at 20 01 32](https://github.com/user-attachments/assets/fb988b80-ba36-465f-a7ec-dd46b3fdec78)
