### PR TITLE
[ios] Fix `add` and `edit` OSM place buttons visibility for less than 3 months outdated maps

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -677,14 +677,14 @@ public class PlacePageView extends Fragment
       UiUtils.showIf(Editor.nativeShouldShowEditPlace(), mEditPlace);
       UiUtils.showIf(Editor.nativeShouldShowAddBusiness(), mAddOrganisation);
       UiUtils.showIf(Editor.nativeShouldShowAddPlace(), mAddPlace);
-      mEditPlace.setEnabled(Editor.nativeShouldEnableEditPlace());
-      mAddOrganisation.setEnabled(Editor.nativeShouldEnableAddPlace());
-      mAddPlace.setEnabled(Editor.nativeShouldEnableAddPlace());
+      mEditPlace.setEnabled(Editor.nativeCanEditPlace());
+      mAddOrganisation.setEnabled(Editor.nativeCanEditPlace());
+      mAddPlace.setEnabled(Editor.nativeCanEditPlace());
       TextView mTvEditPlace = mEditPlace.findViewById(R.id.tv__editor);
       TextView mTvAddBusiness = mAddPlace.findViewById(R.id.tv__editor);
       TextView mTvAddPlace = mAddPlace.findViewById(R.id.tv__editor);
       final int editPlaceButtonColor =
-          Editor.nativeShouldEnableEditPlace()
+          Editor.nativeCanEditPlace()
               ? ContextCompat.getColor(getContext(),
                                        UiUtils.getStyledResourceId(getContext(), androidx.appcompat.R.attr.colorAccent))
               : getResources().getColor(R.color.button_accent_text_disabled);

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/editor/Editor.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/editor/Editor.cpp
@@ -185,22 +185,13 @@ JNIEXPORT jboolean JNICALL Java_app_organicmaps_sdk_editor_Editor_nativeShouldSh
   return g_framework->GetPlacePageInfo().ShouldShowAddPlace();
 }
 
-JNIEXPORT jboolean JNICALL Java_app_organicmaps_sdk_editor_Editor_nativeShouldEnableEditPlace(JNIEnv *, jclass)
+JNIEXPORT jboolean JNICALL Java_app_organicmaps_sdk_editor_Editor_nativeCanEditPlace(JNIEnv *, jclass)
 {
   ::Framework * frm = g_framework->NativeFramework();
   if (!frm->HasPlacePageInfo())
     return static_cast<jboolean>(false);
 
-  return g_framework->GetPlacePageInfo().ShouldEnableEditPlace();
-}
-
-JNIEXPORT jboolean JNICALL Java_app_organicmaps_sdk_editor_Editor_nativeShouldEnableAddPlace(JNIEnv *, jclass)
-{
-  ::Framework * frm = g_framework->NativeFramework();
-  if (!frm->HasPlacePageInfo())
-    return static_cast<jboolean>(false);
-
-  return g_framework->GetPlacePageInfo().ShouldEnableAddPlace();
+  return g_framework->GetPlacePageInfo().CanEditPlace();
 }
 
 JNIEXPORT jintArray JNICALL Java_app_organicmaps_sdk_editor_Editor_nativeGetEditableProperties(JNIEnv * env,

--- a/android/sdk/src/main/java/app/organicmaps/sdk/editor/Editor.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/editor/Editor.java
@@ -51,8 +51,7 @@ public final class Editor
   public static native boolean nativeShouldShowEditPlace();
   public static native boolean nativeShouldShowAddBusiness();
   public static native boolean nativeShouldShowAddPlace();
-  public static native boolean nativeShouldEnableEditPlace();
-  public static native boolean nativeShouldEnableAddPlace();
+  public static native boolean nativeCanEditPlace();
   @NonNull
   public static native int[] nativeGetEditableProperties();
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageOSMContributionData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageOSMContributionData.mm
@@ -33,7 +33,7 @@
     case MWMMapNodeStatusNotDownloaded:
     case MWMMapNodeStatusOnDiskOutOfDate:
     case MWMMapNodeStatusPartly:
-      BOOL needsToUpdateMap = !rawData.ShouldEnableAddPlace() || !rawData.ShouldEnableEditPlace();
+      BOOL needsToUpdateMap = !rawData.CanEditPlace();
       _state = needsToUpdateMap ? PlacePageOSMContributionStateShouldUpdateMap
                                 : PlacePageOSMContributionStateCanAddOrEditPlace;
       _showAddPlace = !needsToUpdateMap && shouldShowAddPlace;

--- a/libs/map/place_page_info.hpp
+++ b/libs/map/place_page_info.hpp
@@ -108,8 +108,7 @@ public:
   bool ShouldShowAddBusiness() const { return IsBuilding(); }
   bool ShouldShowEditPlace() const;
 
-  bool ShouldEnableAddPlace() const { return m_canEditOrAdd; }
-  bool ShouldEnableEditPlace() const { return m_canEditOrAdd; }
+  bool CanEditPlace() const { return m_canEditOrAdd; }
 
   /// @returns true if Back API button should be displayed.
   bool HasApiUrl() const { return !m_apiUrl.empty(); }


### PR DESCRIPTION
**Bug description:**
When the map is outdated but not too much (less than 3 mo) the `Add place` and `Edit place` are always shown. But on the updated maps, the place may only have 1 button. 

This is incorrect behaviour. These buttons' visibility should be the same as for updated maps. 

This PR fixes the issue.

### Results (map is outdated < 3mo)
Before / After
<img width="300" height="2556" alt="image" src="https://github.com/user-attachments/assets/2c78a5a3-9494-4b26-b340-c4c549654bde" /> <img width="300" height="2556" alt="IMG_9358" src="https://github.com/user-attachments/assets/cd14d2e7-3284-4f79-b5ae-8a59009b1410" />
