### PR TITLE
[android] Reduce the height of the Place Plage preview by removing azimuth to north

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/DirectionFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/DirectionFragment.java
@@ -32,6 +32,7 @@ public class DirectionFragment extends BaseMwmDialogFragment implements Location
   private TextView mTvDistance;
   private TextView mTvAzimuth;
 
+  // It is always non-null, initialized immediately after creating this fragment.
   private MapObject mMapObject;
 
   @Override
@@ -78,7 +79,7 @@ public class DirectionFragment extends BaseMwmDialogFragment implements Location
     });
   }
 
-  public void setMapObject(MapObject object)
+  public void setMapObject(@NonNull MapObject object)
   {
     mMapObject = object;
     refreshViews();
@@ -86,6 +87,7 @@ public class DirectionFragment extends BaseMwmDialogFragment implements Location
 
   private void refreshViews()
   {
+    // TODO(AB): Remove unnecessary null check.
     if (mMapObject != null && isResumed())
     {
       mTvTitle.setText(mMapObject.getTitle());
@@ -107,8 +109,8 @@ public class DirectionFragment extends BaseMwmDialogFragment implements Location
   public void onPause()
   {
     super.onPause();
-    MwmApplication.from(requireContext()).getLocationHelper().removeListener(this);
     MwmApplication.from(requireContext()).getSensorHelper().removeListener(this);
+    MwmApplication.from(requireContext()).getLocationHelper().removeListener(this);
   }
 
   @Override
@@ -121,11 +123,13 @@ public class DirectionFragment extends BaseMwmDialogFragment implements Location
   @Override
   public void onLocationUpdated(@NonNull Location location)
   {
+    // TODO(AB): Remove unnecessary null check.
     if (mMapObject != null)
     {
       final DistanceAndAzimut distanceAndAzimuth = Framework.nativeGetDistanceAndAzimuthFromLatLon(
           mMapObject.getLat(), mMapObject.getLon(), location.getLatitude(), location.getLongitude(), 0.0);
       mTvDistance.setText(distanceAndAzimuth.getDistance().toString(requireContext()));
+      mTvAzimuth.setText(StringUtils.formatUsingUsLocale("%.0f°", Math.toDegrees(distanceAndAzimuth.getAzimuth())));
     }
   }
 
@@ -133,6 +137,7 @@ public class DirectionFragment extends BaseMwmDialogFragment implements Location
   public void onCompassUpdated(double north)
   {
     final Location last = MwmApplication.from(requireContext()).getLocationHelper().getSavedLocation();
+    // TODO(AB): Remove unnecessary null check.
     if (last == null || mMapObject == null)
       return;
 
@@ -140,11 +145,6 @@ public class DirectionFragment extends BaseMwmDialogFragment implements Location
         mMapObject.getLat(), mMapObject.getLon(), last.getLatitude(), last.getLongitude(), north);
 
     if (da.getAzimuth() >= 0)
-    {
       mAvDirection.setAzimuth(da.getAzimuth());
-      final DistanceAndAzimut daAbs = Framework.nativeGetDistanceAndAzimuthFromLatLon(
-          mMapObject.getLat(), mMapObject.getLon(), last.getLatitude(), last.getLongitude(), 0.0);
-      mTvAzimuth.setText(StringUtils.formatUsingUsLocale("%.0f°", Math.toDegrees(daAbs.getAzimuth())));
-    }
   }
 }

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -108,7 +108,6 @@ public class PlacePageView extends Fragment
   private TextView mTvSubtitle;
   private ArrowView mAvDirection;
   private TextView mTvDistance;
-  private TextView mTvAzimuth;
   private TextView mTvAddress;
   // Details.
   private TextView mTvLatlon;
@@ -246,11 +245,9 @@ public class PlacePageView extends Fragment
 
     View directionFrame = mPreview.findViewById(R.id.direction_frame);
     mTvDistance = mPreview.findViewById(R.id.tv__straight_distance);
-    mTvAzimuth = mPreview.findViewById(R.id.tv__azimuth);
     mAvDirection = mPreview.findViewById(R.id.av__direction);
     UiUtils.hide(mTvDistance);
     UiUtils.hide(mAvDirection);
-    UiUtils.hide(mTvAzimuth);
     directionFrame.setOnClickListener(this);
 
     mTvAddress = mPreview.findViewById(R.id.tv__address);
@@ -373,10 +370,7 @@ public class PlacePageView extends Fragment
     UiUtils.hideIf(mMapObject.isTrack(), mFrame.findViewById(R.id.ll__place_latlon),
                    mFrame.findViewById(R.id.ll__place_open_in));
     if (mMapObject.isTrack())
-    {
       UiUtils.hide(mTvSubtitle);
-      UiUtils.hide(mTvAzimuth, mAvDirection, mTvDistance);
-    }
   }
 
   private <T extends Fragment> void updateViewFragment(Class<T> controllerClass, String fragmentTag,
@@ -727,7 +721,6 @@ public class PlacePageView extends Fragment
   {
     UiUtils.hide(mTvDistance);
     UiUtils.hide(mAvDirection);
-    UiUtils.hide(mTvAzimuth);
 
     if (l == null)
       return;
@@ -750,7 +743,6 @@ public class PlacePageView extends Fragment
     if (mMapObject.isTrack())
       return;
     UiUtils.showIf(l != null, mTvDistance);
-    UiUtils.showIf(l != null, mTvAzimuth);
     if (l == null)
       return;
 
@@ -759,7 +751,6 @@ public class PlacePageView extends Fragment
     DistanceAndAzimut distanceAndAzimuth =
         Framework.nativeGetDistanceAndAzimuthFromLatLon(lat, lon, l.getLatitude(), l.getLongitude(), 0.0);
     mTvDistance.setText(distanceAndAzimuth.getDistance().toString(requireContext()));
-    mTvAzimuth.setText(StringUtils.formatUsingUsLocale("%.0f°", Math.toDegrees(distanceAndAzimuth.getAzimuth())));
   }
 
   private void refreshLatLon()

--- a/android/app/src/main/res/layout/place_page_preview.xml
+++ b/android/app/src/main/res/layout/place_page_preview.xml
@@ -171,13 +171,6 @@
             android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"
             android:textSize="@dimen/text_size_body_3"
             tools:text="2000 km" />
-          <TextView
-            android:id="@+id/tv__azimuth"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"
-            android:textSize="@dimen/text_size_body_4"
-            tools:text="123°" />
         </LinearLayout>
       </LinearLayout>
     </LinearLayout>


### PR DESCRIPTION
- Users complained that PP preview takes too much empty space (100% agree)
- Azimuth to North is very specific and needed only to a few users, so no need to show it in the PP preview
- It is now only shown if user presses on the arrow/distance to the selected place.

Before | After
-------|------
<img width="1440" height="2560" alt="выява" src="https://github.com/user-attachments/assets/dc3cd69e-0c6c-433c-a0cc-fd5d5f1e2161" />|<img width="1440" height="2560" alt="выява" src="https://github.com/user-attachments/assets/702452a4-04ad-4401-9421-f012f2f63bbf" />
