### PR TITLE
GeoJson import support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -185,6 +185,28 @@
         <action android:name="android.intent.action.VIEW"/>
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
+        <data android:scheme="http"/>
+        <data android:scheme="https"/>
+        <data android:scheme="content"/>
+        <data android:scheme="file"/>
+        <data android:scheme="data"/>
+        <data android:host="*"/>
+        <data android:mimeType="application/geo+json"/>
+        <data android:mimeType="application/vnd.geo+json"/>
+      </intent-filter>
+
+      <intent-filter>
+        <action android:name="android.intent.action.SEND"/>
+        <action android:name="android.intent.action.SEND_MULTIPLE"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <data android:mimeType="application/geo+json"/>
+        <data android:mimeType="application/vnd.geo+json"/>
+      </intent-filter>
+
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
         <data android:scheme="content"/>
         <data android:scheme="file"/>
         <data android:scheme="data"/>
@@ -256,6 +278,15 @@
         <data android:pathPattern="/.*\\..*\\..*\\..*\\..*\\..*\\..*\\.KMB" />
         <data android:pathPattern="/.*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.kmb" />
         <data android:pathPattern="/.*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.KMB" />
+        <!-- GeoJson format -->
+        <data android:pathPattern="/.*\\.geojson" />
+        <data android:pathPattern="/.*\\..*\\.geojson" />
+        <data android:pathPattern="/.*\\..*\\..*\\.geojson" />
+        <data android:pathPattern="/.*\\..*\\..*\\..*\\.geojson" />
+        <data android:pathPattern="/.*\\..*\\..*\\..*\\..*\\.geojson" />
+        <data android:pathPattern="/.*\\..*\\..*\\..*\\..*\\..*\\.geojson" />
+        <data android:pathPattern="/.*\\..*\\..*\\..*\\..*\\..*\\..*\\.geojson" />
+        <data android:pathPattern="/.*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.geojson" />
       </intent-filter>
 
       <!-- Duplicates the intent-filter above except it doesn't have mimeType, see

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -1148,8 +1148,9 @@ JNIEXPORT jobjectArray JNICALL Java_app_organicmaps_sdk_Framework_nativeGetMovab
 
 JNIEXPORT jobjectArray JNICALL Java_app_organicmaps_sdk_Framework_nativeGetBookmarksFilesExts(JNIEnv * env, jclass)
 {
-  static std::array<std::string, 4> const kBookmarkExtensions = {
-      std::string{kKmzExtension}, std::string{kKmlExtension}, std::string{kKmbExtension}, std::string{kGpxExtension}};
+  static std::array<std::string, 5> const kBookmarkExtensions = {
+      std::string{kKmzExtension}, std::string{kKmlExtension}, std::string{kKmbExtension},
+      std::string{kGpxExtension}, std::string{kGeoJsonExtension}};
 
   return jni::ToJavaStringArray(env, kBookmarkExtensions);
 }

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -1148,9 +1148,9 @@ JNIEXPORT jobjectArray JNICALL Java_app_organicmaps_sdk_Framework_nativeGetMovab
 
 JNIEXPORT jobjectArray JNICALL Java_app_organicmaps_sdk_Framework_nativeGetBookmarksFilesExts(JNIEnv * env, jclass)
 {
-  static std::array<std::string, 5> const kBookmarkExtensions = {
-      std::string{kKmzExtension}, std::string{kKmlExtension}, std::string{kKmbExtension},
-      std::string{kGpxExtension}, std::string{kGeoJsonExtension}};
+  static std::array<std::string, 5> const kBookmarkExtensions = {std::string{kKmzExtension}, std::string{kKmlExtension},
+                                                                 std::string{kKmbExtension}, std::string{kGpxExtension},
+                                                                 std::string{kGeoJsonExtension}};
 
   return jni::ToJavaStringArray(env, kBookmarkExtensions);
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/BookmarkManager.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/BookmarkManager.java
@@ -410,7 +410,7 @@ public enum BookmarkManager {
   @WorkerThread
   public boolean importBookmarksFile(@NonNull ContentResolver resolver, @NonNull Uri uri, @NonNull File tempDir)
   {
-    Logger.w(TAG, "Importing bookmarks from " + uri);
+    Logger.i(TAG, "Importing bookmarks from " + uri);
     try
     {
       String filename = getBookmarksFilenameFromUri(resolver, uri);

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -72,6 +72,7 @@ static KmlFileType convertFileTypeToCore(MWMKmlFileType fileType)
   case MWMKmlFileTypeText: return KmlFileType::Text;
   case MWMKmlFileTypeBinary: return KmlFileType::Binary;
   case MWMKmlFileTypeGpx: return KmlFileType::Gpx;
+  case MWMKmlFileTypeGeoJson: return KmlFileType::GeoJson;
   }
 }
 

--- a/iphone/CoreApi/CoreApi/Common/MWMTypes.h
+++ b/iphone/CoreApi/CoreApi/Common/MWMTypes.h
@@ -29,7 +29,8 @@ typedef NS_ENUM(NSUInteger, MWMTheme) {
 typedef NS_ENUM(NSUInteger, MWMKmlFileType) {
   MWMKmlFileTypeText,
   MWMKmlFileTypeBinary,
-  MWMKmlFileTypeGpx
+  MWMKmlFileTypeGpx,
+  MWMKmlFileTypeGeoJson
 } NS_SWIFT_NAME(KmlFileType);
 
 typedef uint64_t MWMMarkID;

--- a/iphone/Maps/OMaps.plist
+++ b/iphone/Maps/OMaps.plist
@@ -54,6 +54,23 @@
 				<string>com.google.earth.kmz</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeIconFiles</key>
+			<array>
+				<string>320-pro.png</string>
+				<string>64-pro.png</string>
+				<string>44x58-pro.png</string>
+				<string>22x29-pro.png</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>GeoJson</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.geojson</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
@@ -253,6 +270,28 @@
 				<key>public.mime-type</key>
 				<array>
 					<string>application/gpx+xml</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>GeoJSON Files</string>
+			<key>UTTypeIdentifier</key>
+			<string>public.geojson</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>geojson</string>
+					<string>GeoJson</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/geo+json</string>
 				</array>
 			</dict>
 		</dict>

--- a/iphone/Maps/UI/DocumentPicker/DocumentPicker.swift
+++ b/iphone/Maps/UI/DocumentPicker/DocumentPicker.swift
@@ -5,7 +5,7 @@ final class DocumentPicker: NSObject {
   private var completionHandler: URLsCompletionHandler?
 
   func present(from rootViewController: UIViewController,
-               fileTypes: [FileType] = [.kml, .kmz, .gpx],
+               fileTypes: [FileType] = [.kml, .kmz, .gpx, .geojson],
                completionHandler: @escaping URLsCompletionHandler) {
     self.completionHandler = completionHandler
     let documentPickerViewController: UIDocumentPickerViewController

--- a/iphone/Maps/UI/DocumentPicker/FileType.swift
+++ b/iphone/Maps/UI/DocumentPicker/FileType.swift
@@ -10,6 +10,7 @@ extension FileType {
   static let kml = FileType(fileExtension: "kml", typeIdentifier: "com.google.earth.kml")
   static let kmz = FileType(fileExtension: "kmz", typeIdentifier: "com.google.earth.kmz")
   static let gpx = FileType(fileExtension: "gpx", typeIdentifier: "com.topografix.gpx")
+  static let geojson = FileType(fileExtension: "geojson", typeIdentifier: "public.geojson")
 }
 
 // MARK: - FileType + UTType

--- a/libs/kml/CMakeLists.txt
+++ b/libs/kml/CMakeLists.txt
@@ -12,6 +12,8 @@ set(SRC
   serdes_binary.cpp
   serdes_binary.hpp
   serdes_binary_v8.hpp
+  serdes_geojson.cpp
+  serdes_geojson.hpp
   serdes_gpx.cpp
   serdes_gpx.hpp
   type_utils.cpp
@@ -30,7 +32,10 @@ set(SRC
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
-target_link_libraries(${PROJECT_NAME} indexer)
+target_link_libraries(${PROJECT_NAME}
+    indexer
+    glaze::glaze
+)
 
 omim_add_test_subdirectory(kml_tests)
 

--- a/libs/kml/color_parser.cpp
+++ b/libs/kml/color_parser.cpp
@@ -211,4 +211,18 @@ std::optional<uint32_t> ParseOSMColor(std::string_view c)
   return {};
 }
 
+// Try to parse sequentially: Hex color, OSM color, Garmin color.
+std::optional<uint32_t> ParseColor(std::string_view c)
+{
+    auto maybeColor = ParseHexColor(c);
+    if (maybeColor)
+        return maybeColor;
+
+    maybeColor = ParseOSMColor(c);
+    if (maybeColor)
+        return maybeColor;
+
+    return ParseGarminColor(c);
+}
+
 }  // namespace kml

--- a/libs/kml/color_parser.cpp
+++ b/libs/kml/color_parser.cpp
@@ -214,15 +214,15 @@ std::optional<uint32_t> ParseOSMColor(std::string_view c)
 // Try to parse sequentially: Hex color, OSM color, Garmin color.
 std::optional<uint32_t> ParseColor(std::string_view c)
 {
-    auto maybeColor = ParseHexColor(c);
-    if (maybeColor)
-        return maybeColor;
+  auto maybeColor = ParseHexColor(c);
+  if (maybeColor)
+    return maybeColor;
 
-    maybeColor = ParseOSMColor(c);
-    if (maybeColor)
-        return maybeColor;
+  maybeColor = ParseOSMColor(c);
+  if (maybeColor)
+    return maybeColor;
 
-    return ParseGarminColor(c);
+  return ParseGarminColor(c);
 }
 
 }  // namespace kml

--- a/libs/kml/color_parser.cpp
+++ b/libs/kml/color_parser.cpp
@@ -212,7 +212,7 @@ std::optional<uint32_t> ParseOSMColor(std::string_view c)
 }
 
 // Try to parse sequentially: Hex color, OSM color, Garmin color.
-std::optional<uint32_t> ParseColor(std::string_view c)
+std::optional<uint32_t> ParseHexOsmGarminColor(std::string_view c)
 {
   auto maybeColor = ParseHexColor(c);
   if (maybeColor)

--- a/libs/kml/color_parser.hpp
+++ b/libs/kml/color_parser.hpp
@@ -19,6 +19,7 @@ constexpr uint32_t ToRGBA(Channel red, Channel green, Channel blue, Channel alph
 std::optional<uint32_t> ParseHexColor(std::string_view c);
 std::optional<uint32_t> ParseGarminColor(std::string_view c);
 std::optional<uint32_t> ParseOSMColor(std::string_view c);
+std::optional<uint32_t> ParseColor(std::string_view c);
 
 PredefinedColor MapPredefinedColor(uint32_t rgba);
 std::string_view MapGarminColor(uint32_t rgba);

--- a/libs/kml/color_parser.hpp
+++ b/libs/kml/color_parser.hpp
@@ -19,7 +19,7 @@ constexpr uint32_t ToRGBA(Channel red, Channel green, Channel blue, Channel alph
 std::optional<uint32_t> ParseHexColor(std::string_view c);
 std::optional<uint32_t> ParseGarminColor(std::string_view c);
 std::optional<uint32_t> ParseOSMColor(std::string_view c);
-std::optional<uint32_t> ParseColor(std::string_view c);
+std::optional<uint32_t> ParseHexOsmGarminColor(std::string_view c);
 
 PredefinedColor MapPredefinedColor(uint32_t rgba);
 std::string_view MapGarminColor(uint32_t rgba);

--- a/libs/kml/kml_tests/CMakeLists.txt
+++ b/libs/kml/kml_tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRC
   minzoom_quadtree_tests.cpp
   serdes_tests.cpp
   tests_data.hpp
+  geojson_tests.cpp
 )
 
 omim_add_test(${PROJECT_NAME} ${SRC})

--- a/libs/kml/kml_tests/geojson_tests.cpp
+++ b/libs/kml/kml_tests/geojson_tests.cpp
@@ -10,12 +10,13 @@ namespace geojson_tests
 static kml::FileData LoadGeojsonFromString(std::string_view content)
 {
   TEST_NO_THROW(
-  {
-    kml::FileData dataFromText;
-    kml::DeserializerGeoJson des(dataFromText);
-    des.Deserialize(content);
-    return dataFromText;
-  }, ());
+      {
+        kml::FileData dataFromText;
+        kml::DeserializerGeoJson des(dataFromText);
+        des.Deserialize(content);
+        return dataFromText;
+      },
+      ());
 }
 
 UNIT_TEST(GeoJson_Parse_Basic)
@@ -81,10 +82,11 @@ UNIT_TEST(GeoJson_Parse_Basic)
 
 UNIT_TEST(GeoJson_Parse_basic_2)
 {
-    std::string_view constexpr input = R"({"type":"FeatureCollection","features":[{"type":"Feature","properties":{"marker-color":"#000000","label":"Hello GeoJson","description":"First import test"},"geometry":{"coordinates":[30.568097444337525,50.46385629798317],"type":"Point"},"id":0}]})";
-    kml::FileData const dataFromText = LoadGeojsonFromString(input);
+  std::string_view constexpr input =
+      R"({"type":"FeatureCollection","features":[{"type":"Feature","properties":{"marker-color":"#000000","label":"Hello GeoJson","description":"First import test"},"geometry":{"coordinates":[30.568097444337525,50.46385629798317],"type":"Point"},"id":0}]})";
+  kml::FileData const dataFromText = LoadGeojsonFromString(input);
 
-    TEST_EQUAL(dataFromText.m_bookmarksData.size(), 1, ());
+  TEST_EQUAL(dataFromText.m_bookmarksData.size(), 1, ());
 }
 
 }  // namespace geojson_tests

--- a/libs/kml/kml_tests/geojson_tests.cpp
+++ b/libs/kml/kml_tests/geojson_tests.cpp
@@ -61,6 +61,26 @@ UNIT_TEST(GeoJson_Parse_Basic)
         /* Bookmark color */
         "marker-color": "red"
       }
+    },
+    {
+      /* MultiPoint feature is not supported and should be ignored */
+      "type": "Feature",
+      "geometry": {
+        "coordinates": [
+          [
+            31.055034,
+            29.989067
+          ],
+          [
+            35.182237,
+            31.773850
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "properties": {
+        "marker-color": "green"
+      }
     }
   ]
 })";

--- a/libs/kml/kml_tests/geojson_tests.cpp
+++ b/libs/kml/kml_tests/geojson_tests.cpp
@@ -59,7 +59,7 @@ UNIT_TEST(GeoJson_Parse_Basic)
       "properties": {
         "name": "Bookmark 1",
         /* Bookmark color */
-        "marker-color": "red"
+        "marker-color": "green"
       }
     },
     {
@@ -89,7 +89,8 @@ UNIT_TEST(GeoJson_Parse_Basic)
 
   TEST_EQUAL(dataFromText.m_bookmarksData.size(), 1, ());
   auto bookmark = dataFromText.m_bookmarksData.front();
-  TEST_EQUAL(bookmark.m_color, kml::ColorData{.m_rgba = 0xFF0000FF}, ());
+  auto green = kml::ColorData{.m_predefinedColor = kml::PredefinedColor::Green, .m_rgba = 0x008000FF};
+  TEST_EQUAL(bookmark.m_color, green, ());
   TEST_EQUAL(kml::GetDefaultStr(bookmark.m_name), "Bookmark 1", ());
   TEST_EQUAL(bookmark.m_point, mercator::FromLatLon(29.8310316130992, 31.02177966625902), ());
 
@@ -107,6 +108,12 @@ UNIT_TEST(GeoJson_Parse_basic_2)
   kml::FileData const dataFromText = LoadGeojsonFromString(input);
 
   TEST_EQUAL(dataFromText.m_bookmarksData.size(), 1, ());
+  auto bookmark = dataFromText.m_bookmarksData.front();
+  // We don't have PredefinedColor::Black option. So fallback to the closest one Brown
+  auto brownColor = kml::ColorData{.m_predefinedColor = kml::PredefinedColor::Brown, .m_rgba = 0x00000FF};
+  TEST_EQUAL(bookmark.m_color, brownColor, ());
+  TEST_EQUAL(kml::GetDefaultStr(bookmark.m_name), "Hello GeoJson", ());
+  TEST(bookmark.m_point.EqualDxDy(mercator::FromLatLon(50.46385629798317, 30.568097444337525), 0.000001), ());
 }
 
 }  // namespace geojson_tests

