### PR TITLE
[ios] Refactor PlacePage

### DIFF
--- a/iphone/Maps/Classes/MapViewController.h
+++ b/iphone/Maps/Classes/MapViewController.h
@@ -38,8 +38,7 @@
 - (void)openFullPlaceDescriptionWithHtml:(NSString * _Nonnull)htmlString;
 - (void)openDrivingOptions;
 - (void)showTrackRecordingPlacePage;
-
-- (void)setPlacePageTopBound:(CGFloat)bound duration:(double)duration;
+- (void)setPlacePageTopBound:(CGFloat)bound;
 
 + (void)setViewport:(double)lat lon:(double)lon zoomLevel:(int)zoomlevel;
 

--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -235,7 +235,6 @@ NSString * const kSettingsSegue = @"Map2Settings";
     [self.placePageVC removeFromParentViewController];
     self.placePageVC = nil;
     self.placePageContainer.hidden = YES;
-    [self setPlacePageTopBound:0 duration:0];
   }];
 }
 
@@ -854,7 +853,7 @@ NSString * const kSettingsSegue = @"Map2Settings";
   return _downloadDialog;
 }
 
-- (void)setPlacePageTopBound:(CGFloat)bound duration:(double)duration
+- (void)setPlacePageTopBound:(CGFloat)bound
 {
   self.visibleAreaBottom.constant = bound;
   self.sideButtonsAreaBottom.constant = bound;

--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -229,7 +229,7 @@ NSString * const kSettingsSegue = @"Map2Settings";
 - (void)hideRegularPlacePage
 {
   [self stopObservingTrackRecordingUpdates];
-  [self.placePageVC closeAnimatedWithCompletion:^{
+  [self.placePageVC closeWithCompletion:^{
     [self.placePageVC.view removeFromSuperview];
     [self.placePageVC willMoveToParentViewController:nil];
     [self.placePageVC removeFromParentViewController];

--- a/iphone/Maps/UI/PlacePage/PlacePageBuilder.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageBuilder.swift
@@ -4,10 +4,11 @@
     guard let viewController = storyboard.instantiateInitialViewController() as? PlacePageViewController else {
       fatalError()
     }
+    let mapViewController = MapViewController.shared()!
     viewController.isPreviewPlus = data.isPreviewPlus
     let interactor = PlacePageInteractor(viewController: viewController,
                                          data: data,
-                                         mapViewController: MapViewController.shared()!)
+                                         mapViewController: mapViewController)
     let layout: IPlacePageLayout
     switch data.objectType {
     case .POI, .bookmark:
@@ -21,7 +22,9 @@
     @unknown default:
       fatalError()
     }
-    let presenter = PlacePagePresenter(view: viewController, headerView: layout.headerViewController)
+    let presenter = PlacePagePresenter(view: viewController,
+                                       headerView: layout.headerViewController,
+                                       mapViewController: mapViewController)
     viewController.setLayout(layout)
     viewController.interactor = interactor
     interactor.presenter = presenter
@@ -48,7 +51,9 @@
     @unknown default:
       fatalError()
     }
-    let presenter = PlacePagePresenter(view: viewController, headerView: layout.headerViewController)
+    let presenter = PlacePagePresenter(view: viewController,
+                                       headerView: layout.headerViewController,
+                                       mapViewController: MapViewController.shared()!)
     viewController.interactor = interactor
     interactor.presenter = presenter
     layout.presenter = presenter

--- a/iphone/Maps/UI/PlacePage/PlacePageBuilder.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageBuilder.swift
@@ -4,11 +4,8 @@
     guard let viewController = storyboard.instantiateInitialViewController() as? PlacePageViewController else {
       fatalError()
     }
-    let mapViewController = MapViewController.shared()!
     viewController.isPreviewPlus = data.isPreviewPlus
-    let interactor = PlacePageInteractor(viewController: viewController,
-                                         data: data,
-                                         mapViewController: mapViewController)
+    let interactor = PlacePageInteractor(data: data)
     let layout: IPlacePageLayout
     switch data.objectType {
     case .POI, .bookmark:
@@ -24,7 +21,7 @@
     }
     let presenter = PlacePagePresenter(view: viewController,
                                        headerView: layout.headerViewController,
-                                       mapViewController: mapViewController)
+                                       mapViewController: MapViewController.shared()!)
     viewController.setLayout(layout)
     viewController.interactor = interactor
     interactor.presenter = presenter
@@ -34,9 +31,7 @@
 
   @objc static func update(_ viewController: PlacePageViewController, with data: PlacePageData) {
     viewController.isPreviewPlus = data.isPreviewPlus
-    let interactor = PlacePageInteractor(viewController: viewController,
-                                         data: data,
-                                         mapViewController: MapViewController.shared()!)
+    let interactor = PlacePageInteractor(data: data)
     let layout: IPlacePageLayout
     let storyboard = viewController.storyboard!
     switch data.objectType {

--- a/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
@@ -1,7 +1,7 @@
 protocol PlacePageInteractorProtocol: AnyObject {
   func viewWillAppear()
   func viewWillDisappear()
-  func updateTopBound(_ bound: CGFloat, duration: TimeInterval)
+  func updateTopBound(_ bound: CGFloat)
   func close()
 }
 
@@ -90,8 +90,8 @@ extension PlacePageInteractor: PlacePageInteractorProtocol {
     unsubscribeFromTrackActivePointUpdates()
   }
 
-  func updateTopBound(_ bound: CGFloat, duration: TimeInterval) {
-    presenter?.updateTopBound(bound, duration: duration)
+  func updateTopBound(_ bound: CGFloat) {
+    presenter?.updateTopBound(bound)
   }
 
   func close() {

--- a/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
@@ -2,6 +2,7 @@ protocol PlacePageInteractorProtocol: AnyObject {
   func viewWillAppear()
   func viewWillDisappear()
   func updateTopBound(_ bound: CGFloat, duration: TimeInterval)
+  func close()
 }
 
 class PlacePageInteractor: NSObject {
@@ -95,6 +96,10 @@ extension PlacePageInteractor: PlacePageInteractorProtocol {
 
   func updateTopBound(_ bound: CGFloat, duration: TimeInterval) {
     mapViewController?.setPlacePageTopBound(bound, duration: duration)
+  }
+
+  func close() {
+    presenter?.closeAnimated()
   }
 }
 

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageTrackLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageTrackLayout.swift
@@ -102,7 +102,7 @@ class PlacePageTrackLayout: IPlacePageLayout {
 private extension PlacePageTrackLayout {
   func updateTrackRelatedSections() {
     guard let trackData = placePageData.trackData else {
-      presenter?.closeAnimated()
+      presenter?.close()
       return
     }
     editTrackViewController.data = .track(trackData)

--- a/iphone/Maps/UI/PlacePage/PlacePagePresenter.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePagePresenter.swift
@@ -1,6 +1,6 @@
 protocol PlacePagePresenterProtocol: AnyObject {
   func layoutIfNeeded()
-  func updateTopBound(_ bound: CGFloat, duration: TimeInterval)
+  func updateTopBound(_ bound: CGFloat)
   func updatePreviewOffset()
   func showNextStop()
   func openURL(_ path: String)
@@ -33,8 +33,8 @@ extension PlacePagePresenter: PlacePagePresenterProtocol {
     view.layoutIfNeeded()
   }
 
-  func updateTopBound(_ bound: CGFloat, duration: TimeInterval) {
-    mapViewController?.setPlacePageTopBound(bound, duration: duration)
+  func updateTopBound(_ bound: CGFloat) {
+    mapViewController?.setPlacePageTopBound(bound)
   }
 
   func updatePreviewOffset() {

--- a/iphone/Maps/UI/PlacePage/PlacePagePresenter.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePagePresenter.swift
@@ -10,10 +10,14 @@ protocol PlacePagePresenterProtocol: AnyObject {
 final class PlacePagePresenter: NSObject {
   private weak var view: PlacePageViewProtocol!
   private weak var headerView: PlacePageHeaderViewProtocol!
+  private weak var mapViewController: MapViewController?
 
-  init(view: PlacePageViewProtocol, headerView: PlacePageHeaderViewProtocol) {
+  init(view: PlacePageViewProtocol,
+       headerView: PlacePageHeaderViewProtocol,
+       mapViewController: MapViewController) {
     self.view = view
     self.headerView = headerView
+    self.mapViewController = mapViewController
   }
 }
 
@@ -33,7 +37,7 @@ extension PlacePagePresenter: PlacePagePresenterProtocol {
   }
 
   func closeAnimated() {
-    view.closeAnimated(completion: nil)
+    mapViewController?.dismissPlacePage()
   }
 
   func showAlert(_ alert: UIAlertController) {

--- a/iphone/Maps/UI/PlacePage/PlacePagePresenter.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePagePresenter.swift
@@ -1,16 +1,21 @@
 protocol PlacePagePresenterProtocol: AnyObject {
-  func updatePreviewOffset()
   func layoutIfNeeded()
+  func updateTopBound(_ bound: CGFloat, duration: TimeInterval)
+  func updatePreviewOffset()
   func showNextStop()
-  func closeAnimated()
+  func openURL(_ path: String)
+  func showActivity(_ activity: ActivityViewController, from sourceView: UIView)
   func showAlert(_ alert: UIAlertController)
-  func showShareTrackMenu()
+  func showInfoAlert(title: String, message: String)
+  func showShareSheet(for placePageData: PlacePageData, from sourceView: UIView)
+  func showToast(_ message: String)
+  func close()
 }
 
 final class PlacePagePresenter: NSObject {
   private weak var view: PlacePageViewProtocol!
   private weak var headerView: PlacePageHeaderViewProtocol!
-  private weak var mapViewController: MapViewController?
+  private weak var mapViewController: MapViewController!
 
   init(view: PlacePageViewProtocol,
        headerView: PlacePageHeaderViewProtocol,
@@ -24,27 +29,65 @@ final class PlacePagePresenter: NSObject {
 // MARK: - PlacePagePresenterProtocol
 
 extension PlacePagePresenter: PlacePagePresenterProtocol {
-  func updatePreviewOffset() {
-    view.updatePreviewOffset()
-  }
-
   func layoutIfNeeded() {
     view.layoutIfNeeded()
+  }
+
+  func updateTopBound(_ bound: CGFloat, duration: TimeInterval) {
+    mapViewController?.setPlacePageTopBound(bound, duration: duration)
+  }
+
+  func updatePreviewOffset() {
+    view.updatePreviewOffset()
   }
 
   func showNextStop() {
     view.showNextStop()
   }
 
-  func closeAnimated() {
-    mapViewController?.dismissPlacePage()
+  func showActivity(_ activity: ActivityViewController, from sourceView: UIView) {
+    activity.present(inParentViewController: mapViewController, anchorView: sourceView)
+  }
+
+  func showShareSheet(for placePageData: PlacePageData, from sourceView: UIView) {
+    switch placePageData.objectType {
+    case .POI, .bookmark:
+      let shareViewController = ActivityViewController.share(forPlacePage: placePageData)
+      shareViewController.present(inParentViewController: mapViewController, anchorView: sourceView)
+    case .track:
+      headerView.showShareTrackMenu()
+    default:
+      guard let coordinates = LocationManager.lastLocation()?.coordinate else {
+        view?.showAlert(UIAlertController.unknownCurrentPosition())
+        return
+      }
+      let activity = ActivityViewController.share(forMyPosition: coordinates)
+      activity.present(inParentViewController: mapViewController, anchorView: sourceView)
+    }
   }
 
   func showAlert(_ alert: UIAlertController) {
+    guard let view else { return }
+    iPadSpecific {
+      alert.popoverPresentationController?.sourceView = view.view
+      alert.popoverPresentationController?.sourceRect = view.view.frame
+    }
     view.showAlert(alert)
   }
 
-  func showShareTrackMenu() {
-    headerView.showShareTrackMenu()
+  func showInfoAlert(title: String, message: String) {
+    MWMAlertViewController.activeAlert().presentInfoAlert(title, text: message)
+  }
+
+  func openURL(_ path: String) {
+    mapViewController?.openUrl(path, externally: true)
+  }
+
+  func showToast(_ message: String) {
+    Toast.show(withText: message, alignment: .bottom)
+  }
+
+  func close() {
+    mapViewController?.dismissPlacePage()
   }
 }

--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -272,7 +272,7 @@ final class PlacePageScrollView: UIScrollView {
     let scrollPosition = CGPoint(x: point.x, y: min(scrollView.contentSize.height - scrollView.height, point.y))
     let bound = view.height + scrollPosition.y
     if animated {
-      updateTopBound(bound, duration: kDefaultAnimationDuration)
+      updateTopBound(bound)
       UIView.animate(withDuration: kDefaultAnimationDuration, animations: { [weak scrollView] in
         scrollView?.contentOffset = scrollPosition
         self.layoutIfNeeded()
@@ -293,9 +293,9 @@ final class PlacePageScrollView: UIScrollView {
     }
   }
 
-  private func updateTopBound(_ bound: CGFloat, duration: TimeInterval) {
+  private func updateTopBound(_ bound: CGFloat) {
     alternativeSizeClass(iPhone: {
-      interactor?.updateTopBound(bound, duration: duration)
+      interactor?.updateTopBound(bound)
     }, iPad: {})
   }
 }
@@ -339,20 +339,23 @@ extension PlacePageViewController: PlacePageViewProtocol {
 
   @objc
   func close(completion: @escaping (() -> Void)) {
-    print(#function)
     view.isUserInteractionEnabled = false
+    let onCloseCompletion = {
+      self.interactor?.updateTopBound(.zero)
+      completion()
+    }
     alternativeSizeClass(iPhone: {
       self.scrollTo(CGPoint(x: 0, y: -self.scrollView.height + 1),
                     forced: true,
-                    completion: completion)
+                    completion: onCloseCompletion)
     }, iPad: {
       UIView.animate(withDuration: kDefaultAnimationDuration,
                      animations: {
         let frame = self.view.frame
         self.view.minX = frame.minX - frame.width
         self.view.alpha = 0
-      }) { complete in
-        completion()
+      }) { _ in
+        onCloseCompletion()
       }
     })
   }
@@ -372,7 +375,7 @@ extension PlacePageViewController: UIScrollViewDelegate {
     onOffsetChanged(scrollView.contentOffset.y)
 
     let bound = view.height + scrollView.contentOffset.y
-    updateTopBound(bound, duration: 0)
+    updateTopBound(bound)
   }
 
   func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {

--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -1,5 +1,6 @@
 protocol PlacePageViewProtocol: AnyObject {
   var interactor: PlacePageInteractorProtocol? { get set }
+  var view: UIView! { get }
 
   func setLayout(_ layout: IPlacePageLayout)
   func updatePreviewOffset()


### PR DESCRIPTION
This PR:
1. Doesn't change the behavior
2. Move all UI code from the `Interactor` to the to `Presenter` to follow the clear `view-interactor-presenter` pattern. Remove all UI-related references from the `Interactor` that should only handle the business logic and call the `presenter` to update the view.
3. Remove unused duration arg from the PPVC related methods
4. Refactor PP closing (in the master the close method is called 3 times for just 1 close)