### PR TITLE
[android] Use OpenGL on Emulator API 30 and 36 (Android 11 and 16)

### DIFF
--- a/drape/support_manager.cpp
+++ b/drape/support_manager.cpp
@@ -108,9 +108,17 @@ bool SupportManager::IsVulkanForbidden()
 }
 
 bool SupportManager::IsVulkanForbidden(std::string const & deviceName, Version apiVersion,
-                                       Version driverVersion, bool isCustomROM)
+                                       Version driverVersion, bool isCustomROM, int sdkVersion)
 {
-  LOG(LINFO, ("Device =", deviceName, "API =", apiVersion, "Driver =", driverVersion));
+  LOG(LINFO, ("Device =", deviceName, "API =", apiVersion, "Driver =", driverVersion, "SDK =", sdkVersion));
+
+  // Vulkan crashes on Android Emulator (API 30 and API 36), likely due to some bug in the emulator's driver.
+  // TODO(AB): Remove this workaround when it is fixed.
+  if (deviceName == "SwiftShader Device (LLVM 10.0.0)" && (sdkVersion == 30 || sdkVersion == 36))
+  {
+    LOG(LWARNING, ("Use OpenGL instead of Vulkan on Android Emulator due to crashes caused by graphics driver."));
+    return true;
+  }
 
   static char const * kBannedDevices[] = {
     /// @todo Should we ban all PowerVR Rogue devices?

--- a/drape/support_manager.hpp
+++ b/drape/support_manager.hpp
@@ -39,7 +39,8 @@ public:
 
   using Version = std::array<uint32_t, 3>;
   static bool IsVulkanForbidden();
-  static bool IsVulkanForbidden(std::string const & deviceName, Version apiVersion, Version driverVersion, bool isCustomROM);
+  static bool IsVulkanForbidden(std::string const & deviceName, Version apiVersion, Version driverVersion,
+                                bool isCustomROM, int sdkVersion);
   static bool IsVulkanTexturePartialUpdateBuggy(int sdkVersion, std::string const & deviceName,
                                                 Version apiVersion, Version driverVersion);
 

--- a/drape/vulkan/vulkan_context_factory.cpp
+++ b/drape/vulkan/vulkan_context_factory.cpp
@@ -1,6 +1,5 @@
 #include "drape/vulkan/vulkan_context_factory.hpp"
 
-#include "drape/drape_diagnostics.hpp"
 #include "drape/support_manager.hpp"
 #include "drape/vulkan/vulkan_pipeline.hpp"
 #include "drape/vulkan/vulkan_utils.hpp"
@@ -8,9 +7,7 @@
 #include "base/assert.hpp"
 #include "base/logging.hpp"
 #include "base/macros.hpp"
-#include "base/src_point.hpp"
 
-#include <array>
 #include <vector>
 
 namespace dp
@@ -168,7 +165,8 @@ VulkanContextFactory::VulkanContextFactory(uint32_t appVersionCode, int sdkVersi
   dp::SupportManager::Version driverVersion{VK_VERSION_MAJOR(gpuProperties.driverVersion),
                                             VK_VERSION_MINOR(gpuProperties.driverVersion),
                                             VK_VERSION_PATCH(gpuProperties.driverVersion)};
-  if (dp::SupportManager::Instance().IsVulkanForbidden(gpuProperties.deviceName, apiVersion, driverVersion, isCustomROM))
+  if (dp::SupportManager::Instance().IsVulkanForbidden(gpuProperties.deviceName, apiVersion, driverVersion,
+                                                       isCustomROM, sdkVersion))
   {
     LOG_ERROR_VK("GPU/Driver configuration is not supported.");
     return;


### PR DESCRIPTION
OM crashes, likely due to some bugs in the Vulkan driver; this PR workarounds it.