### PR TITLE
Removed SignedRound and replaced std::round with std::lround where needed

### DIFF
--- a/base/base_tests/math_test.cpp
+++ b/base/base_tests/math_test.cpp
@@ -45,6 +45,19 @@ void TestMaxULPs()
 }
 }  // namespace
 
+UNIT_TEST(round_lround_smoke)
+{
+  TEST_EQUAL(std::round(0.4), 0.0, ());
+  TEST_EQUAL(std::round(0.6), 1.0, ());
+  TEST_EQUAL(std::round(-0.4), 0.0, ());
+  TEST_EQUAL(std::round(-0.6), -1.0, ());
+
+  TEST_EQUAL(std::lround(0.4), 0l, ());
+  TEST_EQUAL(std::lround(0.6), 1l, ());
+  TEST_EQUAL(std::lround(-0.4), 0l, ());
+  TEST_EQUAL(std::lround(-0.6), -1l, ());
+}
+
 UNIT_TEST(PowUInt)
 {
   TEST_EQUAL(PowUint(3, 10), 59049, ());

--- a/base/math.hpp
+++ b/base/math.hpp
@@ -104,12 +104,6 @@ bool Between(T const a, T const b, T const x)
   return a <= x && x <= b;
 }
 
-// This function is deprecated. Use std::round instead.
-inline int SignedRound(double x)
-{
-  return x > 0.0 ? static_cast<int>(x + 0.5) : static_cast<int>(x - 0.5);
-}
-
 // Computes x^n.
 template <typename T>
 T PowUint(T x, uint64_t n)

--- a/drape/stipple_pen_resource.cpp
+++ b/drape/stipple_pen_resource.cpp
@@ -5,6 +5,7 @@
 #include "base/logging.hpp"
 #include "base/shared_buffer_manager.hpp"
 
+#include <cmath>
 #include <cstring>
 #include <iomanip>
 #include <numeric>
@@ -122,7 +123,7 @@ void StipplePenRasterizator::RasterizeTriangle(uint8_t * pixels) const
 
   while (trgH > 0)
   {
-    uint8_t const base = std::round(trgH * tan);
+    uint8_t const base = std::lround(trgH * tan);
     uint32_t const left = (m_patternLength - base) / 2;
     memset(pixels + 1, 0, left);
     memset(pixels + left + 1, 255, base);

--- a/drape/stipple_pen_resource.hpp
+++ b/drape/stipple_pen_resource.hpp
@@ -9,6 +9,7 @@
 #include "geometry/point2d.hpp"
 #include "geometry/rect2d.hpp"
 
+#include <cmath>
 #include <map>
 #include <mutex>
 
@@ -22,7 +23,7 @@ using PenPatternT = buffer_vector<uint16_t, 2>;
 
 inline uint16_t PatternFloat2Pixel(double d)
 {
-  auto const px = static_cast<uint16_t>(std::round(d));
+  uint16_t const px = std::lround(d);
   //ASSERT(px > 0, (d));
   return px > 0 ? px : 1;
 }

--- a/drape_frontend/gui/ruler_helper.cpp
+++ b/drape_frontend/gui/ruler_helper.cpp
@@ -10,6 +10,7 @@
 #include "base/macros.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <iterator>
 #include <limits>
 #include <set>
@@ -113,7 +114,7 @@ RulerHelper::RulerHelper()
 void RulerHelper::Update(ScreenBase const & screen)
 {
   m2::PointD pivot = screen.PixelRect().Center();
-  int const minPxWidth = math::SignedRound(kMinPixelWidth * df::VisualParams::Instance().GetVisualScale());
+  int const minPxWidth = std::lround(kMinPixelWidth * df::VisualParams::Instance().GetVisualScale());
   m2::PointD pt1 = screen.PtoG(pivot);
   m2::PointD pt0 = screen.PtoG(pivot - m2::PointD(minPxWidth, 0));
 
@@ -133,7 +134,7 @@ void RulerHelper::Update(ScreenBase const & screen)
     double const a = ang::AngleTo(pt1, pt0);
     pt0 = mercator::GetSmPoint(pt1, cos(a) * metersDiff, sin(a) * metersDiff);
 
-    m_pixelLength = math::SignedRound(pivot.Length(screen.GtoP(pt0)));
+    m_pixelLength = std::round(pivot.Length(screen.GtoP(pt0)));
   }
 
   int drawScale = df::GetDrawTileScale(screen);

--- a/drape_frontend/traffic_renderer.cpp
+++ b/drape_frontend/traffic_renderer.cpp
@@ -15,6 +15,7 @@
 
 #include <array>
 #include <algorithm>
+#include <cmath>
 #include <utility>
 
 namespace df
@@ -323,7 +324,7 @@ bool TrafficRenderer::CanBeRenderedAsLine(RoadClass const & roadClass, int zoomL
   if (it == lineDrawerEnd)
     return false;
 
-  width = std::max(1, math::SignedRound(TrafficRenderer::GetPixelWidthInternal(roadClass, zoomLevel)));
+  width = std::max(1l, std::lround(TrafficRenderer::GetPixelWidthInternal(roadClass, zoomLevel)));
   return width <= dp::SupportManager::Instance().GetMaxLineWidth();
 }
 }  // namespace df

