### PR TITLE
[ios] Fix new route building `transport options segment control` and `estimates labels` issues

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
@@ -16,7 +16,7 @@ final class NavigationDashboardViewController: UIViewController {
     static let settingsButtonInsetRight: CGFloat = -16
     static let settingsButtonSpacing: CGFloat = 8
 
-    static let transportOptionsCollectionInsets = UIEdgeInsets(top: 6, left: 16, bottom: 0, right: -36)
+    static let transportOptionsCollectionInsets = UIEdgeInsets(top: 6, left: 16, bottom: 0, right: -20)
     static let transportOptionsCollectionHeight: CGFloat = 44
 
     static let routePointsInsets = UIEdgeInsets(top: 8, left: 16, bottom: -8, right: -16)

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/EstimatesView.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/EstimatesView.swift
@@ -24,6 +24,11 @@ final class EstimatesView: UIView {
   }
 
   private func layout() {
+    estimatesLabel.adjustsFontSizeToFitWidth = true
+    estimatesLabel.minimumScaleFactor = 0.5
+    estimatesLabel.allowsDefaultTighteningForTruncation = true
+    estimatesLabel.numberOfLines = 1
+
     addSubview(estimatesLabel)
 
     estimatesLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/TransportOptions/TransportOptionsSegmentedControl.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/TransportOptions/TransportOptionsSegmentedControl.swift
@@ -43,9 +43,9 @@ struct TransportOptionsSegmentedControlView: View {
   let onSelect: (MWMRouterType) -> Void
 
   private enum Constants {
-    static let spacing: CGFloat = 8
-    static let imageSize: CGFloat = 20
+    static let spacing: CGFloat = 4
     static let padding: CGFloat = 6
+    static let imagePadding: CGFloat = 4
     static let animationDuration: Double = kDefaultAnimationDuration / 2
   }
 
@@ -55,7 +55,7 @@ struct TransportOptionsSegmentedControlView: View {
 
   var body: some View {
     HStack(spacing: Constants.spacing) {
-      ForEach(viewModel.options, id: \.self) { type in
+      ForEach(viewModel.options, id: \.rawValue) { type in
         Button {
           impactGenerator.impactOccurred()
           withAnimation {
@@ -73,13 +73,14 @@ struct TransportOptionsSegmentedControlView: View {
               .renderingMode(.template)
               .resizable()
               .scaledToFit()
-              .frame(height: Constants.imageSize)
+              .padding(.vertical, Constants.imagePadding)
               .foregroundColor(viewModel.selected == type ? .white : Color(uiColor: .blackSecondaryText()))
           }
           .padding(Constants.padding)
           .frame(maxWidth: .infinity)
           .animation(.easeIn(duration: Constants.animationDuration), value: viewModel.selected)
         }
+        .buttonStyle(.plain)
       }
     }
     .frame(maxWidth: .infinity)


### PR DESCRIPTION
This PR fixes issues:
1. The accessibility setting `Button shapes` breaks the transport options segment control style.
<img width="293" height="170" alt="image" src="https://github.com/user-attachments/assets/dbb2622c-0600-4d96-879e-2c8faec2de38" />

### **Before / After**
<img width="310" height="274" alt="image" src="https://github.com/user-attachments/assets/fe00f355-6bbd-4807-a1fb-b7aea1eb0b23" /> <img width="313" height="245" alt="image" src="https://github.com/user-attachments/assets/1d067075-41f1-4cf2-a1c8-40e735297e09" />

2. Automatically tightens/reduces the estimates label font if needed
<img width="311" height="248" alt="image" src="https://github.com/user-attachments/assets/968dd29e-d4fb-46fe-b7ea-a3112ddb37dd" />

3. Slightly reduces spacing between transport options and the close button and increases buttons size
<img width="340" height="729" alt="image" src="https://github.com/user-attachments/assets/e7f320a5-9819-47d9-b715-db1258d7c010" />




