### PR TITLE
Update categories_cuisines.txt

### DIFF
--- a/data/categories_cuisines.txt
+++ b/data/categories_cuisines.txt
@@ -1344,7 +1344,7 @@ sr:Веганска|Вегетаријанска|Вегетаријанци|Ве
 # nl:Barbecue
 # fi:Grilli
 # fr:Barbecue
-# de:Grill
+# de:Barbecue
 # hu:Grill
 # id:Barbekyu
 # it:Barbecue


### PR DESCRIPTION
Changed translation of cuisine=barbecue in German from "Grill" to "Barbecue" since cuisine=Grill als uses "Grill". So when adding a restaurant, it can be better distinguished between more traditional European/Middle Eastern grill and the more American Barbecue cuisine.