### PR TITLE
[qt] Remove shaders compiler from resources

### DIFF
--- a/dev_sandbox/CMakeLists.txt
+++ b/dev_sandbox/CMakeLists.txt
@@ -66,15 +66,12 @@ set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${BUNDLE_NAME})
 
 set(BUNDLE_EXECUTABLE ${BUNDLE_NAME})
 
-set(BUNDLE_FOLDER ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/${BUNDLE_NAME}.app)
+set(BUNDLE_FOLDER ${CMAKE_BINARY_DIR}/${BUNDLE_NAME}.app)
 set(RESOURCES_FOLDER ${BUNDLE_FOLDER}/Contents/Resources)
 set(DATA_DIR ${OMIM_ROOT}/data)
 
-execute_process(
-  COMMAND mkdir -p ${RESOURCES_FOLDER}/shaders_compiler
-)
-
 function(copy_resources)
+  execute_process(COMMAND mkdir -p ${RESOURCES_FOLDER})
   foreach(file ${ARGN})
     execute_process(
       COMMAND cp -r ${DATA_DIR}/${file} ${RESOURCES_FOLDER}

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -94,10 +94,8 @@ set(BUNDLE_FOLDER ${CMAKE_BINARY_DIR}/${BUNDLE_NAME}.app)
 set(RESOURCES_FOLDER ${BUNDLE_FOLDER}/Contents/Resources)
 set(DATA_DIR ${OMIM_ROOT}/data)
 
-execute_process(
-    COMMAND mkdir -p ${RESOURCES_FOLDER}/shaders_compiler
-)
 function(copy_resources)
+  execute_process(COMMAND mkdir -p ${RESOURCES_FOLDER})
   foreach(file ${ARGN})
     execute_process(
       COMMAND cp -r ${DATA_DIR}/${file} ${RESOURCES_FOLDER}
@@ -147,9 +145,6 @@ if (NOT PLATFORM_LINUX)
 endif()
 
 if (PLATFORM_MAC)
-  execute_process(
-    COMMAND cp -r ${OMIM_ROOT}/tools/shaders_compiler/macos ${RESOURCES_FOLDER}/shaders_compiler
-  )
   if (BUILD_DESIGNER)
     execute_process(
         COMMAND cp ${PROJECT_SOURCE_DIR}/res/mac/designer.icns ${RESOURCES_FOLDER}
@@ -159,10 +154,6 @@ if (PLATFORM_MAC)
         COMMAND cp ${PROJECT_SOURCE_DIR}/res/mac/mac.icns ${RESOURCES_FOLDER}
     )
   endif ()
-elseif (PLATFORM_LINUX)
-  execute_process(
-    COMMAND cp -r ${OMIM_ROOT}/tools/shaders_compiler/linux ${RESOURCES_FOLDER}/shaders_compiler
-  )
 endif()
 
 if (PLATFORM_MAC)


### PR DESCRIPTION
The only place where shaders compiler is used:
https://github.com/organicmaps/organicmaps/blob/eae93eac4990f0f72f351329bd53a6979b630c40/libs/shaders/shaders_tests/gl_shaders_mobile_compile_test.cpp#L26

shaders_tests are not run neither from designer nor from normal app

Same for dev sandbox app.
Also fixed resources path in dev_sandbox. 