### PR TITLE
[ios] Skip addBoorkmark/routeRemoveStop when there is no place page data

### DIFF
--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -332,6 +332,7 @@ extension PlacePageViewController: PlacePageViewProtocol {
 
   @objc
   func closeAnimated(completion: (() -> Void)? = nil) {
+    view.isUserInteractionEnabled = false
     alternativeSizeClass(iPhone: {
       self.scrollTo(CGPoint(x: 0, y: -self.scrollView.height + 1),
                     forced: true) {
@@ -361,7 +362,7 @@ extension PlacePageViewController: PlacePageViewProtocol {
 extension PlacePageViewController: UIScrollViewDelegate {
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
     if scrollView.contentOffset.y < -scrollView.height + 1 && beginDragging {
-      rootViewController.dismissPlacePage()
+      closeAnimated()
     }
     onOffsetChanged(scrollView.contentOffset.y)
 


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/10567 
Sometimes, during the fast taps on one of the action button, the action can be triggered multiple times when the current place page data object is deinitialized. The app should not crash in such situations. The fix prevents the double-tap action handling.

The issue can be easily reproduced by the double-tapping on the `remove stop` button during the _route building_.