### PR TITLE
[ios] Fix CarPlay initial viewport and scale

### DIFF
--- a/iphone/Maps/Classes/CarPlay/CarplayPlaceholderView.swift
+++ b/iphone/Maps/Classes/CarPlay/CarplayPlaceholderView.swift
@@ -29,12 +29,10 @@ class CarplayPlaceholderView: UIView {
     descriptionLabel.numberOfLines = 0
     containerView.addSubview(descriptionLabel)
 
+    switchButton.setStyleAndApply(.flatNormalButtonBig)
     switchButton.setTitle(L("car_continue_on_the_phone"), for: .normal)
     switchButton.addTarget(self, action: #selector(onSwitchButtonTap), for: .touchUpInside)
-    switchButton.titleLabel?.font = UIFont.medium16()
     switchButton.titleLabel?.lineBreakMode = .byWordWrapping
-    switchButton.titleLabel?.textAlignment = .center
-    switchButton.layer.cornerRadius = 8
     containerView.addSubview(switchButton)
 
     updateColors()

--- a/iphone/Maps/Classes/EAGLView.mm
+++ b/iphone/Maps/Classes/EAGLView.mm
@@ -31,7 +31,6 @@ class GraphicsContextFactory;
   // It's possible when we add/remove subviews (bookmark balloons) and it hangs the map without this check
   CGRect m_lastViewSize;
   bool m_presentAvailable;
-  double main_visualScale;
 }
 @property(nonatomic, readwrite) BOOL graphicContextInitialized;
 @end
@@ -217,13 +216,12 @@ double getExactDPI(double contentScaleFactor)
 
 - (void)updateVisualScaleTo:(CGFloat)visualScale
 {
-  main_visualScale = df::VisualParams::Instance().GetVisualScale();
   GetFramework().UpdateVisualScale(visualScale);
 }
 
 - (void)updateVisualScaleToMain
 {
-  GetFramework().UpdateVisualScale(main_visualScale);
+  GetFramework().UpdateVisualScale(UIScreen.mainScreen.scale);
 }
 
 @end

--- a/iphone/Maps/UI/CarPlay/CarPlayMapViewController.swift
+++ b/iphone/Maps/UI/CarPlay/CarPlayMapViewController.swift
@@ -179,7 +179,7 @@ final class CarPlayMapViewController: MWMViewController {
     frame.origin = origin
     frame.size = CGSize(width: viewBounds.width - origin.x,
                         height: viewBounds.height - origin.y)
-    FrameworkHelper.setVisibleViewport(frame, scaleFactor: mapView?.contentScaleFactor ?? 1)
+    updateVisibleViewPort(frame: frame)
   }
 
   private func updateVisibleViewPortToNavigationState() {
@@ -192,11 +192,16 @@ final class CarPlayMapViewController: MWMViewController {
     frame.origin = origin
     frame.size = CGSize(width: viewBounds.width - (origin.x + mapControlsWidth),
                         height: viewBounds.height - origin.y)
-    FrameworkHelper.setVisibleViewport(frame, scaleFactor: mapView?.contentScaleFactor ?? 1)
+    updateVisibleViewPort(frame: frame)
   }
 
   private func updateVisibleViewPortToDefaultState() {
-    FrameworkHelper.setVisibleViewport(view.bounds, scaleFactor: mapView?.contentScaleFactor ?? 1)
+    updateVisibleViewPort(frame: view.bounds)
+  }
+
+  private func updateVisibleViewPort(frame: CGRect) {
+    guard CarPlayService.shared.isCarplayActivated else { return }
+    FrameworkHelper.setVisibleViewport(frame, scaleFactor: mapView?.contentScaleFactor ?? 1)
   }
 
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {


### PR DESCRIPTION
Fixes https://github.com/organicmaps/organicmaps/issues/10900

###  Bug description
Incorrect viewport and map scale while switching from the CarPlay to the iPhone.

### How to reproduce:
1. Terminate the app
2. Connect to the car
3. Run the app in CarPlay
4. Switch to the Phone by tapping `Continue on the Phone`
5. The viewport will be incorrect (the location arrow will be in the top-left corner), and the zoom scale may be incorrect.

https://github.com/user-attachments/assets/a38fb34e-aac3-4ae1-88cb-ab7068856f42

### Solution:
1. The `updateVisibleViewPortToDefaultState` was called from the `viewDidLayoutSubviews` when the VC is removed from the stack, updates the viewport unexpectedly and overwrites the correct viewport with CP screen size when it shouldn't. It may break the viewport when switching to the phone.
2. When the app was not running and launched from the CarPlay, the main_visualScale was initialized with CP scale (usually it is 2). Then, when the user switches to the phonem, these incorrect values can be used in `UpdateVisualScale`. The current screen's scale should be used instead in the `updateVisualScaleToMain` without intermediate values.

https://github.com/user-attachments/assets/2c55b5f7-f1cc-4f7b-89c3-4b03ed57dc02
