### PR TITLE
[ios] Fix transport options segm control layout on iPad for ios26

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
@@ -318,10 +318,17 @@ final class NavigationDashboardViewController: UIViewController {
     closeButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     settingsButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
 
+    let grabberTopConstraint: NSLayoutConstraint
+    if isiPad {
+      grabberTopConstraint = grabberView.topAnchor.constraint(equalTo: availableAreaView.safeAreaLayoutGuide.topAnchor)
+    } else {
+      grabberTopConstraint = grabberView.topAnchor.constraint(equalTo: availableAreaView.topAnchor, constant: Constants.grabberTopInset)
+    }
+
     NSLayoutConstraint.activate([
       grabberView.centerXAnchor.constraint(equalTo: availableAreaView.centerXAnchor),
       grabberView.widthAnchor.constraint(equalToConstant: Constants.grabberWidth),
-      grabberView.topAnchor.constraint(equalTo: availableAreaView.topAnchor, constant: Constants.grabberTopInset),
+      grabberTopConstraint,
       grabberView.heightAnchor.constraint(equalToConstant: Constants.grabberHeight),
 
       closeButton.trailingAnchor.constraint(equalTo: availableAreaView.safeAreaLayoutGuide.trailingAnchor, constant: Constants.closeButtonInsets.right),


### PR DESCRIPTION
Before / After
<img width="300" height="320" alt="image" src="https://github.com/user-attachments/assets/7fe5ae13-561d-49fb-9862-860301b5afb0" /> 
<img width="300" height="416" alt="image" src="https://github.com/user-attachments/assets/2810531d-9256-4708-bf4d-b08550812570" />

iPhone isn't changed

