### PR TITLE
[android] Refactoring regression fix

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryAdapter.java
@@ -56,14 +56,23 @@ public class FeatureCategoryAdapter extends RecyclerView.Adapter<RecyclerView.Vi
   @Override
   public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType)
   {
-    @LayoutRes
-    final int layoutId = switch (viewType)
+    final LayoutInflater inflater = LayoutInflater.from(parent.getContext());
+    switch (viewType)
     {
-      case TYPE_CATEGORY -> R.layout.item_feature_category;
-      case TYPE_FOOTER -> R.layout.item_feature_category_footer;
-      default -> throw new IllegalArgumentException("Unsupported");
-    };
-    return new FeatureViewHolder(LayoutInflater.from(parent.getContext()).inflate(layoutId, parent, false));
+    case TYPE_CATEGORY ->
+    {
+      return new FeatureViewHolder(inflater.inflate(R.layout.item_feature_category, parent, false));
+    }
+    case TYPE_FOOTER ->
+    {
+      return new FooterViewHolder(inflater.inflate(R.layout.item_feature_category_footer, parent, false),
+                                  (FooterListener) mFragment);
+    }
+    default ->
+    {
+      throw new IllegalArgumentException("Unsupported viewType: " + viewType);
+    }
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixes #11038

- Problem caused due to `item_feature_category_footer.xml` being wrapped with `FeatureViewHolder` instead of `FooterViewHolder`

- Introduced as part of [refactoring](https://github.com/organicmaps/organicmaps/commit/548aa1ad9d6066daa3c3df152fb6d474e0aa2ed1#diff-a974a0a4515c7e4e18628d519635b018341de06bcf1c2c666db4577c6b5ef108:~:text=56-,%40Override,%7D,-78) 


CC @biodranik 