### PR TITLE
[gpx] Save bookmark color to gpx export

### DIFF
--- a/data/test_data/gpx/export_test.gpx
+++ b/data/test_data/gpx/export_test.gpx
@@ -19,6 +19,12 @@
     <xsi:gpx><color>#FF00FF00</color></xsi:gpx>
   </extensions>
 </wpt>
+<wpt lat="48.209849" lon="16.376029">
+  <name>Point with color</name>
+  <extensions>
+    <xsi:gpx><color>#FFFFC800</color></xsi:gpx>
+  </extensions>
+</wpt>
 <trk>
   <name>Some random route</name>
   <extensions>

--- a/data/test_data/gpx/export_test.gpx
+++ b/data/test_data/gpx/export_test.gpx
@@ -15,6 +15,9 @@
 <wpt lat="48.209847" lon="16.376028">
   <name><![CDATA[Point cdata name ><&"]]></name>
   <desc><![CDATA[Point cdata desc ><&"]]></desc>
+  <extensions>
+    <xsi:gpx><color>#FF00FF00</color></xsi:gpx>
+  </extensions>
 </wpt>
 <trk>
   <name>Some random route</name>

--- a/data/test_data/gpx/point_with_predefined_color_1.gpx
+++ b/data/test_data/gpx/point_with_predefined_color_1.gpx
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="Organic Maps" xmlns="http://www.topografix.com/GPX/1/1"
+    xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3"
+    xmlns:gpx_style="http://www.topografix.com/GPX/gpx_style/0/2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd http://www.topografix.com/GPX/gpx_style/0/2 https://www.topografix.com/GPX/gpx_style/0/2/gpx_style.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 https://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd">
+<metadata>
+</metadata>
+<wpt lat="48.209846" lon="16.376023">
+  <name>Point 1</name>
+  <desc>Point 1</desc>
+</wpt>
+</gpx>

--- a/data/test_data/gpx/point_with_predefined_color_2.gpx
+++ b/data/test_data/gpx/point_with_predefined_color_2.gpx
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="Organic Maps" xmlns="http://www.topografix.com/GPX/1/1"
+    xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3"
+    xmlns:gpx_style="http://www.topografix.com/GPX/gpx_style/0/2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd http://www.topografix.com/GPX/gpx_style/0/2 https://www.topografix.com/GPX/gpx_style/0/2/gpx_style.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 https://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd">
+<metadata>
+</metadata>
+<wpt lat="48.209846" lon="16.376023">
+  <name>Point 1</name>
+  <desc>Point 1</desc>
+  <extensions>
+    <xsi:gpx><color>#FF0066CC</color></xsi:gpx>
+  </extensions>
+</wpt>
+</gpx>

--- a/libs/kml/color_parser.cpp
+++ b/libs/kml/color_parser.cpp
@@ -1,6 +1,7 @@
 #include "color_parser.hpp"
 
 #include "coding/hex.hpp"
+#include "types.hpp"
 
 #include "base/string_utils.hpp"
 
@@ -29,6 +30,98 @@ std::optional<uint32_t> ParseHexColor(std::string_view c)
   case 4: return ToRGBA(colorBytes[1], colorBytes[2], colorBytes[3], colorBytes[0]);
   default: return {};
   }
+}
+
+std::tuple<int, int, int> ExtractRGB(uint32_t color)
+{
+  return {(color >> 24) & 0xFF, (color >> 16) & 0xFF, (color >> 8) & 0xFF};
+}
+
+
+static int ColorDistance(uint32_t color1, uint32_t color2)
+{
+  auto const [r1, g1, b1] = ExtractRGB(color1);
+  auto const [r2, g2, b2] = ExtractRGB(color2);
+  return (r1 - r2) * (r1 - r2) + (g1 - g2) * (g1 - g2) + (b1 - b2) * (b1 - b2);
+}
+
+struct RGBAToGarmin
+{
+  uint32_t rgba;
+  std::string_view color;
+};
+
+auto constexpr kRGBAToGarmin = std::to_array<RGBAToGarmin>({{0x000000ff, "Black"},
+                                                            {0x8b0000ff, "DarkRed"},
+                                                            {0x006400ff, "DarkGreen"},
+                                                            {0xb5b820ff, "DarkYellow"},
+                                                            {0x00008bff, "DarkBlue"},
+                                                            {0x8b008bff, "DarkMagenta"},
+                                                            {0x008b8bff, "DarkCyan"},
+                                                            {0xccccccff, "LightGray"},
+                                                            {0x444444ff, "DarkGray"},
+                                                            {0xff0000ff, "Red"},
+                                                            {0x00ff00ff, "Green"},
+                                                            {0xffff00ff, "Yellow"},
+                                                            {0x0000ffff, "Blue"},
+                                                            {0xff00ffff, "Magenta"},
+                                                            {0x00ffffff, "Cyan"},
+                                                            {0xffffffff, "White"}});
+
+std::string_view MapGarminColor(uint32_t rgba)
+{
+  std::string_view closestColor = kRGBAToGarmin[0].color;
+  auto minDistance = std::numeric_limits<int>::max();
+  for (auto const & [rgbaGarmin, color] : kRGBAToGarmin)
+  {
+    auto const distance = ColorDistance(rgba, rgbaGarmin);
+
+    if (distance == 0)
+      return color;  // Exact match.
+
+    if (distance < minDistance)
+    {
+      minDistance = distance;
+      closestColor = color;
+    }
+  }
+  return closestColor;
+}
+
+struct RGBAToPredefined
+{
+  uint32_t rgba;
+  PredefinedColor predefinedColor;
+};
+
+static std::array<RGBAToPredefined, kOrderedPredefinedColors.size()> buildRGBAToPredefined()
+{
+  auto res = std::array<RGBAToPredefined, kOrderedPredefinedColors.size()>();
+  for (size_t i = 0; i < kOrderedPredefinedColors.size(); ++i)
+    res[i] = {ColorFromPredefinedColor(kOrderedPredefinedColors[i]).GetRGBA(), kOrderedPredefinedColors[i]};
+  return res;
+}
+
+auto const kRGBAToPredefined = buildRGBAToPredefined();
+
+PredefinedColor MapPredefinedColor(uint32_t rgba)
+{
+  auto closestColor = kRGBAToPredefined[0].predefinedColor;
+  auto minDistance = std::numeric_limits<int>::max();
+  for (auto const & [rgbaGarmin, color] : kRGBAToPredefined)
+  {
+    auto const distance = ColorDistance(rgba, rgbaGarmin);
+
+    if (distance == 0)
+      return color;  // Exact match.
+
+    if (distance < minDistance)
+    {
+      minDistance = distance;
+      closestColor = color;
+    }
+  }
+  return closestColor;
 }
 
 // Garmin extensions spec: https://www8.garmin.com/xmlschemas/GpxExtensionsv3.xsd

--- a/libs/kml/color_parser.cpp
+++ b/libs/kml/color_parser.cpp
@@ -32,16 +32,15 @@ std::optional<uint32_t> ParseHexColor(std::string_view c)
   }
 }
 
