### PR TITLE
[github] Fix Android release publishing

### DIFF
--- a/.github/workflows/android-release.yaml
+++ b/.github/workflows/android-release.yaml
@@ -60,6 +60,8 @@ jobs:
     name: Android Release
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: write  # To publish the release on GitHub Releases.
     needs: tag
     strategy:
       fail-fast: false


### PR DESCRIPTION
Fixes this: https://github.com/organicmaps/organicmaps/actions/runs/17365235074/job/49290996349

Documentation says that `contents: write` or `contents: write` + `workflows: write` should be enough. Let's start with less permissions:
https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release