### PR TITLE
[ios] Fix route points reordering when there is only 1 point

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardInteractor.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardInteractor.swift
@@ -113,6 +113,10 @@ extension NavigationDashboard {
         router.rebuild(withBestRouter: false)
         return .show(points: router.points(), routerType: router.type())
 
+      case .swapStartAndFinishPoints:
+        router.swapStartAndFinish()
+        return .show(points: router.points(), routerType: router.type())
+
       case .updateVisibleAreaInsets(let insets):
         mapViewController.updateVisibleAreaInsets(for: self, insets: insets)
         return .none

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardRequest.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardRequest.swift
@@ -10,7 +10,8 @@ extension NavigationDashboard {
     case selectRoutePoint(MWMRoutePoint?)
     case deleteRoutePoint(MWMRoutePoint)
     case moveRoutePoint(from: Int, to: Int)
-    
+    case swapStartAndFinishPoints
+
     case addRoutePointButtonDidTap
     case startButtonDidTap
     case settingsButtonDidTap

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointCollectionViewCell.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointCollectionViewCell.swift
@@ -11,6 +11,7 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
     let showCloseButton: Bool
     let maskedCorners: CACornerMask
     let isPlaceholder: Bool
+    let showSeparator: Bool
     let onCloseHandler: (() -> Void)?
   }
 
@@ -34,7 +35,6 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
     let separatorInsets = UIEdgeInsets(top: 0, left: Constants.logoImageLeadingInset + Constants.logoSize + Constants.horizontalSpacing, bottom: 0, right: 0)
     return contentBackgroundView.addSeparator(.bottom, insets: separatorInsets)
   }()
