### PR TITLE
Fixes #10721 |  prevent splash screen content from being overlapped | 

### DIFF
--- a/android/app/src/main/java/app/organicmaps/SplashActivity.java
+++ b/android/app/src/main/java/app/organicmaps/SplashActivity.java
@@ -78,7 +78,8 @@ public class SplashActivity extends AppCompatActivity
     ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.root_view), new OnApplyWindowInsetsListener() {
       @NonNull
       @Override
-      public WindowInsetsCompat onApplyWindowInsets(@NonNull View v, @NonNull WindowInsetsCompat insets) {
+      public WindowInsetsCompat onApplyWindowInsets(@NonNull View v, @NonNull WindowInsetsCompat insets)
+      {
         Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
         v.setPadding(0, 0, 0, systemBars.bottom);
         return insets;

--- a/android/app/src/main/java/app/organicmaps/SplashActivity.java
+++ b/android/app/src/main/java/app/organicmaps/SplashActivity.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.View;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -16,6 +17,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import app.organicmaps.display.DisplayManager;
 import app.organicmaps.downloader.DownloaderActivity;
@@ -69,6 +74,16 @@ public class SplashActivity extends AppCompatActivity
 
     UiThread.cancelDelayedTasks(mInitCoreDelayedTask);
     setContentView(R.layout.activity_splash);
+
+    ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.root_view), new OnApplyWindowInsetsListener() {
+      @NonNull
+      @Override
+      public WindowInsetsCompat onApplyWindowInsets(@NonNull View v, @NonNull WindowInsetsCompat insets) {
+        Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+        v.setPadding(0, 0, 0, systemBars.bottom);
+        return insets;
+      }
+    });
     mPermissionRequest = registerForActivityResult(new ActivityResultContracts.RequestMultiplePermissions(),
         result -> Config.setLocationRequested());
     mApiRequest = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {

--- a/android/app/src/main/res/layout/activity_splash.xml
+++ b/android/app/src/main/res/layout/activity_splash.xml
@@ -4,6 +4,7 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root_view"
   android:orientation="vertical"
   android:gravity="center">
 

--- a/android/app/src/main/res/layout/activity_splash.xml
+++ b/android/app/src/main/res/layout/activity_splash.xml
@@ -4,7 +4,7 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/root_view"
+  android:id="@+id/root_view"
   android:orientation="vertical"
   android:gravity="center">
 


### PR DESCRIPTION
Fixes #10721
Used WindowInsetsCompat to apply bottom padding based on system navigation bar height. This prevents content overlap.

Tested on Android 14 Android 15 Android 16

android 14
![image](https://github.com/user-attachments/assets/f1538767-a19a-4a11-b7fc-d139a5911ea3)



android 15
https://github.com/user-attachments/assets/c87d7f05-e180-4246-bde6-066018a1d5f7

android 16
![Screenshot_20250624_143458](https://github.com/user-attachments/assets/fa023897-e7c0-43e4-bb79-af1c8f215618)

