### PR TITLE
[ios]  Fix crosshair jumping when adding osm place from the place page

### DIFF
--- a/libs/drape_frontend/user_event_stream.cpp
+++ b/libs/drape_frontend/user_event_stream.cpp
@@ -413,8 +413,9 @@ bool UserEventStream::OnSetCenter(ref_ptr<SetCenterEvent> centerEvent)
   m2::PointD const & center = centerEvent->GetCenter();
   auto const zoom = centerEvent->GetZoom();
   auto const scaleFactor = centerEvent->GetScaleFactor();
+  auto const trackVisibleViewport = centerEvent->TrackVisibleViewport();
 
-  if (centerEvent->TrackVisibleViewport())
+  if (trackVisibleViewport)
   {
     m_needTrackCenter = true;
     m_trackedCenter = center;
@@ -425,7 +426,10 @@ bool UserEventStream::OnSetCenter(ref_ptr<SetCenterEvent> centerEvent)
   if (zoom != kDoNotChangeZoom)
   {
     screen.SetFromParams(center, screen.GetAngle(), GetScreenScale(zoom));
-    screen.MatchGandP3d(center, m_visibleViewport.Center());
+    if (trackVisibleViewport)
+      screen.MatchGandP3d(center, m_visibleViewport.Center());
+    else
+      screen.MatchGandP3d(center, screen.PixelRectIn3d().Center());
   }
   else if (scaleFactor > 0.0)
   {
@@ -435,7 +439,10 @@ bool UserEventStream::OnSetCenter(ref_ptr<SetCenterEvent> centerEvent)
   else
   {
     GetTargetScreen(screen);
-    screen.MatchGandP3d(center, m_visibleViewport.Center());
+    if (trackVisibleViewport)
+      screen.MatchGandP3d(center, m_visibleViewport.Center());
+    else
+      screen.MatchGandP3d(center, screen.PixelRectIn3d().Center());
   }
 
   ShrinkAndScaleInto(screen, df::GetWorldRect());


### PR DESCRIPTION
Closes [#10549 ](https://github.com/organicmaps/organicmaps/issues/9122)

### Bug description
While debugging, I found that the crosshair point (screen center) is calculated incorrectly and depends on how much the PP is opened during the add point tap.

Here is what happens when the `add place` is tapped (and the PP is still opened because the animation is not started):
1. `void DrapeEngine::EnableChoosePositionMode` is called
https://github.com/organicmaps/organicmaps/blob/fbb0100c83abf00566e8f0c44884c09322be31b0/libs/drape_frontend/drape_engine.cpp#L653-L673
2. `FrontendRenderer::AcceptMessage` jumps to the `case Message::Type::SetAddNewPlaceMode:`
https://github.com/organicmaps/organicmaps/blob/fbb0100c83abf00566e8f0c44884c09322be31b0/libs/drape_frontend/frontend_renderer.cpp#L797-L820
3. New event `SetCenterEvent` is created in
with `trackVisibleViewport = false` - marker that should skip the actual viewport and use the whole viewport (not clipped by the opened PP)
https://github.com/organicmaps/organicmaps/blob/fbb0100c83abf00566e8f0c44884c09322be31b0/libs/drape_frontend/frontend_renderer.cpp#L810-L813
4. But in the `bool UserEventStream::OnSetCenter(ref_ptr<SetCenterEvent> centerEvent)` the `trackVisibleViewport = false` is taken into account only in the
https://github.com/organicmaps/organicmaps/blob/fbb0100c83abf00566e8f0c44884c09322be31b0/libs/drape_frontend/user_event_stream.cpp#L411-L421
but **skipped** in the calculating the **actual point** to zoom the map
https://github.com/organicmaps/organicmaps/blob/fbb0100c83abf00566e8f0c44884c09322be31b0/libs/drape_frontend/user_event_stream.cpp#L425-L439

At that point, the PP dismissal animation is not finished and the `m_visibleViewport` has the **old value** (smaller than full screen), so the final crosshair point center (zoom point) is incorrect while adding place.

### Solution
This fix ignores the `m_visibleViewport` and uses the full screen size when the `trackVisibleViewport` is disabled.

### Result
![Simulator Screen Recording - iPhone 16 Pro - 2025-08-31 at 21 34 01](https://github.com/user-attachments/assets/717b2e79-60f6-4d6d-bf44-a835284ba58e)
