### PR TITLE
[android] Show again missed bookmark subtitle with underlying types

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -372,7 +372,7 @@ public class PlacePageView extends Fragment
       refreshDistanceToObject(loc);
     UiUtils.hideIf(mMapObject.isTrack(), mFrame.findViewById(R.id.ll__place_latlon),
                    mFrame.findViewById(R.id.ll__place_open_in));
-    if (mMapObject.isTrack() || mMapObject.isBookmark())
+    if (mMapObject.isTrack())
     {
       UiUtils.hide(mTvSubtitle);
       UiUtils.hide(mTvAzimuth, mAvDirection, mTvDistance);

--- a/libs/map/place_page_info.cpp
+++ b/libs/map/place_page_info.cpp
@@ -142,13 +142,6 @@ std::string Info::FormatSubtitle(bool withTypes, bool withMainType) const
     result += sv;
   };
 
-/// @todo(KK): Remove, when the category name will be displayed in the "Edit cell" on the Place Page on the specific
-/// platform.
-#if !defined(TARGET_OS_IPHONE)
-  if (IsBookmark())
-    append(m_bookmarkCategoryName);
-#endif
-
   if (!withTypes)
     return result;
 
@@ -264,11 +257,6 @@ void Info::SetTitlesForBookmark()
   m_uiTitle = GetBookmarkName();
 
   std::vector<std::string> subtitle;
-/// @todo(KK): Remove, when the category name will be displayed in the "edit" of the cell on the Place Page on the
-/// specific platform.
-#if !defined(TARGET_OS_IPHONE)
-  subtitle.push_back(m_bookmarkCategoryName);
-#endif
   if (!m_bookmarkData.m_featureTypes.empty())
     subtitle.push_back(GetLocalizedFeatureType(m_bookmarkData.m_featureTypes));
   m_uiSubtitle = strings::JoinStrings(subtitle, feature::kFieldsSeparator);
@@ -287,11 +275,6 @@ void Info::SetCustomName(std::string const & name)
 void Info::SetTitlesForTrack(Track const & track)
 {
   m_uiTitle = track.GetName();
-/// @todo(KK): Remove, when the category name will be displayed in the "Edit cell" on the Place Page on the specific
-/// platform.
-#if !defined(TARGET_OS_IPHONE)
-  m_uiSubtitle = m_bookmarkCategoryName;
-#endif
 
   std::vector<std::string> statistics;
   auto const length = track.GetLengthMeters();

--- a/libs/map/place_page_info.hpp
+++ b/libs/map/place_page_info.hpp
@@ -250,7 +250,7 @@ private:
   kml::MarkGroupId m_markGroupId = kml::kInvalidMarkGroupId;
   /// If not invalid, bookmark is bound to this place page.
   kml::MarkId m_bookmarkId = kml::kInvalidMarkId;
-  /// Bookmark category name. Empty, if it's not bookmark;
+  /// Bookmark category name. Empty, if it's not bookmark; used only on iOS now.
   std::string m_bookmarkCategoryName;
   kml::BookmarkData m_bookmarkData;
   /// If not invalid, track is bound to this place page.


### PR DESCRIPTION
Fixes #11210

Need to test, also need to filter out duplicate subtitle == title for bookmarks.