### PR TITLE
[ios] Fix opening websites with percent encoding characters

### DIFF
--- a/iphone/Maps/Categories/UIKitCategories.m
+++ b/iphone/Maps/Categories/UIKitCategories.m
@@ -227,20 +227,26 @@
 
 - (BOOL)openUrl:(NSString *)urlString externally:(BOOL)externally
 {
-  // TODO: This is a temporary workaround to open cyrillic/non-ASCII URLs.
-  // URLs in OSM are stored in UTF-8. NSURL constructor documentation says:
-  // > Must be a URL that conforms to RFC 2396. This method parses URLString according to RFCs 1738 and 1808.
-  // The right way to encode the URL string should be:
-  // 1. Split the (non-ASCII) string into components (host, path, query, fragment, etc.)
-  // 2. Encode each component separately (they have different allowed characters).
-  // 3. Merge them back into the string and create NSURL.
-  NSMutableCharacterSet * charset = [[NSMutableCharacterSet alloc] init];
-  [charset formUnionWithCharacterSet:NSCharacterSet.URLHostAllowedCharacterSet];
-  [charset formUnionWithCharacterSet:NSCharacterSet.URLPathAllowedCharacterSet];
-  [charset formUnionWithCharacterSet:NSCharacterSet.URLQueryAllowedCharacterSet];
-  [charset formUnionWithCharacterSet:NSCharacterSet.URLFragmentAllowedCharacterSet];
-  [charset addCharactersInString:@"#;/?:@&=+$,"];
-  NSString * encoded = [urlString stringByAddingPercentEncodingWithAllowedCharacters:charset];
+  NSString * encoded = urlString;
+
+  if (![urlString canBeConvertedToEncoding:NSASCIIStringEncoding])
+  {
+    // TODO: This is a temporary workaround to open cyrillic/non-ASCII URLs.
+    // URLs in OSM are stored in UTF-8. NSURL constructor documentation says:
+    // > Must be a URL that conforms to RFC 2396. This method parses URLString according to RFCs 1738 and 1808.
+    // The right way to encode the URL string should be:
+    // 1. Split the (non-ASCII) string into components (host, path, query, fragment, etc.)
+    // 2. Encode each component separately (they have different allowed characters).
+    // 3. Merge them back into the string and create NSURL.
+    NSMutableCharacterSet * charset = [[NSMutableCharacterSet alloc] init];
+    [charset formUnionWithCharacterSet:NSCharacterSet.URLHostAllowedCharacterSet];
+    [charset formUnionWithCharacterSet:NSCharacterSet.URLPathAllowedCharacterSet];
+    [charset formUnionWithCharacterSet:NSCharacterSet.URLQueryAllowedCharacterSet];
+    [charset formUnionWithCharacterSet:NSCharacterSet.URLFragmentAllowedCharacterSet];
+    [charset addCharactersInString:@"#;/?:@&=+$,"];
+    encoded = [urlString stringByAddingPercentEncodingWithAllowedCharacters:charset];
+  }
+
   // Matrix has an url with two hashes which doesn't work for NSURL and NSURLComponent.
   NSRange const matrixUrl = [encoded rangeOfString:@"#/#"];
   if (matrixUrl.location != NSNotFound)


### PR DESCRIPTION
Reported by user, fixes opening of websites like this one: https://www.openstreetmap.org/way/1245855481#map=17/49.448456/0.816851&layers=V