### PR TITLE
[Android] fix gradle repos error

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
     }
 }
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
**Symptomps:** gradle build gives error:

```
Build was configured to prefer settings repositories over project repositories but repository 'maven' was added by initialization script '~/.gradle/init.gradle'
```

This happens when user has default repo defined in `~/.gradle/init.gradle`. @AndrewShkrob  added line [settings.gradle:9](https://github.com/organicmaps/organicmaps/blob/master/android/settings.gradle#L9) in commit https://github.com/organicmaps/organicmaps/commit/547401d62f9529a27a28d5410382f7b462debdf8.

**Fix:** Changed repositories mode to prevent Gradle failure.