--- a/libs/kml/kml_tests/geojson_tests.cpp
+++ b/libs/kml/kml_tests/geojson_tests.cpp
@@ -1,0 +1,90 @@
+#include "testing/testing.hpp"
+
+#include "geometry/mercator.hpp"
+
+#include "kml/serdes_geojson.hpp"
+
+namespace geojson_tests
+{
+
+static kml::FileData LoadGeojsonFromString(std::string_view content)
+{
+  TEST_NO_THROW(
+  {
+    kml::FileData dataFromText;
+    kml::DeserializerGeoJson des(dataFromText);
+    des.Deserialize(content);
+    return dataFromText;
+  }, ());
+}
+
+UNIT_TEST(GeoJson_Parse_Basic)
+{
+  std::string_view constexpr input = R"({
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "stroke": "blue" /* Line color */
+      },
+      "geometry": {
+        "coordinates": [
+          [
+            14.949382505528291,
+            8.16007148457335
+          ],
+          [
+            26.888888114204264,
+            9.708105796659268
+          ],
+          [
+            37.54707497642465,
+            6.884595662842159
+          ]
+        ],
+        "type": "LineString"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "coordinates": [
+          31.02177966625902,
+          29.8310316130992
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "name": "Bookmark 1",
+        /* Bookmark color */
+        "marker-color": "red"
+      }
+    }
+  ]
+})";
+
+  kml::FileData const dataFromText = LoadGeojsonFromString(input);
+
+  TEST_EQUAL(dataFromText.m_bookmarksData.size(), 1, ());
+  auto bookmark = dataFromText.m_bookmarksData.front();
+  TEST_EQUAL(bookmark.m_color, kml::ColorData{.m_rgba = 0xFF0000FF}, ());
+  TEST_EQUAL(kml::GetDefaultStr(bookmark.m_name), "Bookmark 1", ());
+  TEST_EQUAL(bookmark.m_point, mercator::FromLatLon(29.8310316130992, 31.02177966625902), ());
+
+  TEST_EQUAL(dataFromText.m_tracksData.size(), 1, ());
+  auto track = dataFromText.m_tracksData.front();
+  TEST_EQUAL(track.m_layers.front().m_color, kml::ColorData{.m_rgba = 0x0000FFFF}, ());
+  TEST_EQUAL(track.m_geometry.m_lines.empty(), false, ());
+  TEST_EQUAL(track.m_geometry.m_lines.front().size(), 3, ());
+}
+
+UNIT_TEST(GeoJson_Parse_basic_2)
+{
+    std::string_view constexpr input = R"({"type":"FeatureCollection","features":[{"type":"Feature","properties":{"marker-color":"#000000","label":"Hello GeoJson","description":"First import test"},"geometry":{"coordinates":[30.568097444337525,50.46385629798317],"type":"Point"},"id":0}]})";
+    kml::FileData const dataFromText = LoadGeojsonFromString(input);
+
+    TEST_EQUAL(dataFromText.m_bookmarksData.size(), 1, ());
+}
+
+}  // namespace geojson_tests

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -1,0 +1,201 @@
+#include "kml/serdes_geojson.hpp"
+#include "kml/color_parser.hpp"
+
+#include "geometry/mercator.hpp"
+
+#include <map>
+#include <string>
+
+namespace kml
+{
+namespace geojson
+{
+
+bool GeoJsonFeature::isPoint() {
+    return this->geometry.type == "Point";
+}
+
+bool GeoJsonFeature::isLine() {
+    return this->geometry.type == "LineString";
+}
+
+bool GeojsonParser::Parse(std::string_view & json_content) {
+    geojson::GeoJsonData geoJsonData;
+
+    constexpr glz::opts opts {
+      .comments = true,
+      .error_on_unknown_keys = false,
+      .error_on_missing_keys = false
+    };
+    auto ec = glz::read<opts>(geoJsonData, json_content);
+
+    if (ec) {
+        std::string err = glz::format_error(ec, json_content);
+        LOG(LWARNING, ("Error parsing JSON:", err));
+        return false;
+    }
+
+    // Copy bookmarks from parsed geoJsonData into m_fileData.
+    for(auto feature : geoJsonData.features) {
+        if (feature.isPoint())
+        {
+            double longitude = feature.geometry.coordinates.at(0).get_number();
+            double latitude  = feature.geometry.coordinates.at(1).get_number();
+
+            std::map<std::string, glz::json_t> *props_json = &feature.properties;
+            BookmarkData bookmark;
+
+            // Parse label
+            if (props_json->contains("name") && (*props_json)["name"].is_string()) {
+                auto name = kml::LocalizableString();
+                kml::SetDefaultStr(name, (*props_json)["name"].get_string());
+                bookmark.m_name = name;
+            }
+            else if (props_json->contains("label") && (*props_json)["label"].is_string()) {
+                auto name = kml::LocalizableString();
+                kml::SetDefaultStr(name, (*props_json)["label"].get_string());
+                bookmark.m_name = name;
+            }
+
+            // Parse description
+            if (props_json->contains("description") && (*props_json)["description"].is_string()) {
+                auto descr = kml::LocalizableString();
+                kml::SetDefaultStr(descr, (*props_json)["description"].get_string());
+                bookmark.m_description = descr;
+            }
+
+            // Parse color
+            if (props_json->contains("marker-color") && (*props_json)["marker-color"].is_string()) {
+                auto colorRGBA = ParseColor((*props_json)["marker-color"].get_string());
+                if (colorRGBA) {
+                    bookmark.m_color = ColorData{.m_rgba = *colorRGBA};
+                }
+            }
+
+            // Parse icon
+            //if (props_json->contains("marker-symbol") && (*props_json)["marker-symbol"].is_string()) {
+            //    auto const markerSymbol = (*props_json)["marker-symbol"].get<std::string>()
+            //    bookmark.m_icon = ???;
+            //}
+
+            // UMap custom properties
+            if (props_json->contains("_umap_options") && (*props_json)["_umap_options"].is_object()) {
+                glz::json_t::object_t umap_options = (*props_json)["_umap_options"].get_object();
+                // Parse color from properties['_umap_options']['color']
+                if (umap_options.contains("color") && umap_options["color"].is_string()) {
+                    auto colorRGBA = ParseColor(umap_options["color"].get_string());
+                    if (colorRGBA) {
+                        bookmark.m_color = ColorData{.m_rgba = *colorRGBA};
+                    }
+                }
+
+                // TODO: Store 'umap_options' as a JSON string in some bookmark field.
+            }
+
+            bookmark.m_point = mercator::FromLatLon(latitude, longitude);
+            m_fileData.m_bookmarksData.push_back(bookmark);
+        }
+    }
+
+    // Copy tracks from parsed geoJsonData into m_fileData.
+    for(auto feature : geoJsonData.features) {
+        if (feature.isLine())
+        {
+            auto rawCoordinates = feature.geometry.coordinates;
+            std::vector<std::vector<double>> lineCoords;
+
+            lineCoords.resize(rawCoordinates.size());
+
+            // Convert 'rawCoordinates' from json_t to vector<double> with type checks
+            std::transform(rawCoordinates.begin(), rawCoordinates.end(), lineCoords.begin(),
+                           [](const glz::json_t& json)
+            {
+                std::vector<double> result;
+                if (json.is_array()) {
+                    for(glz::json_t json_element: json.get_array()) {
+                        if (json_element.is_number())
+                            result.push_back(json_element.get_number());
+                    }
+                }
+
+                return result;
+            });
+
+            // Convert GeoJson properties to KML properties
+            std::map<std::string, glz::json_t> *props_json = &feature.properties;
+            TrackData track;
+
+            // Parse label
+            if (props_json->contains("name") && (*props_json)["name"].is_string()) {
+                auto name = kml::LocalizableString();
+                kml::SetDefaultStr(name, (*props_json)["name"].get_string());
+                track.m_name = name;
+            }
+            else if (props_json->contains("label") && (*props_json)["label"].is_string()) {
+                auto name = kml::LocalizableString();
+                kml::SetDefaultStr(name, (*props_json)["label"].get_string());
+                track.m_name = name;
+            }
+
+            // Parse color
+            ColorData *lineColor = nullptr;
+            if (props_json->contains("stroke") && (*props_json)["stroke"].is_string()) {
+                auto colorRGBA = ParseColor((*props_json)["stroke"].get_string());
+                if (colorRGBA) {
+                    //track.m_layers.push_back(TrackLayer{.m_color = ColorData{.m_rgba = *colorRGBA}});
+                    lineColor = new ColorData{.m_rgba = *colorRGBA};
+                }
+            }
+
+            // UMap custom properties
+            if (props_json->contains("_umap_options") && (*props_json)["_umap_options"].is_object()) {
+                glz::json_t::object_t umap_options = (*props_json)["_umap_options"].get_object();
+                // Parse color from properties['_umap_options']['color']
+                if (umap_options.contains("color") && umap_options["color"].is_string()) {
+                    auto colorRGBA = ParseColor(umap_options["color"].get_string());
+                    if (colorRGBA) {
+                        lineColor = new ColorData{.m_rgba = *colorRGBA};
+                    }
+                }
+
+                // TODO: Store 'umap_options' as a JSON string in some bookmark field.
+            }
+
+            if (lineColor != nullptr) {
+                track.m_layers.push_back(TrackLayer{.m_color = *lineColor});
+                delete lineColor;
+            }
+
+
+            // Copy coordinates
+            std::vector<m2::PointD> points;
+            points.resize(lineCoords.size());
+            for(size_t i=0; i<lineCoords.size(); i++) {
+                auto pairCoords = lineCoords[i];
+                points.at(i) = mercator::FromLatLon(pairCoords[1], pairCoords[0]);
+            }
+
+            track.m_geometry.AddLine(points);
+            track.m_geometry.AddTimestamps({});
+            m_fileData.m_tracksData.push_back(track);
+        }
+    }
+
+    return true;
+}
+
+}  // namespace geojson
+
+void DeserializerGeoJson::Deserialize(std::string_view & content)
+{
+    geojson::GeojsonParser parser(m_fileData);
+    if (!parser.Parse(content))
+    {
+        // Print corrupted GeoJson file for debug and restore purposes.
+        if (!content.empty() && content[0] == '{')
+            LOG(LWARNING, (content));
+        MYTHROW(DeserializeException, ("Could not parse GeoJson."));
+    }
+}
+
+}  // namespace kml

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -216,7 +216,7 @@ bool GeojsonParser::Parse(std::string_view & json_content)
           points[i] = mercator::FromLatLon(pointCoords[1], pointCoords[0]);
       }
 