--- a/drape_frontend/visual_params.cpp
+++ b/drape_frontend/visual_params.cpp
@@ -186,7 +186,7 @@ int GetTileScaleBase(m2::RectD const & r)
 {
   double const sz = std::max(r.SizeX(), r.SizeY());
   ASSERT_GREATER(sz, 0., ("Rect should not be a point:", r));
-  return std::max(1, math::SignedRound(std::log2(mercator::Bounds::kRangeX / sz)));
+  return std::max(1l, std::lround(std::log2(mercator::Bounds::kRangeX / sz)));
 }
 
 double GetTileScaleBase(double drawScale)
@@ -224,12 +224,12 @@ m2::RectD GetRectForDrawScale(int drawScale, m2::PointD const & center)
 
 m2::RectD GetRectForDrawScale(double drawScale, m2::PointD const & center, uint32_t tileSize, double visualScale)
 {
-  return GetRectForDrawScale(math::SignedRound(drawScale), center, tileSize, visualScale);
+  return GetRectForDrawScale(static_cast<int>(std::lround(drawScale)), center, tileSize, visualScale);
 }
 
 m2::RectD GetRectForDrawScale(double drawScale, m2::PointD const & center)
 {
-  return GetRectForDrawScale(math::SignedRound(drawScale), center);
+  return GetRectForDrawScale(static_cast<int>(std::lround(drawScale)), center);
 }
 
 uint32_t CalculateTileSize(uint32_t screenWidth, uint32_t screenHeight)

--- a/ge0/url_generator.cpp
+++ b/ge0/url_generator.cpp
@@ -133,7 +133,7 @@ int LatToInt(double lat, int maxValue)
   //       000111111222222...LLLLLMMMM
 
   double const x = (lat + 90.0) / 180.0 * maxValue;
-  return x < 0 ? 0 : (x > maxValue ? maxValue : static_cast<int>(x + 0.5));
+  return x < 0 ? 0 : (x > maxValue ? maxValue : std::lround(x));
 }
 
 // Make lon in [-180, 180)

--- a/generator/cells_merger.cpp
+++ b/generator/cells_merger.cpp
@@ -4,6 +4,7 @@
 #include "base/stl_helpers.hpp"
 
 #include <algorithm>
