### PR TITLE
[Android] Check browser availability before showing OAuth login UI.

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
@@ -57,7 +57,7 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
     mProgress = view.findViewById(R.id.osm_login_progress);
     final String dataVersion = DateUtils.getShortDateFormatter().format(Framework.getDataVersion());
 
-    if (BuildConfig.FLAVOR.equals("google"))
+    if (BuildConfig.FLAVOR.equals("google") && Utils.isBrowserAvailable(requireContext()))
     {
       // Hide login and password inputs and Forgot password button
       UiUtils.hide(view.findViewById(R.id.osm_username_container), view.findViewById(R.id.osm_password_container),

--- a/android/app/src/main/java/app/organicmaps/util/Utils.java
+++ b/android/app/src/main/java/app/organicmaps/util/Utils.java
@@ -189,6 +189,7 @@ public class Utils
     final Intent intent = new Intent(Intent.ACTION_VIEW);
     intent.setData(Uri.parse("https://osm.org"));
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    intent.addCategory(Intent.CATEGORY_BROWSABLE);
 
     // Check that an app exists to open URL
     return intent.resolveActivity(context.getPackageManager()) != null;
@@ -230,22 +231,12 @@ public class Utils
     final Intent intent = new Intent(Intent.ACTION_VIEW);
     intent.setData(uri);
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    intent.addCategory(Intent.CATEGORY_BROWSABLE);
 
-    try
-    {
+    if (intent.resolveActivity(context.getPackageManager()) != null)
       context.startActivity(intent);
-    }
-    catch (ActivityNotFoundException e)
-    {
+    else
       Toast.makeText(context, failMessage, Toast.LENGTH_SHORT).show();
-      Logger.e(TAG, "ActivityNotFoundException", e);
-    }
-    catch (AndroidRuntimeException e)
-    {
-      Logger.e(TAG, "AndroidRuntimeException", e);
-      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      context.startActivity(intent);
-    }
   }
 
   private static boolean isHttpOrHttpsScheme(@NonNull String url)

--- a/android/app/src/main/java/app/organicmaps/util/Utils.java
+++ b/android/app/src/main/java/app/organicmaps/util/Utils.java
@@ -213,17 +213,31 @@ public class Utils
     if (TextUtils.isEmpty(url))
       return;
 
-    final Intent intent = new Intent(Intent.ACTION_VIEW);
     Uri uri =
         isHttpOrHttpsScheme(url) ? Uri.parse(url) : new Uri.Builder().scheme("http").appendEncodedPath(url).build();
+
+    Utils.openUri(context, uri, R.string.browser_not_available);
+  }
+
+  /**
+   * Attempts to open a URI in another app via the system app chooser.
+   * @param context the app context
+   * @param uri the URI to open.
+   * @param failMessage string id: message to show in a toast when the system can't find an app to open with.
+   */
+  public static void openUri(@NonNull Context context, @NonNull Uri uri, Integer failMessage)
+  {
+    final Intent intent = new Intent(Intent.ACTION_VIEW);
     intent.setData(uri);
+    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
     try
     {
       context.startActivity(intent);
     }
     catch (ActivityNotFoundException e)
     {
-      Toast.makeText(context, context.getString(R.string.browser_not_available), Toast.LENGTH_LONG).show();
+      Toast.makeText(context, failMessage, Toast.LENGTH_SHORT).show();
       Logger.e(TAG, "ActivityNotFoundException", e);
     }
     catch (AndroidRuntimeException e)
@@ -232,28 +246,6 @@ public class Utils
       intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       context.startActivity(intent);
     }
-  }
-
-  /**
-   * Attempts to open a URI in another app via the system app chooser.
-   * @param context the app context
-   * @param uri the URI to open.
-   * @param failMessage string id: message to show in a toast when the system can't find an app to open with.
-   * @param action (optional) the Intent action to use. If none is provided, defaults to Intent.ACTION_VIEW.
-   */
-  public static void openUri(@NonNull Context context, @NonNull Uri uri, Integer failMessage, @NonNull String... action)
-  {
-    final String act = (action != null && action.length > 0 && action[0] != null) ? action[0] : Intent.ACTION_VIEW;
-    final Intent intent = new Intent(act);
-    intent.setData(uri);
-    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-
-    // https://developer.android.com/guide/components/intents-common
-    // check that an app exists to open with, otherwise it'll crash
-    if (intent.resolveActivity(context.getPackageManager()) != null)
-      context.startActivity(intent);
-    else
-      Toast.makeText(context, failMessage, Toast.LENGTH_SHORT).show();
   }
 
   private static boolean isHttpOrHttpsScheme(@NonNull String url)

--- a/android/app/src/main/java/app/organicmaps/util/Utils.java
+++ b/android/app/src/main/java/app/organicmaps/util/Utils.java
@@ -181,6 +181,19 @@ public class Utils
     }
   }
 
+  /*
+   * Check if WebBrowser intent could be opened.
+   */
+  public static boolean isBrowserAvailable(Context context)
+  {
+    final Intent intent = new Intent(Intent.ACTION_VIEW);
+    intent.setData(Uri.parse("https://osm.org"));
+    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+    // Check that an app exists to open URL
+    return intent.resolveActivity(context.getPackageManager()) != null;
+  }
+
   public static void showFacebookPage(Activity activity)
   {
     try


### PR DESCRIPTION
Fixes #10741
Fixes #10689

I couldn't reproduce the issue. So I don't know why OM can't open browser. Maybe some permissions problem. Changed behaviour: if browser coulnd't be found then we fallback to login + password UI (no browser required).

## Update 2025-07-02

Unified `Utils.openUri` and `Utils.openUrl` functions.
Rebased on `master`.

## Update 2025-07-09

Replaced try-catch with if-else block for browser availability check.