### PR TITLE
Do not autozoom to show the full route when adding stops

### DIFF
--- a/libs/map/routing_manager.cpp
+++ b/libs/map/routing_manager.cpp
@@ -407,7 +407,8 @@ void RoutingManager::OnBuildRouteReady(Route const & route, RouterResultCode cod
 
   // Validate route (in case of bicycle routing it can be invalid).
   ASSERT(route.IsValid(), ());
-  if (route.IsValid() && m_currentRouterType != routing::RouterType::Ruler)
+  // Do not show the full route if one or more stops were added, for easier multi-stop trip planning.
+  if (route.IsValid() && route.GetSubrouteCount() < 2 && m_currentRouterType != routing::RouterType::Ruler)
   {
     m2::RectD routeRect = route.GetPoly().GetLimitRect();
     routeRect.Scale(kRouteScaleMultiplier);


### PR DESCRIPTION
This should simplify route planning and avoid unnecessary zoom in back and back again.

Based on discussion in https://github.com/orgs/organicmaps/discussions/4178#discussioncomment-14109633

Fixes the issue from this video:

https://github.com/user-attachments/assets/4cc9b362-ae2b-4af5-894b-99d1265248ea

