### PR TITLE
[legal] removed vendor lock

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -20,11 +20,5 @@ organizations and licensed in different ways:
 
 Please refer to their LICENCE, COPYING or NOTICE files for terms of use.
 Some icons files may be copyrighted by (C) 2020 My.com B.V. (Mail.Ru Group)
-See also the `.reuse/dep5` and `data/copyright.html` file for a full list of copyright notices.
-
-If you use Organic Maps source code or its user interface in your project, please include a visible,
-human-readable mention of the “Organic Maps Project” and a clickable link to https://organicmaps.app.
-To respect the work of all project contributors and to comply with license attribution terms,
-this notice should appear in user-visible locations, such as the product’s “About” and “Main Menu” screens.
-
-For white-label use cases, please contact us at `legal@organicmaps.app`.
+See also the `.reuse/dep5` and `data/copyright.html` file for a full list of
+copyright notices.

--- a/NOTICE
+++ b/NOTICE
@@ -16,7 +16,15 @@ limitations under the License.
 Most libraries in the following directories made by other people and
 organizations and licensed in different ways:
 * `3party`
-* `tools`
+* `tools/osmctools`
+
 Please refer to their LICENCE, COPYING or NOTICE files for terms of use.
 Some icons files may be copyrighted by (C) 2020 My.com B.V. (Mail.Ru Group)
 See also the `.reuse/dep5` and `data/copyright.html` file for a full list of copyright notices.
+
+If you use Organic Maps source code or its user interface in your project, please include a visible,
+human-readable mention of the “Organic Maps Project” and a clickable link to https://organicmaps.app.
+To respect the work of all project contributors and to comply with license attribution terms,
+this notice should appear in user-visible locations, such as the product’s “About” and “Main Menu” screens.
+
+For white-label use cases, please contact us at `legal@organicmaps.app`.

--- a/README.md
+++ b/README.md
@@ -186,16 +186,4 @@ The Organic Maps community abides by the CNCF [code of conduct](https://github.c
 
 ## License
 
-Organic Maps is licensed under the [Apache License 2.0](LICENSE).
-
-### Attribution for forks and derivative apps based on Organic Maps
-
-If you use Organic Maps source code or its user interface in your project, please include a visible, human-readable mention of the “Organic Maps Project” and a clickable link to https://organicmaps.app. To respect the work of all project contributors and to comply with license attribution terms, this notice should appear in user-visible locations, such as the product’s “About” and “Main Menu” screens.
-
-### 🤝 White-label
-
-For inquiries about white-labeling or using our servers for your products, please contact us in advance at:
-
-**legal@organicmaps.app**
-
-Thank you!
+Organic Maps is licensed under multiple licenses located at LICENSES directory.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Please join our beta program, suggest your features, and report bugs:
 
 - **Rate us on the [App Store](https://apps.apple.com/app/organic-maps/id1567437057)
 and [Google Play](https://play.google.com/store/apps/details?id=app.organicmaps)**.
-- **Star us on Forgejo**.
+- **Star us on Github**.
 - Report bugs or issues to [the issue tracker](https://github.com/organicmaps/organicmaps/issues).
 - Subscribe to our [Telegram Channel](https://t.me/OrganicMapsApp) or to the [[matrix] space](https://matrix.to/#/#organicmaps:matrix.org) for updates.
 - Join our [Telegram Group](https://t.me/OrganicMaps) to discuss with other users.
@@ -183,3 +183,19 @@ and [Google Play](https://play.google.com/store/apps/details?id=app.organicmaps)
   - Güncellemelerimizi [Instagram](https://instagram.com/organicmapstr/) üzerinden takip edin.
 
 The Organic Maps community abides by the CNCF [code of conduct](https://github.com/organicmaps/organicmaps/blob/master/docs/CODE_OF_CONDUCT.md).
+
+## License
+
+Organic Maps is licensed under the [Apache License 2.0](LICENSE).
+
+### Attribution for forks and derivative apps based on Organic Maps
+
+If you use Organic Maps source code or its user interface in your project, please include a visible, human-readable mention of the “Organic Maps Project” and a clickable link to https://organicmaps.app. To respect the work of all project contributors and to comply with license attribution terms, this notice should appear in user-visible locations, such as the product’s “About” and “Main Menu” screens.
+
+### 🤝 White-label
+
+For inquiries about white-labeling or using our servers for your products, please contact us in advance at:
+
+**legal@organicmaps.app**
+
+Thank you!


### PR DESCRIPTION
The removal of vendor lock-in from the community driven project ensures broader accessibility and aligns with open-source principles.

The core objectives of the community project must remain distinct from any independent commercial software development efforts to preserve its integrity and collaborative nature.

See also:

1. [LEGAL](https://github.com/organicmaps/organicmaps/blob/master/LEGAL)
2. [DCO.md](https://github.com/organicmaps/organicmaps/blob/375d0d3497c531df37b8c7e493a38c17fc29f4b2/docs/DCO.md)
3. [GOVERNANCE.md](https://github.com/organicmaps/organicmaps/blob/375d0d3497c531df37b8c7e493a38c17fc29f4b2/docs/GOVERNANCE.md)
