### PR TITLE
Add Glaze JSON parser

### DIFF
--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -38,14 +38,14 @@ jobs:
         cmake-build-type: [ Debug, Release ]
         environment:
           - os: ubuntu-24.04
-            cc: clang-18
-            cxx: clang++-18
+            cc: clang-19
+            cxx: clang++-19
             unity: OFF
             run-tests: OFF
 
           - os: ubuntu-24.04
-            cc: clang-18
-            cxx: clang++-18
+            cc: clang-19
+            cxx: clang++-19
 
           - os: ubuntu-24.04
             cc: gcc-14
@@ -91,19 +91,18 @@ jobs:
         run: |
           sudo apt update -y
           sudo apt install -y \
-              ninja-build \
+              clang-19 \
               libgl1-mesa-dev \
               libglvnd-dev \
               libharfbuzz-dev \
-              libxrandr-dev \
-              libxinerama-dev \
+              libqt6svg6-dev \
               libxcursor-dev \
               libxi-dev \
+              libxinerama-dev \
+              libxrandr-dev \
+              ninja-build \
               qt6-base-dev \
-              libqt6svg6-dev \
               qt6-positioning-dev \
-              libqt6positioning6-plugins \
-              libqt6positioning6
 
       - name: Install build tools and dependencies (macOS)
         if: ${{ runner.os == 'macOS' }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -83,3 +83,7 @@
   path = 3party/imgui/imgui
   url = https://github.com/ocornut/imgui
   branch = master
+[submodule "3party/glaze"]
+  path = 3party/glaze
+  url = https://github.com/stephenberry/glaze
+  branch = main

--- a/3party/CMakeLists.txt
+++ b/3party/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 
 add_subdirectory(agg)
 add_subdirectory(bsdiff-courgette)
+add_subdirectory(glaze)
 add_subdirectory(minizip)
 add_subdirectory(open-location-code)
 add_subdirectory(opening_hours)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -99,7 +99,6 @@ _Ubuntu 24.04 or newer:_
 ```bash
 sudo apt update && sudo apt install -y \
     build-essential \
-    clang \
     cmake \
     ninja-build \
     python3 \
@@ -112,8 +111,6 @@ sudo apt update && sudo apt install -y \
     libharfbuzz-dev \
     libicu-dev \
     libqt6svg6-dev \
-    libqt6positioning6-plugins \
-    libqt6positioning6 \
     libsqlite3-dev \
     libxrandr-dev \
     libxinerama-dev \
@@ -145,8 +142,9 @@ and apply the [Ubuntu workarounds accordingly](#workarounds-for-older-ubuntu-ver
 
 ```bash
 sudo dnf install -y \
-    clang \
     cmake \
+    gcc \
+    gcc-c++ \
     ninja-build \
     freetype-devel \
     libicu-devel \
@@ -240,7 +238,7 @@ tools/unix/build_omim.sh -d help
 #### Build issues
 
 - If you get "not enough memory" errors during builds, you may disable
-  [CMake Unity Builds](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html) by passing 
+  [CMake Unity Builds](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html) by passing
   `-DCMAKE_UNITY_BUILD=OFF` option to `cmake` invocation. Or you can reduce Unity build batch size from
   the default `50` to a lower value (`2`-`16`) by passing `-DCMAKE_UNITY_BUILD_BATCH_SIZE=8`.
   Note that these changes may significantly increase the build time.

--- a/libs/platform/chunks_download_strategy.cpp
+++ b/libs/platform/chunks_download_strategy.cpp
@@ -10,30 +10,28 @@
 #include "base/logging.hpp"
 #include "base/macros.hpp"
 
-using namespace std;
-
 namespace downloader
 {
-ChunksDownloadStrategy::ChunksDownloadStrategy(vector<string> const & urls)
+ChunksDownloadStrategy::ChunksDownloadStrategy(std::vector<std::string> const & urls)
 {
   // init servers list
   for (size_t i = 0; i < urls.size(); ++i)
     m_servers.push_back(ServerT(urls[i], SERVER_READY));
 }
 
-pair<ChunksDownloadStrategy::ChunkT *, int> ChunksDownloadStrategy::GetChunk(RangeT const & range)
+std::pair<ChunksDownloadStrategy::ChunkT *, int> ChunksDownloadStrategy::GetChunk(RangeT const & range)
 {
-  vector<ChunkT>::iterator i = lower_bound(m_chunks.begin(), m_chunks.end(), range.first, LessChunks());
+  std::vector<ChunkT>::iterator i = lower_bound(m_chunks.begin(), m_chunks.end(), range.first, LessChunks());
 
   if (i != m_chunks.end() && i->m_pos == range.first)
   {
     ASSERT_EQUAL((i + 1)->m_pos, range.second + 1, ());
-    return pair<ChunkT *, int>(&(*i), distance(m_chunks.begin(), i));
+    return std::pair<ChunkT *, int>(&(*i), std::distance(m_chunks.begin(), i));
   }
   else
   {
     LOG(LERROR, ("Downloader error. Invalid chunk range: ", range));
-    return pair<ChunkT *, int>(static_cast<ChunkT *>(0), -1);
+    return std::pair<ChunkT *, int>(static_cast<ChunkT *>(0), -1);
   }
 }
 
@@ -62,7 +60,7 @@ void ChunksDownloadStrategy::AddChunk(RangeT const & range, ChunkStatusT status)
   m_chunks.push_back(ChunkT(range.second + 1, CHUNK_AUX));
 }
 
-void ChunksDownloadStrategy::SaveChunks(int64_t fileSize, string const & fName)
+void ChunksDownloadStrategy::SaveChunks(int64_t fileSize, std::string const & fName)
 {
   if (!m_chunks.empty())
   {
@@ -84,7 +82,7 @@ void ChunksDownloadStrategy::SaveChunks(int64_t fileSize, string const & fName)
   UNUSED_VALUE(Platform::RemoveFileIfExists(fName));
 }
 
-int64_t ChunksDownloadStrategy::LoadOrInitChunks(string const & fName, int64_t fileSize, int64_t chunkSize)
+int64_t ChunksDownloadStrategy::LoadOrInitChunks(std::string const & fName, int64_t fileSize, int64_t chunkSize)
 {
   ASSERT(fileSize > 0, ());
   ASSERT(chunkSize > 0, ());
@@ -129,10 +127,10 @@ int64_t ChunksDownloadStrategy::LoadOrInitChunks(string const & fName, int64_t f
   return 0;
 }
 
-string ChunksDownloadStrategy::ChunkFinished(bool success, RangeT const & range)
+std::string ChunksDownloadStrategy::ChunkFinished(bool success, RangeT const & range)
 {
-  pair<ChunkT *, int> res = GetChunk(range);
-  string url;
+  std::pair<ChunkT *, int> res = GetChunk(range);
+  std::string url;
   // find server which was downloading this chunk
   if (res.first)
   {
@@ -162,7 +160,7 @@ string ChunksDownloadStrategy::ChunkFinished(bool success, RangeT const & range)
   return url;
 }
 
-ChunksDownloadStrategy::ResultT ChunksDownloadStrategy::NextChunk(string & outUrl, RangeT & range)
+ChunksDownloadStrategy::ResultT ChunksDownloadStrategy::NextChunk(std::string & outUrl, RangeT & range)
 {
   // If no servers at all.
   if (m_servers.empty())

--- a/libs/platform/country_file.cpp
+++ b/libs/platform/country_file.cpp
@@ -8,9 +8,7 @@
 
 namespace platform
 {
-using namespace std;
-
-string GetFileName(string const & countryName, MapFileType type)
+std::string GetFileName(std::string const & countryName, MapFileType type)
 {
   ASSERT(!countryName.empty(), ());
 
@@ -34,9 +32,9 @@ CountryFile::CountryFile(std::string name, MwmSize size, std::string sha1)
   , m_sha1(std::move(sha1))
 {}
 
-string DebugPrint(CountryFile const & file)
+std::string DebugPrint(CountryFile const & file)
 {
-  ostringstream os;
+  std::ostringstream os;
   os << "CountryFile [" << file.m_name << "]";
   return os.str();
 }

--- a/libs/platform/get_text_by_id.cpp
+++ b/libs/platform/get_text_by_id.cpp
@@ -11,7 +11,7 @@
 
 namespace platform
 {
-using namespace std;
+using std::string;
 
 namespace
 {

--- a/libs/platform/http_client.cpp
+++ b/libs/platform/http_client.cpp
@@ -6,10 +6,10 @@
 
 #include <sstream>
 
-using namespace std;
-
 namespace platform
 {
+using std::string;
+
 HttpClient::HttpClient(string const & url) : m_urlRequested(url) {}
 
 bool HttpClient::RunHttpRequest(string & response, SuccessChecker checker /* = nullptr */)
@@ -164,7 +164,7 @@ HttpClient::Headers const & HttpClient::GetHeaders() const
 // static
 string HttpClient::NormalizeServerCookies(string && cookies)
 {
-  istringstream is(cookies);
+  std::istringstream is(cookies);
   string str, result;
 
   // Split by ", ". Can have invalid tokens here, expires= can also contain a comma.
@@ -195,7 +195,7 @@ string HttpClient::NormalizeServerCookies(string && cookies)
 
 string DebugPrint(HttpClient const & request)
 {
-  ostringstream ostr;
+  std::ostringstream ostr;
   ostr << "HTTP " << request.ErrorCode() << " url [" << request.UrlRequested() << "]";
   if (request.WasRedirected())
     ostr << " was redirected to [" << request.UrlReceived() << "]";

--- a/libs/platform/http_request.cpp
+++ b/libs/platform/http_request.cpp
@@ -19,12 +19,12 @@
 
 #include "defines.hpp"
 
-using namespace std;
-
 class HttpThread;
 
 namespace downloader
 {
+using std::string;
+
 namespace non_http_error_code
 {
 string DebugPrint(long errorCode)
@@ -37,7 +37,7 @@ string DebugPrint(long errorCode)
   case kNonHttpResponse: return "Non-http response";
   case kInvalidURL: return "Invalid URL";
   case kCancelled: return "Cancelled";
-  default: return to_string(errorCode);
+  default: return std::to_string(errorCode);
   }
 }
 }  // namespace non_http_error_code
@@ -117,12 +117,12 @@ class FileHttpRequest
   , public IHttpThreadCallback
 {
   ChunksDownloadStrategy m_strategy;
-  typedef pair<HttpThread *, int64_t> ThreadHandleT;
-  typedef list<ThreadHandleT> ThreadsContainerT;
+  typedef std::pair<HttpThread *, int64_t> ThreadHandleT;
+  typedef std::list<ThreadHandleT> ThreadsContainerT;
   ThreadsContainerT m_threads;
 
-  string m_filePath;
-  unique_ptr<FileWriter> m_writer;
+  std::string m_filePath;
+  std::unique_ptr<FileWriter> m_writer;
 
   size_t m_goodChunksCount;
   bool m_doCleanProgressFiles;
@@ -130,13 +130,13 @@ class FileHttpRequest
   ChunksDownloadStrategy::ResultT StartThreads()
   {
     string url;
-    pair<int64_t, int64_t> range;
+    std::pair<int64_t, int64_t> range;
     ChunksDownloadStrategy::ResultT result;
     while ((result = m_strategy.NextChunk(url, range)) == ChunksDownloadStrategy::ENextChunk)
     {
       HttpThread * p = CreateNativeHttpThread(url, *this, range.first, range.second, m_progress.m_bytesTotal);
       ASSERT(p, ());
-      m_threads.push_back(make_pair(p, range.first));
+      m_threads.push_back(std::make_pair(p, range.first));
     }
     return result;
   }
@@ -207,7 +207,7 @@ class FileHttpRequest
 #endif
 
     bool const isChunkOk = (httpOrErrorCode == 200);
-    string const urlError = m_strategy.ChunkFinished(isChunkOk, make_pair(begRange, endRange));
+    string const urlError = m_strategy.ChunkFinished(isChunkOk, std::make_pair(begRange, endRange));
 
     // remove completed chunk from the list, beg is the key
     RemoveHttpThreadByKey(begRange);
@@ -278,8 +278,8 @@ class FileHttpRequest
   }
 
 public:
-  FileHttpRequest(vector<string> const & urls, string const & filePath, int64_t fileSize, Callback && onFinish,
-                  Callback && onProgress, int64_t chunkSize, bool doCleanProgressFiles)
+  FileHttpRequest(std::vector<std::string> const & urls, std::string const & filePath, int64_t fileSize,
+                  Callback && onFinish, Callback && onProgress, int64_t chunkSize, bool doCleanProgressFiles)
     : HttpRequest(std::move(onFinish), std::move(onProgress))
     , m_strategy(urls)
     , m_filePath(filePath)
@@ -304,7 +304,7 @@ public:
     }
 
     // Create file and reserve needed size.
-    unique_ptr<FileWriter> writer(new FileWriter(filePath + DOWNLOADING_FILE_EXTENSION, openMode));
+    std::unique_ptr<FileWriter> writer(new FileWriter(filePath + DOWNLOADING_FILE_EXTENSION, openMode));
 
     // Assign here, because previous functions can throw an exception.
     m_writer.swap(writer);
@@ -360,7 +360,7 @@ HttpRequest * HttpRequest::PostJson(string const & url, string const & postData,
   return new MemoryHttpRequest(url, postData, std::move(onFinish), std::move(onProgress));
 }
 
-HttpRequest * HttpRequest::GetFile(vector<string> const & urls, string const & filePath, int64_t fileSize,
+HttpRequest * HttpRequest::GetFile(std::vector<string> const & urls, string const & filePath, int64_t fileSize,
                                    Callback && onFinish, Callback && onProgress, int64_t chunkSize,
                                    bool doCleanOnCancel)
 {

--- a/libs/platform/http_thread_qt.cpp
+++ b/libs/platform/http_thread_qt.cpp
@@ -11,10 +11,8 @@
 #include <QSslError>
 #include <QUrl>
 
-using namespace std;
-
-HttpThread::HttpThread(string const & url, downloader::IHttpThreadCallback & cb, int64_t beg, int64_t end, int64_t size,
-                       string const & pb)
+HttpThread::HttpThread(std::string const & url, downloader::IHttpThreadCallback & cb, int64_t beg, int64_t end,
+                       int64_t size, std::string const & pb)
   : m_callback(cb)
   , m_begRange(beg)
   , m_endRange(end)
@@ -145,8 +143,8 @@ void HttpThread::OnDownloadFinished()
 namespace downloader
 {
 
-HttpThread * CreateNativeHttpThread(string const & url, downloader::IHttpThreadCallback & cb, int64_t beg, int64_t end,
-                                    int64_t size, string const & pb)
+HttpThread * CreateNativeHttpThread(std::string const & url, downloader::IHttpThreadCallback & cb, int64_t beg,
+                                    int64_t end, int64_t size, std::string const & pb)
 {
   return new HttpThread(url, cb, beg, end, size, pb);
 }

--- a/libs/platform/local_country_file.cpp
+++ b/libs/platform/local_country_file.cpp
@@ -16,11 +16,10 @@
 
 namespace platform
 {
-using namespace std;
 
 LocalCountryFile::LocalCountryFile() : m_version(0) {}
 
-LocalCountryFile::LocalCountryFile(string directory, CountryFile countryFile, int64_t version)
+LocalCountryFile::LocalCountryFile(std::string directory, CountryFile countryFile, int64_t version)
   : m_directory(std::move(directory))
   , m_countryFile(std::move(countryFile))
   , m_version(version)
@@ -58,7 +57,7 @@ void LocalCountryFile::DeleteFromDisk(MapFileType type) const
     LOG(LERROR, (type, "from", *this, "wasn't deleted from disk."));
 }
 
-string LocalCountryFile::GetPath(MapFileType type) const
+std::string LocalCountryFile::GetPath(MapFileType type) const
 {
   return base::JoinPath(m_directory, GetFileName(type));
 }
@@ -114,7 +113,7 @@ bool LocalCountryFile::ValidateIntegrity() const
 }
 
 // static
-LocalCountryFile LocalCountryFile::MakeForTesting(string countryFileName, int64_t version)
+LocalCountryFile LocalCountryFile::MakeForTesting(std::string countryFileName, int64_t version)
 {
   LocalCountryFile localFile(GetPlatform().WritableDir(), CountryFile(std::move(countryFileName)), version);
   localFile.SyncWithDisk();
@@ -122,18 +121,18 @@ LocalCountryFile LocalCountryFile::MakeForTesting(string countryFileName, int64_
 }
 
 // static
-LocalCountryFile LocalCountryFile::MakeTemporary(string const & fullPath)
+LocalCountryFile LocalCountryFile::MakeTemporary(std::string const & fullPath)
 {
-  string name = fullPath;
+  auto name = fullPath;
   base::GetNameFromFullPath(name);
   base::GetNameWithoutExt(name);
 
   return LocalCountryFile(base::GetDirectory(fullPath), CountryFile(std::move(name)), 0 /* version */);
 }
 
-string DebugPrint(LocalCountryFile const & file)
+std::string DebugPrint(LocalCountryFile const & file)
 {
-  ostringstream os;
+  std::ostringstream os;
   os << "LocalCountryFile [" << file.m_directory << ", " << DebugPrint(file.m_countryFile) << ", " << file.m_version
      << ", [";
 

--- a/libs/platform/local_country_file_utils.cpp
+++ b/libs/platform/local_country_file_utils.cpp
@@ -25,7 +25,7 @@
 
 namespace platform
 {
-using namespace std;
+using std::string;
 
 namespace
 {
@@ -42,8 +42,8 @@ bool IsSpecialName(string const & name) { return name == "." || name == ".."; }
 */
 bool IsDownloaderFile(string const & name)
 {
-  static regex const filter(".*\\.(downloading|resume|ready)[0-9]?$");
-  return regex_match(name.begin(), name.end(), filter);
+  static std::regex const filter(".*\\.(downloading|resume|ready)[0-9]?$");
+  return std::regex_match(name.begin(), name.end(), filter);
 }
 
 bool IsDiffFile(string const & name)
@@ -80,7 +80,7 @@ inline string GetDataDirFullPath(string const & dataDir)
   return dataDir.empty() ? platform.WritableDir() : base::JoinPath(platform.WritableDir(), dataDir);
 }
 
-void FindAllDiffsInDirectory(string const & dir, vector<LocalCountryFile> & diffs)
+void FindAllDiffsInDirectory(string const & dir, std::vector<LocalCountryFile> & diffs)
 {
   Platform & platform = GetPlatform();
 
@@ -139,7 +139,7 @@ void DeleteDownloaderFilesForCountry(int64_t version, string const & dataDir, Co
 }
 
 size_t FindAllLocalMapsInDirectoryAndCleanup(string const & directory, int64_t version, int64_t latestVersion,
-                                             vector<LocalCountryFile> & localFiles)
+                                             std::vector<LocalCountryFile> & localFiles)
 {
   Platform & platform = GetPlatform();
   size_t const szBefore = localFiles.size();
@@ -192,7 +192,7 @@ size_t FindAllLocalMapsInDirectoryAndCleanup(string const & directory, int64_t v
   */
 }
 
-void FindAllDiffs(string const & dataDir, vector<LocalCountryFile> & diffs)
+void FindAllDiffs(std::string const & dataDir, std::vector<LocalCountryFile> & diffs)
 {
   string const dir = GetDataDirFullPath(dataDir);
   FindAllDiffsInDirectory(dir, diffs);
@@ -204,12 +204,13 @@ void FindAllDiffs(string const & dataDir, vector<LocalCountryFile> & diffs)
     FindAllDiffsInDirectory(base::JoinPath(dir, fwt.first /* subdir */), diffs);
 }
 
-void FindAllLocalMapsAndCleanup(int64_t latestVersion, vector<LocalCountryFile> & localFiles)
+void FindAllLocalMapsAndCleanup(int64_t latestVersion, std::vector<LocalCountryFile> & localFiles)
 {
   FindAllLocalMapsAndCleanup(latestVersion, string(), localFiles);
 }
 
-void FindAllLocalMapsAndCleanup(int64_t latestVersion, string const & dataDir, vector<LocalCountryFile> & localFiles)
+void FindAllLocalMapsAndCleanup(int64_t latestVersion, string const & dataDir,
+                                std::vector<LocalCountryFile> & localFiles)
 {
   string const dir = GetDataDirFullPath(dataDir);
 
@@ -275,7 +276,7 @@ void FindAllLocalMapsAndCleanup(int64_t latestVersion, string const & dataDir, v
 
 void CleanupMapsDirectory(int64_t latestVersion)
 {
-  vector<LocalCountryFile> localFiles;
+  std::vector<LocalCountryFile> localFiles;
   FindAllLocalMapsAndCleanup(latestVersion, localFiles);
 }
 
@@ -296,13 +297,13 @@ bool ParseVersion(string const & s, int64_t & version)
   return true;
 }
 
-shared_ptr<LocalCountryFile> PreparePlaceForCountryFiles(int64_t version, CountryFile const & countryFile)
+std::shared_ptr<LocalCountryFile> PreparePlaceForCountryFiles(int64_t version, CountryFile const & countryFile)
 {
   return PreparePlaceForCountryFiles(version, string(), countryFile);
 }
 
-shared_ptr<LocalCountryFile> PreparePlaceForCountryFiles(int64_t version, string const & dataDir,
-                                                         CountryFile const & countryFile)
+std::shared_ptr<LocalCountryFile> PreparePlaceForCountryFiles(int64_t version, string const & dataDir,
+                                                              CountryFile const & countryFile)
 {
   string const dir = PrepareDirToDownloadCountry(version, dataDir);
   return (!dir.empty() ? make_shared<LocalCountryFile>(dir, countryFile, version) : nullptr);
@@ -322,7 +323,7 @@ string GetFileDownloadPath(int64_t version, string const & dataDir, string const
   return GetFilePath(version, dataDir, countryName, type) + READY_FILE_EXTENSION;
 }
 
-unique_ptr<ModelReader> GetCountryReader(LocalCountryFile const & file, MapFileType type)
+std::unique_ptr<ModelReader> GetCountryReader(LocalCountryFile const & file, MapFileType type)
 {
   Platform & platform = GetPlatform();
   if (file.IsInBundle())
@@ -378,7 +379,7 @@ string CountryIndexes::GetPath(LocalCountryFile const & localFile, Index index)
 }
 
 // static
-void CountryIndexes::GetIndexesExts(vector<string> & exts)
+void CountryIndexes::GetIndexesExts(std::vector<string> & exts)
 {
   exts.push_back(kBitsExt);
   exts.push_back(kNodesExt);

--- a/libs/platform/platform_android.cpp
+++ b/libs/platform/platform_android.cpp
@@ -18,8 +18,6 @@
 #include <sys/stat.h>
 #include <unistd.h>  // for sysconf
 
-using namespace std;
-
 Platform::Platform()
 {
   /// @see initialization routine in android/sdk/src/main/cpp/com/.../Platform.hpp
@@ -31,22 +29,22 @@ namespace
 class DbgLogger
 {
 public:
-  explicit DbgLogger(string const & file) : m_file(file) {}
+  explicit DbgLogger(std::string const & file) : m_file(file) {}
 
   ~DbgLogger() { LOG(LDEBUG, ("Source for file", m_file, "is", m_src)); }
 
   void SetSource(char src) { m_src = src; }
 
 private:
-  string const & m_file;
+  std::string const & m_file;
   char m_src;
 };
 }  // namespace
 #endif
 
-unique_ptr<ModelReader> Platform::GetReader(string const & file, string searchScope) const
+std::unique_ptr<ModelReader> Platform::GetReader(std::string const & file, std::string searchScope) const
 {
-  string ext = base::GetFileExtension(file);
+  std::string ext = base::GetFileExtension(file);
   strings::AsciiToLower(ext);
   ASSERT(!ext.empty(), ());
 
@@ -87,17 +85,17 @@ unique_ptr<ModelReader> Platform::GetReader(string const & file, string searchSc
     {
     case 'w':
     {
-      string const path = base::JoinPath(m_writableDir, file);
+      auto const path = base::JoinPath(m_writableDir, file);
       if (IsFileExistsByFullPath(path))
-        return make_unique<FileReader>(path, logPageSize, logPageCount);
+        return std::make_unique<FileReader>(path, logPageSize, logPageCount);
       break;
     }
 
     case 's':
     {
-      string const path = base::JoinPath(m_settingsDir, file);
+      auto const path = base::JoinPath(m_settingsDir, file);
       if (IsFileExistsByFullPath(path))
-        return make_unique<FileReader>(path, logPageSize, logPageCount);
+        return std::make_unique<FileReader>(path, logPageSize, logPageCount);
       break;
     }
 
@@ -107,7 +105,7 @@ unique_ptr<ModelReader> Platform::GetReader(string const & file, string searchSc
       break;
 
     case 'r':
-      ASSERT_EQUAL(file.find("assets/"), string::npos, ());
+      ASSERT_EQUAL(file.find("assets/"), std::string::npos, ());
       try
       {
         return make_unique<ZipFileReader>(m_resourcesDir, "assets/" + file, logPageSize, logPageCount);
@@ -127,7 +125,7 @@ unique_ptr<ModelReader> Platform::GetReader(string const & file, string searchSc
   return nullptr;
 }
 
-void Platform::GetFilesByRegExp(string const & directory, string const & regexp, FilesList & res)
+void Platform::GetFilesByRegExp(std::string const & directory, std::string const & regexp, FilesList & res)
 {
   if (ZipFileReader::IsZip(directory))
   {
@@ -136,12 +134,12 @@ void Platform::GetFilesByRegExp(string const & directory, string const & regexp,
     FilesT fList;
     ZipFileReader::FilesList(directory, fList);
 
-    regex exp(regexp);
+    std::regex exp(regexp);
 
     for (FilesT::iterator it = fList.begin(); it != fList.end(); ++it)
     {
-      string & name = it->first;
-      if (regex_search(name.begin(), name.end(), exp))
+      std::string & name = it->first;
+      if (std::regex_search(name.begin(), name.end(), exp))
       {
         // Remove assets/ prefix - clean files are needed for fonts white/blacklisting logic
         size_t const ASSETS_LENGTH = 7;
@@ -166,7 +164,7 @@ int Platform::PreCachingDepth() const
   return 3;
 }
 
-bool Platform::GetFileSizeByName(string const & fileName, uint64_t & size) const
+bool Platform::GetFileSizeByName(std::string const & fileName, uint64_t & size) const
 {
   try
   {
@@ -181,7 +179,7 @@ bool Platform::GetFileSizeByName(string const & fileName, uint64_t & size) const
 }
 
 // static
-Platform::EError Platform::MkDir(string const & dirName)
+Platform::EError Platform::MkDir(std::string const & dirName)
 {
   if (0 != mkdir(dirName.c_str(), 0755))
     return ErrnoToError();
@@ -202,16 +200,16 @@ void Platform::GetSystemFontNames(FilesList & res) const
 {
   bool wasRoboto = false;
 
-  string const path = "/system/fonts/";
+  std::string const path = "/system/fonts/";
   pl::EnumerateFiles(path, [&](char const * entry)
   {
-    string name(entry);
+    std::string name(entry);
     if (name != "Roboto-Medium.ttf" && name != "Roboto-Regular.ttf")
     {
       if (!name.starts_with("NotoNaskh") && !name.starts_with("NotoSans"))
         return;
 
-      if (name.find("-Regular") == string::npos)
+      if (name.find("-Regular") == std::string::npos)
         return;
     }
     else
@@ -222,7 +220,7 @@ void Platform::GetSystemFontNames(FilesList & res) const
 
   if (!wasRoboto)
   {
-    string droidSans = path + "DroidSans.ttf";
+    std::string droidSans = path + "DroidSans.ttf";
     if (IsFileExistsByFullPath(droidSans))
       res.push_back(std::move(droidSans));
   }

--- a/libs/platform/platform_tests/CMakeLists.txt
+++ b/libs/platform/platform_tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC
   downloader_tests/downloader_test.cpp
   downloader_utils_tests.cpp
   get_text_by_id_tests.cpp
+  glaze_test.cpp
   jansson_test.cpp
   language_test.cpp
   local_country_file_tests.cpp
@@ -24,4 +25,5 @@ target_link_libraries(${PROJECT_NAME}
   platform_tests_support
   platform
   cppjansson
+  glaze::glaze
 )

--- a/libs/platform/platform_tests/country_file_tests.cpp
+++ b/libs/platform/platform_tests/country_file_tests.cpp
@@ -7,8 +7,6 @@
 
 #include <string>
 
-using namespace std;
-
 namespace platform
 {
 UNIT_TEST(CountryFile_Smoke)
@@ -16,7 +14,7 @@ UNIT_TEST(CountryFile_Smoke)
   {
     CountryFile cf("One");
     TEST_EQUAL("One", cf.GetName(), ());
-    string const mapFileName = cf.GetFileName(MapFileType::Map);
+    auto const mapFileName = cf.GetFileName(MapFileType::Map);
 
     TEST_EQUAL("One" DATA_FILE_EXTENSION, mapFileName, ());
     TEST_EQUAL(0, cf.GetRemoteSize(), ());
@@ -25,7 +23,7 @@ UNIT_TEST(CountryFile_Smoke)
   {
     CountryFile cf("Three", 666, "xxxSHAxxx");
     TEST_EQUAL("Three", cf.GetName(), ());
-    string const mapFileName = cf.GetFileName(MapFileType::Map);
+    auto const mapFileName = cf.GetFileName(MapFileType::Map);
 
     TEST_EQUAL("Three" DATA_FILE_EXTENSION, mapFileName, ());
     TEST_EQUAL(666, cf.GetRemoteSize(), ());

--- a/libs/platform/platform_tests/get_text_by_id_tests.cpp
+++ b/libs/platform/platform_tests/get_text_by_id_tests.cpp
@@ -4,12 +4,9 @@
 
 #include <string>
 
-using namespace platform;
-using namespace std;
-
 UNIT_TEST(GetTextByIdEnglishTest)
 {
-  string const shortJson =
+  std::string const shortJson =
       "\
       {\
       \"make_a_slight_right_turn\":\"Make a slight right turn.\",\
@@ -32,7 +29,7 @@ UNIT_TEST(GetTextByIdEnglishTest)
 
 UNIT_TEST(GetTextByIdRussianTest)
 {
-  string const shortJson =
+  std::string const shortJson =
       "\
       {\
       \"in_800_meters\":\"Через восемьсот метров.\",\
@@ -55,7 +52,7 @@ UNIT_TEST(GetTextByIdRussianTest)
 
 UNIT_TEST(GetTextByIdKoreanTest)
 {
-  string const shortJson =
+  std::string const shortJson =
       "\
       {\
       \"in_700_meters\":\"700 미터 앞\",\
@@ -78,7 +75,7 @@ UNIT_TEST(GetTextByIdKoreanTest)
 
 UNIT_TEST(GetTextByIdArabicTest)
 {
-  string const shortJson =
+  std::string const shortJson =
       "\
       {\
       \"in_1_kilometer\":\"بعد كيلو متر واحدٍ\",\
@@ -101,7 +98,7 @@ UNIT_TEST(GetTextByIdArabicTest)
 
 UNIT_TEST(GetTextByIdFrenchTest)
 {
-  string const shortJson =
+  std::string const shortJson =
       "\
       {\
       \"in_1_5_kilometers\":\"Dans un virgule cinq kilomètre.\",\

--- a/libs/platform/platform_tests/glaze_test.cpp
+++ b/libs/platform/platform_tests/glaze_test.cpp
@@ -1,0 +1,90 @@
+#include "testing/testing.hpp"
+
+#include "glaze/json.hpp"
+
+#include <optional>
+#include <string>
+
+enum class LocationSource
+{
+  GPS,
+  Network,
+  Unknown
+};
+
+// If enumeration should be represented as string instead of integer in JSON,
+// then enum should be declared in the global namespace.
+template <>
+struct glz::meta<LocationSource>
+{
+  using enum LocationSource;
+  static constexpr auto value = glz::enumerate(GPS, Network, Unknown);
+};
+
+// For our test macros.
+std::string DebugPrint(LocationSource source)
+{
+  return std::string{glz::get_enum_name(source)};
+}
+
+namespace glaze_test
+{
+struct Location
+{
+  LocationSource source;
+  double latitude;
+  double longitude;
+  double accuracy;
+  std::optional<double> altitude;
+  std::optional<double> altitudeAccuracy;
+};
+
+struct AccessToken
+{
+  Location location;
+  std::string accessToken;
+};
+
+UNIT_TEST(Glaze_Smoke)
+{
+  std::string_view constexpr fullJsonWithComments = R"({
+  "location": {
+    "source": "GPS",  // Where the location data comes from.
+    "latitude": 47.3345141,
+    "longitude": 8.5312839,
+    "accuracy": 22,
+    "altitude": 100.5,
+    "altitudeAccuracy": 5.0
+  },
+  /* Access token for authentication
+   * This token is used to access protected resources.
+   */
+  "accessToken": "2:vC65Xv0mxMtsNVf4:hY5YSIkuFfnAU77z"
+})";
+
+  AccessToken token;
+  auto error = glz::read_jsonc(token, fullJsonWithComments);
+  TEST(!error, (glz::format_error(error, fullJsonWithComments)));
+
+  TEST_EQUAL(token.location.source, LocationSource::GPS, ());
+  TEST_EQUAL(token.location.latitude, 47.3345141, ());
+  TEST_EQUAL(token.location.longitude, 8.5312839, ());
+  TEST_EQUAL(token.location.accuracy, 22.0, ());
+  TEST_EQUAL(token.location.altitude, 100.5, ());
+  TEST_EQUAL(token.location.altitudeAccuracy, 5.0, ());
+  TEST_EQUAL(token.accessToken, "2:vC65Xv0mxMtsNVf4:hY5YSIkuFfnAU77z", ());
+
+  std::string_view constexpr partialJson =
+      R"({"location":{"source":"Network","latitude":47.3345141,"longitude":8.5312839,"accuracy":22},"accessToken":""})";
+
+  token.location.source = LocationSource::Network;
+  token.location.altitude = {};
+  token.location.altitudeAccuracy = {};
+  token.accessToken = {};
+
+  std::string buffer;
+  error = glz::write_json(token, buffer);
+  TEST(!error, (glz::format_error(error, "Failed to write JSON")));
+  TEST_EQUAL(buffer, partialJson, ());
+}
+}  // namespace glaze_test

--- a/libs/platform/platform_tests/local_country_file_tests.cpp
+++ b/libs/platform/platform_tests/local_country_file_tests.cpp
@@ -25,14 +25,17 @@
 
 namespace local_country_file_tests
 {
-using namespace platform;
-using namespace platform::tests_support;
-using namespace std;
+using platform::CountryFile;
+using platform::LocalCountryFile;
+using platform::tests_support::ScopedDir;
+using platform::tests_support::ScopedFile;
 
 // Checks that all unsigned numbers less than 10 ^ 18 can be parsed as
 // a timestamp.
 UNIT_TEST(LocalCountryFile_ParseVersion)
 {
+  using namespace platform;
+
   int64_t version = 0;
   TEST(ParseVersion("1", version), ());
   TEST_EQUAL(version, 1, ());
@@ -88,8 +91,8 @@ UNIT_TEST(LocalCountryFile_DiskFiles)
     TEST(!localFile.OnDisk(MapFileType::Map), ());
     TEST(!localFile.OnDisk(MapFileType::Diff), ());
 
-    string const mapFileName = countryFile.GetFileName(MapFileType::Map);
-    string const mapFileContents("map");
+    std::string const mapFileName = countryFile.GetFileName(MapFileType::Map);
+    std::string const mapFileContents("map");
     ScopedFile testMapFile(mapFileName, mapFileContents);
 
     localFile.SyncWithDisk();
@@ -110,7 +113,7 @@ UNIT_TEST(LocalCountryFile_DiskFiles)
 UNIT_TEST(LocalCountryFile_CleanupMapFiles)
 {
   Platform & platform = GetPlatform();
-  string const mapsDir = platform.WritableDir();
+  std::string const mapsDir = platform.WritableDir();
 
   // Two fake directories for test country files and indexes.
   ScopedDir dir3("3");
@@ -125,7 +128,7 @@ UNIT_TEST(LocalCountryFile_CleanupMapFiles)
   ScopedFile irelandMapFile(dir4, irelandFile, MapFileType::Map);
 
   // Check FindAllLocalMaps()
-  vector<LocalCountryFile> localFiles;
+  std::vector<LocalCountryFile> localFiles;
   FindAllLocalMapsAndCleanup(4 /* latestVersion */, localFiles);
   TEST(base::IsExist(localFiles, irelandLocalFile), (irelandLocalFile, localFiles));
 
@@ -170,7 +173,7 @@ UNIT_TEST(LocalCountryFile_CleanupPartiallyDownloadedFiles)
       {base::JoinPath(latestDir.GetRelativePath(), "Russia_Southern.mwm.downloading"), ScopedFile::Mode::Create}
   };
 
-  CleanupMapsDirectory(101010 /* latestVersion */);
+  platform::CleanupMapsDirectory(101010 /* latestVersion */);
 
   for (ScopedFile & file : toBeDeleted)
   {
@@ -204,10 +207,10 @@ UNIT_TEST(LocalCountryFile_DirectoryLookup)
   ScopedFile testIrelandMapFile(testDir, irelandFile, MapFileType::Map);
   ScopedFile testNetherlandsMapFile(testDir, netherlandsFile, MapFileType::Map);
 
-  vector<LocalCountryFile> localFiles;
+  std::vector<LocalCountryFile> localFiles;
   FindAllLocalMapsInDirectoryAndCleanup(testDir.GetFullPath(), 150309 /* version */, -1 /* latestVersion */,
                                         localFiles);
-  sort(localFiles.begin(), localFiles.end());
+  std::sort(localFiles.begin(), localFiles.end());
   for (LocalCountryFile & localFile : localFiles)
     localFile.SyncWithDisk();
 
@@ -217,8 +220,8 @@ UNIT_TEST(LocalCountryFile_DirectoryLookup)
   LocalCountryFile expectedNetherlandsFile(testDir.GetFullPath(), netherlandsFile, 150309);
   expectedNetherlandsFile.SyncWithDisk();
 
-  vector<LocalCountryFile> expectedLocalFiles = {expectedIrelandFile, expectedNetherlandsFile};
-  sort(expectedLocalFiles.begin(), expectedLocalFiles.end());
+  std::vector expectedLocalFiles = {expectedIrelandFile, expectedNetherlandsFile};
+  std::sort(expectedLocalFiles.begin(), expectedLocalFiles.end());
   TEST_EQUAL(expectedLocalFiles, localFiles, ());
 }
 
@@ -236,9 +239,9 @@ UNIT_TEST(LocalCountryFile_AllLocalFilesLookup)
 
   ScopedFile testItalyMapFile(testDir, italyFile, MapFileType::Map);
 
-  vector<LocalCountryFile> localFiles;
+  std::vector<LocalCountryFile> localFiles;
   FindAllLocalMapsAndCleanup(10101 /* latestVersion */, localFiles);
-  multiset<LocalCountryFile> localFilesSet(localFiles.begin(), localFiles.end());
+  std::multiset<LocalCountryFile> localFilesSet(localFiles.begin(), localFiles.end());
 
   bool worldFound = false;
   bool worldCoastsFound = false;
@@ -269,7 +272,7 @@ UNIT_TEST(LocalCountryFile_PreparePlaceForCountryFiles)
 
   CountryFile italyFile("Italy");
   LocalCountryFile expectedItalyFile(platform.WritableDir(), italyFile, 0 /* version */);
-  shared_ptr<LocalCountryFile> italyLocalFile = PreparePlaceForCountryFiles(0 /* version */, italyFile);
+  auto italyLocalFile = PreparePlaceForCountryFiles(0 /* version */, italyFile);
   TEST(italyLocalFile.get(), ());
   TEST_EQUAL(expectedItalyFile, *italyLocalFile, ());
 
@@ -277,19 +280,21 @@ UNIT_TEST(LocalCountryFile_PreparePlaceForCountryFiles)
 
   CountryFile germanyFile("Germany");
   LocalCountryFile expectedGermanyFile(directoryForV1.GetFullPath(), germanyFile, 1 /* version */);
-  shared_ptr<LocalCountryFile> germanyLocalFile = PreparePlaceForCountryFiles(1 /* version */, germanyFile);
+  auto germanyLocalFile = PreparePlaceForCountryFiles(1 /* version */, germanyFile);
   TEST(germanyLocalFile.get(), ());
   TEST_EQUAL(expectedGermanyFile, *germanyLocalFile, ());
 
   CountryFile franceFile("France");
   LocalCountryFile expectedFranceFile(directoryForV1.GetFullPath(), franceFile, 1 /* version */);
-  shared_ptr<LocalCountryFile> franceLocalFile = PreparePlaceForCountryFiles(1 /* version */, franceFile);
+  auto franceLocalFile = PreparePlaceForCountryFiles(1 /* version */, franceFile);
   TEST(franceLocalFile.get(), ());
   TEST_EQUAL(expectedFranceFile, *franceLocalFile, ());
 }
 
 UNIT_TEST(LocalCountryFile_CountryIndexes)
 {
+  using platform::CountryIndexes;
+
   ScopedDir testDir("101010");
 
   CountryFile germanyFile("Germany");
@@ -298,11 +303,11 @@ UNIT_TEST(LocalCountryFile_CountryIndexes)
              CountryIndexes::IndexesDir(germanyLocalFile), ());
   CountryIndexes::PreparePlaceOnDisk(germanyLocalFile);
 
-  string const bitsPath = CountryIndexes::GetPath(germanyLocalFile, CountryIndexes::Index::Bits);
+  auto const bitsPath = CountryIndexes::GetPath(germanyLocalFile, CountryIndexes::Index::Bits);
   TEST(!Platform::IsFileExistsByFullPath(bitsPath), (bitsPath));
   {
     FileWriter writer(bitsPath);
-    string const contents = "bits index";
+    std::string const contents = "bits index";
     writer.Write(contents.data(), contents.size());
   }
   TEST(Platform::IsFileExistsByFullPath(bitsPath), (bitsPath));
@@ -314,6 +319,8 @@ UNIT_TEST(LocalCountryFile_CountryIndexes)
 
 UNIT_TEST(LocalCountryFile_DoNotDeleteUserFiles)
 {
+  using platform::CountryIndexes;
+
   base::ScopedLogLevelChanger const criticalLogLevel(LCRITICAL);
 
   ScopedDir testDir("101010");
@@ -322,10 +329,10 @@ UNIT_TEST(LocalCountryFile_DoNotDeleteUserFiles)
   LocalCountryFile germanyLocalFile(testDir.GetFullPath(), germanyFile, 101010 /* version */);
   CountryIndexes::PreparePlaceOnDisk(germanyLocalFile);
 
-  string const userFilePath = base::JoinPath(CountryIndexes::IndexesDir(germanyLocalFile), "user-data.txt");
+  auto const userFilePath = base::JoinPath(CountryIndexes::IndexesDir(germanyLocalFile), "user-data.txt");
   {
     FileWriter writer(userFilePath);
-    string const data = "user data";
+    std::string const data = "user data";
     writer.Write(data.data(), data.size());
   }
   TEST(!CountryIndexes::DeleteFromDisk(germanyLocalFile), ("Indexes dir should not be deleted for:", germanyLocalFile));
@@ -336,7 +343,7 @@ UNIT_TEST(LocalCountryFile_DoNotDeleteUserFiles)
 
 UNIT_TEST(LocalCountryFile_MakeTemporary)
 {
-  string const path = GetPlatform().WritablePathForFile("minsk-pass" DATA_FILE_EXTENSION);
+  auto const path = GetPlatform().WritablePathForFile("minsk-pass" DATA_FILE_EXTENSION);
   LocalCountryFile file = LocalCountryFile::MakeTemporary(path);
   TEST_EQUAL(file.GetPath(MapFileType::Map), path, ());
 }

--- a/libs/platform/platform_tests_support/test_socket.cpp
+++ b/libs/platform/platform_tests_support/test_socket.cpp
@@ -5,9 +5,6 @@
 #include <algorithm>
 #include <chrono>
 
-using namespace std;
-using namespace std::chrono;
-
 namespace platform
 {
 namespace tests_support
@@ -17,7 +14,7 @@ TestSocket::~TestSocket()
   m_isConnected = false;
 }
 
-bool TestSocket::Open(string const & host, uint16_t port)
+bool TestSocket::Open(std::string const & host, uint16_t port)
 {
   if (m_isConnected)
     return false;
@@ -36,13 +33,13 @@ bool TestSocket::Read(uint8_t * data, uint32_t count)
   if (!m_isConnected)
     return false;
 
-  unique_lock<mutex> lock(m_inputMutex);
+  std::unique_lock<std::mutex> lock(m_inputMutex);
 
-  m_inputCondition.wait_for(lock, milliseconds(m_timeoutMs), [this]() { return !m_input.empty(); });
+  m_inputCondition.wait_for(lock, std::chrono::milliseconds(m_timeoutMs), [this]() { return !m_input.empty(); });
   if (m_input.size() < count)
     return false;
 
-  copy(m_input.begin(), m_input.end(), data);
+  std::copy(m_input.begin(), m_input.end(), data);
   m_input.erase(m_input.begin(), m_input.begin() + count);
   return true;
 }
@@ -53,7 +50,7 @@ bool TestSocket::Write(uint8_t const * data, uint32_t count)
     return false;
 
   {
-    lock_guard<mutex> lg(m_outputMutex);
+    std::lock_guard lg(m_outputMutex);
     m_output.insert(m_output.end(), data, data + count);
   }
   m_outputCondition.notify_one();
@@ -64,10 +61,10 @@ void TestSocket::SetTimeout(uint32_t milliseconds)
 {
   m_timeoutMs = milliseconds;
 }
-size_t TestSocket::ReadServer(vector<uint8_t> & destination)
+size_t TestSocket::ReadServer(std::vector<uint8_t> & destination)
 {
-  unique_lock<mutex> lock(m_outputMutex);
-  m_outputCondition.wait_for(lock, milliseconds(m_timeoutMs), [this]() { return !m_output.empty(); });
+  std::unique_lock lock(m_outputMutex);
+  m_outputCondition.wait_for(lock, std::chrono::milliseconds(m_timeoutMs), [this]() { return !m_output.empty(); });
 
   size_t const outputSize = m_output.size();
   destination.insert(destination.end(), m_output.begin(), m_output.end());

--- a/libs/platform/platform_unix_impl.cpp
+++ b/libs/platform/platform_unix_impl.cpp
@@ -21,8 +21,6 @@
 #include <sys/vfs.h>
 #endif
 
-using namespace std;
-
 namespace
 {
 struct CloseDir
@@ -36,7 +34,7 @@ struct CloseDir
 }  // namespace
 
 // static
-Platform::EError Platform::RmDir(string const & dirName)
+Platform::EError Platform::RmDir(std::string const & dirName)
 {
   if (rmdir(dirName.c_str()) != 0)
     return ErrnoToError();
@@ -44,7 +42,7 @@ Platform::EError Platform::RmDir(string const & dirName)
 }
 
 // static
-Platform::EError Platform::GetFileType(string const & path, EFileType & type)
+Platform::EError Platform::GetFileType(std::string const & path, EFileType & type)
 {
   struct stat stats;
   if (stat(path.c_str(), &stats) != 0)
@@ -59,7 +57,7 @@ Platform::EError Platform::GetFileType(string const & path, EFileType & type)
 }
 
 // static
-bool Platform::IsFileExistsByFullPath(string const & filePath)
+bool Platform::IsFileExistsByFullPath(std::string const & filePath)
 {
   struct stat s;
   return stat(filePath.c_str(), &s) == 0;
@@ -67,11 +65,11 @@ bool Platform::IsFileExistsByFullPath(string const & filePath)
 
 #if !defined(OMIM_OS_IPHONE)
 // static
-void Platform::DisableBackupForFile(string const & /*filePath*/) {}
+void Platform::DisableBackupForFile(std::string const & /*filePath*/) {}
 #endif
 
 // static
-string Platform::GetCurrentWorkingDirectory() noexcept
+std::string Platform::GetCurrentWorkingDirectory() noexcept
 {
   char path[PATH_MAX];
   char const * const dir = getcwd(path, PATH_MAX);
@@ -80,9 +78,9 @@ string Platform::GetCurrentWorkingDirectory() noexcept
   return dir;
 }
 
-bool Platform::IsDirectoryEmpty(string const & directory)
+bool Platform::IsDirectoryEmpty(std::string const & directory)
 {
-  unique_ptr<DIR, CloseDir> dir(opendir(directory.c_str()));
+  std::unique_ptr<DIR, CloseDir> dir(opendir(directory.c_str()));
   if (!dir)
     return true;
 
@@ -98,7 +96,7 @@ bool Platform::IsDirectoryEmpty(string const & directory)
   return true;
 }
 
-bool Platform::GetFileSizeByFullPath(string const & filePath, uint64_t & size)
+bool Platform::GetFileSizeByFullPath(std::string const & filePath, uint64_t & size)
 {
   struct stat s;
   if (stat(filePath.c_str(), &s) == 0)
@@ -134,9 +132,9 @@ Platform::TStorageStatus Platform::GetWritableStorageStatus(uint64_t neededSize)
 namespace pl
 {
 
-void EnumerateFiles(string const & directory, function<void(char const *)> const & fn)
+void EnumerateFiles(std::string const & directory, std::function<void(char const *)> const & fn)
 {
-  unique_ptr<DIR, CloseDir> dir(opendir(directory.c_str()));
+  std::unique_ptr<DIR, CloseDir> dir(opendir(directory.c_str()));
   if (!dir)
     return;
 
@@ -145,13 +143,13 @@ void EnumerateFiles(string const & directory, function<void(char const *)> const
     fn(entry->d_name);
 }
 
-void EnumerateFilesByRegExp(string const & directory, string const & regexp, vector<string> & res)
+void EnumerateFilesByRegExp(std::string const & directory, std::string const & regexp, std::vector<std::string> & res)
 {
-  regex exp(regexp);
+  std::regex exp(regexp);
   EnumerateFiles(directory, [&](char const * entry)
   {
-    string const name(entry);
-    if (regex_search(name.begin(), name.end(), exp))
+    std::string const name(entry);
+    if (std::regex_search(name.begin(), name.end(), exp))
       res.push_back(name);
   });
 }

--- a/libs/platform/platform_win.cpp
+++ b/libs/platform/platform_win.cpp
@@ -17,9 +17,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-using namespace std;
-
-static bool GetUserWritableDir(string & outDir)
+static bool GetUserWritableDir(std::string & outDir)
 {
   char pathBuf[MAX_PATH] = {0};
   if (SUCCEEDED(::SHGetFolderPathA(NULL, CSIDL_LOCAL_APPDATA | CSIDL_FLAG_CREATE, NULL, SHGFP_TYPE_CURRENT, pathBuf)))
@@ -34,7 +32,7 @@ static bool GetUserWritableDir(string & outDir)
 }
 
 /// @return Full path to the executable file
-static bool GetPathToBinary(string & outPath)
+static bool GetPathToBinary(std::string & outPath)
 {
   // get path to executable
   char pathBuf[MAX_PATH] = {0};
@@ -56,7 +54,7 @@ std::unique_ptr<Socket> CreateSocket()
 
 Platform::Platform()
 {
-  string path;
+  std::string path;
   CHECK(GetPathToBinary(path), ("Can't get path to binary"));
 
   // resources path:
@@ -80,7 +78,7 @@ Platform::Platform()
   // writable path:
   // 1. the same as resources if we have write access to this folder
   // 2. otherwise, use system-specific folder
-  string const tmpFilePath = base::JoinPath(m_resourcesDir, "mapswithmetmptestfile");
+  auto const tmpFilePath = base::JoinPath(m_resourcesDir, "mapswithmetmptestfile");
   try
   {
     FileWriter tmpfile(tmpFilePath);
@@ -106,16 +104,16 @@ Platform::Platform()
   LOG(LINFO, ("Settings Directory:", m_settingsDir));
 }
 
-bool Platform::IsFileExistsByFullPath(string const & filePath)
+bool Platform::IsFileExistsByFullPath(std::string const & filePath)
 {
   return ::GetFileAttributesA(filePath.c_str()) != INVALID_FILE_ATTRIBUTES;
 }
 
 // static
-void Platform::DisableBackupForFile(string const & filePath) {}
+void Platform::DisableBackupForFile(std::string const & filePath) {}
 
 // static
-string Platform::GetCurrentWorkingDirectory() noexcept
+std::string Platform::GetCurrentWorkingDirectory() noexcept
 {
   char path[MAX_PATH];
   char const * const dir = getcwd(path, MAX_PATH);
@@ -125,7 +123,7 @@ string Platform::GetCurrentWorkingDirectory() noexcept
 }
 
 // static
-Platform::EError Platform::RmDir(string const & dirName)
+Platform::EError Platform::RmDir(std::string const & dirName)
 {
   if (_rmdir(dirName.c_str()) != 0)
     return ErrnoToError();
@@ -133,7 +131,7 @@ Platform::EError Platform::RmDir(string const & dirName)
 }
 
 // static
-Platform::EError Platform::GetFileType(string const & path, EFileType & type)
+Platform::EError Platform::GetFileType(std::string const & path, EFileType & type)
 {
   struct _stat32 stats;
   if (_stat32(path.c_str(), &stats) != 0)
@@ -147,12 +145,12 @@ Platform::EError Platform::GetFileType(string const & path, EFileType & type)
   return ERR_OK;
 }
 
-string Platform::DeviceName() const
+std::string Platform::DeviceName() const
 {
   return OMIM_OS_NAME;
 }
 
-string Platform::DeviceModel() const
+std::string Platform::DeviceModel() const
 {
   return {};
 }
@@ -189,12 +187,12 @@ Platform::TStorageStatus Platform::GetWritableStorageStatus(uint64_t neededSize)
   return STORAGE_OK;
 }
 
-bool Platform::IsDirectoryEmpty(string const & directory)
+bool Platform::IsDirectoryEmpty(std::string const & directory)
 {
   return PathIsDirectoryEmptyA(directory.c_str());
 }
 
-bool Platform::GetFileSizeByFullPath(string const & filePath, uint64_t & size)
+bool Platform::GetFileSizeByFullPath(std::string const & filePath, uint64_t & size)
 {
   HANDLE hFile =
       CreateFileA(filePath.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);

--- a/libs/platform/settings.cpp
+++ b/libs/platform/settings.cpp
@@ -18,7 +18,7 @@
 
 namespace settings
 {
-using namespace std;
+using std::string;
 
 std::string_view kMeasurementUnits = "Units";
 std::string_view kMapLanguageCode = "MapLanguageCode";
@@ -54,7 +54,7 @@ namespace impl
 template <class T, size_t N>
 bool FromStringArray(string const & s, T (&arr)[N])
 {
-  istringstream in(s);
+  std::istringstream in(s);
   size_t count = 0;
   while (count < N && in >> arr[count])
   {
@@ -70,7 +70,7 @@ bool FromStringArray(string const & s, T (&arr)[N])
 template <>
 string ToString<m2::AnyRectD>(m2::AnyRectD const & rect)
 {
-  ostringstream out;
+  std::ostringstream out;
   out.precision(12);
   m2::PointD glbZero(rect.GlobalZero());
   out << glbZero.x << " " << glbZero.y << " ";
@@ -99,7 +99,7 @@ bool FromString<m2::AnyRectD>(string const & str, m2::AnyRectD & rect)
 template <>
 string ToString<m2::RectD>(m2::RectD const & rect)
 {
-  ostringstream stream;
+  std::ostringstream stream;
   stream.precision(12);
   stream << rect.minX() << " " << rect.minY() << " " << rect.maxX() << " " << rect.maxY();
   return stream.str();
@@ -139,7 +139,7 @@ namespace impl
 template <typename T>
 string ToStringScalar(T const & v)
 {
-  ostringstream stream;
+  std::ostringstream stream;
   stream.precision(12);
   stream << v;
   return stream.str();
@@ -148,7 +148,7 @@ string ToStringScalar(T const & v)
 template <typename T>
 bool FromStringScalar(string const & str, T & v)
 {
-  istringstream stream(str);
+  std::istringstream stream(str);
   if (stream)
   {
     stream >> v;
@@ -224,7 +224,7 @@ namespace impl
 template <class TPair>
 string ToStringPair(TPair const & value)
 {
-  ostringstream stream;
+  std::ostringstream stream;
   stream.precision(12);
   stream << value.first << " " << value.second;
   return stream.str();
@@ -233,7 +233,7 @@ string ToStringPair(TPair const & value)
 template <class TPair>
 bool FromStringPair(string const & str, TPair & value)
 {
-  istringstream stream(str);
+  std::istringstream stream(str);
   if (stream)
   {
     stream >> value.first;
@@ -247,8 +247,8 @@ bool FromStringPair(string const & str, TPair & value)
 }
 }  // namespace impl
 
-typedef pair<int, int> IPairT;
-typedef pair<double, double> DPairT;
+typedef std::pair<int, int> IPairT;
+typedef std::pair<double, double> DPairT;
 
 template <>
 string ToString<IPairT>(IPairT const & v)


### PR DESCRIPTION
- It's fast
- Supports JSON with comments
- Compile time reflection (easy to use, see unit test)
- Also supports [CSV](https://stephenberry.github.io/glaze/csv/) and [BEVE](https://stephenberry.github.io/glaze/binary/)
- It even has a [thread pool](https://stephenberry.github.io/glaze/thread-pool/) and [optional HTTP client/server support](https://stephenberry.github.io/glaze/networking/http-rest-support/) 😱

More info: https://stephenberry.github.io/glaze/

We can replace jansson with glaze in our code, and use it in any new code requiring JSON.

Basic usage example: https://github.com/organicmaps/organicmaps/pull/10986/commits/d26da69bc0e3c41bbdb849bdb0e95bbbdd887802#diff-950b68aa006f985d763c9f3e4274df1bb9226211394ad4925f45a8e6467e2fc3R48-R89

Advanced usage example: https://github.com/stephenberry/glaze/blob/main/tests/json_test/json_test.cpp

CC @hemanggs @AndrewShkrob @Raghaddahi @Osyotr @strump 