### PR TITLE
[ios] Fix iOS26 UI issues

### DIFF
--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInterfaces.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInterfaces.swift
@@ -60,7 +60,6 @@ protocol IBookmarksListView: AnyObject {
   func setTitle(_ title: String)
   func setInfo(_ info: IBookmarksListInfoViewModel)
   func setSections(_ sections: [IBookmarksListSectionViewModel])
-  func setMoreItemTitle(_ itemTitle: String)
   func showMenu(_ items: [IBookmarksListMenuItem], from source: BookmarkToolbarButtonSource)
   func showColorPicker(with pickerType: ColorPickerType, _ completion: ((UIColor) -> Void)?)
   func enableEditing(_ enable: Bool)

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListPresenter.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListPresenter.swift
@@ -215,7 +215,6 @@ extension BookmarksListPresenter: IBookmarksListPresenter {
   func viewDidLoad() {
     reload()
     view.setTitle(bookmarkGroup.title)
-    view.setMoreItemTitle(L("placepage_more_button"))
     view.enableEditing(true)
 
     let info = BookmarksListInfo(title: bookmarkGroup.title,

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.swift
@@ -1,6 +1,11 @@
 final class BookmarksListViewController: MWMViewController {
   var presenter: IBookmarksListPresenter!
 
+  private enum Constants {
+    static let headerHeight = CGFloat(60)
+    static let iOS26ToolbarBottomSpacing = CGFloat(16)
+  }
+
   private var sections: [IBookmarksListSectionViewModel]?
   private let cellStrategy = BookmarksListCellStrategy()
 
@@ -8,6 +13,7 @@ final class BookmarksListViewController: MWMViewController {
 
   @IBOutlet private var tableView: UITableView!
   @IBOutlet private var toolBar: UIToolbar!
+  @IBOutlet private weak var toolBarBottomConstraint: NSLayoutConstraint!
   @IBOutlet private var sortToolbarItem: UIBarButtonItem!
   @IBOutlet private var moreToolbarItem: UIBarButtonItem!
   private let searchController = UISearchController(searchResultsController: nil)
@@ -39,7 +45,11 @@ final class BookmarksListViewController: MWMViewController {
     searchController.searchBar.applyTheme()
     navigationItem.searchController = searchController
     navigationItem.hidesSearchBarWhenScrolling = false
-    
+    if #available(iOS 26.0, *), !isiPad {
+      // Additional inset to the bottom toolbar search.
+      toolBarBottomConstraint.constant = Constants.iOS26ToolbarBottomSpacing
+    }
+
     cellStrategy.registerCells(tableView)
     cellStrategy.cellCheckHandler = { [weak self] (viewModel, index, checked) in
       self?.presenter.checkItem(in: viewModel, at: index, checked: checked)
@@ -63,6 +73,7 @@ final class BookmarksListViewController: MWMViewController {
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
     updateInfoSize()
+    tableView.contentInset.bottom = toolBar.height
   }
 
   private func updateInfoSize() {
@@ -106,7 +117,7 @@ extension BookmarksListViewController: UITableViewDataSource {
 
 extension BookmarksListViewController: UITableViewDelegate {
   func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-    60
+    Constants.headerHeight
   }
 
   func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.xib
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.xib
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24127" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BookmarksListViewController" customModule="OMaps" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BookmarksListViewController" customModule="Organic_Maps" customModuleProvider="target">
             <connections>
                 <outlet property="moreToolbarItem" destination="Hhy-7w-Mz0" id="0bI-d2-WuP"/>
                 <outlet property="sortToolbarItem" destination="BWR-ft-be3" id="iiS-BA-nqF"/>
                 <outlet property="tableView" destination="fva-qQ-WqU" id="XoT-Z8-nGb"/>
                 <outlet property="toolBar" destination="cD8-kh-Gmp" id="1M2-EB-fbH"/>
+                <outlet property="toolBarBottomConstraint" destination="FgV-RT-cCW" id="s0d-uM-lhV"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -23,7 +24,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="60" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="fva-qQ-WqU">
-                    <rect key="frame" x="0.0" y="56" width="375" height="567"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                     <inset key="separatorInset" minX="56" minY="0.0" maxX="0.0" maxY="0.0"/>
                     <userDefinedRuntimeAttributes>
@@ -35,7 +36,7 @@
                     </connections>
                 </tableView>
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cD8-kh-Gmp">
-                    <rect key="frame" x="0.0" y="623" width="375" height="44"/>
+                    <rect key="frame" x="0.0" y="619" width="375" height="48"/>
                     <items>
                         <barButtonItem width="8" style="plain" systemItem="fixedSpace" id="E0V-Le-AEM"/>
                         <barButtonItem title="Sort" style="plain" id="BWR-ft-be3">
@@ -63,8 +64,8 @@
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="cD8-kh-Gmp" secondAttribute="trailing" id="LZs-Au-R4I"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="fva-qQ-WqU" secondAttribute="trailing" id="OsX-Pn-Js4"/>
                 <constraint firstItem="fva-qQ-WqU" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="d61-I4-Ku3"/>
+                <constraint firstAttribute="bottom" secondItem="fva-qQ-WqU" secondAttribute="bottom" id="i6G-0W-mED"/>
                 <constraint firstItem="cD8-kh-Gmp" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="jVJ-nY-UBF"/>
-                <constraint firstItem="cD8-kh-Gmp" firstAttribute="top" secondItem="fva-qQ-WqU" secondAttribute="bottom" id="lQL-J0-O69"/>
                 <constraint firstItem="fva-qQ-WqU" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="yZs-bO-F39"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>

--- a/iphone/Maps/Categories/UIViewController+Navigation.h
+++ b/iphone/Maps/Categories/UIViewController+Navigation.h
@@ -2,7 +2,4 @@
 
 - (void)goBack;
 
-- (UIBarButtonItem *)buttonWithImage:(UIImage *)image action:(SEL)action;
-- (NSArray<UIBarButtonItem *> *)alignedNavBarButtonItems:(NSArray<UIBarButtonItem *> *)items;
-
 @end

--- a/iphone/Maps/Categories/UIViewController+Navigation.m
+++ b/iphone/Maps/Categories/UIViewController+Navigation.m
@@ -1,33 +1,7 @@
 #import "UIButton+Orientation.h"
 #import "UIViewController+Navigation.h"
 
-static CGFloat const kButtonExtraWidth = 16.0;
-
 @implementation UIViewController (Navigation)
-
-- (UIBarButtonItem *)negativeSpacer
-{
-  UIBarButtonItem * spacer = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace
-                                                                           target:nil
-                                                                           action:nil];
-  spacer.width = -kButtonExtraWidth;
-  return spacer;
-}
-
-- (UIBarButtonItem *)buttonWithImage:(UIImage *)image action:(SEL)action
-{
-  UIButton * button =
-      [[UIButton alloc] initWithFrame:CGRectMake(0, 0, image.size.width + kButtonExtraWidth, image.size.height)];
-  [button setImage:image forState:UIControlStateNormal];
-  [button matchInterfaceOrientation];
-  [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
-  return [[UIBarButtonItem alloc] initWithCustomView:button];
-}
-
-- (NSArray<UIBarButtonItem *> *)alignedNavBarButtonItems:(NSArray<UIBarButtonItem *> *)items
-{
-  return [@[[self negativeSpacer]] arrayByAddingObjectsFromArray:items];
-}
 
 - (void)goBack
 {

--- a/iphone/Maps/Core/Theme/CornerRadius.swift
+++ b/iphone/Maps/Core/Theme/CornerRadius.swift
@@ -1,5 +1,6 @@
 enum CornerRadius {
   case modalSheet
+  case iOS26ModalSheet // TODO: Remove after iOS26 adoption for the PlacePage and Menu screen
   case buttonDefault
   case buttonDefaultSmall
   case buttonDefaultBig
@@ -12,6 +13,7 @@ extension CornerRadius {
   var value: CGFloat {
     switch self {
     case .modalSheet: return 12
+    case .iOS26ModalSheet: return 38
     case .buttonDefault: return 8
     case .buttonDefaultSmall: return 6
     case .buttonDefaultBig: return 12

--- a/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
@@ -476,7 +476,11 @@ extension GlobalStyleSheet: IStyleSheet {
         s.shadowOffset = CGSize(width: 0, height: 1)
         s.shadowOpacity = 0.3
         s.shadowRadius = 6
-        s.cornerRadius = .modalSheet
+        if #available(iOS 26.0, *) {
+          s.cornerRadius = .iOS26ModalSheet
+        } else {
+          s.cornerRadius = .modalSheet
+        }
         s.clip = false
         s.maskedCorners = isiPad ? [] : [.layerMinXMinYCorner, .layerMaxXMinYCorner]
       }

--- a/iphone/Maps/Core/Theme/Renderers/UISearchBarRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/UISearchBarRenderer.swift
@@ -23,6 +23,10 @@ extension UISearchBar {
 
 class UISearchBarRenderer: UIViewRenderer {
   class func render(_ control: UISearchBar, style: Style) {
+    if #available(iOS 26.0, *) {
+      // The search bar customizations breaks the new `LiquidGlass` style that was introduced in iOS 26.0. The native iOS style will be used.
+      return
+    }
     super.render(control, style: style)
     if #available(iOS 13, *) {
       let searchTextField = control.searchTextField

--- a/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderButtonTableViewCell.xib
+++ b/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderButtonTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24127" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,9 +17,11 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Add Maps Button" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="dOW-mN-UY7">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Add Maps Button" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dOW-mN-UY7">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="44" id="OoU-w6-jd5"/>
+                        </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <color key="textColor" systemColor="linkColor"/>
                         <nil key="highlightedColor"/>
@@ -29,6 +31,12 @@
                         </userDefinedRuntimeAttributes>
                     </label>
                 </subviews>
+                <constraints>
+                    <constraint firstItem="dOW-mN-UY7" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="2c4-Gb-L9l"/>
+                    <constraint firstItem="dOW-mN-UY7" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="8dG-pP-sP7"/>
+                    <constraint firstAttribute="bottom" secondItem="dOW-mN-UY7" secondAttribute="bottom" id="9fl-qo-ABB"/>
+                    <constraint firstAttribute="trailing" secondItem="dOW-mN-UY7" secondAttribute="trailing" id="Ynu-yn-sk2"/>
+                </constraints>
             </tableViewCellContentView>
             <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
             <userDefinedRuntimeAttributes>
@@ -39,7 +47,7 @@
     </objects>
     <resources>
         <systemColor name="linkColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iphone/Maps/UI/Downloader/DownloadMapsViewController.swift
+++ b/iphone/Maps/UI/Downloader/DownloadMapsViewController.swift
@@ -80,7 +80,16 @@ class DownloadMapsViewController: MWMViewController {
     tableView.registerNib(cell: MWMMapDownloaderButtonTableViewCell.self)
     title = dataSource.title
     if mode == .downloaded {
-      let addMapsButton = button(with: UIImage(named: "ic_nav_bar_add"), action: #selector(onAddMaps))
+      let image: UIImage
+      if #available(iOS 13.0, *) {
+        image = UIImage(systemName: "plus", withConfiguration: UIImage.SymbolConfiguration(weight: .medium))!
+      } else {
+        image = UIImage(resource: .icNavBarAdd)
+      }
+      let addMapsButton = UIBarButtonItem(image: image,
+                                          style: .plain,
+                                          target: self,
+                                          action: #selector(onAddMaps))
       navigationItem.rightBarButtonItem = addMapsButton
     }
     noMapsContainer.isHidden = !dataSource.isEmpty || Storage.shared().downloadInProgress()
@@ -92,7 +101,6 @@ class DownloadMapsViewController: MWMViewController {
     searchController.searchBar.applyTheme()
     navigationItem.searchController = searchController
     navigationItem.hidesSearchBarWhenScrolling = false
-    
     configButtons()
   }
 

--- a/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.mm
+++ b/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.mm
@@ -22,7 +22,8 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
 {}
 
 @property(weak, nonatomic) IBOutlet UITableView * tableView;
-@property(weak, nonatomic) IBOutlet UISearchBar * searchBar;
+@property(nonatomic) UISearchController * searchViewController;
+
 @property(nonatomic) NSString * selectedType;
 @property(nonatomic) BOOL isSearch;
 @property(nonatomic) MWMObjectsCategorySelectorDataSource * dataSource;
@@ -71,7 +72,14 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
 }
 - (void)configSearchBar
 {
-  self.searchBar.placeholder = L(@"search");
+  self.searchViewController = [[UISearchController alloc] initWithSearchResultsController:nil];
+  self.searchViewController.obscuresBackgroundDuringPresentation = NO;
+  self.searchViewController.hidesNavigationBarDuringPresentation = NO;
+  self.searchViewController.searchBar.placeholder = L(@"search");
+  self.searchViewController.searchBar.delegate = self;
+  [self.searchViewController.searchBar applyTheme];
+  self.navigationItem.hidesSearchBarWhenScrolling = NO;
+  self.navigationItem.searchController = self.searchViewController;
 }
 
 - (void)configEmptySearchResultsDisclaimer

--- a/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapHeaderView.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapHeaderView.swift
@@ -65,6 +65,7 @@ final class SearchOnMapHeaderView: UIView {
     searchBar.setStyle(.defaultSearchBar)
     searchBar.placeholder = L("search")
     searchBar.showsCancelButton = false
+    searchBar.searchBarStyle = .minimal
     if #available(iOS 13.0, *) {
       searchBar.searchTextField.clearButtonMode = .always
       searchBar.returnKeyType = .search
@@ -82,10 +83,14 @@ final class SearchOnMapHeaderView: UIView {
   private func layoutView() {
     addSubview(grabberView)
     addSubview(grabberTapHandlerView)
-    addSubview(searchBar)
     addSubview(cancelContainer)
+    addSubview(searchBar)
+
     cancelContainer.addSubview(cancelButton)
-    separator = addSeparator(.bottom)
+    if #available(iOS 26.0, *) {}
+    else {
+      separator = addSeparator(.bottom)
+    }
 
     grabberView.translatesAutoresizingMaskIntoConstraints = false
     grabberTapHandlerView.translatesAutoresizingMaskIntoConstraints = false

--- a/iphone/Maps/UI/Storyboard/Main.storyboard
+++ b/iphone/Maps/UI/Storyboard/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wns-nH-AQU">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24127" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wns-nH-AQU">
     <device id="iPad13_0rounded" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -267,7 +267,7 @@
                 <navigationController id="Psz-BY-Fy4" customClass="MWMNavigationController" sceneMemberID="viewController">
                     <value key="contentSizeForViewInPopover" type="size" width="600" height="600"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="SUN-3A-xgM">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="56"/>
+                        <rect key="frame" x="0.0" y="10" width="600" height="54"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -651,7 +651,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="interactive" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="JbV-y9-HBo">
-                                <rect key="frame" x="0.0" y="80" width="1032" height="1251"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1032" height="1376"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="TableView:PressBackground"/>
@@ -661,50 +661,20 @@
                                     <outlet property="delegate" destination="QlF-CJ-cEG" id="QFe-QZ-zDw"/>
                                 </connections>
                             </tableView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rI9-RR-sKP" userLabel="Status Bar Background">
-                                <rect key="frame" x="0.0" y="-28" width="1032" height="108"/>
-                                <color key="backgroundColor" red="0.1215686275" green="0.59999999999999998" blue="0.32156862749999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="108" id="Qw2-w6-Efn"/>
-                                </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="SearchStatusBarView"/>
-                                </userDefinedRuntimeAttributes>
-                            </view>
-                            <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="gzF-B7-8pj">
-                                <rect key="frame" x="0.0" y="24" width="1032" height="56"/>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="2uI-k6-ahr"/>
-                                </constraints>
-                                <color key="barTintColor" red="0.1215686275" green="0.59999999999999998" blue="0.32156862749999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <textInputTraits key="textInputTraits"/>
-                                <connections>
-                                    <outlet property="delegate" destination="QlF-CJ-cEG" id="E9l-Dh-dkk"/>
-                                </connections>
-                            </searchBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="lsu-H8-wQc"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="gzF-B7-8pj" secondAttribute="trailing" id="05P-0L-iQz"/>
                             <constraint firstAttribute="trailing" secondItem="JbV-y9-HBo" secondAttribute="trailing" id="9Eh-BE-WvD"/>
-                            <constraint firstItem="rI9-RR-sKP" firstAttribute="bottom" secondItem="gzF-B7-8pj" secondAttribute="bottom" id="Cct-ww-qJd"/>
-                            <constraint firstItem="lsu-H8-wQc" firstAttribute="bottom" secondItem="JbV-y9-HBo" secondAttribute="bottom" id="JxK-xu-ZHw"/>
+                            <constraint firstAttribute="bottom" secondItem="JbV-y9-HBo" secondAttribute="bottom" id="JxK-xu-ZHw"/>
                             <constraint firstItem="JbV-y9-HBo" firstAttribute="leading" secondItem="MIY-NW-Joh" secondAttribute="leading" id="MFw-S4-taL"/>
-                            <constraint firstItem="JbV-y9-HBo" firstAttribute="top" secondItem="rI9-RR-sKP" secondAttribute="bottom" id="X6Z-Ta-uoQ"/>
-                            <constraint firstItem="gzF-B7-8pj" firstAttribute="top" secondItem="lsu-H8-wQc" secondAttribute="top" id="YYe-8d-Lnc"/>
-                            <constraint firstItem="gzF-B7-8pj" firstAttribute="leading" secondItem="lsu-H8-wQc" secondAttribute="leading" id="gQZ-gg-Opf"/>
-                            <constraint firstAttribute="trailing" secondItem="rI9-RR-sKP" secondAttribute="trailing" id="p51-up-UeV"/>
-                            <constraint firstItem="rI9-RR-sKP" firstAttribute="leading" secondItem="MIY-NW-Joh" secondAttribute="leading" id="uJM-3a-T9n"/>
+                            <constraint firstItem="JbV-y9-HBo" firstAttribute="top" secondItem="MIY-NW-Joh" secondAttribute="top" id="Z4w-zP-8Bk"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="PressBackground"/>
                         </userDefinedRuntimeAttributes>
                     </view>
                     <connections>
-                        <outlet property="searchBar" destination="gzF-B7-8pj" id="X59-8C-1yC"/>
                         <outlet property="tableView" destination="JbV-y9-HBo" id="uQw-El-Xes"/>
                         <segue destination="Lfa-Zp-orR" kind="custom" identifier="CategorySelectorToEditorSegue" customClass="MWMSegue" id="gFM-Ca-ARt"/>
                     </connections>
@@ -722,7 +692,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="interactive" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="ina-WD-kps">
-                                <rect key="frame" x="0.0" y="80" width="1032" height="1251"/>
+                                <rect key="frame" x="0.0" y="88" width="1032" height="1243"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="TableView:PressBackground"/>
@@ -733,7 +703,7 @@
                                 </connections>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HEU-Bu-3wh" userLabel="Status Bar Background">
-                                <rect key="frame" x="0.0" y="-28" width="1032" height="108"/>
+                                <rect key="frame" x="0.0" y="-20" width="1032" height="108"/>
                                 <color key="backgroundColor" red="0.1215686275" green="0.59999999999999998" blue="0.32156862749999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
@@ -744,7 +714,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="z6s-26-dP6">
-                                <rect key="frame" x="0.0" y="24" width="1032" height="56"/>
+                                <rect key="frame" x="0.0" y="24" width="1032" height="64"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="UAk-z1-2EY"/>
@@ -1053,8 +1023,8 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="4Cc-99-mlN"/>
-        <segue reference="OEF-kR-jKi"/>
+        <segue reference="urr-1u-jhn"/>
+        <segue reference="gFM-Ca-ARt"/>
         <segue reference="0A8-4b-0A2"/>
     </inferredMetricsTieBreakers>
     <resources>


### PR DESCRIPTION
This PR fixes some issues but not all described in the https://github.com/organicmaps/organicmaps/issues/11403

### 1. Search bar fixes
#### Bookmarks
<img width="600" height="827" alt="image" src="https://github.com/user-attachments/assets/dced2468-e3f2-44a6-b701-e3344218cd40" />

#### Maps downloading
<img width="600" height="826" alt="image" src="https://github.com/user-attachments/assets/66d9d1a0-296f-47f1-8faa-08c5de9f8d49" />
<img width="600" height="824" alt="image" src="https://github.com/user-attachments/assets/a550b892-9592-4940-af3f-d7a0ef3b0af0" />
<img width="600" height="831" alt="image" src="https://github.com/user-attachments/assets/91b0346a-1306-48cf-bb0b-cffb8a7e155b" />

#### Select category during editing (also fixed for <18ios)
<img width="600" height="835" alt="image" src="https://github.com/user-attachments/assets/921999ca-e756-4ff7-b912-7e824ccb3b13" />

#### In the recently deleted search screen was not moved to the bottom to avoid conflict with toolbar items
<img width="600" height="835" alt="image" src="https://github.com/user-attachments/assets/4d7cdd7e-4183-4bd6-bbfe-26c65aa53329" />

#### For the iPad, the position wasn't changed - it is still in the navbar
<img width="500" height="892" alt="image" src="https://github.com/user-attachments/assets/295e3dab-142a-4d53-a461-3aa308ca8772" />
<img width="500" height="892" alt="image" src="https://github.com/user-attachments/assets/f89bd44b-1c6a-480e-b273-f180c4624c0a" />


### 2. Fix the download button position 
Before / After
<img width="300" height="775" alt="image" src="https://github.com/user-attachments/assets/4eeb03e7-5cf9-4573-8010-5a2a33043493" /> <img width="300" height="819" alt="image" src="https://github.com/user-attachments/assets/fbaaa079-c281-414e-9ac1-0bab9ceb902c" />

### 3. Fixed the `Search screen` search bar and updated the modal screen corner radiuses to match the iOS 26 modal screen style (an additional step is to replace the `Cancel` with a circle `X` button)

<img width="600" height="820" alt="image" src="https://github.com/user-attachments/assets/6218d3fc-ef03-473f-b323-a6b610ce3cfa" />
<img width="600" height="821" alt="image" src="https://github.com/user-attachments/assets/13627721-91bb-419b-8b16-5defe2aedb6b" />
