### PR TITLE
[linux] Fix zero file creation (birth) time

### DIFF
--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -1029,9 +1029,9 @@ UNIT_CLASS_TEST(Runner, Bookmarks_SpecialXMLNames)
   BookmarkManager bmManager(BM_CALLBACKS);
   bmManager.EnableTestMode(true);
 
-  auto const file1Name = "file1";
+  auto const fileNameFromMemory = "";
   BookmarkManager::KMLDataCollection kmlDataCollection1;
-  kmlDataCollection1.emplace_back(file1Name /* filePath */,
+  kmlDataCollection1.emplace_back(fileNameFromMemory /* filePath */,
                                   LoadKmlData(MemReader(kmlString3, strlen(kmlString3)), KmlFileType::Text));
   bmManager.CreateCategories(std::move(kmlDataCollection1));
 
@@ -1056,29 +1056,29 @@ UNIT_CLASS_TEST(Runner, Bookmarks_SpecialXMLNames)
 
   bmManager.GetEditSession().DeleteBmCategory(catId, true);
 
-  auto const file2Name = "file2";
+  auto const fileNameOnDisk = "file1";
   BookmarkManager::KMLDataCollection kmlDataCollection2;
-  kmlDataCollection2.emplace_back(file1Name /* filePath */, LoadKmlFile(fileNameTmp, GetActiveKmlFileType()));
+  kmlDataCollection2.emplace_back(fileNameOnDisk /* filePath */, LoadKmlFile(fileNameTmp, GetActiveKmlFileType()));
   bmManager.CreateCategories(std::move(kmlDataCollection2));
 
   BookmarkManager::KMLDataCollection kmlDataCollection3;
-  kmlDataCollection3.emplace_back(file2Name /* filePath */,
+  kmlDataCollection3.emplace_back(fileNameFromMemory /* filePath */,
                                   LoadKmlData(MemReader(kmlString3, strlen(kmlString3)), KmlFileType::Text));
 
   bmManager.CreateCategories(std::move(kmlDataCollection3));
 
   TEST_EQUAL(bmManager.GetBmGroupsCount(), 2, ());
-  auto const catId2 = bmManager.GetSortedBmGroupIdList().front();
-  auto const catId3 = bmManager.GetSortedBmGroupIdList().back();
+  auto const lastModifiedCatId = bmManager.GetSortedBmGroupIdList().front();
+  auto const olderCatId = bmManager.GetSortedBmGroupIdList().back();
 
-  TEST_EQUAL(bmManager.GetUserMarkIds(catId2).size(), 1, ());
-  TEST_EQUAL(bmManager.GetCategoryName(catId2), expectedName, ());
-  TEST_EQUAL(bmManager.GetCategoryFileName(catId2), file1Name, ());
-  TEST_EQUAL(bmManager.GetCategoryFileName(catId3), file2Name, ());
+  TEST_EQUAL(bmManager.GetUserMarkIds(lastModifiedCatId).size(), 1, ());
+  TEST_EQUAL(bmManager.GetCategoryName(olderCatId), expectedName, ());
+  TEST_EQUAL(bmManager.GetCategoryFileName(lastModifiedCatId), fileNameFromMemory, ());
+  TEST_EQUAL(bmManager.GetCategoryFileName(olderCatId), fileNameOnDisk, ());
 
-  auto const bmId1 = *bmManager.GetUserMarkIds(catId2).begin();
+  auto const bmId1 = *bmManager.GetUserMarkIds(lastModifiedCatId).begin();
   auto const * bm1 = bmManager.GetBookmark(bmId1);
-  auto const bmId2 = *bmManager.GetUserMarkIds(catId3).begin();
+  auto const bmId2 = *bmManager.GetUserMarkIds(olderCatId).begin();
   auto const * bm2 = bmManager.GetBookmark(bmId2);
   TEST(EqualBookmarks(*bm1, *bm2), ());
   TEST_EQUAL(kml::GetDefaultStr(bm1->GetName()), "![X1]{X2}(X3)", ());

--- a/libs/platform/platform_android.cpp
+++ b/libs/platform/platform_android.cpp
@@ -232,6 +232,9 @@ time_t Platform::GetFileCreationTime(std::string const & path)
   struct stat st;
   if (0 == stat(path.c_str(), &st))
     return st.st_atim.tv_sec;
+
+  LOG(LERROR, ("GetFileCreationTime stat failed for", path, "with error", strerror(errno)));
+  // TODO(AB): Refactor to return std::optional<time_t>.
   return 0;
 }
 
@@ -241,5 +244,8 @@ time_t Platform::GetFileModificationTime(std::string const & path)
   struct stat st;
   if (0 == stat(path.c_str(), &st))
     return st.st_mtim.tv_sec;
+
+  LOG(LERROR, ("GetFileModificationTime stat failed for", path, "with error", strerror(errno)));
+  // TODO(AB): Refactor to return std::optional<time_t>.
   return 0;
 }

--- a/libs/platform/platform_mac.mm
+++ b/libs/platform/platform_mac.mm
@@ -188,6 +188,9 @@ time_t Platform::GetFileCreationTime(std::string const & path)
   struct stat st;
   if (0 == stat(path.c_str(), &st))
     return st.st_birthtimespec.tv_sec;
+
+  LOG(LERROR, ("GetFileCreationTime stat failed for", path, "with error", strerror(errno)));
+  // TODO(AB): Refactor to return std::optional<time_t>.
   return 0;
 }
 
@@ -197,5 +200,8 @@ time_t Platform::GetFileModificationTime(std::string const & path)
   struct stat st;
   if (0 == stat(path.c_str(), &st))
     return st.st_mtimespec.tv_sec;
+
+  LOG(LERROR, ("GetFileModificationTime stat failed for", path, "with error", strerror(errno)));
+  // TODO(AB): Refactor to return std::optional<time_t>.
   return 0;
 }


### PR DESCRIPTION
Observed in Ubuntu 24 via Orb on arm-based Mac. Fixes failing `GetFileCreationTime_GetFileModificationTime` test.