### PR TITLE
[android] Fix speed limit view

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/NavigationController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/NavigationController.java
@@ -261,12 +261,7 @@ public class NavigationController implements TrafficManager.TrafficCallback, Nav
   private void updateSpeedLimit(@NonNull final RoutingInfo info)
   {
     final Location location = MwmApplication.from(mFrame.getContext()).getLocationHelper().getSavedLocation();
-    if (location == null)
-    {
-      mSpeedLimit.setSpeedLimit(0, false);
-      return;
-    }
-    final boolean speedLimitExceeded = info.speedLimitMps < location.getSpeed();
+    final boolean speedLimitExceeded = location != null && info.speedLimitMps < location.getSpeed();
     mSpeedLimit.setSpeedLimit(StringUtils.nativeFormatSpeed(info.speedLimitMps), speedLimitExceeded);
   }
 }


### PR DESCRIPTION
We are hiding speed limit view when no location (-> no current speed) is available. That doesn't sound right...

The change is to not hide speed limit view in this case.