+#include <cmath>
 
 namespace
 {
@@ -42,8 +43,8 @@ CellsMerger::CellsMerger(std::vector<m2::RectD> && cells)
   auto const sideSize = cells.front().SizeX();
   for (auto const & cell : cells)
   {
-    auto const xIdx = static_cast<int32_t>(std::round((cell.minX() - minX) / sideSize));
-    auto const yIdx = static_cast<int32_t>(std::round((cell.minY() - minY) / sideSize));
+    int32_t const xIdx = std::lround((cell.minX() - minX) / sideSize);
+    int32_t const yIdx = std::lround((cell.minY() - minY) / sideSize);
     m_matrix.emplace(m2::PointI{xIdx, yIdx}, cell);
     m_maxX = std::max(m_maxX, xIdx);
     m_maxY = std::max(m_maxY, yIdx);

--- a/generator/maxspeeds_builder.cpp
+++ b/generator/maxspeeds_builder.cpp
@@ -23,6 +23,7 @@
 #include "base/string_utils.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <fstream>
 #include <sstream>
 #include <utility>

--- a/generator/srtm_parser.cpp
+++ b/generator/srtm_parser.cpp
@@ -8,6 +8,7 @@
 #include "base/file_name_utils.hpp"
 #include "base/logging.hpp"
 
+#include <cmath>
 #include <fstream>
 #include <iomanip>
 #include <sstream>
@@ -116,8 +117,8 @@ geometry::Altitude SrtmTile::GetHeight(ms::LatLon const & coord) const
     lt += 1;
   lt = 1 - lt;  // from North to South
 
-  auto const row = static_cast<size_t>(std::round(kArcSecondsInDegree * lt));
-  auto const col = static_cast<size_t>(std::round(kArcSecondsInDegree * ln));
+  auto const row = std::lround(kArcSecondsInDegree * lt);
+  auto const col = std::lround(kArcSecondsInDegree * ln);
 
   size_t const ix = row * (kArcSecondsInDegree + 1) + col;
 

--- a/geometry/geometry_tests/screen_test.cpp
+++ b/geometry/geometry_tests/screen_test.cpp
@@ -5,28 +5,28 @@
 
 #include "testing/testing.hpp"
 
+#include <cmath>
 
-using namespace test;
-
-namespace
+namespace screen_test
 {
-  void check_set_from_rect(ScreenBase & screen, int width, int height)
-  {
-    screen.OnSize(0, 0, width, height);
+using test::is_equal;
 
-    m2::PointD b1(0.0, 0.0);
-    m2::PointD b2(300.0, 300.0);
-    screen.SetFromRect(m2::AnyRectD(m2::RectD(b1, b2)));
+static void check_set_from_rect(ScreenBase & screen, int width, int height)
+{
+  screen.OnSize(0, 0, width, height);
 
-    b1 = screen.GtoP(b1);
-    b2 = screen.GtoP(b2);
+  m2::PointD b1(0.0, 0.0);
+  m2::PointD b2(300.0, 300.0);
+  screen.SetFromRect(m2::AnyRectD(m2::RectD(b1, b2)));
 
-    // check that we are in boundaries.
-    TEST(math::Between(0, width, math::SignedRound(b1.x)), ());
-    TEST(math::Between(0, width, math::SignedRound(b2.x)), ());
-    TEST(math::Between(0, height, math::SignedRound(b1.y)), ());
-    TEST(math::Between(0, height, math::SignedRound(b2.y)), ());
-  }
+  b1 = screen.GtoP(b1);
+  b2 = screen.GtoP(b2);
+
+  // check that we are in boundaries.
+  TEST(math::Between(0, width, static_cast<int>(std::lround(b1.x))), ());
+  TEST(math::Between(0, width, static_cast<int>(std::lround(b2.x))), ());
+  TEST(math::Between(0, height, static_cast<int>(std::lround(b1.y))), ());
+  TEST(math::Between(0, height, static_cast<int>(std::lround(b2.y))), ());
 }
 
 UNIT_TEST(ScreenBase_P2G2P)
@@ -221,3 +221,4 @@ UNIT_TEST(ScreenBase_CombineTransforms)
   TEST(is_equal(p1, pp1), (p1, pp1));
   TEST(is_equal(p2, pp2), (p2, pp2));
 }
+}  // namespace screen_test

--- a/geometry/screenbase.cpp
+++ b/geometry/screenbase.cpp
@@ -218,18 +218,18 @@ void ScreenBase::SetAngle(double angle)
   UpdateDependentParameters();
 }
 
-int ScreenBase::GetWidth() const { return math::SignedRound(m_PixelRect.SizeX()); }
+int ScreenBase::GetWidth() const { return std::lround(m_PixelRect.SizeX()); }
 
