### PR TITLE
Fix bookmark color change

### DIFF
--- a/libs/kml/kml_tests/gpx_tests.cpp
+++ b/libs/kml/kml_tests/gpx_tests.cpp
@@ -311,6 +311,13 @@ UNIT_TEST(Color)
   TEST_EQUAL(dataFromFile.m_tracksData.size(), 3, ());
 }
 
+UNIT_TEST(ParseExportedGpxColor)
+{
+  kml::FileData const dataFromFile = LoadGpxFromFile("test_data/gpx/point_with_predefined_color_2.gpx");
+  TEST_EQUAL(0x0066CCFF, dataFromFile.m_bookmarksData[0].m_color.m_rgba, ());
+  TEST_EQUAL(kml::PredefinedColor::Blue, dataFromFile.m_bookmarksData[0].m_color.m_predefinedColor, ());
+}
+
 UNIT_TEST(MultiTrackNames)
 {
   kml::FileData dataFromFile = LoadGpxFromFile("test_data/gpx/color.gpx");

--- a/libs/map/bookmark.cpp
+++ b/libs/map/bookmark.cpp
@@ -216,11 +216,16 @@ kml::PredefinedColor Bookmark::GetColor() const
   return m_data.m_color.m_predefinedColor;
 }
 
+void Bookmark::InvalidateRGBAColor()
+{
+  m_data.m_color.m_rgba = kInvalidColor;
+}
+
 void Bookmark::SetColor(kml::PredefinedColor color)
 {
   SetDirty();
   m_data.m_color.m_predefinedColor = color;
-  m_data.m_color.m_rgba = kInvalidColor;
+  InvalidateRGBAColor();
 }
 
 std::string Bookmark::GetPreferredName() const

--- a/libs/map/bookmark.hpp
+++ b/libs/map/bookmark.hpp
@@ -40,6 +40,7 @@ public:
   void SetCustomName(std::string const & customName);
 
   kml::PredefinedColor GetColor() const;
+  void InvalidateRGBAColor();
   void SetColor(kml::PredefinedColor color);
 
   m2::RectD GetViewport() const;

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -2240,7 +2240,10 @@ void BookmarkManager::UpdateBookmark(kml::MarkId bmID, kml::BookmarkData const &
   ASSERT(bookmark->GetGroupId() != kml::kInvalidMarkGroupId, ());
 
   if (prevColor != bookmark->GetColor())
+  {
+    bookmark->InvalidateRGBAColor();
     SetLastEditedBmColor(bookmark->GetColor());
+  }
 }
 
 void BookmarkManager::ChangeTrackColor(kml::TrackId trackId, dp::Color color)

--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -371,6 +371,27 @@ UNIT_TEST(Bookmarks_Timestamp)
   DeleteCategoryFiles(arrCat);
 }
 
+UNIT_TEST(Bookmarks_ChangeColorForImportedBookmark)
+{
+  Framework fm(kFrameworkParams);
+  BookmarkManager & bmManager = fm.GetBookmarkManager();
+  bmManager.EnableTestMode(true);
+
+  auto const cat1 = bmManager.CreateBookmarkCategory("cat1", false /* autoSave */);
+  kml::BookmarkData bm1;
+  kml::SetDefaultStr(bm1.m_name, "1");
+  bm1.m_point = m2::PointD(38, 20);
+  bm1.m_color.m_predefinedColor = kml::PredefinedColor::Blue;
+  bm1.m_color.m_rgba = 0x0066CCFF;
+  auto const * pBm1 = bmManager.GetEditSession().CreateBookmark(std::move(bm1), cat1);
+  bm1.m_color.m_predefinedColor = kml::PredefinedColor::Orange;
+  bmManager.GetEditSession().UpdateBookmark(pBm1->GetId(), bm1);
+  bmManager.SaveBookmarkCategory(cat1);
+  pBm1 = bmManager.GetBookmark(pBm1->GetId());
+  TEST_EQUAL(pBm1->GetData().m_color.m_predefinedColor, kml::PredefinedColor::Orange, ());
+  TEST_EQUAL(pBm1->GetData().m_color.m_rgba, 0, ());
+}
+
 UNIT_TEST(Bookmarks_Getting)
 {
   Framework fm(kFrameworkParams);


### PR DESCRIPTION
Follow-up for #11238 
SetColor was not called actually, so reset of internal state was not done properly.
Fixed it and added the test.