### PR TITLE
[android] Export all debug symbols

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,6 +99,8 @@ android {
     resourceConfigurations += [project.ext.supportedLocalizations]
 
     setProperty('archivesBaseName', appName.replaceAll('\\s','') + '-' + defaultConfig.versionCode)
+
+    ndk.debugSymbolLevel = 'full'
   }
 
   flavorDimensions += 'default'

--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -14,7 +14,6 @@ android {
 
     minSdk propMinSdkVersion.toInteger()
     targetSdk propTargetSdkVersion.toInteger()
-    ndk.debugSymbolLevel = 'symbol_table'
 
     externalNativeBuild {
       def pchFlag = 'OFF'


### PR DESCRIPTION
`ndk.debugSymbolLevel` should be configured in the app module

Let's try to export all symbols, not only table
| Full | Symbol table |
|--------|--------|
| ![telegram-cloud-photo-size-2-5422756623836904818-y](https://github.com/user-attachments/assets/4f88d533-cc5e-4e5b-af10-e28e0bcbed7b) | ![telegram-cloud-photo-size-2-5422877222223610868-y](https://github.com/user-attachments/assets/cf0e7103-1280-4b9d-ba3f-f56ba06df5f1) |

Google play console supports files up to 300 mb. Should be ok
https://developer.android.com/build/include-native-symbols

<img width="855" alt="image" src="https://github.com/user-attachments/assets/772987bc-5252-4470-adf3-196162a32272" />
