### PR TITLE
[android-auto] Reload symbols on dpi change

### DIFF
--- a/dev_sandbox/main.cpp
+++ b/dev_sandbox/main.cpp
@@ -11,6 +11,8 @@
 #include "base/logging.hpp"
 #include "base/macros.hpp"
 
+#include "drape_frontend/visual_params.hpp"
+
 #include "std/target_os.hpp"
 
 #include <chrono>
@@ -613,6 +615,14 @@ int main(int argc, char * argv[])
     ImGui::Text("My positon mode: %s", GetMyPoisitionText(framework.GetMyPositionMode()).data());
     if (ImGui::Button("Next Position Mode"))
       framework.SwitchMyPositionNextMode();
+    ImGui::NewLine();
+    ImGui::Separator();
+    ImGui::NewLine();
+    float visualScale = df::VisualParams::Instance().GetVisualScale();
+    ImGui::Text("Visual Scale: ");
+    if (ImGui::SliderFloat(" ", &visualScale, df::VisualParams::kMdpiScale,
+                           df::VisualParams::kXxxhdpiScale))
+      framework.UpdateVisualScale(visualScale);
     ImGui::NewLine();
     ImGui::Separator();
     ImGui::NewLine();

--- a/drape/texture_manager.cpp
+++ b/drape/texture_manager.cpp
@@ -10,6 +10,8 @@
 #include "drape/texture_of_colors.hpp"
 #include "drape/tm_read_resources.hpp"
 
+#include "drape_frontend/visual_params.hpp"
+
 #include "base/math.hpp"
 
 #include <algorithm>
@@ -404,6 +406,7 @@ void TextureManager::Init(ref_ptr<dp::GraphicsContext> context, Params const & p
 void TextureManager::OnSwitchMapStyle(ref_ptr<dp::GraphicsContext> context)
 {
   CHECK(m_isInitialized, ());
+  m_resPostfix = df::VisualParams::Instance().GetResourcePostfix();
 
   // Here we need invalidate only textures which can be changed in map style switch.
   // Now we update only symbol textures, if we need update other textures they must be added here.

--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -981,6 +981,11 @@ void DrapeEngine::UpdateVisualScale(double vs, bool needStopRendering)
   m_threadCommutator->PostMessage(ThreadsCommutator::RenderThread,
                                   make_unique_dp<RecoverContextDependentResourcesMessage>(),
                                   MessagePriority::Normal);
+  // Calling UpdateMapStyle() to reload resources for correct visual scale.
+  // This call updates only symbols textures. Other "scale-dependent" resources remain unchanged.
+  // TODO: A proper fix is still needed.
+  if (GetApiVersion() == dp::ApiVersion::Vulkan)
+    UpdateMapStyle();
 }
 
 void DrapeEngine::UpdateMyPositionRoutingOffset(bool useDefault, int offsetY)


### PR DESCRIPTION
Added "Visual scale" config for dev sandbox.

Added `UpdateMapStyle` call while changing dpi with vulkan
This call will fix an issue with huge icons on AA. 
It only fixes icons. Other textures that depend on visual scale param are unchanged. A big refactoring is needed to reload them.

| | Phone | Android Auto |
|--------|--------|--------|
| Before | <img width="1082" height="631" alt="Screenshot 2025-07-14 at 22 02 58" src="https://github.com/user-attachments/assets/b0fd4d6f-d581-43d4-a892-7a32b4c0ce73" /> | <img width="1081" height="628" alt="Screenshot 2025-07-14 at 22 03 17" src="https://github.com/user-attachments/assets/10f16ff6-0b7b-40e9-8b74-bcb38b4e12c9" /> |
| After | <img width="1079" height="620" alt="Screenshot 2025-07-14 at 21 57 56" src="https://github.com/user-attachments/assets/437fc0c3-ee40-4fec-9ca0-346865902e5a" /> | <img width="1087" height="652" alt="Screenshot 2025-07-14 at 21 57 44" src="https://github.com/user-attachments/assets/26271f7e-eca8-4002-859c-05ccbbcf66ab" /> | 

https://github.com/organicmaps/organicmaps/issues/4760
https://github.com/organicmaps/organicmaps/issues/5761
https://github.com/organicmaps/organicmaps/issues/5760