-std::tuple<int, int, int> ExtractRGB(uint32_t color)
+std::tuple<int, int, int> ExtractRGB(uint32_t rgbaColor)
 {
-  return {(color >> 24) & 0xFF, (color >> 16) & 0xFF, (color >> 8) & 0xFF};
+  return {(rgbaColor >> 24) & 0xFF, (rgbaColor >> 16) & 0xFF, (rgbaColor >> 8) & 0xFF};
 }
 
-
-static int ColorDistance(uint32_t color1, uint32_t color2)
+static int ColorDistance(uint32_t rgbaColor1, uint32_t rgbaColor2)
 {
-  auto const [r1, g1, b1] = ExtractRGB(color1);
-  auto const [r2, g2, b2] = ExtractRGB(color2);
+  auto const [r1, g1, b1] = ExtractRGB(rgbaColor1);
+  auto const [r2, g2, b2] = ExtractRGB(rgbaColor2);
   return (r1 - r2) * (r1 - r2) + (g1 - g2) * (g1 - g2) + (b1 - b2) * (b1 - b2);
 }
 

--- a/libs/kml/color_parser.hpp
+++ b/libs/kml/color_parser.hpp
@@ -4,6 +4,8 @@
 #include <optional>
 #include <string_view>
 
+#include "types.hpp"
+
 namespace kml
 {
 
@@ -17,5 +19,8 @@ constexpr uint32_t ToRGBA(Channel red, Channel green, Channel blue, Channel alph
 std::optional<uint32_t> ParseHexColor(std::string_view c);
 std::optional<uint32_t> ParseGarminColor(std::string_view c);
 std::optional<uint32_t> ParseOSMColor(std::string_view c);
+
+PredefinedColor MapPredefinedColor(uint32_t rgba);
+std::string_view MapGarminColor(uint32_t rgba);
 
 }  // namespace kml

--- a/libs/kml/kml_tests/gpx_tests.cpp
+++ b/libs/kml/kml_tests/gpx_tests.cpp
@@ -1,5 +1,6 @@
 #include "testing/testing.hpp"
 
+#include "kml/color_parser.hpp"
 #include "kml/serdes_common.hpp"
 #include "kml/serdes_gpx.hpp"
 
@@ -413,11 +414,11 @@ UNIT_TEST(ParseFromString)
 
 UNIT_TEST(MapGarminColor)
 {
-  TEST_EQUAL("DarkCyan", kml::gpx::MapGarminColor(0x008b8bff), ());
-  TEST_EQUAL("White", kml::gpx::MapGarminColor(0xffffffff), ());
-  TEST_EQUAL("DarkYellow", kml::gpx::MapGarminColor(0xb4b820ff), ());
-  TEST_EQUAL("DarkYellow", kml::gpx::MapGarminColor(0xb6b820ff), ());
-  TEST_EQUAL("DarkYellow", kml::gpx::MapGarminColor(0xb5b721ff), ());
+  TEST_EQUAL("DarkCyan", kml::MapGarminColor(0x008b8bff), ());
+  TEST_EQUAL("White", kml::MapGarminColor(0xffffffff), ());
+  TEST_EQUAL("DarkYellow", kml::MapGarminColor(0xb4b820ff), ());
+  TEST_EQUAL("DarkYellow", kml::MapGarminColor(0xb6b820ff), ());
+  TEST_EQUAL("DarkYellow", kml::MapGarminColor(0xb5b721ff), ());
 }
 
 }  // namespace gpx_tests

