### PR TITLE
[android] Show osm description tag contents

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -144,6 +144,8 @@ public class PlacePageView extends Fragment
   private ImageView mColorIcon;
   private TextView mTvCategory;
   private ImageView mEditBookmark;
+  private View mOsmDescriptionContainer;
+  private TextView mTvOsmDescription;
 
   // Data
   private CoordinatesFormat mCoordsFormat = CoordinatesFormat.LatLonDecimal;
@@ -260,6 +262,10 @@ public class PlacePageView extends Fragment
     mColorIcon.setOnClickListener(this);
     mTvCategory.setOnClickListener(this);
     mEditBookmark.setOnClickListener(this);
+
+    mOsmDescriptionContainer = mFrame.findViewById(R.id.osm_description_container);
+    mTvOsmDescription = mFrame.findViewById(R.id.tv__osm_description);
+    mTvOsmDescription.setOnLongClickListener(this);
 
     MaterialButton shareButton = mPreview.findViewById(R.id.share_button);
     shareButton.setOnClickListener(this::shareClickListener);
@@ -470,7 +476,17 @@ public class PlacePageView extends Fragment
       mToolbar.setTitle(mMapObject.getTitle());
     setTextAndColorizeSubtitle();
     UiUtils.setTextAndHideIfEmpty(mTvAddress, mMapObject.getAddress());
+
     refreshCategoryPreview();
+
+    final String osmDescription = mMapObject.getOsmDescription();
+    if (osmDescription.isEmpty())
+      mOsmDescriptionContainer.setVisibility(GONE);
+    else
+    {
+      mTvOsmDescription.setText(osmDescription);
+      mOsmDescriptionContainer.setVisibility(VISIBLE);
+    }
   }
 
   void refreshCategoryPreview()
@@ -839,6 +855,8 @@ public class PlacePageView extends Fragment
       items.add(mTvSecondaryTitle.getText().toString());
     else if (id == R.id.tv__address)
       items.add(mTvAddress.getText().toString());
+    else if (id == R.id.tv__osm_description)
+      items.add(mTvOsmDescription.getText().toString());
     else if (id == R.id.ll__place_latlon)
     {
       final double lat = mMapObject.getLat();

--- a/android/app/src/main/res/layout/place_page_preview.xml
+++ b/android/app/src/main/res/layout/place_page_preview.xml
@@ -246,6 +246,36 @@
     </LinearLayout>
   </LinearLayout>
 
+  <LinearLayout
+    android:id="@+id/osm_description_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?ppBackground"
+    android:orientation="vertical">
+
+    <include layout="@layout/place_page_shadow_gap" />
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:background="?ppBackground"
+      android:orientation="horizontal">
+
+      <TextView
+        android:id="@+id/tv__osm_description"
+        style="@style/MwmTextAppearance.PlacePage"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:padding="@dimen/margin_half_plus"
+        android:layout_weight="1"
+        android:background="?clickableBackground"
+        android:textAllCaps="false"
+        tools:text="Some very long text for a very very very very very very very very very very very very very very very very very very very very very very very very looooooong descriptions that doesn't fit into the cell. Interesting, how will it look for even longer text" />
+    </LinearLayout>
+
+  </LinearLayout>
+
   <androidx.fragment.app.FragmentContainerView
     android:id="@+id/place_page_track_fragment"
     android:layout_width="match_parent"

--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/Bookmark.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/Bookmark.java
@@ -29,11 +29,11 @@ public class Bookmark extends MapObject
   public Bookmark(@NonNull FeatureId featureId, @IntRange(from = 0) long categoryId,
                   @IntRange(from = 0) long bookmarkId, String title, @Nullable String secondaryTitle,
                   @Nullable String subtitle, @Nullable String address, @Nullable RoutePointInfo routePointInfo,
-                  @OpeningMode int openingMode, @NonNull Popularity popularity, @NonNull String description,
-                  @Nullable String[] rawTypes)
+                  @OpeningMode int openingMode, @NonNull Popularity popularity, @NonNull String wikiArticle,
+                  @NonNull String osmDescription, @Nullable String[] rawTypes)
   {
     super(featureId, BOOKMARK, title, secondaryTitle, subtitle, address, 0, 0, "", routePointInfo, openingMode,
-          popularity, description, RoadWarningMarkType.UNKNOWN.ordinal(), rawTypes);
+          popularity, wikiArticle, osmDescription, RoadWarningMarkType.UNKNOWN.ordinal(), rawTypes);
 
     mCategoryId = categoryId;
     mBookmarkId = bookmarkId;

--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/MapObject.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/MapObject.java
@@ -71,6 +71,8 @@ public class MapObject implements PlacePageData
   @NonNull
   private String mWikiArticle;
   @NonNull
+  private final String mOsmDescription;
+  @NonNull
   private final RoadWarningMarkType mRoadWarningMarkType;
   @Nullable
   private List<String> mRawTypes;
