### PR TITLE
Fix QOpenGLContext creation on Windows

### DIFF
--- a/qt/qt_common/helpers.cpp
+++ b/qt/qt_common/helpers.cpp
@@ -80,6 +80,9 @@ void SetDefaultSurfaceFormat(QString const & platformName)
 #if defined(OMIM_OS_LINUX)
     LOG(LINFO, ("Set default OpenGL version to ES 3.0"));
     fmt.setVersion(3, 0);
+#elif defined(OMIM_OS_WINDOWS)
+    fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
+    fmt.setVersion(3, 2);
 #else
     LOG(LINFO, ("Set default OGL version to 3.2"));
     fmt.setProfile(QSurfaceFormat::CoreProfile);
@@ -87,7 +90,7 @@ void SetDefaultSurfaceFormat(QString const & platformName)
 #endif
   }
 
-#ifdef ENABLE_OPENGL_DIAGNOSTICS
+#if defined(ENABLE_OPENGL_DIAGNOSTICS)
   fmt.setOption(QSurfaceFormat::DebugContext);
 #endif
   QSurfaceFormat::setDefaultFormat(fmt);

--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -409,6 +409,10 @@ void MapWidget::initializeGL()
   emit BeforeEngineCreation();
   CreateEngine();
   m_framework.EnterForeground();
+
+  doneCurrent();
+  m_contextFactory->WaitForInitialization(nullptr);
+  makeCurrent();
 }
 
 void MapWidget::paintGL()

--- a/qt/qt_common/qtoglcontextfactory.hpp
+++ b/qt/qt_common/qtoglcontextfactory.hpp
@@ -5,6 +5,7 @@
 
 #include <QtGui/QOpenGLContext>
 
+#include <latch>
 #include <memory>
 
 namespace qt
@@ -28,6 +29,7 @@ public:
   dp::GraphicsContext * GetResourcesUploadContext() override;
   bool IsDrawContextCreated() const override { return m_drawContext != nullptr; }
   bool IsUploadContextCreated() const override { return m_uploadContext != nullptr; }
+  void WaitForInitialization(dp::GraphicsContext * context) override;
 
 private:
   std::unique_ptr<QOffscreenSurface> CreateSurface();
@@ -38,6 +40,9 @@ private:
   std::unique_ptr<QtUploadOGLContext> m_uploadContext;
   std::unique_ptr<QOffscreenSurface> m_uploadSurface;
   bool m_preparedToShutdown = false;
+
+  std::latch m_mainThreadReady = std::latch(1);
+  std::latch m_contextsCreated = std::latch(2);
 };
 }  // namespace common
 }  // namespace qt


### PR DESCRIPTION
Fixes #10582 

Inside `QOpenGLWidget::initializeGL` the context from `QOpenGLWidget` (let's call it main) is current, and the call to `CreateEngine` spawns two threads that are trying to create new OpenGL contexts and share them with the main context. Now if you're lucky `initializeGL` finishes and releases the main context and new contexts are created before anyone makes the main context current. Sometimes you are not lucky and new contexts are being created while the main context is still current in the main thread, causing all sorts of crashes and glitches (see image in the linked issue).