### PR TITLE
[routing] Better turn notifications TTS logging

### DIFF
--- a/libs/routing/turns_notification_manager.cpp
+++ b/libs/routing/turns_notification_manager.cpp
@@ -147,6 +147,11 @@ void NotificationManager::GenerateTurnNotifications(std::vector<TurnItemDist> co
     return;
   turnNotifications.emplace_back(std::move(secondNotification));
 
+  // Log turn notifications TTS
+  if (!turnNotifications.empty())
+    for (auto const & notification : turnNotifications)
+      LOG(LINFO, ("TTS:", notification));
+
   // Turn notification with word "Then" (about the second turn) will be pronounced.
   // When this second turn become the first one the first notification about the turn
   // shall be skipped.

--- a/libs/routing/turns_tts_text.cpp
+++ b/libs/routing/turns_tts_text.cpp
@@ -229,8 +229,6 @@ std::string GetTtsText::GetTurnNotification(Notification const & notification) c
     // trim leading spaces
     strings::Trim(cleanOut);
 
-    LOG(LINFO, ("TTSn", thenStr + cleanOut));
-
     return thenStr + cleanOut;
   }
 
@@ -247,7 +245,7 @@ std::string GetTtsText::GetTurnNotification(Notification const & notification) c
   {
     out = thenStr + dirStr;
   }
-  LOG(LINFO, ("TTS", out));
+
   return out;
 }
 


### PR DESCRIPTION
GitHub is not letting me reopen the PR https://github.com/organicmaps/organicmaps/pull/11168, so here is a new one.

Previously only the second part of the TTS turn notification was logged. Now it will add to log the full turn notification TTS.