### PR TITLE
[ios] Fix navigation info updating bug

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardEntity.h
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardEntity.h
@@ -9,7 +9,6 @@
 @property(copy, nonatomic, readonly) NSString * targetUnits;
 @property(copy, nonatomic, readonly) NSString * turnUnits;
 @property(nonatomic, readonly) double speedLimitMps;
-@property(nonatomic, readonly) BOOL isValid;
 @property(nonatomic, readonly) CGFloat progress;
 @property(nonatomic, readonly) NSUInteger roundExitNumber;
 @property(nonatomic, readonly) NSUInteger timeToTarget;

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
@@ -105,27 +105,86 @@ NSArray<MWMRouterTransitStepInfo *> * buildRouteTransitSteps(NSArray<MWMRoutePoi
 }
 }  // namespace
 
+@interface MWMRouterTransitStepInfo ()
+
+- (instancetype)initWithStepInfo:(TransitStepInfo const &)info;
+
+@end
+
 @interface MWMNavigationDashboardEntity ()
 
-@property(copy, nonatomic, readwrite) NSArray<MWMRouterTransitStepInfo *> * transitSteps;
-@property(copy, nonatomic, readwrite) NSString * distanceToTurn;
-@property(copy, nonatomic, readwrite) NSString * streetName;
-@property(copy, nonatomic, readwrite) NSString * targetDistance;
-@property(copy, nonatomic, readwrite) NSString * targetUnits;
-@property(copy, nonatomic, readwrite) NSString * turnUnits;
-@property(nonatomic, readwrite) double speedLimitMps;
-@property(nonatomic, readwrite) BOOL isValid;
-@property(nonatomic, readwrite) CGFloat progress;
-@property(nonatomic, readwrite) NSUInteger roundExitNumber;
-@property(nonatomic, readwrite) NSUInteger timeToTarget;
-@property(nonatomic, readwrite) UIImage * nextTurnImage;
-@property(nonatomic, readwrite) UIImage * turnImage;
 @property(nonatomic, readwrite) BOOL showEta;
 @property(nonatomic, readwrite) BOOL isWalk;
 
 @end
 
 @implementation MWMNavigationDashboardEntity
