### PR TITLE
[android] Navigation service crash permission fix

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/NavigationService.java
+++ b/android/app/src/main/java/app/organicmaps/routing/NavigationService.java
@@ -226,12 +226,20 @@ public class NavigationService extends Service implements LocationListener
     }
 
     Logger.i(TAG, "Starting Navigation Foreground service");
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+
+    try
+    {
       ServiceCompat.startForeground(
           this, NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build(),
           ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION | ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
-    else
-      ServiceCompat.startForeground(this, NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build(), 0);
+    }
+    catch (SecurityException e)
+    {
+      // It is unknown why, but on Android 14+ devices starting services fails despite permission checks above.
+      Logger.e(TAG, "Failed to start foreground service, stopping the service", e);
+      stopSelf();
+      return START_NOT_STICKY;
+    }
 
     final LocationHelper locationHelper = MwmApplication.from(this).getLocationHelper();
 


### PR DESCRIPTION
Fixes https://github.com/organicmaps/organicmaps/issues/9395

Should silence such crashes, so we can rely on users feedback about non-working navigation service.