### PR TITLE
Commented out flaky benchmark that randomly fails on CI

### DIFF
--- a/libs/drape/drape_tests/vertex_buffer_tests.cpp
+++ b/libs/drape/drape_tests/vertex_buffer_tests.cpp
@@ -88,8 +88,10 @@ UNIT_TEST(VertexBuffer_Benchmark)
 
   LOG(LINFO,
       ("vector time:", t1, "buffer_vector time:", t2, "boost::small_vector time:", t3, "reserved vector time:", t4));
-  TEST_LESS(t2, t1, ());
-  TEST_LESS(t3, t2, ());
+  // TODO(AB): Commented out because it is frequently flaky on Mac OS CI.
+  // TEST_LESS(t2, t1, ());
+  // TODO(AB): Commented out because it is frequently flaky on Linux CI.
+  // TEST_LESS(t3, t2, ());
   // TODO: Fix this condition
   // TEST_LESS(t4, t3, ());
 }


### PR DESCRIPTION
```
Running vertex_buffer_tests.cpp::VertexBuffer_Benchmark
vector time: 270 buffer_vector time: 136 boost::small_vector time: 144 reserved vector time: 145
FAILED
drape_tests/vertex_buffer_tests.cpp:92 TEST(t3 < t2) 144 136 
Test took 704 ms
```
https://github.com/organicmaps/organicmaps/actions/runs/18079710901/job/51441269389?pr=11448#step:14:210