### PR TITLE
[libs][linux] Fix incorrect include of `fcntl.h`

### DIFF
--- a/libs/coding/files_container.cpp
+++ b/libs/coding/files_container.cpp
@@ -8,18 +8,13 @@
 #include <cstring>
 #include <sstream>
 
-#ifndef OMIM_OS_WINDOWS
-#include <stdio.h>
+#ifdef OMIM_OS_WINDOWS
+#include <windows.h>
+#else
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>  // _SC_PAGESIZE
-#ifdef OMIM_OS_ANDROID
-#include <fcntl.h>
-#else
-#include <sys/fcntl.h>
-#endif
-#else
-#include <windows.h>
 #endif
 
 #include <errno.h>

--- a/libs/coding/files_container.cpp
+++ b/libs/coding/files_container.cpp
@@ -9,7 +9,7 @@
 #include <sstream>
 
 #ifdef OMIM_OS_WINDOWS
-#include <windows.h>
+#include "std/windows.hpp"
 #else
 #include <fcntl.h>
 #include <sys/mman.h>

--- a/libs/coding/mmap_reader.cpp
+++ b/libs/coding/mmap_reader.cpp
@@ -9,14 +9,10 @@
 #ifdef OMIM_OS_WINDOWS
 #include <windows.h>
 #else
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#ifdef OMIM_OS_ANDROID
-#include <fcntl.h>
-#else
-#include <sys/fcntl.h>
-#endif
 #endif
 
 class MmapReader::MmapData

--- a/libs/coding/mmap_reader.cpp
+++ b/libs/coding/mmap_reader.cpp
@@ -7,7 +7,7 @@
 #include <cstring>
 
 #ifdef OMIM_OS_WINDOWS
-#include <windows.h>
+#include "std/windows.hpp"
 #else
 #include <fcntl.h>
 #include <sys/mman.h>


### PR DESCRIPTION
The POSIX standard says, that `fcntl.h` is to be included as `#include <fcntl.h>`.

This change fixes the compiler warnings that happen with `musl` libc :
```
/usr/include/sys/fcntl.h:1:2: warning: #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-Wcpp]
    1 | #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>
      |  ^~~~~~~
In file included from /home/ferenc/github.com/organicmaps/organicmaps/libs/coding/mmap_reader.cpp:18,
                 from /home/ferenc/github.com/organicmaps/organicmaps/build-alpine-3.21/build-alpine-3.21/libs/coding/CMakeFiles/coding.dir/Unity/unity_0_cxx.cxx:40:
/usr/include/sys/fcntl.h:1:2: warning: #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-Wcpp]
    1 | #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>
      |  ^~~~~~~
````

This happens because of the explicit [warning in the proxy header]( https://git.musl-libc.org/cgit/musl/tree/include/sys/fcntl.h)