### PR TITLE
[android] Set default theme as NavAuto.

### DIFF
--- a/android/app/src/main/java/app/organicmaps/sdk/util/Config.java
+++ b/android/app/src/main/java/app/organicmaps/sdk/util/Config.java
@@ -255,13 +255,13 @@ public final class Config
   @NonNull
   public static String getUiThemeSettings(@NonNull Context context)
   {
-    final String autoTheme = context.getString(R.string.theme_auto);
-    final String res = getString(KEY_MISC_UI_THEME_SETTINGS, autoTheme);
+    final String defaultTheme = context.getString(R.string.theme_nav_auto);
+    final String res = getString(KEY_MISC_UI_THEME_SETTINGS, defaultTheme);
     if (ThemeUtils.isValidTheme(context, res) || ThemeUtils.isAutoTheme(context, res)
         || ThemeUtils.isNavAutoTheme(context, res))
       return res;
 
-    return autoTheme;
+    return defaultTheme;
   }
 
   public static boolean setUiThemeSettings(@NonNull Context context, String theme)

--- a/platform/settings.cpp
+++ b/platform/settings.cpp
@@ -23,7 +23,6 @@ using namespace std;
 std::string_view kMeasurementUnits = "Units";
 std::string_view kMapLanguageCode = "MapLanguageCode";
 std::string_view kDeveloperMode = "DeveloperMode";
-std::string_view kNightMode = "NightMode";
 std::string_view kDonateUrl = "DonateUrl";
 std::string_view kNY = "NY";
 

--- a/platform/settings.hpp
+++ b/platform/settings.hpp
@@ -12,7 +12,6 @@ namespace settings
 extern std::string_view kMeasurementUnits;
 extern std::string_view kDeveloperMode;
 extern std::string_view kMapLanguageCode;
-extern std::string_view kNightMode;
 // The following two settings are configured externally at the metaserver.
 extern std::string_view kDonateUrl;
 extern std::string_view kNY;

--- a/qt/preferences_dialog.cpp
+++ b/qt/preferences_dialog.cpp
@@ -152,20 +152,15 @@ namespace qt
 
       nightModeRadioBox->setLayout(layout);
 
-      int i;
-      if (!settings::Get(settings::kNightMode, i))
-      {
-        i = static_cast<int>(MapStyleIsDark(framework.GetMapStyle()) ? NightMode::On : NightMode::Off);
-        settings::Set(settings::kNightMode, i);
-      }
-      nightModeGroup->button(i)->setChecked(true);
+      int const btn = MapStyleIsDark(framework.GetMapStyle()) ? 1 : 0;
+      nightModeGroup->button(btn)->setChecked(true);
 
       void (QButtonGroup::* buttonClicked)(int) = &QButtonGroup::idClicked;
       connect(nightModeGroup, buttonClicked, [&framework](int i)
       {
-        NightMode nightMode = static_cast<NightMode>(i);
-        settings::Set(settings::kNightMode, i);
-        framework.SetMapStyle((nightMode == NightMode::Off) ? GetLightMapStyleVariant(framework.GetMapStyle()) : GetDarkMapStyleVariant(framework.GetMapStyle()));
+        auto const currStyle = framework.GetMapStyle();
+        framework.SetMapStyle((i == 0) ? GetLightMapStyleVariant(currStyle) :
+                                         GetDarkMapStyleVariant(currStyle));
       });
     }
 


### PR DESCRIPTION
@AndrewShkrob Is it ok with AA? Because R.string.theme_nav_auto is absent there.

When the user downloads the app in the evening, they should see the light theme by default (like on iOS).