### PR TITLE
Fix #10782 | Updated padding dimens

### DIFF
--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -120,7 +120,7 @@
 
   <dimen name="nav_frame_padding">@dimen/margin_half</dimen>
   <dimen name="zoom_buttons_margin">64dp</dimen>
-  <dimen name="map_buttons_bottom_margin">136dp</dimen>
+  <dimen name="map_buttons_bottom_margin">180dp</dimen>
   <dimen name="map_buttons_bottom_max_width">300dp</dimen>
 
   <dimen name="appbar_elevation">4dp</dimen>


### PR DESCRIPTION
Fix #10782

Updated the padding values to shift the map buttons up.

Android 14
![WhatsApp Image 2025-06-27 at 15 47 51_9ffb5695](https://github.com/user-attachments/assets/d1af47fe-d623-4637-bbcb-8cad24cc39f5)
