### PR TITLE
[ios] Disable track recording live activity widget for apps running on macos

### DIFF
--- a/iphone/Maps/Core/TrackRecorder/TrackRecordingManager.swift
+++ b/iphone/Maps/Core/TrackRecorder/TrackRecordingManager.swift
@@ -57,7 +57,7 @@ final class TrackRecordingManager: NSObject {
     let locationManager = LocationManager.self
     var activityManager: TrackRecordingActivityManager? = nil
     #if canImport(ActivityKit)
-    if #available(iOS 16.2, *) {
+    if #available(iOS 16.2, *), !ProcessInfo.processInfo.isiOSAppOnMac {
       activityManager = TrackRecordingLiveActivityManager.shared
     }
     #endif


### PR DESCRIPTION
There are a bunch of crashes of the track recording live activity widget running for macOS.
This PR disables it.

<img width="1241" height="412" alt="image" src="https://github.com/user-attachments/assets/400349fb-0b20-4004-98d1-089eb00188c0" />