-int ScreenBase::GetHeight() const { return math::SignedRound(m_PixelRect.SizeY()); }
+int ScreenBase::GetHeight() const { return std::lround(m_PixelRect.SizeY()); }
 
 ScreenBase::MatrixT ScreenBase::CalcTransform(m2::PointD const & oldPt1,
                                                     m2::PointD const & oldPt2,
                                                     m2::PointD const & newPt1,
-                                                    m2::PointD const & newPt2, 
+                                                    m2::PointD const & newPt2,
                                                     bool allowRotate,
                                                     bool allowScale)
 {
-  
+
   double const s = allowScale ? newPt1.Length(newPt2) / oldPt1.Length(oldPt2) : 1.0;
   double const a = allowRotate ? ang::AngleTo(newPt1, newPt2) - ang::AngleTo(oldPt1, oldPt2) : 0.0;
 

--- a/indexer/feature_impl.cpp
+++ b/indexer/feature_impl.cpp
@@ -1,18 +1,19 @@
 #include "indexer/feature_impl.hpp"
 
-#include "base/math.hpp"
+#include <algorithm>
+#include <cmath>
 
 namespace feature
 {
 
 uint8_t PopulationToRank(uint64_t p)
 {
-  return static_cast<uint8_t>(std::min(0xFF, math::SignedRound(log(double(p)) / log(1.1))));
+  return std::min(0xFFl, std::lround(std::log(double(p)) / std::log(1.1)));
 }
 
 uint64_t RankToPopulation(uint8_t r)
 {
-  return static_cast<uint64_t>(pow(1.1, r));
+  return static_cast<uint64_t>(std::pow(1.1, r));
 }
 
 } // namespace feature

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -921,7 +921,7 @@ double GetRadiusByPopulationForRouting(uint64_t p, LocalityType localityType)
 
 uint64_t GetPopulationByRadius(double r)
 {
-  return math::SignedRound(pow(r / 550.0, 3.6));
+  return std::lround(pow(r / 550.0, 3.6));
 }
 
 }  // namespace ftypes

--- a/indexer/scales.cpp
+++ b/indexer/scales.cpp
@@ -2,9 +2,9 @@
 
 #include "indexer/feature_algo.hpp"
 #include "geometry/mercator.hpp"
-#include "base/math.hpp"
 
 #include <algorithm>
