### PR TITLE
[ios] Check that pp data exists before update the TR PP screen

### DIFF
--- a/iphone/CoreApi/CoreApi/PlacePageData/PlacePageData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/PlacePageData.mm
@@ -124,7 +124,7 @@ static PlacePageRoadType convertRoadType(RoadWarningMarkType roadType)
 
 - (void)handleActiveTrackSelectionPointChanged
 {
-  if (!self || !rawData().IsTrack())
+  if (!self || !PlacePageData.hasData || !rawData().IsTrack())
     return;
   auto const & trackInfo = GetFramework().GetBookmarkManager().GetTrackSelectionInfo(rawData().GetTrackId());
   auto const latlon = mercator::ToLatLon(trackInfo.m_trackPoint);


### PR DESCRIPTION
Every time before the PP screen is created the pp data existance should be checked like done in the
https://github.com/organicmaps/organicmaps/blob/53718e1bce241716bcd0018a47ab8036fbb72d09/iphone/Maps/Classes/MapViewController.mm#L275-L279

This PR adds the same check to the track recording PP update callback to fix the crash when the user interacts with the chart:
<img width="1316" height="344" alt="image" src="https://github.com/user-attachments/assets/dae1d788-ef12-43e6-9e02-594981c9e0b7" />
