### PR TITLE
[android] Fix hide PP category for other map objects other than track and bookmark

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -257,6 +257,9 @@ public class PlacePageView extends Fragment
     mColorIcon = mFrame.findViewById(R.id.item_icon);
     mTvCategory = mFrame.findViewById(R.id.tv__category);
     mEditBookmark = mFrame.findViewById(R.id.edit_Bookmark);
+    mColorIcon.setOnClickListener(this);
+    mTvCategory.setOnClickListener(this);
+    mEditBookmark.setOnClickListener(this);
 
     MaterialButton shareButton = mPreview.findViewById(R.id.share_button);
     shareButton.setOnClickListener(this::shareClickListener);
@@ -480,7 +483,6 @@ public class PlacePageView extends Fragment
           Graphics.drawCircle(track.getColor(), R.dimen.place_page_icon_size, requireContext().getResources());
       mColorIcon.setImageDrawable(circle);
       mTvCategory.setText(BookmarkManager.INSTANCE.getCategoryById(track.getCategoryId()).getName());
-      UiUtils.show(mColorIcon, mTvCategory, categoryContainer);
     }
     else if (mMapObject.isBookmark())
     {
@@ -492,13 +494,9 @@ public class PlacePageView extends Fragment
                                                       R.dimen.place_page_icon_mark_size, requireContext());
         mColorIcon.setImageDrawable(circle);
         mTvCategory.setText(BookmarkManager.INSTANCE.getCategoryById(bookmark.getCategoryId()).getName());
-        UiUtils.show(mColorIcon, mTvCategory, categoryContainer);
       }
     }
-
-    mColorIcon.setOnClickListener(this::onClick);
-    mTvCategory.setOnClickListener(this::onClick);
-    mEditBookmark.setOnClickListener(this::onClick);
+    UiUtils.showIf(mMapObject.isTrack() || mMapObject.isBookmark(), categoryContainer);
   }
 
   void showColorDialog()


### PR DESCRIPTION
Hides category bar for map objects other than track and bookmarks

<img width="200" alt="Screenshot_20250808-000944" src="https://github.com/user-attachments/assets/a539f05d-ffc7-460e-b166-a776f7d37be8" />
<img width="200" alt="Screenshot_20250808-000949" src="https://github.com/user-attachments/assets/117fff5f-d91f-477a-9c15-edeaf214ed1f" />
<img width="200" alt="Screenshot_20250808-000954" src="https://github.com/user-attachments/assets/0d7aa893-e072-4694-8c1a-1fa567ba8b1f" />

CC @AndrewShkrob