### PR TITLE
[ios] Fixed ATM translation in the PlacePage

### DIFF
--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
@@ -104,7 +104,7 @@ NSString * GetLocalizedMetadataValueString(MapObject::MetadataID metaID, std::st
       }
     });
 
-    _atm = rawData.HasAtm() ? NSLocalizedString(@"type.amenity.atm", nil) : nil;
+    _atm = rawData.HasAtm() ? NSLocalizedStringFromTable(@"type.amenity.atm", @"LocalizableTypes", nil) : nil;
 
     _address = rawData.GetSecondarySubtitle().empty() ? nil : @(rawData.GetSecondarySubtitle().c_str());
     _coordFormats = @[


### PR DESCRIPTION
Fixes this:

![telegram-cloud-photo-size-2-5215526594993585462-y](https://github.com/user-attachments/assets/472a77ca-db7f-4ea8-b24c-a39bc1a85427)
