### PR TITLE
Revert "[tools] Ability to run generate_symbols with specified OUT_PATH."

### DIFF
--- a/tools/unix/generate_symbols.sh
+++ b/tools/unix/generate_symbols.sh
@@ -18,11 +18,7 @@ fi
 export PYTHONDONTWRITEBYTECODE=1
 
 OMIM_PATH="${OMIM_PATH:-$(cd "$(dirname "$0")/../.."; pwd)}"
-
-if [ -z "${OUT_PATH}" ]; then
-  OUT_PATH="$OMIM_PATH/out/release"
-fi
-
+OUT_PATH="$OMIM_PATH/out/release"
 SKIN_GENERATOR="${SKIN_GENERATOR:-$OUT_PATH/skin_generator_tool}"
 DATA_PATH="$OMIM_PATH/data"
 


### PR DESCRIPTION
This reverts commit b456d46057d9ea7564e107f1a4e5ed95ebba3d76.

Alternative fix: https://github.com/organicmaps/organicmaps/pull/10932/files#diff-5309a243e8ca5ad68505ee25d57b037c330d745ec7d943a8564118f888164cf8