### PR TITLE
[ci] fix reviewdog's permissions

### DIFF
--- a/.github/workflows/code-style-check.yaml
+++ b/.github/workflows/code-style-check.yaml
@@ -1,9 +1,11 @@
 name: Code style check
 
 on:
-  pull_request:
+  # pull_request_target is required because pull_request does not provide
+  # sufficient permissions for reviewdog
+  pull_request_target:
     branches: [ master ]
-    paths:  # Should stay in sync with tools/unix/clang-format.sh
+    paths: # Should stay in sync with tools/unix/clang-format.sh
       - '.github/workflows/code-style-check.yaml'
       - 'android/app/src/**.java'
       - 'android/sdk/src/**.java'


### PR DESCRIPTION
Still doesn't work:
https://github.com/organicmaps/organicmaps/actions/runs/16658350875/job/47149016292#step:5:224

```
Saved working directory and index state WIP on (no branch): 351f83f Merge e27cb3b863ede79db81e78ab354eb0d811f2c038 into 7ed19975b1931733443d269e6fa9b6de5b11ff11
libs/routing/turns.hpp:121:-
time=2025-07-31T19:40:22.377Z level=INFO msg="reviewdog: failed to post a review comment: POST https://api.github.com/repos/organicmaps/organicmaps/pulls/11026/reviews: 403 Resource not accessible by integration []"
reviewdog: This GitHub Token doesn't have write permission of Review API [1],
so reviewdog will report results via logging command [2] and create annotations similar to
github-pr-check reporter as a fallback.
[1]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
[2]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
reviewdog: found at least one issue with severity greater than or equal to the given level: error
```

Ref: https://github.com/bemanproject/exemplar/pull/69