### PR TITLE
[map] Sync access to the `GpsTrackCollection` mutable state

### DIFF
--- a/libs/map/gps_track_collection.cpp
+++ b/libs/map/gps_track_collection.cpp
@@ -33,6 +33,8 @@ GpsTrackCollection::GpsTrackCollection() : m_lastId(0), m_elevationInfoDirty(tru
 
 std::pair<size_t, size_t> GpsTrackCollection::Add(std::vector<TItem> const & items)
 {
+  std::lock_guard lock(m_guard);
+
   size_t startId = m_lastId;
   size_t added = 0;
 
@@ -67,6 +69,8 @@ std::pair<size_t, size_t> GpsTrackCollection::Add(std::vector<TItem> const & ite
 
 std::pair<size_t, size_t> GpsTrackCollection::Clear(bool resetIds)
 {
+  std::lock_guard lock(m_guard);
+
   if (m_items.empty())
   {
     if (resetIds)
@@ -93,11 +97,14 @@ std::pair<size_t, size_t> GpsTrackCollection::Clear(bool resetIds)
 
 size_t GpsTrackCollection::GetSize() const
 {
+  std::lock_guard lock(m_guard);
   return m_items.size();
 }
 
 ElevationInfo const & GpsTrackCollection::UpdateAndGetElevationInfo()
 {
+  std::lock_guard lock(m_guard);
+
   if (!m_elevationInfoDirty)
     return m_elevationInfo;
 
@@ -113,5 +120,6 @@ ElevationInfo const & GpsTrackCollection::UpdateAndGetElevationInfo()
 
 bool GpsTrackCollection::IsEmpty() const
 {
+  std::lock_guard lock(m_guard);
   return m_items.empty();
 }

--- a/libs/map/gps_track_collection.hpp
+++ b/libs/map/gps_track_collection.hpp
@@ -7,6 +7,7 @@
 
 #include <deque>
 #include <limits>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -65,7 +66,8 @@ public:
   }
 
 private:
-  std::deque<TItem> m_items;  // asc. sorted by timestamp
+  std::deque<TItem> m_items;   // asc. sorted by timestamp
+  mutable std::mutex m_guard;  // protects mutable shared state
 
   size_t m_lastId;
   TrackStatistics m_statistics;


### PR DESCRIPTION
During the track recording, the points are added to the  `GpsTrackCollection` from the `GpsTrack`'s secondary thread (see below). But at the same time, the `UpdateAndGetElevationInfo` can be accessed and read the internal state from the main queue quite often (every second). This behaviour may produce a data race and crash in the `UpdateAndGetElevationInfo ` during the calculation of the elevation data.

points update in the gps track:
https://github.com/organicmaps/organicmaps/blob/2992d238c678d8966da916564b0396f86fefbdc6/libs/map/gps_track.cpp#L125-L141

The crash can be found by typing the `UpdateAndGetElevationInfo` in the organizer filter, but the bad access line is not correctly shown.
<img width="800" height="438" alt="image" src="https://github.com/user-attachments/assets/6f246c34-72d0-43e3-a7fc-e159c96f9abc" />