+#include <cmath>
 
 namespace scales
 {
@@ -33,12 +33,12 @@ namespace scales
 
   int GetScaleLevel(double ratio)
   {
-    return math::SignedRound(GetScaleLevelD(ratio));
+    return std::lround(GetScaleLevelD(ratio));
   }
 
   int GetScaleLevel(m2::RectD const & r)
   {
-    return math::SignedRound(GetScaleLevelD(r));
+    return std::lround(GetScaleLevelD(r));
   }
 
   namespace

--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -1644,12 +1644,12 @@ UNIT_CLASS_TEST(Runner, Bookmarks_TestSaveRoute)
 {
   BookmarkManager bmManager(BM_CALLBACKS);
   bmManager.EnableTestMode(true);
-  auto const points = {geometry::PointWithAltitude({0.0, 0.0}, 0.0), geometry::PointWithAltitude({0.001, 0.001}, 0.001)};
+  auto const points = {geometry::PointWithAltitude({0.0, 0.0}, 0.0), geometry::PointWithAltitude({0.001, 0.001}, 0)};
   auto const trackId = bmManager.SaveRoute(points, "London", "Paris");
   auto const * track = bmManager.GetTrack(trackId);
   TEST_EQUAL(track->GetName(), "London - Paris", ());
   auto const line = track->GetData().m_geometry.m_lines[0];
-  std::vector const expectedLine = {{geometry::PointWithAltitude(m2::PointD(0.0, 0.0), 0.0), geometry::PointWithAltitude(m2::PointD(0.001, 0.001), 0.001)}};
+  std::vector const expectedLine = {{geometry::PointWithAltitude(m2::PointD(0.0, 0.0), 0.0), geometry::PointWithAltitude(m2::PointD(0.001, 0.001), 0)}};
   TEST_EQUAL(line, expectedLine, ());
 }
 

--- a/platform/distance.cpp
+++ b/platform/distance.cpp
@@ -6,6 +6,8 @@
 
 #include "base/assert.hpp"
 
+#include <cmath>
+
 namespace platform
 {
 using namespace measurement_utils;

--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -113,7 +113,7 @@ std::string FormatLatLonAsDMSImpl(double value, char positive, char negative, in
   // Seconds
   d = d * 60.0;
   if (dac == 0)
-    d = math::SignedRound(d);
+    d = std::round(d);
 
   d = std::modf(d, &i);
   sstream << std::setw(2) << i;
@@ -124,7 +124,7 @@ std::string FormatLatLonAsDMSImpl(double value, char positive, char negative, in
   sstream << "″";
 
   // This condition is too heavy for production purposes (but more correct).
-  //if (math::SignedRound(value * 3600.0 * pow(10, dac)) != 0)
+  //if (std::round(value * 3600.0 * pow(10, dac)) != 0)
   if (!AlmostEqualULPs(value, 0.0))
   {
     char postfix = positive;
@@ -200,7 +200,7 @@ double MpsToUnits(double metersPerSecond, Units units)
 
 int FormatSpeed(double metersPerSecond, Units units)
 {
-  return static_cast<int>(std::round(MpsToUnits(metersPerSecond, units)));
+  return std::lround(MpsToUnits(metersPerSecond, units));
 }
 
 std::string FormatSpeedNumeric(double metersPerSecond, Units units)
@@ -214,8 +214,8 @@ std::string FormatOsmLink(double lat, double lon, int zoom)
 
   // Same as (lon + 180) / 360 * 1UL << 32, but without warnings.
   double constexpr factor = (1 << 30) / 90.0;
-  uint32_t const x = round((lon + 180.0) * factor);
-  uint32_t const y = round((lat + 90.0) * factor * 2.0);
+  uint32_t const x = std::lround((lon + 180.0) * factor);
+  uint32_t const y = std::lround((lat + 90.0) * factor * 2.0);
   uint64_t const code = bits::BitwiseMerge(y, x);
   std::string osmUrl = "https://osm.org/go/";
 

--- a/platform/utm_mgrs_utils.cpp
+++ b/platform/utm_mgrs_utils.cpp
@@ -152,8 +152,8 @@ std::string UTMtoStr(UTMPoint const & point)
   // last 5 digits of UTM and MGRS coordinates could differ (inaccuracy is no more then 1 meter).
   // Some UTM converters truncate easting and northing instead of rounding. Consider this option.
   return std::to_string(point.zoneNumber) + point.zoneLetter + ' ' +
-         std::to_string(static_cast<int>(std::round(point.easting))) + ' ' +
-         std::to_string(static_cast<int>(std::round(point.northing)));
+         std::to_string(std::lround(point.easting)) + ' ' +
+         std::to_string(std::lround(point.northing));
 }
 
 // Build 2 chars string with MGRS 100k designator.

--- a/qt/qt_common/scale_slider.cpp
+++ b/qt/qt_common/scale_slider.cpp
@@ -9,6 +9,7 @@
 
 #include <QtWidgets/QToolBar>
 
+#include <cmath>
 #include <memory>
 
 namespace qt
@@ -67,7 +68,7 @@ void ScaleSlider::SetPosWithBlockedSignals(double pos)
 {
   bool const blocked = signalsBlocked();
   blockSignals(true);
-  setSliderPosition(math::SignedRound(pos * m_factor));
+  setSliderPosition(std::lround(pos * m_factor));
   blockSignals(blocked);
 }
 

--- a/routing/cross_border_graph.hpp
+++ b/routing/cross_border_graph.hpp
@@ -141,7 +141,7 @@ void CrossBorderGraphSerializer::Serialize(CrossBorderGraph const & graph, Sink 
   {
     WriteVarUint(sink, segId);
 
-    WriteVarUint(sink, static_cast<uint64_t>(std::round(seg.m_weight * kDouble2Int)));
+    WriteVarUint(sink, static_cast<uint64_t>(std::lround(seg.m_weight * kDouble2Int)));
 
     writeSegEnding(seg.m_start);
     writeSegEnding(seg.m_end);

--- a/topography_generator/generator.cpp
+++ b/topography_generator/generator.cpp
@@ -14,6 +14,7 @@
 #include "base/thread_pool_computational.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <fstream>
 #include <set>
 #include <vector>
@@ -185,8 +186,8 @@ public:
     double lt = pos.m_lat - m_bottomLat;
     lt = 1 - lt;  // From North to South, the same direction as inside the SRTM tiles.
 
-    auto const row = static_cast<size_t>(std::round(kArcSecondsInDegree * lt));
-    auto const col = static_cast<size_t>(std::round(kArcSecondsInDegree * ln));
+    auto const row = std::lround(kArcSecondsInDegree * lt);
+    auto const col = std::lround(kArcSecondsInDegree * ln);
 
     auto const ix = row * (kArcSecondsInDegree + 1) + col;
     CHECK(ix < m_values.size(), (pos));


### PR DESCRIPTION
See https://clang.llvm.org/extra/clang-tidy/checks/bugprone/incorrect-roundings.html