### PR TITLE
[skin_generator] Remove PNG symbols processing

### DIFF
--- a/tools/skin_generator/generator.cpp
+++ b/tools/skin_generator/generator.cpp
@@ -71,9 +71,6 @@ void SkinGenerator::ProcessSymbols(std::string const & svgDataDir, std::string c
     QDir dir(QString(svgDataDir.c_str()));
     QStringList fileNames = dir.entryList(QDir::Files);
 
-    QDir pngDir(dir.absolutePath() + "/png");
-    fileNames += pngDir.entryList(QDir::Files);
-
     // Separate page for symbols.
     m_pages.emplace_back(SkinPageInfo());
     SkinPageInfo & page = m_pages.back();
@@ -86,25 +83,15 @@ void SkinGenerator::ProcessSymbols(std::string const & svgDataDir, std::string c
     {
       QString const & fileName = fileNames.at(i);
       QString symbolID = fileName.left(fileName.lastIndexOf("."));
-      if (fileName.endsWith(".svg"))
+      QString fullFileName = QString(dir.absolutePath()) + "/" + fileName;
+      if (m_svgRenderer.load(fullFileName))
       {
-        QString fullFileName = QString(dir.absolutePath()) + "/" + fileName;
-        if (m_svgRenderer.load(fullFileName))
-        {
-          QSize svgSize = m_svgRenderer.defaultSize();  // Size of the SVG file
+        QSize svgSize = m_svgRenderer.defaultSize();  // Size of the SVG file
 
-          // Scale symbol to required size
-          QSize size = svgSize * (symbolSizes[j].width() / kMediumIconSize);
+        // Scale symbol to required size
+        QSize size = svgSize * (symbolSizes[j].width() / kMediumIconSize);
 
-          page.m_symbols.emplace_back(size + QSize(4, 4), fullFileName, symbolID);
-        }
-      }
-      else if (fileName.toLower().endsWith(".png"))
-      {
-        QString fullFileName = QString(pngDir.absolutePath()) + "/" + fileName;
-        QPixmap pix(fullFileName);
-        QSize s = pix.size();
-        page.m_symbols.emplace_back(s + QSize(4, 4), fullFileName, symbolID);
+        page.m_symbols.emplace_back(size + QSize(4, 4), fullFileName, symbolID);
       }
     }
   }
@@ -174,17 +161,8 @@ bool SkinGenerator::RenderPages(uint32_t maxSize)
       painter.setClipRect(dstRect.minX() + 2, dstRect.minY() + 2, dstRect.SizeX() - 4, dstRect.SizeY() - 4);
       QRect renderRect(dstRect.minX() + 2, dstRect.minY() + 2, dstRect.SizeX() - 4, dstRect.SizeY() - 4);
 
-      QString fullLowerCaseName = s.m_fullFileName.toLower();
-      if (fullLowerCaseName.endsWith(".svg"))
-      {
-        m_svgRenderer.load(s.m_fullFileName);
-        m_svgRenderer.render(&painter, renderRect);
-      }
-      else if (fullLowerCaseName.endsWith(".png"))
-      {
-        QPixmap pix(s.m_fullFileName);
-        painter.drawPixmap(renderRect, pix);
-      }
+      m_svgRenderer.load(s.m_fullFileName);
+      m_svgRenderer.render(&painter, renderRect);
     }
 
     std::string s = page.m_fileName + ".png";

--- a/tools/unix/generate_symbols.sh
+++ b/tools/unix/generate_symbols.sh
@@ -46,16 +46,11 @@ function BuildSkin() {
   symbolsSuffix=${7-}
 
   echo "Building skin for $styleName/$resourceName"
-  # Set environment
+  # Set path
   STYLE_PATH="$DATA_PATH/styles/$styleType/$styleName"
-  PNG_PATH="$STYLE_PATH/symbols$symbolsSuffix/png"
-  rm -rf "$PNG_PATH" || true
-  ln -s "$STYLE_PATH/$resourceName$symbolsSuffix" "$PNG_PATH"
   # Run skin generator
   "$SKIN_GENERATOR" --symbolWidth $symbolSize --symbolHeight $symbolSize --symbolsDir "$STYLE_PATH/$symbolsFolder" \
       --skinName "$DATA_PATH/symbols/$resourceName/$suffix/basic" --skinSuffix="$symbolsSuffix"
-  # Reset environment
-  rm -r "$PNG_PATH" || true
 }
 
 # Cleanup


### PR DESCRIPTION
Now that all remaining PNG icons in https://github.com/organicmaps/organicmaps/issues/11181 have been removed, we can simplify the skin_generator code to only use SVG icons.