### PR TITLE
Revert "Fix some incorrect usage of std::isspace and std::isdigit"

### DIFF
--- a/libs/base/string_utils.cpp
+++ b/libs/base/string_utils.cpp
@@ -227,15 +227,15 @@ void AsciiToUpper(std::string & s)
 
 void Trim(std::string & s)
 {
-  boost::trim_if(s, [](unsigned char c) { return std::isspace(c); });
+  boost::trim_if(s, ::isspace);
 }
 
 void Trim(std::string_view & sv)
 {
-  auto const beg = std::find_if(sv.cbegin(), sv.cend(), [](unsigned char c) { return !std::isspace(c); });
+  auto const beg = std::find_if(sv.cbegin(), sv.cend(), [](auto c) { return !std::isspace(c); });
   if (beg != sv.end())
   {
-    auto const end = std::find_if(sv.crbegin(), sv.crend(), [](unsigned char c) { return !std::isspace(c); }).base();
+    auto const end = std::find_if(sv.crbegin(), sv.crend(), [](auto c) { return !std::isspace(c); }).base();
     sv = std::string_view(sv.data() + std::distance(sv.begin(), beg), std::distance(beg, end));
   }
   else

--- a/libs/indexer/categories_holder.cpp
+++ b/libs/indexer/categories_holder.cpp
@@ -54,7 +54,7 @@ bool ParseEmoji(CategoriesHolder::Category::Name & name)
 
 void FillPrefixLengthToSuggest(CategoriesHolder::Category::Name & name)
 {
-  if (std::isdigit(static_cast<unsigned char>(name.m_name.front())) && name.m_name.front() != '0')
+  if (std::isdigit(name.m_name.front()) && name.m_name.front() != '0')
   {
     name.m_prefixLengthToSuggest = name.m_name[0] - '0';
     name.m_name = name.m_name.substr(1);


### PR DESCRIPTION
This reverts commit f3bae5ca8543c9f7c8bad78e1a5fef760db6352b.

Revert the wrong merge. Actually, strings::Trim is called from many places (including kml), so should make a valid UTF8 fix with updating comments.