### PR TITLE
[ios] Refactor OSM edits uploading scheduling 

### DIFF
--- a/iphone/Maps/Classes/MapsAppDelegate.mm
+++ b/iphone/Maps/Classes/MapsAppDelegate.mm
@@ -108,6 +108,30 @@ using namespace osm_auth_ios;
   [TrackRecordingManager.shared setup];
 }
 
+- (void)runBackgroundTasks:(NSArray<BackgroundFetchTask *> * _Nonnull)tasks
+         completionHandler:(void (^_Nullable)(UIBackgroundFetchResult))completionHandler
+{
+  self.backgroundFetchScheduler = [[MWMBackgroundFetchScheduler alloc] initWithTasks:tasks
+                                                                   completionHandler:^(UIBackgroundFetchResult result) {
+                                                                     if (completionHandler)
+                                                                       completionHandler(result);
+                                                                   }];
+  [self.backgroundFetchScheduler run];
+}
+
+- (void)scheduleOSMEditsUploadingIfNeeded
+{
+  if (![MWMEditorHelper hasMapEditsOrNotesToUpload])
+  {
+    LOG(LINFO, ("No OSM edits or notes to upload, skipping background task scheduling."));
+    return;
+  }
+  auto tasks = @[[[MWMBackgroundEditsUpload alloc] init]];
+  [self runBackgroundTasks:tasks completionHandler:nil];
+}
+
+// MARK: - UIApplication Lifecycle
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   NSLog(@"application:didFinishLaunchingWithOptions: %@", launchOptions);
@@ -141,17 +165,6 @@ using namespace osm_auth_ios;
   completionHandler(YES);
 }
 
-- (void)runBackgroundTasks:(NSArray<BackgroundFetchTask *> * _Nonnull)tasks
-         completionHandler:(void (^_Nullable)(UIBackgroundFetchResult))completionHandler
-{
-  self.backgroundFetchScheduler = [[MWMBackgroundFetchScheduler alloc] initWithTasks:tasks
-                                                                   completionHandler:^(UIBackgroundFetchResult result) {
-                                                                     if (completionHandler)
-                                                                       completionHandler(result);
-                                                                   }];
-  [self.backgroundFetchScheduler run];
-}
-
 - (void)applicationWillTerminate:(UIApplication *)application
 {
   [self.mapViewController onTerminate];
@@ -171,8 +184,7 @@ using namespace osm_auth_ios;
     }];
   }
 
-  auto tasks = @[[[MWMBackgroundEditsUpload alloc] init]];
-  [self runBackgroundTasks:tasks completionHandler:nil];
+  [self scheduleOSMEditsUploadingIfNeeded];
 
   [MWMRouter saveRouteIfNeeded];
   LOG(LINFO, ("applicationDidEnterBackground - end"));

--- a/iphone/Maps/Core/Editor/MWMEditorHelper.h
+++ b/iphone/Maps/Core/Editor/MWMEditorHelper.h
@@ -1,5 +1,6 @@
 @interface MWMEditorHelper : NSObject
 
-+ (void)uploadEdits:(void (^)(UIBackgroundFetchResult))completionHandler;
++ (BOOL)hasMapEditsOrNotesToUpload;
++ (void)uploadEditsWithTimeout:(NSTimeInterval)timeout completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
 
 @end

--- a/iphone/Maps/Core/Editor/MWMEditorHelper.mm
+++ b/iphone/Maps/Core/Editor/MWMEditorHelper.mm
@@ -2,11 +2,18 @@
 #import <CoreApi/AppInfo.h>
 #import "MWMAuthorizationCommon.h"
 
+#include "editor/osm_auth.hpp"
 #include "editor/osm_editor.hpp"
 
 @implementation MWMEditorHelper
 
-+ (void)uploadEdits:(void (^)(UIBackgroundFetchResult))completionHandler
++ (BOOL)hasMapEditsOrNotesToUpload
+{
+  return osm::Editor::Instance().HaveMapEditsOrNotesToUpload();
+}
+
++ (void)uploadEditsWithTimeout:(NSTimeInterval)timeout
+             completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 {
   if (!osm_auth_ios::AuthorizationHaveCredentials() ||
       Platform::EConnectionType::CONNECTION_NONE == Platform::ConnectionStatus())
@@ -29,7 +36,7 @@
         oauthToken,
         {{"created_by", std::string("Organic Maps " OMIM_OS_NAME " ") + AppInfo.sharedInfo.bundleVersion.UTF8String},
          {"bundle_id", NSBundle.mainBundle.bundleIdentifier.UTF8String}},
-        lambda);
+        lambda, timeout);
   }
 }
 

--- a/libs/editor/osm_editor.hpp
+++ b/libs/editor/osm_editor.hpp
@@ -157,8 +157,9 @@ public:
   using ChangesetTags = std::map<std::string, std::string>;
   /// Tries to upload all local changes to OSM server in a separate thread.
   /// @param[in] tags should provide additional information about client to use in changeset.
+  /// @param[in] timeout is a maximum time allowed for upload operation.
   void UploadChanges(std::string const & oauthToken, ChangesetTags tags,
-                     FinishUploadCallback callBack = FinishUploadCallback());
+                     FinishUploadCallback callBack = FinishUploadCallback(), double const timeout = 120.0);
   // TODO(mgsergio): Test new types from new config but with old classificator (where these types are absent).
   // Editor should silently ignore all types in config which are unknown to him.
   NewFeatureCategories GetNewFeatureCategories() const;
@@ -236,6 +237,7 @@ private:
                     bool needMigrate);
 
   static bool HaveMapEditsToUpload(FeaturesContainer const & features);
+  static bool IsOSMServerReachable(int64_t const pingTimeoutInSeconds);
 
   static FeatureStatus GetFeatureStatusImpl(FeaturesContainer const & features, MwmId const & mwmId, uint32_t index);
 

--- a/libs/storage/pinger.hpp
+++ b/libs/storage/pinger.hpp
@@ -7,11 +7,14 @@
 
 namespace storage
 {
+auto constexpr kDefaultTimeoutInSeconds = 4.0;
+
 class Pinger
 {
 public:
   using Endpoints = std::vector<std::string>;
   // Returns list of available endpoints. Works synchronously.
-  static Endpoints ExcludeUnavailableAndSortEndpoints(Endpoints const & urls);
+  static Endpoints ExcludeUnavailableAndSortEndpoints(Endpoints const & urls,
+                                                      int64_t const timeoutInSeconds = kDefaultTimeoutInSeconds);
 };
 }  // namespace storage


### PR DESCRIPTION
Related issue https://github.com/organicmaps/organicmaps/issues/8247 
The issue may be caused by the bg task termination after 25 seconds in the background when the connection is slow.

Solution: 
~~is to extend the background execution time OR increase osm edits uploading speed.~~
Exit from the edits uploading when there is not enough background processing time or the connection is weak.

This PR:
~~1. Schedule the OSM edits uploading as a [Background processing task](https://developer.apple.com/documentation/backgroundtasks/bgprocessingtask) when possible. The task will be executed by the system in an `appropriate time`. BG processing task may take up to several minutes and requires connectivity (configurable).
3. If the task scheduling is not possible (Low power mode, parents' restrictions, user disables the `Background App Refresh` in the settings, iOS <13.0), the task will be scheduled as earlier using the extended background task (up to 25 sec after going to the background)
4. The p2 will happen only when the OSM server ping timeout is less than 1 sec - eg the connection is fast enough to upload all the edits.~~

1. Checks OSM server connectivity before starting to upload
2. Exits from the Uplading when the `time left is < 3 * ping` (1 sec)
