### PR TITLE
[ios] Log error during the track editing instead of failing

### DIFF
--- a/iphone/Maps/UI/PlacePage/PlacePageManager/MWMPlacePageManager.mm
+++ b/iphone/Maps/UI/PlacePage/PlacePageManager/MWMPlacePageManager.mm
@@ -233,7 +233,7 @@ using namespace storage;
 {
   if (data.objectType != PlacePageObjectTypeTrack)
   {
-    ASSERT_FAIL("editTrack called for non-track object");
+    LOG(LERROR, ("editTrack called for non-track object"));
     return;
   }
   EditTrackViewController * editTrackController =


### PR DESCRIPTION
The bug is quite rare and happens when the user taps on the edit (pencil) button on the PlacePage. I haven't been able to reproduce the bug.
It seems like the tap happens during the PP data object reloading when the object type has changed. It is better to avoid failing in such cases because we cannot prevent user interaction during the every pp reloading.

<img width="1433" height="442" alt="image" src="https://github.com/user-attachments/assets/57bf9632-5e60-4f0a-b450-b3134a9ef8cb" />
