### PR TITLE
[android] Update the Expand of Pop-up

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageViewModel.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageViewModel.java
@@ -3,6 +3,7 @@ package app.organicmaps.widget.placepage;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import app.organicmaps.sdk.bookmarks.data.Bookmark;
 import app.organicmaps.sdk.bookmarks.data.ElevationInfo;
 import app.organicmaps.sdk.bookmarks.data.MapObject;
@@ -16,7 +17,8 @@ public class PlacePageViewModel extends ViewModel
   private final MutableLiveData<Integer> mPlacePageWidth = new MutableLiveData<>();
   private final MutableLiveData<Integer> mPlacePageDistanceToTop = new MutableLiveData<>();
   public boolean isAlertDialogShowing = false;
-
+  // NEW: Store the last place page state
+  private int mLastPlacePageState = BottomSheetBehavior.STATE_COLLAPSED;
   public LiveData<List<PlacePageButtons.ButtonType>> getCurrentButtons()
   {
     return mCurrentButtons;
@@ -55,5 +57,15 @@ public class PlacePageViewModel extends ViewModel
   public void setPlacePageDistanceToTop(int top)
   {
     mPlacePageDistanceToTop.setValue(top);
+  }
+  // NEW: Methods to manage last place page state
+  public int getLastPlacePageState()
+  {
+    return mLastPlacePageState;
+  }
+
+  public void setLastPlacePageState(int state)
+  {
+    mLastPlacePageState = state;
   }
 }


### PR DESCRIPTION
Hi,
This PR updates the expand pop-up function. When a user clicks on any POI, the pop-up will remain expanded for all selected POIs until the user closes either the POI or the pop-up itself. This improves the UI/UX by eliminating the need to repeatedly expand and collapse the pop-up.
Additionally,
to make it clear to the user that the pop-up is expandable, one option could be to change the Bottom Sheet handle icon:
An upward arrow when it is not expanded.
A downward arrow when it is expanded.
This would help users understand that the pop-up is expandable. This feature is not implemented yet, but if you approve, I can add it in the next commit.


BEFORE:-

https://github.com/user-attachments/assets/696407ae-2cb6-461c-a161-e146ad11b740



AFTER



https://github.com/user-attachments/assets/1007a49e-2dd2-4bd0-a93f-6ff181e18cdc

