### PR TITLE
[tools] Ability to run generate_symbols with specified OUT_PATH.

### DIFF
--- a/tools/unix/generate_symbols.sh
+++ b/tools/unix/generate_symbols.sh
@@ -18,7 +18,11 @@ fi
 export PYTHONDONTWRITEBYTECODE=1
 
 OMIM_PATH="${OMIM_PATH:-$(cd "$(dirname "$0")/../.."; pwd)}"
-OUT_PATH="$OMIM_PATH/out/release"
+
+if [ -z "${OUT_PATH}" ]; then
+  OUT_PATH="$OMIM_PATH/out/release"
+fi
+
 SKIN_GENERATOR="${SKIN_GENERATOR:-$OUT_PATH/skin_generator_tool}"
 DATA_PATH="$OMIM_PATH/data"
 


### PR DESCRIPTION
Like
`OUT_PATH=../build-Qt_6_9_0_for_macOS-Debug ./tools/unix/generate_symbols.sh`
to avoid a useless build into hardcoded `out/release`.
