### PR TITLE
[ios] Fix elevation chart crash by skip excessive current point updates

### DIFF
--- a/iphone/Chart/Chart/Views/ChartInfo/ChartPointInfoView.swift
+++ b/iphone/Chart/Chart/Views/ChartInfo/ChartPointInfoView.swift
@@ -94,7 +94,7 @@ final class ChartPointInfoView: UIView {
   func update(x: CGFloat, label: String, points: [ChartLineInfo]) {
     distanceLabel.text = label
     altitudeLabel.text = altitudeText(points[0])
-    layoutIfNeeded()
+    setNeedsLayout()
   }
 
   private func altitudeText(_ point: ChartLineInfo) -> String {

--- a/iphone/Chart/Chart/Views/ChartView.swift
+++ b/iphone/Chart/Chart/Views/ChartView.swift
@@ -16,6 +16,7 @@ public class ChartView: UIView {
   var showPreview: Bool = false // Set true to show the preview
 
   private var tapGR: UITapGestureRecognizer!
+  private var selectedPointDistance: Double = 0
   private var panStartPoint = 0
   private var panGR: UIPanGestureRecognizer!
   private var pinchStartLower = 0
@@ -170,6 +171,8 @@ public class ChartView: UIView {
   }
 
   public func setSelectedPoint(_ x: Double) {
+    guard selectedPointDistance != x else { return }
+    selectedPointDistance = x
     let routeLength = chartData.xAxisValueAt(CGFloat(chartData.pointsCount - 1))
     let upper = chartData.xAxisValueAt(CGFloat(chartPreviewView.maxX))
     var lower = chartData.xAxisValueAt(CGFloat(chartPreviewView.minX))


### PR DESCRIPTION
When the user drags the elevation chart, it runs the chart's `selected point` update mechanism by calling the `onSelectedPointChanged` inside the `ChartView`'s ` func chartPreviewView(_ view: ChartPreviewView, didChangeMinX minX: Int, maxX: Int)`. These updates may be quite often (tens/hundreds per sec) and may cause the `on point update` callback **recursion** and overloads the `layoutSubviews` method on the _short track_ because the ChartView doesn't have a mechanism to skip excessive updates when the parameters are the same. This situation produces a failure with internal error `(null) in -[NSISEngine _flushPendingRemovals] ().`

The fix includes:
1. Skip updates when the current point isn't changed
2. Remove layoutSubviews overloading (this method should recalc the layout immediately and should not be called too frequently. The `setNeedsLayout` allows for batching the layout updates and redraw the view on the next runtime cycle)

<img width="1020" height="840" alt="image" src="https://github.com/user-attachments/assets/4c1b08a3-2583-41ea-97c7-eb6c08a5d476" />