-      track.m_geometry.AddLine(points);
+      track.m_geometry.m_lines.push_back(std::move(points));
       track.m_geometry.AddTimestamps({});
       m_fileData.m_tracksData.push_back(track);
     }

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -11,17 +11,64 @@ namespace kml
 namespace geojson
 {
 
-bool GeoJsonFeature::isPoint()
+std::string DebugPrint(GeoJsonGeometry const & g)
+{
+  if (std::holds_alternative<GeoJsonGeometryPoint>(g))
+  {
+    auto geoPoint = std::get_if<GeoJsonGeometryPoint>(&g);
+    return DebugPrint(*geoPoint);
+  }
+  else if (std::holds_alternative<GeoJsonGeometryLine>(g))
+  {
+    auto geoLine = std::get_if<GeoJsonGeometryLine>(&g);
+    return DebugPrint(*geoLine);
+  }
+  else
+  {
+    auto geoUnknown = std::get_if<GeoJsonGeometryUnknown>(&g);
+    return "GeoJsonGeometryUnknown [type = " + geoUnknown->type + "]";
+  }
+}
+
+std::string DebugPrint(std::map<std::string, glz::json_t> const & p)
+{
+  std::ostringstream out;
+  bool isFirst = true;
+  out << "{";
+  for (auto const & pair : p)
+  {
+    // Add seperator if needed
+    if (isFirst)
+      isFirst = false;
+    else
+      out << ", ";
+
+    out << '"' << pair.first << "\" = " << DebugPrint(pair.second) << ", ";
+  }
+  return out.str();
+}
+
+std::string DebugPrint(glz::json_t const & json)
+{
+  std::string buffer{};
+  if (glz::write_json(json, buffer))
+    return buffer;
+  else
+    return "<JSON_ERROR>";
+  // return glz::write_json(json).value_or("<JSON_ERROR>");
+}
+
+bool GeoJsonFeature::isPoint() const
 {
   return std::holds_alternative<GeoJsonGeometryPoint>(geometry);
 }
 
-bool GeoJsonFeature::isLine()
+bool GeoJsonFeature::isLine() const
 {
   return std::holds_alternative<GeoJsonGeometryLine>(geometry);
 }
 
-bool GeoJsonFeature::isUnknown()
+bool GeoJsonFeature::isUnknown() const
 {
   return std::holds_alternative<GeoJsonGeometryUnknown>(geometry);
 }

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -47,31 +47,35 @@ bool GeojsonParser::Parse(std::string_view & json_content)
       BookmarkData bookmark;
 
       // Parse label
-      if (props_json->contains("name") && (*props_json)["name"].is_string())
+      auto nameVal = (*props_json)["name"];
+      auto labelVal = (*props_json)["label"];
+      if (nameVal.is_string())
       {
         auto name = kml::LocalizableString();
-        kml::SetDefaultStr(name, (*props_json)["name"].get_string());
+        kml::SetDefaultStr(name, nameVal.get_string());
         bookmark.m_name = name;
       }
-      else if (props_json->contains("label") && (*props_json)["label"].is_string())
+      else if (labelVal.is_string())
       {
         auto name = kml::LocalizableString();
-        kml::SetDefaultStr(name, (*props_json)["label"].get_string());
+        kml::SetDefaultStr(name, labelVal.get_string());
         bookmark.m_name = name;
       }
 
       // Parse description
-      if (props_json->contains("description") && (*props_json)["description"].is_string())
+      auto descriptionVal = (*props_json)["description"];
+      if (descriptionVal.is_string())
       {
         auto descr = kml::LocalizableString();
-        kml::SetDefaultStr(descr, (*props_json)["description"].get_string());
+        kml::SetDefaultStr(descr, descriptionVal.get_string());
         bookmark.m_description = descr;
       }
 
       // Parse color
-      if (props_json->contains("marker-color") && (*props_json)["marker-color"].is_string())
+      auto markerColorVal = (*props_json)["marker-color"];
+      if (markerColorVal.is_string())
       {
-        auto colorRGBA = ParseColor((*props_json)["marker-color"].get_string());
+        auto colorRGBA = ParseColor(markerColorVal.get_string());
         if (colorRGBA)
           bookmark.m_color = ColorData{.m_rgba = *colorRGBA};
       }
@@ -83,18 +87,20 @@ bool GeojsonParser::Parse(std::string_view & json_content)
       //}
 
       // UMap custom properties
-      if (props_json->contains("_umap_options") && (*props_json)["_umap_options"].is_object())
+      auto umapOptionsVal = (*props_json)["_umap_options"];
+      if (umapOptionsVal.is_object())
       {
-        glz::json_t::object_t umap_options = (*props_json)["_umap_options"].get_object();
+        glz::json_t::object_t umap_options = umapOptionsVal.get_object();
         // Parse color from properties['_umap_options']['color']
-        if (umap_options.contains("color") && umap_options["color"].is_string())
+        auto colorVal = umap_options["color"];
+        if (colorVal.is_string())
         {
-          auto colorRGBA = ParseColor(umap_options["color"].get_string());
+          auto colorRGBA = ParseColor(colorVal.get_string());
           if (colorRGBA)
             bookmark.m_color = ColorData{.m_rgba = *colorRGBA};
         }
 
-        // TODO: Store 'umap_options' as a JSON string in some bookmark field.
+        // TODO: Store '_umap_options' as a JSON string in some bookmark field.
       }
 
       bookmark.m_point = mercator::FromLatLon(latitude, longitude);
@@ -131,44 +137,50 @@ bool GeojsonParser::Parse(std::string_view & json_content)
       TrackData track;
 
       // Parse label
-      if (props_json->contains("name") && (*props_json)["name"].is_string())
+      auto nameVal = (*props_json)["name"];
+      auto labelVal = (*props_json)["label"];
+      if (nameVal.is_string())
       {
         auto name = kml::LocalizableString();
-        kml::SetDefaultStr(name, (*props_json)["name"].get_string());
+        kml::SetDefaultStr(name, nameVal.get_string());
         track.m_name = name;
       }
-      else if (props_json->contains("label") && (*props_json)["label"].is_string())
+      else if (labelVal.is_string())
       {
         auto name = kml::LocalizableString();
-        kml::SetDefaultStr(name, (*props_json)["label"].get_string());
+        kml::SetDefaultStr(name, labelVal.get_string());
         track.m_name = name;
       }
 
       // Parse color
       ColorData * lineColor = nullptr;
-      if (props_json->contains("stroke") && (*props_json)["stroke"].is_string())
+      auto strokeVal = (*props_json)["stroke"];
+      if (strokeVal.is_string())
       {
-        auto colorRGBA = ParseColor((*props_json)["stroke"].get_string());
+        auto colorRGBA = ParseColor(strokeVal.get_string());
         if (colorRGBA)
-        {
-          // track.m_layers.push_back(TrackLayer{.m_color = ColorData{.m_rgba = *colorRGBA}});
           lineColor = new ColorData{.m_rgba = *colorRGBA};
-        }
       }
 
       // UMap custom properties
-      if (props_json->contains("_umap_options") && (*props_json)["_umap_options"].is_object())
+      auto umapOptionsVal = (*props_json)["_umap_options"];
+      if (umapOptionsVal.is_object())
       {
-        glz::json_t::object_t umap_options = (*props_json)["_umap_options"].get_object();
+        glz::json_t::object_t umap_options = umapOptionsVal.get_object();
         // Parse color from properties['_umap_options']['color']
-        if (umap_options.contains("color") && umap_options["color"].is_string())
+        auto colorVal = (*props_json)["color"];
+        if (colorVal.is_string())
         {
-          auto colorRGBA = ParseColor(umap_options["color"].get_string());
+          auto colorRGBA = ParseColor(colorVal.get_string());
           if (colorRGBA)
+          {
+            if (lineColor != nullptr)
+              delete lineColor;
             lineColor = new ColorData{.m_rgba = *colorRGBA};
+          }
         }
 
-        // TODO: Store 'umap_options' as a JSON string in some bookmark field.
+        // TODO: Store '_umap_options' as a JSON string in some bookmark field.
       }
 
       if (lineColor != nullptr)

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -13,18 +13,17 @@ namespace geojson
 
 bool GeoJsonFeature::isPoint()
 {
-  if (std::get_if<GeoJsonGeometryPoint>(&this->geometry) != nullptr)
-    return true;
-  else
-    return false;
+  return std::holds_alternative<GeoJsonGeometryPoint>(geometry);
 }
 
 bool GeoJsonFeature::isLine()
 {
-  if (std::get_if<GeoJsonGeometryLine>(&this->geometry) != nullptr)
-    return true;
-  else
-    return false;
+  return std::holds_alternative<GeoJsonGeometryLine>(geometry);
+}
+
+bool GeoJsonFeature::isUnknown()
+{
+  return std::holds_alternative<GeoJsonGeometryUnknown>(geometry);
 }
 
 bool GeojsonParser::Parse(std::string_view & json_content)
@@ -112,6 +111,11 @@ bool GeojsonParser::Parse(std::string_view & json_content)
 
       bookmark.m_point = mercator::FromLatLon(latitude, longitude);
       m_fileData.m_bookmarksData.push_back(bookmark);
+    }
+    else if (feature.isUnknown())
+    {
+      GeoJsonGeometryUnknown const * unknownGeometry = std::get_if<GeoJsonGeometryUnknown>(&feature.geometry);
+      LOG(LWARNING, ("GeoJson contains unsupported geometry type:", unknownGeometry->type));
     }
   }
 

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -11,191 +11,202 @@ namespace kml
 namespace geojson
 {
 
-bool GeoJsonFeature::isPoint() {
-    return this->geometry.type == "Point";
+bool GeoJsonFeature::isPoint()
+{
+  return this->geometry.type == "Point";
 }
 
-bool GeoJsonFeature::isLine() {
-    return this->geometry.type == "LineString";
+bool GeoJsonFeature::isLine()
+{
+  return this->geometry.type == "LineString";
 }
 
-bool GeojsonParser::Parse(std::string_view & json_content) {
-    geojson::GeoJsonData geoJsonData;
+bool GeojsonParser::Parse(std::string_view & json_content)
+{
+  geojson::GeoJsonData geoJsonData;
 
-    constexpr glz::opts opts {
-      .comments = true,
-      .error_on_unknown_keys = false,
-      .error_on_missing_keys = false
-    };
-    auto ec = glz::read<opts>(geoJsonData, json_content);
+  constexpr glz::opts opts{.comments = true, .error_on_unknown_keys = false, .error_on_missing_keys = false};
+  auto ec = glz::read<opts>(geoJsonData, json_content);
 
-    if (ec) {
-        std::string err = glz::format_error(ec, json_content);
-        LOG(LWARNING, ("Error parsing JSON:", err));
-        return false;
-    }
+  if (ec)
+  {
+    std::string err = glz::format_error(ec, json_content);
+    LOG(LWARNING, ("Error parsing JSON:", err));
+    return false;
+  }
 
-    // Copy bookmarks from parsed geoJsonData into m_fileData.
-    for(auto feature : geoJsonData.features) {
-        if (feature.isPoint())
+  // Copy bookmarks from parsed geoJsonData into m_fileData.
+  for (auto feature : geoJsonData.features)
+  {
+    if (feature.isPoint())
+    {
+      double longitude = feature.geometry.coordinates.at(0).get_number();
+      double latitude = feature.geometry.coordinates.at(1).get_number();
+
+      std::map<std::string, glz::json_t> * props_json = &feature.properties;
+      BookmarkData bookmark;
+
+      // Parse label
+      if (props_json->contains("name") && (*props_json)["name"].is_string())
+      {
+        auto name = kml::LocalizableString();
+        kml::SetDefaultStr(name, (*props_json)["name"].get_string());
+        bookmark.m_name = name;
+      }
+      else if (props_json->contains("label") && (*props_json)["label"].is_string())
+      {
+        auto name = kml::LocalizableString();
+        kml::SetDefaultStr(name, (*props_json)["label"].get_string());
+        bookmark.m_name = name;
+      }
+
+      // Parse description
+      if (props_json->contains("description") && (*props_json)["description"].is_string())
+      {
+        auto descr = kml::LocalizableString();
+        kml::SetDefaultStr(descr, (*props_json)["description"].get_string());
+        bookmark.m_description = descr;
+      }
+
+      // Parse color
+      if (props_json->contains("marker-color") && (*props_json)["marker-color"].is_string())
+      {
+        auto colorRGBA = ParseColor((*props_json)["marker-color"].get_string());
+        if (colorRGBA)
+          bookmark.m_color = ColorData{.m_rgba = *colorRGBA};
+      }
+
+      // Parse icon
+      // if (props_json->contains("marker-symbol") && (*props_json)["marker-symbol"].is_string()) {
+      //    auto const markerSymbol = (*props_json)["marker-symbol"].get<std::string>()
+      //    bookmark.m_icon = ???;
+      //}
+
+      // UMap custom properties
+      if (props_json->contains("_umap_options") && (*props_json)["_umap_options"].is_object())
+      {
+        glz::json_t::object_t umap_options = (*props_json)["_umap_options"].get_object();
+        // Parse color from properties['_umap_options']['color']
+        if (umap_options.contains("color") && umap_options["color"].is_string())
         {
-            double longitude = feature.geometry.coordinates.at(0).get_number();
-            double latitude  = feature.geometry.coordinates.at(1).get_number();
-
-            std::map<std::string, glz::json_t> *props_json = &feature.properties;
-            BookmarkData bookmark;
-
-            // Parse label
-            if (props_json->contains("name") && (*props_json)["name"].is_string()) {
-                auto name = kml::LocalizableString();
-                kml::SetDefaultStr(name, (*props_json)["name"].get_string());
-                bookmark.m_name = name;
-            }
-            else if (props_json->contains("label") && (*props_json)["label"].is_string()) {
-                auto name = kml::LocalizableString();
-                kml::SetDefaultStr(name, (*props_json)["label"].get_string());
-                bookmark.m_name = name;
-            }
-
-            // Parse description
-            if (props_json->contains("description") && (*props_json)["description"].is_string()) {
-                auto descr = kml::LocalizableString();
-                kml::SetDefaultStr(descr, (*props_json)["description"].get_string());
-                bookmark.m_description = descr;
-            }
-
-            // Parse color
-            if (props_json->contains("marker-color") && (*props_json)["marker-color"].is_string()) {
-                auto colorRGBA = ParseColor((*props_json)["marker-color"].get_string());
-                if (colorRGBA) {
-                    bookmark.m_color = ColorData{.m_rgba = *colorRGBA};
-                }
-            }
-
-            // Parse icon
-            //if (props_json->contains("marker-symbol") && (*props_json)["marker-symbol"].is_string()) {
-            //    auto const markerSymbol = (*props_json)["marker-symbol"].get<std::string>()
-            //    bookmark.m_icon = ???;
-            //}
-
-            // UMap custom properties
-            if (props_json->contains("_umap_options") && (*props_json)["_umap_options"].is_object()) {
-                glz::json_t::object_t umap_options = (*props_json)["_umap_options"].get_object();
-                // Parse color from properties['_umap_options']['color']
-                if (umap_options.contains("color") && umap_options["color"].is_string()) {
-                    auto colorRGBA = ParseColor(umap_options["color"].get_string());
-                    if (colorRGBA) {
-                        bookmark.m_color = ColorData{.m_rgba = *colorRGBA};
-                    }
-                }
-
-                // TODO: Store 'umap_options' as a JSON string in some bookmark field.
-            }
-
-            bookmark.m_point = mercator::FromLatLon(latitude, longitude);
-            m_fileData.m_bookmarksData.push_back(bookmark);
+          auto colorRGBA = ParseColor(umap_options["color"].get_string());
+          if (colorRGBA)
+            bookmark.m_color = ColorData{.m_rgba = *colorRGBA};
         }
-    }
 
-    // Copy tracks from parsed geoJsonData into m_fileData.
-    for(auto feature : geoJsonData.features) {
-        if (feature.isLine())
+        // TODO: Store 'umap_options' as a JSON string in some bookmark field.
+      }
+
+      bookmark.m_point = mercator::FromLatLon(latitude, longitude);
+      m_fileData.m_bookmarksData.push_back(bookmark);
+    }
+  }
+
+  // Copy tracks from parsed geoJsonData into m_fileData.
+  for (auto feature : geoJsonData.features)
+  {
+    if (feature.isLine())
+    {
+      auto rawCoordinates = feature.geometry.coordinates;
+      std::vector<std::vector<double>> lineCoords;
+
+      lineCoords.resize(rawCoordinates.size());
+
+      // Convert 'rawCoordinates' from json_t to vector<double> with type checks
+      std::transform(rawCoordinates.begin(), rawCoordinates.end(), lineCoords.begin(), [](glz::json_t const & json)
+      {
+        std::vector<double> result;
+        if (json.is_array())
         {
-            auto rawCoordinates = feature.geometry.coordinates;
-            std::vector<std::vector<double>> lineCoords;
-
-            lineCoords.resize(rawCoordinates.size());
-
-            // Convert 'rawCoordinates' from json_t to vector<double> with type checks
-            std::transform(rawCoordinates.begin(), rawCoordinates.end(), lineCoords.begin(),
-                           [](const glz::json_t& json)
-            {
-                std::vector<double> result;
-                if (json.is_array()) {
-                    for(glz::json_t json_element: json.get_array()) {
-                        if (json_element.is_number())
-                            result.push_back(json_element.get_number());
-                    }
-                }
-
-                return result;
-            });
-
-            // Convert GeoJson properties to KML properties
-            std::map<std::string, glz::json_t> *props_json = &feature.properties;
-            TrackData track;
-
-            // Parse label
-            if (props_json->contains("name") && (*props_json)["name"].is_string()) {
-                auto name = kml::LocalizableString();
-                kml::SetDefaultStr(name, (*props_json)["name"].get_string());
-                track.m_name = name;
-            }
-            else if (props_json->contains("label") && (*props_json)["label"].is_string()) {
-                auto name = kml::LocalizableString();
-                kml::SetDefaultStr(name, (*props_json)["label"].get_string());
-                track.m_name = name;
-            }
-
-            // Parse color
-            ColorData *lineColor = nullptr;
-            if (props_json->contains("stroke") && (*props_json)["stroke"].is_string()) {
-                auto colorRGBA = ParseColor((*props_json)["stroke"].get_string());
-                if (colorRGBA) {
-                    //track.m_layers.push_back(TrackLayer{.m_color = ColorData{.m_rgba = *colorRGBA}});
-                    lineColor = new ColorData{.m_rgba = *colorRGBA};
-                }
-            }
-
-            // UMap custom properties
-            if (props_json->contains("_umap_options") && (*props_json)["_umap_options"].is_object()) {
-                glz::json_t::object_t umap_options = (*props_json)["_umap_options"].get_object();
-                // Parse color from properties['_umap_options']['color']
-                if (umap_options.contains("color") && umap_options["color"].is_string()) {
-                    auto colorRGBA = ParseColor(umap_options["color"].get_string());
-                    if (colorRGBA) {
-                        lineColor = new ColorData{.m_rgba = *colorRGBA};
-                    }
-                }
-
-                // TODO: Store 'umap_options' as a JSON string in some bookmark field.
-            }
-
-            if (lineColor != nullptr) {
-                track.m_layers.push_back(TrackLayer{.m_color = *lineColor});
-                delete lineColor;
-            }
-
-
-            // Copy coordinates
-            std::vector<m2::PointD> points;
-            points.resize(lineCoords.size());
-            for(size_t i=0; i<lineCoords.size(); i++) {
-                auto pairCoords = lineCoords[i];
-                points.at(i) = mercator::FromLatLon(pairCoords[1], pairCoords[0]);
-            }
-
-            track.m_geometry.AddLine(points);
-            track.m_geometry.AddTimestamps({});
-            m_fileData.m_tracksData.push_back(track);
+          for (glz::json_t json_element : json.get_array())
+            if (json_element.is_number())
+              result.push_back(json_element.get_number());
         }
-    }
 
-    return true;
+        return result;
+      });
+
+      // Convert GeoJson properties to KML properties
+      std::map<std::string, glz::json_t> * props_json = &feature.properties;
+      TrackData track;
+
+      // Parse label
+      if (props_json->contains("name") && (*props_json)["name"].is_string())
+      {
+        auto name = kml::LocalizableString();
+        kml::SetDefaultStr(name, (*props_json)["name"].get_string());
+        track.m_name = name;
+      }
+      else if (props_json->contains("label") && (*props_json)["label"].is_string())
+      {
+        auto name = kml::LocalizableString();
+        kml::SetDefaultStr(name, (*props_json)["label"].get_string());
+        track.m_name = name;
+      }
+
+      // Parse color
+      ColorData * lineColor = nullptr;
+      if (props_json->contains("stroke") && (*props_json)["stroke"].is_string())
+      {
+        auto colorRGBA = ParseColor((*props_json)["stroke"].get_string());
+        if (colorRGBA)
+        {
+          // track.m_layers.push_back(TrackLayer{.m_color = ColorData{.m_rgba = *colorRGBA}});
+          lineColor = new ColorData{.m_rgba = *colorRGBA};
+        }
+      }
+
+      // UMap custom properties
+      if (props_json->contains("_umap_options") && (*props_json)["_umap_options"].is_object())
+      {
+        glz::json_t::object_t umap_options = (*props_json)["_umap_options"].get_object();
+        // Parse color from properties['_umap_options']['color']
+        if (umap_options.contains("color") && umap_options["color"].is_string())
+        {
+          auto colorRGBA = ParseColor(umap_options["color"].get_string());
+          if (colorRGBA)
+            lineColor = new ColorData{.m_rgba = *colorRGBA};
+        }
+
+        // TODO: Store 'umap_options' as a JSON string in some bookmark field.
+      }
+
+      if (lineColor != nullptr)
+      {
+        track.m_layers.push_back(TrackLayer{.m_color = *lineColor});
+        delete lineColor;
+      }
+
+      // Copy coordinates
+      std::vector<m2::PointD> points;
+      points.resize(lineCoords.size());
+      for (size_t i = 0; i < lineCoords.size(); i++)
+      {
+        auto pairCoords = lineCoords[i];
+        points.at(i) = mercator::FromLatLon(pairCoords[1], pairCoords[0]);
+      }
+
+      track.m_geometry.AddLine(points);
+      track.m_geometry.AddTimestamps({});
+      m_fileData.m_tracksData.push_back(track);
+    }
+  }
+
+  return true;
 }
 
 }  // namespace geojson
 
 void DeserializerGeoJson::Deserialize(std::string_view & content)
 {
-    geojson::GeojsonParser parser(m_fileData);
-    if (!parser.Parse(content))
-    {
-        // Print corrupted GeoJson file for debug and restore purposes.
-        if (!content.empty() && content[0] == '{')
-            LOG(LWARNING, (content));
-        MYTHROW(DeserializeException, ("Could not parse GeoJson."));
-    }
+  geojson::GeojsonParser parser(m_fileData);
+  if (!parser.Parse(content))
+  {
+    // Print corrupted GeoJson file for debug and restore purposes.
+    if (!content.empty() && content[0] == '{')
+      LOG(LWARNING, (content));
+    MYTHROW(DeserializeException, ("Could not parse GeoJson."));
+  }
 }
 
 }  // namespace kml

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -83,7 +83,7 @@ bool GeojsonParser::Parse(std::string_view & json_content)
       {
         auto colorRGBA = ParseColor(markerColorVal.get_string());
         if (colorRGBA)
-          bookmark.m_color = ColorData{.m_rgba = *colorRGBA};
+          bookmark.m_color = ColorData{.m_predefinedColor = MapPredefinedColor(*colorRGBA), .m_rgba = *colorRGBA};
       }
 
       // Parse icon

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -90,9 +90,8 @@ bool GeojsonParser::Parse(std::string_view & json_content)
   // Copy bookmarks from parsed geoJsonData into m_fileData.
   for (auto & feature : geoJsonData.features)
   {
-    if (feature.isPoint())
+    if (auto const * point = std::get_if<GeoJsonGeometryPoint>(&feature.geometry))
     {
-      GeoJsonGeometryPoint const * point = std::get_if<GeoJsonGeometryPoint>(&feature.geometry);
       double longitude = point->coordinates.at(0);
       double latitude = point->coordinates.at(1);
 
@@ -143,9 +142,8 @@ bool GeojsonParser::Parse(std::string_view & json_content)
       bookmark.m_point = mercator::FromLatLon(latitude, longitude);
       m_fileData.m_bookmarksData.push_back(bookmark);
     }
-    else if (feature.isUnknown())
+    else if (auto const * unknownGeometry = std::get_if<GeoJsonGeometryUnknown>(&feature.geometry))
     {
-      GeoJsonGeometryUnknown const * unknownGeometry = std::get_if<GeoJsonGeometryUnknown>(&feature.geometry);
       LOG(LWARNING, ("GeoJson contains unsupported geometry type:", unknownGeometry->type));
     }
   }
@@ -153,9 +151,8 @@ bool GeojsonParser::Parse(std::string_view & json_content)
   // Copy tracks from parsed geoJsonData into m_fileData.
   for (auto & feature : geoJsonData.features)
   {
-    if (feature.isLine())
+    if (auto const * lineGeometry = std::get_if<GeoJsonGeometryLine>(&feature.geometry))
     {
-      GeoJsonGeometryLine const * lineGeometry = std::get_if<GeoJsonGeometryLine>(&feature.geometry);
       std::vector<std::vector<double>> lineCoords = lineGeometry->coordinates;
 
       // Convert GeoJson properties to KML properties

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -81,7 +81,7 @@ bool GeojsonParser::Parse(std::string_view & json_content)
       auto markerColorVal = (*props_json)["marker-color"];
       if (markerColorVal.is_string())
       {
-        auto colorRGBA = ParseColor(markerColorVal.get_string());
+        auto colorRGBA = ParseHexOsmGarminColor(markerColorVal.get_string());
         if (colorRGBA)
           bookmark.m_color = ColorData{.m_predefinedColor = MapPredefinedColor(*colorRGBA), .m_rgba = *colorRGBA};
       }
@@ -101,7 +101,7 @@ bool GeojsonParser::Parse(std::string_view & json_content)
         auto colorVal = umap_options["color"];
         if (colorVal.is_string())
         {
-          auto colorRGBA = ParseColor(colorVal.get_string());
+          auto colorRGBA = ParseHexOsmGarminColor(colorVal.get_string());
           if (colorRGBA)
             bookmark.m_color = ColorData{.m_rgba = *colorRGBA};
         }
@@ -152,7 +152,7 @@ bool GeojsonParser::Parse(std::string_view & json_content)
       auto strokeVal = (*props_json)["stroke"];
       if (strokeVal.is_string())
       {
-        auto colorRGBA = ParseColor(strokeVal.get_string());
+        auto colorRGBA = ParseHexOsmGarminColor(strokeVal.get_string());
         if (colorRGBA)
           lineColor = new ColorData{.m_rgba = *colorRGBA};
       }
@@ -166,7 +166,7 @@ bool GeojsonParser::Parse(std::string_view & json_content)
         auto colorVal = (*props_json)["color"];
         if (colorVal.is_string())
         {
-          auto colorRGBA = ParseColor(colorVal.get_string());
+          auto colorRGBA = ParseHexOsmGarminColor(colorVal.get_string());
           if (colorRGBA)
           {
             if (lineColor != nullptr)

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -232,12 +232,17 @@ bool GeojsonParser::Parse(std::string_view & json_content)
       }
 
       // Copy coordinates
-      std::vector<m2::PointD> points;
+      std::vector<geometry::PointWithAltitude> points;
       points.resize(lineCoords.size());
       for (size_t i = 0; i < lineCoords.size(); i++)
       {
-        auto pairCoords = lineCoords[i];
-        points.at(i) = mercator::FromLatLon(pairCoords[1], pairCoords[0]);
+        auto pointCoords = lineCoords[i];
+        if (pointCoords.size() >= 3)
+          // Third coordinate (if present) means altitude
+          points.at(i) =
+              geometry::PointWithAltitude(mercator::FromLatLon(pointCoords[1], pointCoords[0]), pointCoords[2]);
+        else
+          points.at(i) = mercator::FromLatLon(pointCoords[1], pointCoords[0]);
       }
 
       track.m_geometry.AddLine(points);
@@ -251,7 +256,7 @@ bool GeojsonParser::Parse(std::string_view & json_content)
 
 }  // namespace geojson
 
-void DeserializerGeoJson::Deserialize(std::string_view & content)
+void DeserializerGeoJson::Deserialize(std::string_view content)
 {
   geojson::GeojsonParser parser(m_fileData);
   if (!parser.Parse(content))

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -97,6 +97,7 @@ bool GeojsonParser::Parse(std::string_view & json_content)
 
       auto const & props_json = feature.properties;
       BookmarkData bookmark;
+      bookmark.m_color = ColorData{.m_predefinedColor = PredefinedColor::Red};
 
       // Parse "name" or "label"
       if (auto const name = props_json.find("name"); name != props_json.end() && name->second.is_string())

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -66,21 +66,6 @@ std::string DebugPrint(glz::json_t const & json)
     return "<JSON_ERROR>";
 }
 
-bool GeoJsonFeature::isPoint() const
-{
-  return std::holds_alternative<GeoJsonGeometryPoint>(geometry);
-}
-
-bool GeoJsonFeature::isLine() const
-{
-  return std::holds_alternative<GeoJsonGeometryLine>(geometry);
-}
-
-bool GeoJsonFeature::isUnknown() const
-{
-  return std::holds_alternative<GeoJsonGeometryUnknown>(geometry);
-}
-
 bool GeojsonParser::Parse(std::string_view json_content)
 {
   geojson::GeoJsonData geoJsonData;

--- a/libs/kml/serdes_geojson.hpp
+++ b/libs/kml/serdes_geojson.hpp
@@ -98,16 +98,13 @@ struct GeoJsonData
   std::vector<GeoJsonFeature> features;
   std::map<std::string, std::string> properties;
 
-  bool operator==(GeoJsonData const & data) const
-  {
-    return type == data.type && features == data.features && properties == data.properties;
-  }
+  bool operator==(GeoJsonData const & data) const = default;
 
   bool operator!=(GeoJsonData const & data) const { return !operator==(data); }
 };
 
 // Writer and reader
-class GeojsonWriter
+class GeoJsonWriter
 {
 public:
   /*DECLARE_EXCEPTION(WriteGeojsonException, RootException);
@@ -142,7 +139,7 @@ public:
 
   explicit DeserializerGeoJson(FileData & fileData) : m_fileData(fileData) {}
 
-  void Deserialize(std::string_view & content);
+  void Deserialize(std::string_view content);
 
 private:
   FileData & m_fileData;
@@ -150,12 +147,11 @@ private:
 
 }  // namespace kml
 
-/* Glaze setup.
-   Tell Glaze to pick GeoJsonGeometryPoint, GeoJsonGeometryLine or GeoJsonGeometryUnknown depending on "type" property
-*/
+// Tell Glaze to pick GeoJsonGeometryPoint, GeoJsonGeometryLine or GeoJsonGeometryUnknown depending on "type" property
 template <>
 struct glz::meta<kml::geojson::GeoJsonGeometry>
 {
   static constexpr std::string_view tag = "type";  // Field name that serves as tag
+  // TODO: Support Polygon, MultiPoint, MultiLineString, and MultiPolygon
   static constexpr auto ids = std::array{"Point", "LineString"};
 };

--- a/libs/kml/serdes_geojson.hpp
+++ b/libs/kml/serdes_geojson.hpp
@@ -55,6 +55,12 @@ struct GeoJsonGeometryUnknown
 
 using GeoJsonGeometry = std::variant<GeoJsonGeometryPoint, GeoJsonGeometryLine, GeoJsonGeometryUnknown>;
 
+std::string DebugPrint(GeoJsonGeometry const & g);
+
+std::string DebugPrint(glz::json_t const & json);
+
+std::string DebugPrint(std::map<std::string, glz::json_t> const & p);
+
 struct GeoJsonFeature
 {
   std::string type = "Feature";
@@ -69,19 +75,19 @@ struct GeoJsonFeature
   bool operator!=(GeoJsonFeature const & data) const { return !operator==(data); }
 
   // Returns 'true' if geometry type is 'Point'.
-  bool isPoint();
+  bool isPoint() const;
 
   // Returns 'true' if geometry type is 'LineString'.
-  bool isLine();
+  bool isLine() const;
 
   // Returns 'true' if geometry type is neither 'Point' nor 'LineString'.
-  bool isUnknown();
+  bool isUnknown() const;
 
   friend std::string DebugPrint(GeoJsonFeature const & c)
   {
     std::ostringstream out;
-    out << "GeoJsonFeature [type = " << c.type  // << ", geometry = " << DebugPrint(c.geometry)
-        << ", properties = " /*<< json_dumps(&c.m_properties, JSON_COMPACT)*/ << "]";
+    out << "GeoJsonFeature [type = " << c.type << ", geometry = " << DebugPrint(c.geometry)
+        << ", properties = " << DebugPrint(c.properties) << "]";
     return out.str();
   }
 };

--- a/libs/kml/serdes_geojson.hpp
+++ b/libs/kml/serdes_geojson.hpp
@@ -2,7 +2,7 @@
 
 #include "kml/types.hpp"
 
-#include "glaze/json.hpp"
+#include <glaze/json.hpp>
 
 #include "base/exception.hpp"
 

--- a/libs/kml/serdes_geojson.hpp
+++ b/libs/kml/serdes_geojson.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "kml/types.hpp"
+
+#include "glaze/json.hpp"
+
+#include "base/exception.hpp"
+
+namespace kml
+{
+namespace geojson
+{
+
+// Data structures
+
+struct GeoJsonGeometry {
+  std::string type;
+  std::vector<glz::json_t> coordinates;
+
+  bool operator==(GeoJsonGeometry const & data) const
+  {
+      return type == data.type; // && coordinates == data.coordinates;
+  }
+
+  bool operator!=(GeoJsonGeometry const & data) const
+  {
+      return !operator==(data);
+  }
+
+
+  friend std::string DebugPrint(GeoJsonGeometry const & c)
+  {
+    return "GeoJsonGeometry [" + c.type + "]";
+  }
+};
+
+struct GeoJsonFeature
+{
+  std::string type = "Feature";
+  GeoJsonGeometry geometry;
+  std::map<std::string, glz::json_t> properties;
+
+  bool operator==(GeoJsonFeature const & data) const
+  {
+    return type == data.type; //&& m_properties == data.m_properties;
+  }
+
+  bool operator!=(GeoJsonFeature const & data) const
+  {
+    return !operator==(data);
+  }
+
+
+  // Returns 'true' if geometry type is 'Point'.
+  bool isPoint();
+
+  // Returns 'true' if geometry type is 'LineString'.
+  bool isLine();
+
+  friend std::string DebugPrint(GeoJsonFeature const & c)
+  {
+      std::ostringstream out;
+      out << "[type = " << c.type << ", geometry = " << DebugPrint(c.geometry)
+          << ", properties = " /*<< json_dumps(&c.m_properties, JSON_COMPACT)*/ << "]";
+      return out.str();
+  }
+};
+
+
+struct GeoJsonData
+{
+  std::string type = "FeatureCollection";
+  std::vector<GeoJsonFeature> features;
+  std::map<std::string, std::string> properties;
+
+  bool operator==(GeoJsonData const & data) const
+  {
+    return type == data.type && features == data.features && properties == data.properties;
+  }
+
+  bool operator!=(GeoJsonData const & data) const
+  {
+    return !operator==(data);
+  }
+};
+
+
+// Writer and reader
+class GeojsonWriter
+{
+public:
+  /*DECLARE_EXCEPTION(WriteGeojsonException, RootException);
+
+  explicit GeojsonWriter(Writer & writer)
+    : m_writer(writer)
+  {}
+
+  void Write(FileData const & fileData);
+
+private:
+  Writer & m_writer;*/
+};
+
+class GeojsonParser
+{
+public:
+  explicit GeojsonParser(FileData & data): m_fileData(data) {};
+
+  bool Parse(std::string_view & json_content);
+
+private:
+  FileData & m_fileData;
+};
+
+}  // namespace geojson
+
+class DeserializerGeoJson
+{
+public:
+    DECLARE_EXCEPTION(DeserializeException, RootException);
+
+    explicit DeserializerGeoJson(FileData & fileData): m_fileData(fileData) {};
+
+    void Deserialize(std::string_view & content);
+
+private:
+    FileData & m_fileData;
+};
+
+}  // namespace kml

--- a/libs/kml/serdes_geojson.hpp
+++ b/libs/kml/serdes_geojson.hpp
@@ -18,10 +18,6 @@ struct GeoJsonGeometryPoint
   std::string type{"Point"};  // Embedded tag field
   std::vector<double> coordinates;
 
-  bool operator==(GeoJsonGeometryPoint const & data) const { return coordinates == data.coordinates; }
-
-  bool operator!=(GeoJsonGeometryPoint const & data) const { return !operator==(data); }
-
   friend std::string DebugPrint(GeoJsonGeometryPoint const & c)
   {
     std::ostringstream out;
@@ -34,10 +30,6 @@ struct GeoJsonGeometryLine
 {
   std::string type{"LineString"};  // Embedded tag field
   std::vector<std::vector<double>> coordinates;
-
-  bool operator==(GeoJsonGeometryLine const & data) const { return coordinates == data.coordinates; }
-
-  bool operator!=(GeoJsonGeometryLine const & data) const { return !operator==(data); }
 
   friend std::string DebugPrint(GeoJsonGeometryLine const & c)
   {
@@ -67,13 +59,6 @@ struct GeoJsonFeature
   GeoJsonGeometry geometry;
   std::map<std::string, glz::json_t> properties;
 
-  bool operator==(GeoJsonFeature const & data) const
-  {
-    return type == data.type;  //&& m_properties == data.m_properties;
-  }
-
-  bool operator!=(GeoJsonFeature const & data) const { return !operator==(data); }
-
   // Returns 'true' if geometry type is 'Point'.
   bool isPoint() const;
 
@@ -97,10 +82,6 @@ struct GeoJsonData
   std::string type = "FeatureCollection";
   std::vector<GeoJsonFeature> features;
   std::map<std::string, std::string> properties;
-
-  bool operator==(GeoJsonData const & data) const = default;
-
-  bool operator!=(GeoJsonData const & data) const { return !operator==(data); }
 };
 
 // Writer and reader

--- a/libs/kml/serdes_geojson.hpp
+++ b/libs/kml/serdes_geojson.hpp
@@ -13,25 +13,19 @@ namespace geojson
 
 // Data structures
 
-struct GeoJsonGeometry {
+struct GeoJsonGeometry
+{
   std::string type;
   std::vector<glz::json_t> coordinates;
 
   bool operator==(GeoJsonGeometry const & data) const
   {
-      return type == data.type; // && coordinates == data.coordinates;
+    return type == data.type;  // && coordinates == data.coordinates;
   }
 
-  bool operator!=(GeoJsonGeometry const & data) const
-  {
-      return !operator==(data);
-  }
+  bool operator!=(GeoJsonGeometry const & data) const { return !operator==(data); }
 
-
-  friend std::string DebugPrint(GeoJsonGeometry const & c)
-  {
-    return "GeoJsonGeometry [" + c.type + "]";
-  }
+  friend std::string DebugPrint(GeoJsonGeometry const & c) { return "GeoJsonGeometry [" + c.type + "]"; }
 };
 
 struct GeoJsonFeature
@@ -42,14 +36,10 @@ struct GeoJsonFeature
 
   bool operator==(GeoJsonFeature const & data) const
   {
-    return type == data.type; //&& m_properties == data.m_properties;
+    return type == data.type;  //&& m_properties == data.m_properties;
   }
 
-  bool operator!=(GeoJsonFeature const & data) const
-  {
-    return !operator==(data);
-  }
-
+  bool operator!=(GeoJsonFeature const & data) const { return !operator==(data); }
 
   // Returns 'true' if geometry type is 'Point'.
   bool isPoint();
@@ -59,13 +49,12 @@ struct GeoJsonFeature
 
   friend std::string DebugPrint(GeoJsonFeature const & c)
   {
-      std::ostringstream out;
-      out << "[type = " << c.type << ", geometry = " << DebugPrint(c.geometry)
-          << ", properties = " /*<< json_dumps(&c.m_properties, JSON_COMPACT)*/ << "]";
-      return out.str();
+    std::ostringstream out;
+    out << "[type = " << c.type << ", geometry = " << DebugPrint(c.geometry)
+        << ", properties = " /*<< json_dumps(&c.m_properties, JSON_COMPACT)*/ << "]";
+    return out.str();
   }
 };
-
 
 struct GeoJsonData
 {
@@ -78,12 +67,8 @@ struct GeoJsonData
     return type == data.type && features == data.features && properties == data.properties;
   }
 
-  bool operator!=(GeoJsonData const & data) const
-  {
-    return !operator==(data);
-  }
+  bool operator!=(GeoJsonData const & data) const { return !operator==(data); }
 };
-
 
 // Writer and reader
 class GeojsonWriter
@@ -104,7 +89,7 @@ private:
 class GeojsonParser
 {
 public:
-  explicit GeojsonParser(FileData & data): m_fileData(data) {};
+  explicit GeojsonParser(FileData & data) : m_fileData(data) {}
 
   bool Parse(std::string_view & json_content);
 
@@ -117,14 +102,14 @@ private:
 class DeserializerGeoJson
 {
 public:
-    DECLARE_EXCEPTION(DeserializeException, RootException);
+  DECLARE_EXCEPTION(DeserializeException, RootException);
 
-    explicit DeserializerGeoJson(FileData & fileData): m_fileData(fileData) {};
+  explicit DeserializerGeoJson(FileData & fileData) : m_fileData(fileData) {}
 
-    void Deserialize(std::string_view & content);
+  void Deserialize(std::string_view & content);
 
 private:
-    FileData & m_fileData;
+  FileData & m_fileData;
 };
 
 }  // namespace kml

--- a/libs/kml/serdes_geojson.hpp
+++ b/libs/kml/serdes_geojson.hpp
@@ -59,15 +59,6 @@ struct GeoJsonFeature
   GeoJsonGeometry geometry;
   std::map<std::string, glz::json_t> properties;
 
-  // Returns 'true' if geometry type is 'Point'.
-  bool isPoint() const;
-
-  // Returns 'true' if geometry type is 'LineString'.
-  bool isLine() const;
-
-  // Returns 'true' if geometry type is neither 'Point' nor 'LineString'.
-  bool isUnknown() const;
-
   friend std::string DebugPrint(GeoJsonFeature const & c)
   {
     std::ostringstream out;

--- a/libs/kml/serdes_geojson.hpp
+++ b/libs/kml/serdes_geojson.hpp
@@ -11,6 +11,9 @@ namespace kml
 namespace geojson
 {
 
+// object_t means map<string, json_t>.
+typedef glz::json_t::object_t JsonTMap;
+
 // Data structures
 
 struct GeoJsonGeometryPoint
@@ -51,13 +54,13 @@ std::string DebugPrint(GeoJsonGeometry const & g);
 
 std::string DebugPrint(glz::json_t const & json);
 
-std::string DebugPrint(std::map<std::string, glz::json_t> const & p);
+std::string DebugPrint(JsonTMap const & p);
 
 struct GeoJsonFeature
 {
   std::string type = "Feature";
   GeoJsonGeometry geometry;
-  std::map<std::string, glz::json_t> properties;
+  JsonTMap properties;
 
   friend std::string DebugPrint(GeoJsonFeature const & c)
   {

--- a/libs/kml/serdes_geojson.hpp
+++ b/libs/kml/serdes_geojson.hpp
@@ -105,7 +105,7 @@ class GeojsonParser
 public:
   explicit GeojsonParser(FileData & data) : m_fileData(data) {}
 
-  bool Parse(std::string_view & json_content);
+  bool Parse(std::string_view json_content);
 
 private:
   FileData & m_fileData;

--- a/libs/kml/types.cpp
+++ b/libs/kml/types.cpp
@@ -87,6 +87,17 @@ void MultiGeometry::AddLine(std::initializer_list<geometry::PointWithAltitude> l
   m_lines.back().assign(lst);
 }
 
+void MultiGeometry::AddLine(std::vector<m2::PointD> lst)
+{
+    // Convert vector<m2::PointD> to vector<PointWithAltitude>
+    std::vector<geometry::PointWithAltitude> points;
+    for(auto p: lst) {
+        points.push_back(geometry::PointWithAltitude(p));
+    }
+
+    m_lines.push_back(points);
+}
+
 void MultiGeometry::AddTimestamps(std::initializer_list<double> lst)
 {
   m_timestamps.emplace_back();

--- a/libs/kml/types.cpp
+++ b/libs/kml/types.cpp
@@ -89,13 +89,12 @@ void MultiGeometry::AddLine(std::initializer_list<geometry::PointWithAltitude> l
 
 void MultiGeometry::AddLine(std::vector<m2::PointD> lst)
 {
-    // Convert vector<m2::PointD> to vector<PointWithAltitude>
-    std::vector<geometry::PointWithAltitude> points;
-    for(auto p: lst) {
-        points.push_back(geometry::PointWithAltitude(p));
-    }
+  // Convert vector<m2::PointD> to vector<PointWithAltitude>
+  std::vector<geometry::PointWithAltitude> points;
+  for (auto p : lst)
+    points.push_back(geometry::PointWithAltitude(p));
 
-    m_lines.push_back(points);
+  m_lines.push_back(points);
 }
 
 void MultiGeometry::AddTimestamps(std::initializer_list<double> lst)

--- a/libs/kml/types.cpp
+++ b/libs/kml/types.cpp
@@ -87,14 +87,9 @@ void MultiGeometry::AddLine(std::initializer_list<geometry::PointWithAltitude> l
   m_lines.back().assign(lst);
 }
 
-void MultiGeometry::AddLine(std::vector<m2::PointD> lst)
+void MultiGeometry::AddLine(std::vector<geometry::PointWithAltitude> const & lst)
 {
-  // Convert vector<m2::PointD> to vector<PointWithAltitude>
-  std::vector<geometry::PointWithAltitude> points;
-  for (auto p : lst)
-    points.push_back(geometry::PointWithAltitude(p));
-
-  m_lines.push_back(points);
+  m_lines.push_back(lst);
 }
 
 void MultiGeometry::AddTimestamps(std::initializer_list<double> lst)

--- a/libs/kml/types.cpp
+++ b/libs/kml/types.cpp
@@ -87,11 +87,6 @@ void MultiGeometry::AddLine(std::initializer_list<geometry::PointWithAltitude> l
   m_lines.back().assign(lst);
 }
 
-void MultiGeometry::AddLine(std::vector<geometry::PointWithAltitude> const & lst)
-{
-  m_lines.push_back(lst);
-}
-
 void MultiGeometry::AddTimestamps(std::initializer_list<double> lst)
 {
   m_timestamps.emplace_back();

--- a/libs/kml/types.hpp
+++ b/libs/kml/types.hpp
@@ -413,6 +413,7 @@ struct MultiGeometry
 
   /// This method should be used for tests only.
   void AddLine(std::initializer_list<geometry::PointWithAltitude> lst);
+  void AddLine(std::vector<m2::PointD> lst);
   /// This method should be used for tests only.
   void AddTimestamps(std::initializer_list<double> lst);
 

--- a/libs/kml/types.hpp
+++ b/libs/kml/types.hpp
@@ -413,7 +413,6 @@ struct MultiGeometry
 
   /// This method should be used for tests only.
   void AddLine(std::initializer_list<geometry::PointWithAltitude> lst);
-  void AddLine(std::vector<geometry::PointWithAltitude> const & lst);
   /// This method should be used for tests only.
   void AddTimestamps(std::initializer_list<double> lst);
 

--- a/libs/kml/types.hpp
+++ b/libs/kml/types.hpp
@@ -413,7 +413,7 @@ struct MultiGeometry
 
   /// This method should be used for tests only.
   void AddLine(std::initializer_list<geometry::PointWithAltitude> lst);
-  void AddLine(std::vector<m2::PointD> lst);
+  void AddLine(std::vector<geometry::PointWithAltitude> const & lst);
   /// This method should be used for tests only.
   void AddTimestamps(std::initializer_list<double> lst);
 

--- a/libs/map/bookmark_helpers.cpp
+++ b/libs/map/bookmark_helpers.cpp
@@ -4,8 +4,8 @@
 
 #include "kml/serdes.hpp"
 #include "kml/serdes_binary.hpp"
-#include "kml/serdes_gpx.hpp"
 #include "kml/serdes_geojson.hpp"
+#include "kml/serdes_gpx.hpp"
 
 #include "indexer/classificator.hpp"
 #include "indexer/feature_data.hpp"
@@ -356,11 +356,11 @@ std::string GenerateValidAndUniqueFilePathForGPX(std::string const & fileName)
 
 std::string GenerateValidAndUniqueFilePathForGeoJson(std::string const & fileName)
 {
-    std::string filePath = RemoveInvalidSymbols(fileName);
-    if (filePath.empty())
-        filePath = kDefaultBookmarksFileName;
+  std::string filePath = RemoveInvalidSymbols(fileName);
+  if (filePath.empty())
+    filePath = kDefaultBookmarksFileName;
 
-    return GenerateUniqueFileName(GetBookmarksDirectory(), std::move(filePath), kGeoJsonExtension);
+  return GenerateUniqueFileName(GetBookmarksDirectory(), std::move(filePath), kGeoJsonExtension);
 }
 
 std::string GenerateValidAndUniqueTrashedFilePath(std::string const & fileName)
@@ -519,10 +519,10 @@ std::vector<std::string> GetFilePathsToLoadFromKml(std::string const & filePath)
 
 std::vector<std::string> GetFilePathsToLoadFromGeoJson(std::string const & filePath)
 {  // Copy input file to temp GeoJson with unique name.
-    auto fileSavePath = GenerateValidAndUniqueFilePathForGeoJson(base::FileNameFromFullPath(filePath));
-    if (!base::CopyFileX(filePath, fileSavePath))
-        return {};
-    return {std::move(fileSavePath)};
+  auto fileSavePath = GenerateValidAndUniqueFilePathForGeoJson(base::FileNameFromFullPath(filePath));
+  if (!base::CopyFileX(filePath, fileSavePath))
+    return {};
+  return {std::move(fileSavePath)};
 }
 
 std::unique_ptr<kml::FileData> LoadKmlData(Reader const & reader, KmlFileType fileType)
@@ -547,12 +547,12 @@ std::unique_ptr<kml::FileData> LoadKmlData(Reader const & reader, KmlFileType fi
     }
     else if (fileType == KmlFileType::GeoJson)
     {
-        kml::DeserializerGeoJson des(*data);
-        std::string content;
-        reader.ReadAsString(content);
+      kml::DeserializerGeoJson des(*data);
+      std::string content;
+      reader.ReadAsString(content);
 
-        std::string_view content_view(content);
-        des.Deserialize(content_view);
+      std::string_view content_view(content);
+      des.Deserialize(content_view);
     }
     else
     {

--- a/libs/map/bookmark_helpers.hpp
+++ b/libs/map/bookmark_helpers.hpp
@@ -66,6 +66,7 @@ std::string_view constexpr kKmzExtension = ".kmz";
 std::string_view constexpr kKmlExtension = ".kml";
 std::string_view constexpr kKmbExtension = ".kmb";
 std::string_view constexpr kGpxExtension = ".gpx";
+std::string_view constexpr kGeoJsonExtension = ".geojson";
 
 std::string_view constexpr kTrashDirectoryName = ".Trash";
 
@@ -75,7 +76,8 @@ enum class KmlFileType
 {
   Text,
   Binary,
-  Gpx
+  Gpx,
+  GeoJson
 };
 
 inline std::string DebugPrint(KmlFileType fileType)
@@ -85,6 +87,7 @@ inline std::string DebugPrint(KmlFileType fileType)
   case KmlFileType::Text: return "Text";
   case KmlFileType::Binary: return "Binary";
   case KmlFileType::Gpx: return "GPX";
+  case KmlFileType::GeoJson: return "GeoJson";
   }
   UNREACHABLE();
 }
@@ -97,6 +100,7 @@ std::string RemoveInvalidSymbols(std::string const & name);
 std::string GenerateUniqueFileName(std::string const & path, std::string name, std::string_view ext = kKmlExtension);
 std::string GenerateValidAndUniqueFilePathForKML(std::string const & fileName);
 std::string GenerateValidAndUniqueFilePathForGPX(std::string const & fileName);
+std::string GenerateValidAndUniqueFilePathForGeoJson(std::string const & fileName);
 std::string GenerateValidAndUniqueTrashedFilePath(std::string const & fileName);
 /// @}
 
@@ -110,6 +114,7 @@ std::vector<std::string> GetFilePathsToLoadFromKml(std::string const & filePath)
 std::vector<std::string> GetFilePathsToLoadFromGpx(std::string const & filePath);
 std::vector<std::string> GetFilePathsToLoadFromKmb(std::string const & filePath);
 std::vector<std::string> GetFilePathsToLoadFromKmz(std::string const & filePath);
+std::vector<std::string> GetFilePathsToLoadFromGeoJson(std::string const & filePath);
 std::string GetLowercaseFileExt(std::string const & filePath);
 
 bool SaveKmlFileSafe(kml::FileData & kmlData, std::string const & file, KmlFileType fileType);

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -2090,7 +2090,7 @@ void BookmarkManager::LoadBookmarkRoutine(std::string const & filePath, bool isT
       else if (ext == kGpxExtension)
         kmlData = LoadKmlFile(fileToLoad, KmlFileType::Gpx);
       else if (ext == kGeoJsonExtension)
-          kmlData = LoadKmlFile(fileToLoad, KmlFileType::GeoJson);
+        kmlData = LoadKmlFile(fileToLoad, KmlFileType::GeoJson);
       else
         ASSERT(false, ("Unsupported bookmarks extension", ext));
 

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -2089,6 +2089,8 @@ void BookmarkManager::LoadBookmarkRoutine(std::string const & filePath, bool isT
         kmlData = LoadKmlFile(fileToLoad, KmlFileType::Text);
       else if (ext == kGpxExtension)
         kmlData = LoadKmlFile(fileToLoad, KmlFileType::Gpx);
+      else if (ext == kGeoJsonExtension)
+          kmlData = LoadKmlFile(fileToLoad, KmlFileType::GeoJson);
       else
         ASSERT(false, ("Unsupported bookmarks extension", ext));
 

--- a/libs/platform/platform_tests/glaze_test.cpp
+++ b/libs/platform/platform_tests/glaze_test.cpp
@@ -1,6 +1,6 @@
 #include "testing/testing.hpp"
 
-#include "glaze/json.hpp"
+#include <glaze/json.hpp>
 
 #include <optional>
 #include <string>

--- a/xcode/kml/kml.xcodeproj/project.pbxproj
+++ b/xcode/kml/kml.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		45E456142058509200D9F45E /* testingmain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45E456122058508C00D9F45E /* testingmain.cpp */; };
 		464344F3294F952700984CB7 /* gpx_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 464344F2294F952700984CB7 /* gpx_tests.cpp */; };
 		46AA9E60294549B000ECED73 /* serdes_gpx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 464BD0FB294546B20011955A /* serdes_gpx.cpp */; };
+		859113D62227E6252DCB19C5 /* serdes_geojson.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C0232A44C3B0B3F5CF24DD9 /* serdes_geojson.cpp */; };
 		ACBAA59E2E47C53800769B1B /* color_parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ACBAA59D2E47C53800769B1B /* color_parser.cpp */; };
 		ACDD8A7B2A73684F000F2C43 /* serdes_common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ACDD8A782A736045000F2C43 /* serdes_common.cpp */; };
 		E2AA225E25275C6B002589E2 /* minzoom_quadtree_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E2AA225C25275C6B002589E2 /* minzoom_quadtree_tests.cpp */; };
@@ -61,6 +62,8 @@
 		464344F2294F952700984CB7 /* gpx_tests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = gpx_tests.cpp; sourceTree = "<group>"; };
 		464BD0FB294546B20011955A /* serdes_gpx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.cpp.cpp; path = serdes_gpx.cpp; sourceTree = "<group>"; };
 		464BD0FC294546B20011955A /* serdes_gpx.hpp */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.cpp.h; path = serdes_gpx.hpp; sourceTree = "<group>"; };
+		4C0232A44C3B0B3F5CF24DD9 /* serdes_geojson.cpp */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.cpp.cpp; path = serdes_geojson.cpp; sourceTree = "<group>"; };
+		4C0232A54C3B0B3F5CF24DD9 /* serdes_geojson.hpp */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.cpp.h; path = serdes_geojson.hpp; sourceTree = "<group>"; };
 		ACBAA59C2E47C53800769B1B /* color_parser.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = color_parser.hpp; sourceTree = "<group>"; };
 		ACBAA59D2E47C53800769B1B /* color_parser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = color_parser.cpp; sourceTree = "<group>"; };
 		ACDD8A772A736045000F2C43 /* serdes_common.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = serdes_common.hpp; sourceTree = "<group>"; };
@@ -149,6 +152,8 @@
 				ACDD8A772A736045000F2C43 /* serdes_common.hpp */,
 				464BD0FB294546B20011955A /* serdes_gpx.cpp */,
 				464BD0FC294546B20011955A /* serdes_gpx.hpp */,
+				4C0232A44C3B0B3F5CF24DD9 /* serdes_geojson.cpp */,
+				4C0232A54C3B0B3F5CF24DD9 /* serdes_geojson.hpp */,
 				4568C86320BD455600E2192B /* type_utils.cpp */,
 				45E4558F20584AB900D9F45E /* type_utils.hpp */,
 				E2DC9C8925264E0C0098174E /* types_v3.hpp */,
@@ -287,6 +292,7 @@
 				464344F3294F952700984CB7 /* gpx_tests.cpp in Sources */,
 				4568C86420BD455700E2192B /* type_utils.cpp in Sources */,
 				46AA9E60294549B000ECED73 /* serdes_gpx.cpp in Sources */,
+				859113D62227E6252DCB19C5 /* serdes_geojson.cpp in Sources */,
 				ACBAA59E2E47C53800769B1B /* color_parser.cpp in Sources */,
 				45E4559520584ABA00D9F45E /* serdes.cpp in Sources */,
 				E2DC9C9125264E3E0098174E /* types.cpp in Sources */,


### PR DESCRIPTION
Added base support for GeoJson format

### How to test:

Here are 2 test files: [GeoJson-test-files.zip](https://github.com/user-attachments/files/21982502/GeoJson-test-files.zip).

Pick a KML file. Open https://geojson.io and drop KML file on the Globe. Website will generate GeoJson file for you. Import generated GeoJson into OM. Styling information usually is lost during such convertion.

### Limitations:

#### Multiple specifications

GeoJson [specification](https://datatracker.ietf.org/doc/html/rfc7946) doesn't specify all aspects of bookmarks and tracks. No mention of colors or labels or multilanguage. It defines how geometry should be parsed and how to attach properties to it. Different tools generate different GeoJson properties.

| GeoJson.io | [UMap](https://umap.openstreetmap.fr) |
| --- | --- |
| <pre>{<br/>  "type": "Feature",<br/>  "geometry": {<br/>    "type": "Point",<br/>    "coordinates": [<br/>      30.575644936166213,<br/>      50.441704674448374<br/>    ]<br/>  },<br/>  "properties": {<br/>    "name": "Island",<br/>    "marker-color": "green"<br/>  }<br/>}</pre> | <pre>{<br/>  "type": "Feature",<br/>  "geometry": {<br/>    "type": "Point",<br/>    "coordinates": [<br/>      30.575644936166213,<br/>      50.441704674448374<br/>    ]<br/>  },<br/>  "properties": {<br/>    "name": "Hello world",<br/>    "decription": "My first bookmark"<br/>    "_umap_options": {<br/>      "iconClass": "Drop",<br/>      "color": "MediumSeaGreen"<br/>    },<br/>  }<br/>}</pre> |

Differences in properties should be handled correctly.

#### No common styling

There are unofficial GeoJson extensions: by [Mapbox](https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0), by [HERE.com](https://www.here.com/docs/bundle/data-inspector-library-developer-guide/page/pages/style-geojson-visualization.html), from [OSM Wiki](https://wiki.openstreetmap.org/wiki/Geojson_CSS). **I added limited support of MapBox styling**: colors are parsed from properties.

### How parsing works

<img width="500" alt="Geojson parsing scheme" src="https://github.com/user-attachments/assets/9394ed1e-49f5-429b-8dd0-1658594725b3" />

Glaze is used to map GeoJson string into fields of `GeoJsonData`, `GeoJsonFeature`, `GeoJsonGeometry`.

There are two places where Glaze could not handle complex structures:

#### Parsing GeoJson geometry

There are multiple types of geometries:

1. Point:
    ```json
    "geometry": {
      "coordinates": [
        30.575644936166213,
        50.441704674448374
      ],
    }

2. Line:
    ```json
    "geometry": {
      "type": "LineString",
      "coordinates": [
        [ 30.51327567164668, 50.463797474352845 ],
        [ 30.53186054045287, 50.47910894770112 ],
        ...
        [ 30.598519951011752, 50.46328111556454 ]
      ]
    }
3. Polygon, Multiplogon, MultiPoint, MultiLineString, GeometryCollection (unsupported)

And `coordinates` field could be either `vector<double>` or `vector<vector<double>>`. Glaze can't deduce such variance. ~So I decode `coordinates` into `vector<glz::json_t>`. And later we can check what type of JSON object is stored in `glz::json_t` value: array or number.~

Different coordinates formats are parsed using two structures `GeoJsonGeometryPoint`, `GeoJsonGeometryLine` united with `std::variant`. [Tagged Object Types](https://github.com/stephenberry/glaze/blob/main/docs/variant-handling.md#deduction-of-tagged-object-types) feature of Glaze helps to deduce actual type from "type" property.

#### Parsing GeoJson properties

Properties are very hard to parse in a good old C++ way:

**Option A:** mixture of string, float and integer values
```json
  "properties": {
    "name": "Hiking trail",
    "fill-opacity": 0.5,
    "fill": "#ff0000",
    "stroke-opacity": 1,
    "stroke": "#ff0000",
    "stroke-width": 3
  }
```

**Option B:** nested structures
```json
"properties": {
    "name": "Pub",
    "_umap_options": {
        "iconClass": "Drop",
        "color": "MediumSeaGreen"
    },
},
```

**Option C:** nested structures from HERE.com
```json
"properties": {
    "tooltip": "I'm here",
    "style": {
        "color": "blue",
        "hoverColor": "lightblue",
        "hoverOpacity": 0.75
    },
    "width": "7px"
    "featureTags": ["tag"] // Arrays???
}
```

Here Glaze converts `properties` structure into `map<string, glz::json_t>`. And later we analyze `glz::json_t` object to deduce it's type and value.

### Update 2025-09-27:

Added support for GeoJson import to iOS.

### Questions

#### Q1: What about colors?

Current implementation converts colors into hex values `kml::ColorData{.m_rgba = 0x0000FFFF}`. But OM doesn't support custom bookmark colors. Only predefined `kml::ColorData{.m_predefinedColor = PredefinedColor::Blue}`. Should we convert hex colors into predefined colors? Or custom colors will be supported soon?

**Update:** HEX colors for bookmarks are converted to nearest PredefinedColor using `kml::MapPredefinedColor` function.

#### Q2: Is it time to rename `kml` folder?

Folder `libs/kml` contains code to parse KML, KMB, GPX, GeoJson formats. Should we rename it to `serdes`, `export_import`?

#### Q3: UMap UI supports too many colors.

Umap supports 147 CSS colors (see [utils.js](https://github.com/umap-project/umap/blob/master/umap/static/umap/js/modules/utils.js#L513)). `kml::ParseColor` supports 38 colors.

OM and umap has 34 common colors. OM missed 113 colors. For example:

- lightyellow
- salmon
- snow
- blanchedalmond
- bisque
- darkslategray
- mediumvioletred
- peachpuff

OM converts unknown colors to default "red". Should we support more CSS colors?