--- a/libs/kml/kml_tests/gpx_tests.cpp
+++ b/libs/kml/kml_tests/gpx_tests.cpp
@@ -38,14 +38,19 @@ static std::string ReadFile(char const * testFile)
   return sourceFileText;
 }
 
-static std::string ReadFileAndSerialize(char const * testFile)
+static std::string Serialize(kml::FileData const & dataFromFile)
 {
-  kml::FileData const dataFromFile = LoadGpxFromFile(testFile);
   std::string resultBuffer;
   MemWriter<decltype(resultBuffer)> sink(resultBuffer);
   kml::gpx::SerializerGpx ser(dataFromFile);
   ser.Serialize(sink);
   return resultBuffer;
+}
+
+static std::string ReadFileAndSerialize(char const * testFile)
+{
+  kml::FileData const dataFromFile = LoadGpxFromFile(testFile);
+  return Serialize(dataFromFile);
 }
 
 void ImportExportCompare(char const * testFile)
@@ -321,6 +326,20 @@ UNIT_TEST(Empty)
   kml::FileData dataFromFile = LoadGpxFromFile("test_data/gpx/empty.gpx");
   TEST_EQUAL("new", dataFromFile.m_categoryData.m_name[kml::kDefaultLang], ());
   TEST_EQUAL(0, dataFromFile.m_tracksData.size(), ());
+}
+
+UNIT_TEST(ImportExportWptColor)
+{
+  ImportExportCompare("test_data/gpx/point_with_predefined_color_2.gpx");
+}
+
+UNIT_TEST(PointWithPredefinedColor)
+{
+  kml::FileData dataFromFile = LoadGpxFromFile("test_data/gpx/point_with_predefined_color_1.gpx");
+  dataFromFile.m_bookmarksData[0].m_color.m_predefinedColor = kml::PredefinedColor::Blue;
+  auto const actual = Serialize(dataFromFile);
+  auto const expected = ReadFile("test_data/gpx/point_with_predefined_color_2.gpx");
+  TEST_EQUAL(expected, actual, ());
 }
 
 UNIT_TEST(OsmandColor1)

--- a/libs/kml/serdes_gpx.cpp
+++ b/libs/kml/serdes_gpx.cpp
@@ -479,7 +479,7 @@ std::array<RGBAToPredefined, kOrderedPredefinedColors.size()> buildRGBAToPredefi
 
 auto const kRGBAToPredefined = gpx::buildRGBAToPredefined();
 
-PredefinedColor MapPredefinedColor(uint32_t rgba)
+static PredefinedColor MapPredefinedColor(uint32_t rgba)
 {
   auto closestColor = kRGBAToPredefined[0].predefinedColor;
   auto minDistance = std::numeric_limits<int>::max();

--- a/libs/kml/serdes_gpx.hpp
+++ b/libs/kml/serdes_gpx.hpp
@@ -106,8 +106,6 @@ private:
   std::string BuildDescription() const;
 };
 
-std::string_view MapGarminColor(uint32_t rgba);
-
 }  // namespace gpx
 
 class DeserializerGpx

--- a/libs/map/bookmark.cpp
+++ b/libs/map/bookmark.cpp
@@ -56,6 +56,7 @@ std::string GetBookmarkIconType(kml::BookmarkIcon const & icon)
 
 std::string const kCustomImageProperty = "CustomImage";
 std::string const kHasElevationProfileProperty = "has_elevation_profile";
+int constexpr kInvalidColor = 0;
 }  // namespace
 
 Bookmark::Bookmark(m2::PointD const & ptOrg) : Base(ptOrg, UserMark::BOOKMARK), m_groupId(kml::kInvalidMarkGroupId)
@@ -219,6 +220,7 @@ void Bookmark::SetColor(kml::PredefinedColor color)
 {
   SetDirty();
   m_data.m_color.m_predefinedColor = color;
+  m_data.m_color.m_rgba = kInvalidColor;
 }
 
 std::string Bookmark::GetPreferredName() const


### PR DESCRIPTION
Fixes #11190
@biodranik, @vng  here is a draft version and I need some advice about implementation.
During the testing I noticed that Bookmarks in OM require PredefinedColor to be set up - looks like there is a difference with tracks and only several colors are supported. 
So some kind on mapping is required, I tried to implement it in kml::gpx::MapPredefinedColor, trying to re-use existing backward mapping (from PredefinedColor to rgb), but I'm not sure it is a good solution.
Also we have quite similar logic to map rgb to GarminColor, but it operates on different type of color.
From your point of view, what implementation we should have here?