@@ -78,17 +80,18 @@ public class MapObject implements PlacePageData
   public MapObject(@NonNull FeatureId featureId, @MapObjectType int mapObjectType, String title,
                    @Nullable String secondaryTitle, String subtitle, String address, double lat, double lon,
                    String apiId, @Nullable RoutePointInfo routePointInfo, @OpeningMode int openingMode,
-                   Popularity popularity, @NonNull String wikiArticle, int roadWarningType, @Nullable String[] rawTypes)
+                   Popularity popularity, @NonNull String wikiArticle, @NonNull String osmDescription,
+                   int roadWarningType, @Nullable String[] rawTypes)
   {
     this(featureId, mapObjectType, title, secondaryTitle, subtitle, address, lat, lon, new Metadata(), apiId,
-         routePointInfo, openingMode, popularity, wikiArticle, roadWarningType, rawTypes);
+         routePointInfo, openingMode, popularity, wikiArticle, osmDescription, roadWarningType, rawTypes);
   }
 
   public MapObject(@NonNull FeatureId featureId, @MapObjectType int mapObjectType, String title,
                    @Nullable String secondaryTitle, String subtitle, String address, double lat, double lon,
                    Metadata metadata, String apiId, @Nullable RoutePointInfo routePointInfo,
                    @OpeningMode int openingMode, Popularity popularity, @NonNull String wikiArticle,
-                   int roadWarningType, @Nullable String[] rawTypes)
+                   @NonNull String osmDescription, int roadWarningType, @Nullable String[] rawTypes)
   {
     mMapObjectType = mapObjectType;
     mFeatureId = featureId;
@@ -104,6 +107,7 @@ public class MapObject implements PlacePageData
     mOpeningMode = openingMode;
     // mPopularity = popularity;
     mWikiArticle = wikiArticle;
+    mOsmDescription = osmDescription;
     mRoadWarningMarkType = RoadWarningMarkType.values()[roadWarningType];
     if (rawTypes != null)
       mRawTypes = Arrays.asList(rawTypes);
@@ -130,6 +134,7 @@ public class MapObject implements PlacePageData
     // mPopularity =
     //     ParcelCompat.readParcelable(source, Popularity.class.getClassLoader(), Popularity.class);
     mWikiArticle = Objects.requireNonNull(source.readString());
+    mOsmDescription = source.readString();
     mRoadWarningMarkType = RoadWarningMarkType.values()[source.readInt()];
     source.readStringList(mRawTypes);
   }
@@ -139,8 +144,8 @@ public class MapObject implements PlacePageData
                                           @NonNull String title, @NonNull String subtitle, double lat, double lon)
   {
     return new MapObject(featureId, mapObjectType, title, "", subtitle, "", lat, lon, null, "", null,
-                         OPENING_MODE_PREVIEW, Popularity.defaultInstance(), "", RoadWarningMarkType.UNKNOWN.ordinal(),
-                         new String[0]);
+                         OPENING_MODE_PREVIEW, Popularity.defaultInstance(), "", null,
+                         RoadWarningMarkType.UNKNOWN.ordinal(), new String[0]);
   }
 
   /**
@@ -235,6 +240,12 @@ public class MapObject implements PlacePageData
   public void setWikiArticle(@NonNull String wikiArticle)
   {
     mWikiArticle = wikiArticle;
+  }
+
+  @NonNull
+  public String getOsmDescription()
+  {
+    return mOsmDescription;
   }
 
   @NonNull
@@ -367,6 +378,7 @@ public class MapObject implements PlacePageData
     dest.writeInt(mOpeningMode);
     // dest.writeParcelable(mPopularity, 0);
     dest.writeString(mWikiArticle);
+    dest.writeString(mOsmDescription);
     dest.writeInt(getRoadWarningMarkType().ordinal());
     // All collections are deserialized AFTER non-collection and primitive type objects,
     // so collections must be always serialized at the end.

--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/Track.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/Track.java
@@ -25,7 +25,7 @@ public class Track extends MapObject
 
   Track(long trackId, long categoryId, String name, Distance length, int color)
   {
-    super(FeatureId.EMPTY, TRACK, name, "", "", "", 0, 0, "", null, OPENING_MODE_PREVIEW_PLUS, null, "",
+    super(FeatureId.EMPTY, TRACK, name, "", "", "", 0, 0, "", null, OPENING_MODE_PREVIEW_PLUS, null, "", "",
           RoadWarningMarkType.UNKNOWN.ordinal(), null);
     mTrackId = trackId;
     mCategoryId = categoryId;
@@ -38,10 +38,11 @@ public class Track extends MapObject
   Track(@NonNull FeatureId featureId, @IntRange(from = 0) long categoryId, @IntRange(from = 0) long trackId,
         String title, @Nullable String secondaryTitle, @Nullable String subtitle, @Nullable String address,
         @Nullable RoutePointInfo routePointInfo, @OpeningMode int openingMode, @NonNull Popularity popularity,
-        @NonNull String description, @Nullable String[] rawTypes, int color, Distance length, double lat, double lon)
+        @NonNull String wikiArticle, @NonNull String osmDescription, @Nullable String[] rawTypes, int color,
+        Distance length, double lat, double lon)
   {
     super(featureId, TRACK, title, secondaryTitle, subtitle, address, lat, lon, "", routePointInfo, openingMode,
-          popularity, description, RoadWarningMarkType.UNKNOWN.ordinal(), rawTypes);
+          popularity, wikiArticle, osmDescription, RoadWarningMarkType.UNKNOWN.ordinal(), rawTypes);
     mTrackId = trackId;
     mCategoryId = categoryId;
     mColor = color;


### PR DESCRIPTION
No fancy UI yet, but is already usable. Need to think how:
- Switch the language to see other translations
- Show translate button where it is supported
- Allow editing existing descriptions
- Add new descriptions if they are absent (@euf @kirylkaveryn that's the tricky one!)

1 | 2 | 3
--|---|---
![telegram-cloud-photo-size-2-5370594422120642052-y](https://github.com/user-attachments/assets/b8470391-334a-42d3-8154-51d8d0961b3b)|![telegram-cloud-photo-size-2-5370594422120642051-y](https://github.com/user-attachments/assets/4f14d9fc-b6aa-4bfe-9e74-058f6ed5944e)|![telegram-cloud-photo-size-2-5370594422120642050-y](https://github.com/user-attachments/assets/492d2b2f-75ce-47cf-8dae-b6b65ff75b88)
