### PR TITLE
Make UniformRandom standard-conforming

### DIFF
--- a/libs/base/random.hpp
+++ b/libs/base/random.hpp
@@ -12,12 +12,15 @@ class UniformRandom
 
   std::random_device m_rd;
   std::mt19937 m_gen;
-  std::uniform_int_distribution<T> m_distr;
+
+  using distribution_int_type =
+      std::conditional_t<sizeof(T) != 1, T, std::conditional_t<std::is_signed_v<T>, short, unsigned short>>;
+  std::uniform_int_distribution<distribution_int_type> m_distr;
 
 public:
   UniformRandom(T min, T max) : m_gen(m_rd()), m_distr(min, max) {}
   UniformRandom() : UniformRandom(std::numeric_limits<T>::min(), std::numeric_limits<T>::max()) {}
 
-  T operator()() { return m_distr(m_gen); }
+  T operator()() { return static_cast<T>(m_distr(m_gen)); }
 };
 }  // namespace base


### PR DESCRIPTION
`std::uniform_int_distribution<T>` requires `sizeof(T) >= sizeof(short)`