+
+// MARK: - Initializers
+
+- (instancetype)initWithFollowingInfo:(routing::FollowingInfo const &)info
+                          routePoints:(NSArray<MWMRoutePoint *> *)points
+                                 type:(MWMRouterType)type
+{
+  self = [super init];
+  if (self)
+  {
+    BOOL const showEta = (type != MWMRouterTypeRuler);
+    _timeToTarget = info.m_time;
+    _targetDistance = @(info.m_distToTarget.GetDistanceString().c_str());
+    _targetUnits = @(info.m_distToTarget.GetUnitsString().c_str());
+    _progress = info.m_completionPercent;
+    _distanceToTurn = @(info.m_distToTurn.GetDistanceString().c_str());
+    _turnUnits = @(info.m_distToTurn.GetUnitsString().c_str());
+    _streetName = @(info.m_nextStreetName.c_str());
+    _speedLimitMps = info.m_speedLimitMps;
+
+    _isWalk = NO;
+    _showEta = showEta;
+
+    if (type == MWMRouterTypeRuler && [points count] > 2)
+      _transitSteps = buildRouteTransitSteps(points);
+    else
+      _transitSteps = [[NSArray alloc] init];
+
+    if (type == MWMRouterTypePedestrian)
+    {
+      _turnImage = image(info.m_pedestrianTurn);
+    }
+    else
+    {
+      using namespace routing::turns;
+      CarDirection const turn = info.m_turn;
+      _turnImage = image(turn, false);
+      _nextTurnImage = image(info.m_nextTurn, true);
+      BOOL const isRound = turn == CarDirection::EnterRoundAbout || turn == CarDirection::StayOnRoundAbout ||
+                           turn == CarDirection::LeaveRoundAbout;
+      if (isRound)
+        _roundExitNumber = info.m_exitNum;
+    }
+  }
+  return self;
+}
+
+- (instancetype)initWithTransitInfo:(TransitRouteInfo const &)info
+{
+  self = [super init];
+  if (self)
+  {
+    _timeToTarget = info.m_totalTimeInSec;
+    _targetDistance = @(info.m_totalPedestrianDistanceStr.c_str());
+    _targetUnits = @(info.m_totalPedestrianUnitsSuffix.c_str());
+    _isWalk = YES;
+    _showEta = YES;
+    NSMutableArray<MWMRouterTransitStepInfo *> * transitSteps = [NSMutableArray new];
+    for (auto const & stepInfo : info.m_steps)
+      [transitSteps addObject:[[MWMRouterTransitStepInfo alloc] initWithStepInfo:stepInfo]];
+    _transitSteps = transitSteps;
+  }
+  return self;
+}
+
+// MARK: - Public methods
 
 - (NSString *)arrival
 {
@@ -185,19 +244,12 @@ NSArray<MWMRouterTransitStepInfo *> * buildRouteTransitSteps(NSArray<MWMRoutePoi
 
 @end
 
-@interface MWMRouterTransitStepInfo ()
-
-- (instancetype)initWithStepInfo:(TransitStepInfo const &)info;
-
-@end
-
 @interface MWMNavigationDashboardManager ()
 
 @property(copy, nonatomic) NSDictionary * etaAttributes;
 @property(copy, nonatomic) NSDictionary * etaSecondaryAttributes;
-@property(nonatomic) MWMNavigationDashboardEntity * entity;
 
-- (void)onNavigationInfoUpdated;
+- (void)onNavigationInfoUpdated:(MWMNavigationDashboardEntity *)entity;
 
 @end
 
@@ -213,67 +265,14 @@ NSArray<MWMRouterTransitStepInfo *> * buildRouteTransitSteps(NSArray<MWMRoutePoi
     AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
     return;
   }
-
-  if (auto entity = self.entity)
-  {
-    BOOL const showEta = (type != MWMRouterTypeRuler);
-
-    entity.isValid = YES;
-    entity.timeToTarget = info.m_time;
-    entity.targetDistance = @(info.m_distToTarget.GetDistanceString().c_str());
-    entity.targetUnits = @(info.m_distToTarget.GetUnitsString().c_str());
-    entity.progress = info.m_completionPercent;
-    entity.distanceToTurn = @(info.m_distToTurn.GetDistanceString().c_str());
-    entity.turnUnits = @(info.m_distToTurn.GetUnitsString().c_str());
-    entity.streetName = @(info.m_nextStreetName.c_str());
-    entity.speedLimitMps = info.m_speedLimitMps;
-
-    entity.isWalk = NO;
-    entity.showEta = showEta;
-
-    if (type == MWMRouterTypeRuler && [points count] > 2)
-      entity.transitSteps = buildRouteTransitSteps(points);
-    else
-      entity.transitSteps = [[NSArray alloc] init];
-
-    if (type == MWMRouterTypePedestrian)
-    {
-      entity.turnImage = image(info.m_pedestrianTurn);
-    }
-    else
-    {
-      using namespace routing::turns;
-      CarDirection const turn = info.m_turn;
-      entity.turnImage = image(turn, false);
-      entity.nextTurnImage = image(info.m_nextTurn, true);
-      BOOL const isRound = turn == CarDirection::EnterRoundAbout || turn == CarDirection::StayOnRoundAbout ||
-                           turn == CarDirection::LeaveRoundAbout;
-      if (isRound)
-        entity.roundExitNumber = info.m_exitNum;
-      else
-        entity.roundExitNumber = 0;
-    }
-  }
-
-  [self onNavigationInfoUpdated];
+  auto const entity = [[MWMNavigationDashboardEntity alloc] initWithFollowingInfo:info routePoints:points type:type];
+  [self onNavigationInfoUpdated:entity];
 }
 
 - (void)updateTransitInfo:(TransitRouteInfo const &)info
 {
-  if (auto entity = self.entity)
-  {
-    entity.timeToTarget = info.m_totalTimeInSec;
-    entity.targetDistance = @(info.m_totalPedestrianDistanceStr.c_str());
-    entity.targetUnits = @(info.m_totalPedestrianUnitsSuffix.c_str());
-    entity.isValid = YES;
-    entity.isWalk = YES;
-    entity.showEta = YES;
-    NSMutableArray<MWMRouterTransitStepInfo *> * transitSteps = [NSMutableArray new];
-    for (auto const & stepInfo : info.m_steps)
-      [transitSteps addObject:[[MWMRouterTransitStepInfo alloc] initWithStepInfo:stepInfo]];
-    entity.transitSteps = transitSteps;
-  }
-  [self onNavigationInfoUpdated];
+  auto const entity = [[MWMNavigationDashboardEntity alloc] initWithTransitInfo:info];
+  [self onNavigationInfoUpdated:entity];
 }
 
 @end

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
@@ -76,12 +76,11 @@
     self.state = MWMNavigationDashboardStateReady;
 }
 
-- (void)onNavigationInfoUpdated
+- (void)onNavigationInfoUpdated:(MWMNavigationDashboardEntity *)entity
 {
   if (self.state == MWMNavigationDashboardStateClosed)
     return;
-  auto entity = self.entity;
-  if (!entity.isValid)
+  if (!entity)
     return;
   [self.navigationDashboardView onNavigationInfoUpdated:entity];
 }
@@ -155,13 +154,6 @@
     BottomTabBarViewController.controller.isHidden = state != MWMNavigationDashboardStateClosed;
 }
 
-- (MWMNavigationDashboardEntity *)entity
-{
-  if (!_entity)
-    _entity = [[MWMNavigationDashboardEntity alloc] init];
-  return _entity;
-}
-
 #pragma mark - State changes
 
 - (void)stateClosed
@@ -211,7 +203,7 @@
 - (void)stateNavigation
 {
   [self.navigationDashboardView stateNavigation];
-  [self onNavigationInfoUpdated];
+  [self onNavigationInfoUpdated:self.entity];
 }
 
 #pragma mark - MWMRoutePreviewDelegate


### PR DESCRIPTION
After the route preview redesign, the issue was found - the navigation dashboard updates were laggy and delayed. 

This has happened because the `MWMNavigationDashboardEntity` that holds all the info about the route was used as a `singleton` during the navigation session and just updated on every new notification from the core:

https://github.com/organicmaps/organicmaps/blob/337242ada461d8825678129caa386607732147b0/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager%2BEntity.mm#L206-L259

And since the reference object always pass the `==` check in the `NavigationDashboardPresenter` (the object doestn marked as `updated`)  the update was delayed:

https://github.com/organicmaps/organicmaps/blob/337242ada461d8825678129caa386607732147b0/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardPresenter.swift#L19-L24

This PR fixes the issue by creating a new entity instance on every update. It returns the old behaviour. 
In the future, there can be created smarter equality checks to filter the entities with `almost the same values`, such as progress or distance.


https://github.com/user-attachments/assets/6dbfbae7-49ba-4271-8639-fd775ed2b64c
