### PR TITLE
[ios] [map] Remove `DeactivateMapSelection` on Save osm edits

### DIFF
--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -3114,10 +3114,6 @@ osm::Editor::SaveResult Framework::SaveEditedMapObject(osm::EditableMapObject em
 
   auto const result = osm::Editor::Instance().SaveEditedFeature(emo);
 
-  // Automatically select newly created and edited objects.
-  if (m_currentPlacePageInfo)
-    DeactivateMapSelection();
-
   place_page::BuildInfo info;
   info.m_mercator = emo.GetMercator();
   info.m_featureId = emo.GetID();


### PR DESCRIPTION
### Bug description:
When the user taps on `Save` in the OSM Editor both screens are closed: Editor and PP. But the PP should be visible and display updated info:

https://github.com/user-attachments/assets/a949e04d-2036-4d65-ab80-079e3250ea3e


### Solution:
The call of `DeactivateMapSelection` is redundant because it tries to close the current PP at first (before rebuilding the PP). It produces buggy behaviour on the iOS: the PP is closed and does not have time to open to respond to the `ActivateMapSelection` call. 
The PP should only be updated using the `ActivateMapSelection`.

I've tested the changes on the Android and it works OK.

@organicmaps/android  Can you please confirm that nothing is broken?

https://github.com/user-attachments/assets/390ae0b2-7fe5-4b0e-96f6-5ebb88ffc3a6

https://github.com/user-attachments/assets/b9332e30-280d-4f15-9108-7fba42b88448

