### PR TITLE
[ci] Save ccache only for master branch

### DIFF
--- a/.github/workflows/android-check.yaml
+++ b/.github/workflows/android-check.yaml
@@ -102,6 +102,7 @@ jobs:
       - name: Configure ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
+          save: ${{ github.ref_name == 'master' }}
           key: ${{ github.workflow }}-${{ matrix.flavor }}
 
       - name: Compile ${{ matrix.flavor }}

--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -81,6 +81,7 @@ jobs:
             3party/boost
             .git/modules/3party/boost
           key: boost-submodule
+          enableCrossOsArchive: true
 
       - name: Parallel submodules checkout
         run: git submodule update --depth 1 --init --recursive --jobs=20
@@ -120,6 +121,7 @@ jobs:
       - name: Configure ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
+          save: ${{ github.ref_name == 'master' }}
           key: ${{ github.workflow }}-${{ matrix.environment.os }}-${{ matrix.environment.cc }}-${{ matrix.environment.unity }}-${{ matrix.cmake-build-type }}
 
       - name: Configure cmake

--- a/.github/workflows/ios-check.yaml
+++ b/.github/workflows/ios-check.yaml
@@ -67,6 +67,7 @@ jobs:
       - name: Configure XCode cache
         uses: irgaly/xcode-cache@v1
         with:
+          delete-used-deriveddata-cache: ${{ github.ref_name != 'master' }}
           key: xcode-cache-deriveddata-${{ github.workflow }}-${{ matrix.buildType }}-${{ github.sha }}
           restore-keys: xcode-cache-deriveddata-${{ github.workflow }}-${{ matrix.buildType }}
 


### PR DESCRIPTION
Looks like GutHub has started to strictly monitor the size occupied by caches.
The official limit is 10G. Previously, I've seen that we have ~90G of caches. Now it's only 10G - the max amount.
It leads to the situation when our caches from master branch are being removed and we see cache misses in PRs.
Let's save caches only for master branch.
This will result in a slightly slower builds in general but should save us from builds with no caches.