-  private lazy var dotSeparatorView: UIView = makeDotSeparator()
   private var didTapClose: (() -> Void)?
 
   override init(frame: CGRect) {
@@ -79,7 +79,6 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
     contentView.addSubview(contentBackgroundView)
     textStackView.addArrangedSubview(titleLabel)
     contentBackgroundView.addSubview(logoImageView)
-    contentBackgroundView.addSubview(dotSeparatorView)
     contentBackgroundView.addSubview(textStackView)
     contentBackgroundView.addSubview(closeButton)
     contentBackgroundView.addSubview(reorderButton)
@@ -100,9 +99,6 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
       logoImageView.centerYAnchor.constraint(equalTo: contentBackgroundView.centerYAnchor),
       logoImageView.widthAnchor.constraint(equalToConstant: Constants.logoSize),
       logoImageView.heightAnchor.constraint(equalToConstant: Constants.logoSize),
-
-      dotSeparatorView.centerXAnchor.constraint(equalTo: logoImageView.centerXAnchor),
-      dotSeparatorView.centerYAnchor.constraint(equalTo: bottomAnchor),
 
       textStackView.leadingAnchor.constraint(equalTo: logoImageView.trailingAnchor, constant: Constants.horizontalSpacing),
       textStackView.centerYAnchor.constraint(equalTo: contentBackgroundView.centerYAnchor),
@@ -143,8 +139,7 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
       closeButton.isHidden = !viewModel.showCloseButton
       reorderButton.isHidden = false
       contentBackgroundView.layer.maskedCorners = viewModel.maskedCorners
-      separatorView.isHidden = false
-      dotSeparatorView.isHidden = false
+      separatorView.isHidden = !viewModel.showSeparator
     case .addPoint:
       titleLabel.text = L("placepage_add_stop")
       logoImageView.image = UIImage(resource: .icAddButton)
@@ -154,7 +149,6 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
       reorderButton.isHidden = true
       contentBackgroundView.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
       separatorView.isHidden = true
-      dotSeparatorView.isHidden = true
     }
   }
 

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePoints.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePoints.swift
@@ -18,6 +18,7 @@ extension NavigationDashboard.RoutePoints {
   static let empty = NavigationDashboard.RoutePoints(points: [])
 
   var count: Int { 2 + intermediate.count }
+  var hasStartAndFinish: Bool { start != nil && finish != nil }
 
   subscript(index: Int) -> MWMRoutePoint? {
     switch index {
@@ -65,19 +66,22 @@ extension NavigationDashboard.RoutePoints {
   mutating func movePoint(from sourceIndex: Int, to destinationIndex: Int) {
     guard sourceIndex != destinationIndex else { return }
     var points = self.points
-    let pointToMove = points[sourceIndex]
-    points.remove(at: sourceIndex)
-    points.insert(pointToMove, at: destinationIndex)
-    for (index, point) in points.enumerated() {
-      switch index {
-      case 0:
-        point.type = .start
-      case points.count - 1:
-        point.type = .finish
-      default:
-        point.type = .intermediate
+    if points.count == 1, let point = points.first {
+      point.type = point.type == .start ? .finish : .start
+    } else {
+      let pointToMove = points.remove(at: sourceIndex)
+      points.insert(pointToMove, at: destinationIndex)
+      for (index, point) in points.enumerated() {
+        switch index {
+        case 0:
+          point.type = .start
+        case points.count - 1:
+          point.type = .finish
+        default:
+          point.type = .intermediate
+        }
       }
-      self = NavigationDashboard.RoutePoints(points: points)
     }
+    self = NavigationDashboard.RoutePoints(points: points)
   }
 }

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointsView.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointsView.swift
@@ -105,7 +105,7 @@ extension RoutePointsView: UIScrollViewDelegate {
 // MARK: - UICollectionViewDataSource, UICollectionViewDelegate
 extension RoutePointsView: UICollectionViewDataSource, UICollectionViewDelegate {
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    routePoints.count + 1
+    routePoints.hasStartAndFinish ? routePoints.count + 1 : routePoints.count
   }
 
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -147,19 +147,24 @@ extension RoutePointsView: UICollectionViewDragDelegate, UICollectionViewDropDel
     return [dragItem]
   }
 
+  func collectionView(_ collectionView: UICollectionView, dragPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
+    let parameters = UIDragPreviewParameters()
+    parameters.backgroundColor = .clear
+    return parameters
+  }
+
   func collectionView(_ collectionView: UICollectionView, performDropWith coordinator: UICollectionViewDropCoordinator) {
     guard let destinationIndexPath = coordinator.destinationIndexPath,
-          destinationIndexPath.item < routePoints.count else { return }
+          destinationIndexPath.row < routePoints.count else { return }
 
     for item in coordinator.items {
-      if let sourceIndexPath = item.sourceIndexPath, let _ = item.dragItem.localObject as? MWMRoutePoint {
+      if let sourceIndexPath = item.sourceIndexPath {
         guard sourceIndexPath != destinationIndexPath,
-              sourceIndexPath.row < routePoints.count,
-              destinationIndexPath.row < routePoints.count else {
+              sourceIndexPath.row < routePoints.count else {
           return
         }
 
-        routePoints.movePoint(from: sourceIndexPath.item, to: destinationIndexPath.item)
+        routePoints.movePoint(from: sourceIndexPath.row, to: destinationIndexPath.row)
         collectionView.performBatchUpdates {
           collectionView.moveItem(at: sourceIndexPath, to: destinationIndexPath)
         }
@@ -169,7 +174,11 @@ extension RoutePointsView: UICollectionViewDragDelegate, UICollectionViewDropDel
           configure(cell, at: indexPath)
         }
         coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
-        interactor?.process(.moveRoutePoint(from: sourceIndexPath.item, to: destinationIndexPath.item))
+        if !routePoints.hasStartAndFinish {
+          interactor?.process(.swapStartAndFinishPoints)
+        } else {
+          interactor?.process(.moveRoutePoint(from: sourceIndexPath.row, to: destinationIndexPath.row))
+        }
       }
     }
   }
@@ -185,17 +194,23 @@ extension RoutePointsView: UICollectionViewDragDelegate, UICollectionViewDropDel
     }
     return UICollectionViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
   }
+
+  func collectionView(_ collectionView: UICollectionView, dropPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
+    let parameters = UIDragPreviewParameters()
+    parameters.backgroundColor = .clear
+    return parameters
+  }
 }
 
 private extension NavigationDashboard.RoutePoints {
   func cellViewModel(for index: Int, onCloseHandler: (() -> Void)?) -> RoutePointCollectionViewCell.CellType {
     let point = self[index]
     let maskedCorners: CACornerMask
-    switch point?.type {
-    case .start:
+    switch index {
+    case 0:
       maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
     default:
-      maskedCorners = []
+      maskedCorners = hasStartAndFinish ? [] : [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
     }
     let viewModel = RoutePointCollectionViewCell.PointViewModel(
       title: title(for: index),
@@ -203,6 +218,7 @@ private extension NavigationDashboard.RoutePoints {
       showCloseButton: point?.type == .intermediate,
       maskedCorners: maskedCorners,
       isPlaceholder: point == nil,
+      showSeparator: hasStartAndFinish ? true : index < points.count,
       onCloseHandler: onCloseHandler
     )
     return .point(viewModel)

--- a/iphone/Maps/Core/Routing/MWMRouter.h
+++ b/iphone/Maps/Core/Routing/MWMRouter.h
@@ -46,6 +46,9 @@ typedef void (^MWMImageHeightBlock)(UIImage *, NSString *, NSString *);
 + (void)continueRouteToPointAndRebuild:(MWMRoutePoint *)point;
 + (void)removePointAndRebuild:(MWMRoutePoint *)point;
 + (void)replacePointAndRebuild:(MWMRoutePoint *)point withPoint:(MWMRoutePoint *)newPoint;
+/// Swaps start and finish points and rebuilds the route.
+/// If there is only start or finish point, it becomes the opposite.
++ (void)swapStartAndFinish;
 + (void)removePoints;
 
 + (void)buildFromPoint:(MWMRoutePoint *)start bestRouter:(BOOL)bestRouter;

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -264,6 +264,27 @@ char const * kRenderAltitudeImagesQueueLabel = "mapsme.mwmrouter.renderAltitudeI
   }
 }
 
++ (void)swapStartAndFinish
+{
+  auto const points = GetFramework().GetRoutingManager().GetRoutePoints();
+  CHECK(!points.empty(), ("Should never be empty"));
+  auto & rm = GetFramework().GetRoutingManager();
+  if (points.size() == 1)
+  {
+    RouteMarkType currentType = points[0].m_pointType;
+    ASSERT(currentType != RouteMarkType::Intermediate, ("There should be no intermediate points if points count is 1"));
+    RouteMarkType targetType = currentType == RouteMarkType::Start ? RouteMarkType::Finish : RouteMarkType::Start;
+    rm.MoveRoutePoint(currentType, 0, targetType, 0);
+  }
+  else
+  {
+    rm.MoveRoutePoint(0, points.size() - 1);
+    rm.MoveRoutePoint(points.size() - 2, 0);
+  }
+
+  [self rebuildWithBestRouter:NO];
+}
+
 + (void)removePoints
 {
   GetFramework().GetRoutingManager().RemoveRoutePoints();


### PR DESCRIPTION
This PR fixes the crash when the user attempts to reorder route point cells when there is only one `Route from` point that exists.
Now:
1. The `from/to` point can be reordered
2. The  `add stop` is hidden when there is only 1 point (route from) because it is redundant in this state

https://github.com/user-attachments/assets/7bc6206b-bef0-4641-acfa-a1e5ced08a32
