### PR TITLE
Open in another app now generates geo: URI with a q= query compatible with Google Maps

### DIFF
--- a/ge0/ge0_tests/url_generator_tests.cpp
+++ b/ge0/ge0_tests/url_generator_tests.cpp
@@ -345,7 +345,7 @@ UNIT_TEST(GenerateShortShowMapUrl_UnicodeMixedWithOtherChars)
 UNIT_TEST(GenerateGeoUri_SmokeTest)
 {
   string res = GenerateGeoUri(33.8904075, 35.5066454, 16.5, "Falafel M. Sahyoun");
-  TEST_EQUAL("geo:33.8904075,35.5066454?z=16.5(Falafel%20M.%20Sahyoun)", res, ());
+  TEST_EQUAL("geo:33.8904075,35.5066454?z=16.5&q=33.8904075,35.5066454(Falafel%20M.%20Sahyoun)", res, ());
 
   // geo:33.8904075,35.5066454?z=16.5(Falafel%20M.%20Sahyoun)
   // geo:33.890408,35.506645?z=16.5(Falafel%20M.%20Sahyoun)

--- a/ge0/url_generator.cpp
+++ b/ge0/url_generator.cpp
@@ -107,6 +107,8 @@ std::string GenerateGeoUri(double lat, double lon, double zoom, std::string cons
 {
   std::ostringstream oss;
   oss << "geo:" << std::fixed << std::setprecision(7) << lat << ',' << lon << "?z=" << std::setprecision(1) << zoom;
+  // For Google Maps compatibility, otherwise it doesn't select the point on the map, only shows the area.
+  oss << "&q=" << std::setprecision(7) << lat << ',' << lon;
 
   if (!name.empty())
     oss << '(' << url::UrlEncode(name) << ')';


### PR DESCRIPTION
It works on my Android (c), but should be tested in as many geo: supporting apps as possible.

There is also a related issue with zoom level: https://github.com/organicmaps/organicmaps/issues/10320