### PR TITLE
[android-auto] Fix theme issues

### DIFF
--- a/android/app/src/main/java/app/organicmaps/car/screens/NavigationScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/NavigationScreen.java
@@ -73,8 +73,7 @@ public class NavigationScreen extends BaseMapScreen implements RoutingController
   public Template onGetTemplate()
   {
     final NavigationTemplate.Builder builder = new NavigationTemplate.Builder();
-    builder.setBackgroundColor(ThemeUtils.isNightMode(getCarContext()) ? Colors.NAVIGATION_TEMPLATE_BACKGROUND_NIGHT
-                                                                       : Colors.NAVIGATION_TEMPLATE_BACKGROUND_DAY);
+    builder.setBackgroundColor(Colors.NAVIGATION_TEMPLATE_BACKGROUND);
     builder.setActionStrip(createActionStrip());
     builder.setMapActionStrip(UiHelpers.createMapActionStrip(getCarContext(), getSurfaceRenderer()));
 

--- a/android/app/src/main/java/app/organicmaps/car/util/Colors.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/Colors.java
@@ -11,8 +11,7 @@ public final class Colors
   public static final CarColor OPENING_HOURS_CLOSES_SOON = CarColor.YELLOW;
   public static final CarColor OPENING_HOURS_CLOSED = CarColor.RED;
   public static final CarColor START_NAVIGATION = CarColor.GREEN;
-  public static final CarColor NAVIGATION_TEMPLATE_BACKGROUND_DAY = CarColor.GREEN;
-  public static final CarColor NAVIGATION_TEMPLATE_BACKGROUND_NIGHT = CarColor.DEFAULT;
+  public static final CarColor NAVIGATION_TEMPLATE_BACKGROUND = CarColor.GREEN;
   public static final CarColor BUTTON_ACCEPT = CarColor.GREEN;
 
   private Colors() {}


### PR DESCRIPTION
From now on we will use green background for navigation templates in night mode. We already used green background in day mode.

Before
<img width="400" src="https://github.com/user-attachments/assets/50dcc02f-e7d0-4668-a5dd-98523f981b4f" />

After
<img width="400" src="https://github.com/user-attachments/assets/f425ccfd-f3bc-437c-bc1a-aa86a1e78153" />

Rationale:
* Morons from google