### PR TITLE
Revert "[ios] [github] add simulator pre-boot before running the tests"

### DIFF
--- a/.github/workflows/ios-check.yaml
+++ b/.github/workflows/ios-check.yaml
@@ -42,7 +42,6 @@ jobs:
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       TEST_RESULTS_BUNDLE_NAME: OMaps-Test-Results
-      SIMULATOR_DEVICE: 'iPhone 16 Pro Max'
     strategy:
       fail-fast: false
       matrix:
@@ -83,15 +82,12 @@ jobs:
         if: matrix.buildType == 'Debug'
         shell: bash
         run: |
-          # Start sim before the build to make sure it's booted when tests start.
-          xcrun simctl boot "${{ env.SIMULATOR_DEVICE }}" || true
-          xcrun simctl bootstatus "${{ env.SIMULATOR_DEVICE }}" -b
           xcodebuild test \
             -workspace xcode/omim.xcworkspace \
             -scheme OMaps \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination "platform=iOS Simulator,name=${{ env.SIMULATOR_DEVICE }},OS=latest" \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max,OS=latest' \
             -quiet \
             -resultBundlePath ${{ env.TEST_RESULTS_BUNDLE_NAME }}.xcresult \
             CODE_SIGNING_REQUIRED=NO \


### PR DESCRIPTION
This reverts commit e614e322a2a9490f4ea0db206804b30ef70fe47c https://github.com/organicmaps/organicmaps/pull/9946 because it doesnt fix the issue https://github.com/organicmaps/organicmaps/issues/9867