### PR TITLE
[ios] Show multiline titles in bookmark lists

### DIFF
--- a/iphone/Maps/Bookmarks/Categories/Categories/BMCCategoryCell.xib
+++ b/iphone/Maps/Bookmarks/Categories/Categories/BMCCategoryCell.xib
@@ -31,7 +31,7 @@
                             <action selector="onVisibleChanged:" destination="KGk-i7-Jjw" eventType="valueChanged" id="fV8-pr-hNc"/>
                         </connections>
                     </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="My Places" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jut-eq-wia">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="My Places" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jut-eq-wia">
                         <rect key="frame" x="56" y="10" width="204" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>


### PR DESCRIPTION
Some bookmark list titles can be long and one line is not enough to show them in full, specially in smaller devices. This PR allows bookmark list titles to span multiple lines.

<img width="320" src="https://github.com/user-attachments/assets/5e93e217-790d-41da-b619-78c5d04c4db9" /> <img width="320" src="https://github.com/user-attachments/assets/005d6a01-8589-4b56-945b-a317b2e19a40" /> 
