### PR TITLE
Revert "[ios] Fix iOS26 search bars appearance and layout"

### DIFF
--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.swift
@@ -1,11 +1,6 @@
 final class BookmarksListViewController: MWMViewController {
   var presenter: IBookmarksListPresenter!
 
-  private enum Constants {
-    static let headerHeight = CGFloat(60)
-    static let iOS26ToolbarBottomSpacing = CGFloat(16)
-  }
-
   private var sections: [IBookmarksListSectionViewModel]?
   private let cellStrategy = BookmarksListCellStrategy()
 
@@ -13,7 +8,6 @@ final class BookmarksListViewController: MWMViewController {
 
   @IBOutlet private var tableView: UITableView!
   @IBOutlet private var toolBar: UIToolbar!
-  @IBOutlet private weak var toolBarBottomConstraint: NSLayoutConstraint!
   @IBOutlet private var sortToolbarItem: UIBarButtonItem!
   @IBOutlet private var moreToolbarItem: UIBarButtonItem!
   private let searchController = UISearchController(searchResultsController: nil)
@@ -45,11 +39,7 @@ final class BookmarksListViewController: MWMViewController {
     searchController.searchBar.applyTheme()
     navigationItem.searchController = searchController
     navigationItem.hidesSearchBarWhenScrolling = false
-    if #available(iOS 26.0, *), !isiPad {
-      // Additional inset to the bottom toolbar search.
-      toolBarBottomConstraint.constant = Constants.iOS26ToolbarBottomSpacing
-    }
-
+    
     cellStrategy.registerCells(tableView)
     cellStrategy.cellCheckHandler = { [weak self] (viewModel, index, checked) in
       self?.presenter.checkItem(in: viewModel, at: index, checked: checked)
@@ -73,7 +63,6 @@ final class BookmarksListViewController: MWMViewController {
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
     updateInfoSize()
-    tableView.contentInset.bottom = toolBar.height
   }
 
   private func updateInfoSize() {
@@ -117,7 +106,7 @@ extension BookmarksListViewController: UITableViewDataSource {
 
 extension BookmarksListViewController: UITableViewDelegate {
   func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-    Constants.headerHeight
+    60
   }
 
   func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.xib
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.xib
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24127" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BookmarksListViewController" customModule="Organic_Maps" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BookmarksListViewController" customModule="OMaps" customModuleProvider="target">
             <connections>
                 <outlet property="moreToolbarItem" destination="Hhy-7w-Mz0" id="0bI-d2-WuP"/>
                 <outlet property="sortToolbarItem" destination="BWR-ft-be3" id="iiS-BA-nqF"/>
                 <outlet property="tableView" destination="fva-qQ-WqU" id="XoT-Z8-nGb"/>
                 <outlet property="toolBar" destination="cD8-kh-Gmp" id="1M2-EB-fbH"/>
-                <outlet property="toolBarBottomConstraint" destination="FgV-RT-cCW" id="s0d-uM-lhV"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -24,7 +23,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="60" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="fva-qQ-WqU">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <rect key="frame" x="0.0" y="56" width="375" height="567"/>
                     <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                     <inset key="separatorInset" minX="56" minY="0.0" maxX="0.0" maxY="0.0"/>
                     <userDefinedRuntimeAttributes>
@@ -36,7 +35,7 @@
                     </connections>
                 </tableView>
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cD8-kh-Gmp">
-                    <rect key="frame" x="0.0" y="619" width="375" height="48"/>
+                    <rect key="frame" x="0.0" y="623" width="375" height="44"/>
                     <items>
                         <barButtonItem width="8" style="plain" systemItem="fixedSpace" id="E0V-Le-AEM"/>
                         <barButtonItem title="Sort" style="plain" id="BWR-ft-be3">
@@ -64,8 +63,8 @@
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="cD8-kh-Gmp" secondAttribute="trailing" id="LZs-Au-R4I"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="fva-qQ-WqU" secondAttribute="trailing" id="OsX-Pn-Js4"/>
                 <constraint firstItem="fva-qQ-WqU" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="d61-I4-Ku3"/>
-                <constraint firstAttribute="bottom" secondItem="fva-qQ-WqU" secondAttribute="bottom" id="i6G-0W-mED"/>
                 <constraint firstItem="cD8-kh-Gmp" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="jVJ-nY-UBF"/>
+                <constraint firstItem="cD8-kh-Gmp" firstAttribute="top" secondItem="fva-qQ-WqU" secondAttribute="bottom" id="lQL-J0-O69"/>
                 <constraint firstItem="fva-qQ-WqU" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="yZs-bO-F39"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>

--- a/iphone/Maps/Core/Theme/CornerRadius.swift
+++ b/iphone/Maps/Core/Theme/CornerRadius.swift
@@ -1,6 +1,5 @@
 enum CornerRadius {
   case modalSheet
-  case iOS26ModalSheet // TODO: Remove after iOS26 adoption for the PlacePage and Menu screen
   case buttonDefault
   case buttonDefaultSmall
   case buttonDefaultBig
@@ -13,7 +12,6 @@ extension CornerRadius {
   var value: CGFloat {
     switch self {
     case .modalSheet: return 12
-    case .iOS26ModalSheet: return 38
     case .buttonDefault: return 8
     case .buttonDefaultSmall: return 6
     case .buttonDefaultBig: return 12

--- a/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
@@ -476,11 +476,7 @@ extension GlobalStyleSheet: IStyleSheet {
         s.shadowOffset = CGSize(width: 0, height: 1)
         s.shadowOpacity = 0.3
         s.shadowRadius = 6
-        if #available(iOS 26.0, *) {
-          s.cornerRadius = .iOS26ModalSheet
-        } else {
-          s.cornerRadius = .modalSheet
-        }
+        s.cornerRadius = .modalSheet
         s.clip = false
         s.maskedCorners = isiPad ? [] : [.layerMinXMinYCorner, .layerMaxXMinYCorner]
       }

--- a/iphone/Maps/Core/Theme/Renderers/UISearchBarRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/UISearchBarRenderer.swift
@@ -23,10 +23,6 @@ extension UISearchBar {
 
 class UISearchBarRenderer: UIViewRenderer {
   class func render(_ control: UISearchBar, style: Style) {
-    if #available(iOS 26.0, *) {
-      // The search bar customizations breaks the new `LiquidGlass` style that was introduced in iOS 26.0. The native iOS style will be used.
-      return
-    }
     super.render(control, style: style)
     if #available(iOS 13, *) {
       let searchTextField = control.searchTextField

--- a/iphone/Maps/UI/Downloader/DownloadMapsViewController.swift
+++ b/iphone/Maps/UI/Downloader/DownloadMapsViewController.swift
@@ -101,6 +101,7 @@ class DownloadMapsViewController: MWMViewController {
     searchController.searchBar.applyTheme()
     navigationItem.searchController = searchController
     navigationItem.hidesSearchBarWhenScrolling = false
+    
     configButtons()
   }
 

--- a/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.mm
+++ b/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.mm
@@ -22,8 +22,7 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
 {}
 
 @property(weak, nonatomic) IBOutlet UITableView * tableView;
-@property(nonatomic) UISearchController * searchViewController;
-
+@property(weak, nonatomic) IBOutlet UISearchBar * searchBar;
 @property(nonatomic) NSString * selectedType;
 @property(nonatomic) BOOL isSearch;
 @property(nonatomic) MWMObjectsCategorySelectorDataSource * dataSource;
@@ -72,14 +71,7 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
 }
 - (void)configSearchBar
 {
-  self.searchViewController = [[UISearchController alloc] initWithSearchResultsController:nil];
-  self.searchViewController.obscuresBackgroundDuringPresentation = NO;
-  self.searchViewController.hidesNavigationBarDuringPresentation = NO;
-  self.searchViewController.searchBar.placeholder = L(@"search");
-  self.searchViewController.searchBar.delegate = self;
-  [self.searchViewController.searchBar applyTheme];
-  self.navigationItem.hidesSearchBarWhenScrolling = NO;
-  self.navigationItem.searchController = self.searchViewController;
+  self.searchBar.placeholder = L(@"search");
 }
 
 - (void)configEmptySearchResultsDisclaimer

--- a/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapHeaderView.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapHeaderView.swift
@@ -65,7 +65,6 @@ final class SearchOnMapHeaderView: UIView {
     searchBar.setStyle(.defaultSearchBar)
     searchBar.placeholder = L("search")
     searchBar.showsCancelButton = false
-    searchBar.searchBarStyle = .minimal
     if #available(iOS 13.0, *) {
       searchBar.searchTextField.clearButtonMode = .always
       searchBar.returnKeyType = .search
@@ -83,14 +82,10 @@ final class SearchOnMapHeaderView: UIView {
   private func layoutView() {
     addSubview(grabberView)
     addSubview(grabberTapHandlerView)
-    addSubview(cancelContainer)
     addSubview(searchBar)
-
+    addSubview(cancelContainer)
     cancelContainer.addSubview(cancelButton)
-    if #available(iOS 26.0, *) {}
-    else {
-      separator = addSeparator(.bottom)
-    }
+    separator = addSeparator(.bottom)
 
     grabberView.translatesAutoresizingMaskIntoConstraints = false
     grabberTapHandlerView.translatesAutoresizingMaskIntoConstraints = false

--- a/iphone/Maps/UI/Storyboard/Main.storyboard
+++ b/iphone/Maps/UI/Storyboard/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24127" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wns-nH-AQU">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wns-nH-AQU">
     <device id="iPad13_0rounded" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -267,7 +267,7 @@
                 <navigationController id="Psz-BY-Fy4" customClass="MWMNavigationController" sceneMemberID="viewController">
                     <value key="contentSizeForViewInPopover" type="size" width="600" height="600"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="SUN-3A-xgM">
-                        <rect key="frame" x="0.0" y="10" width="600" height="54"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="56"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -651,7 +651,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="interactive" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="JbV-y9-HBo">
-                                <rect key="frame" x="0.0" y="0.0" width="1032" height="1376"/>
+                                <rect key="frame" x="0.0" y="80" width="1032" height="1251"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="TableView:PressBackground"/>
@@ -661,20 +661,50 @@
                                     <outlet property="delegate" destination="QlF-CJ-cEG" id="QFe-QZ-zDw"/>
                                 </connections>
                             </tableView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rI9-RR-sKP" userLabel="Status Bar Background">
+                                <rect key="frame" x="0.0" y="-28" width="1032" height="108"/>
+                                <color key="backgroundColor" red="0.1215686275" green="0.59999999999999998" blue="0.32156862749999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="108" id="Qw2-w6-Efn"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="SearchStatusBarView"/>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="gzF-B7-8pj">
+                                <rect key="frame" x="0.0" y="24" width="1032" height="56"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="2uI-k6-ahr"/>
+                                </constraints>
+                                <color key="barTintColor" red="0.1215686275" green="0.59999999999999998" blue="0.32156862749999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <connections>
+                                    <outlet property="delegate" destination="QlF-CJ-cEG" id="E9l-Dh-dkk"/>
+                                </connections>
+                            </searchBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="lsu-H8-wQc"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstAttribute="trailing" secondItem="gzF-B7-8pj" secondAttribute="trailing" id="05P-0L-iQz"/>
                             <constraint firstAttribute="trailing" secondItem="JbV-y9-HBo" secondAttribute="trailing" id="9Eh-BE-WvD"/>
-                            <constraint firstAttribute="bottom" secondItem="JbV-y9-HBo" secondAttribute="bottom" id="JxK-xu-ZHw"/>
+                            <constraint firstItem="rI9-RR-sKP" firstAttribute="bottom" secondItem="gzF-B7-8pj" secondAttribute="bottom" id="Cct-ww-qJd"/>
+                            <constraint firstItem="lsu-H8-wQc" firstAttribute="bottom" secondItem="JbV-y9-HBo" secondAttribute="bottom" id="JxK-xu-ZHw"/>
                             <constraint firstItem="JbV-y9-HBo" firstAttribute="leading" secondItem="MIY-NW-Joh" secondAttribute="leading" id="MFw-S4-taL"/>
-                            <constraint firstItem="JbV-y9-HBo" firstAttribute="top" secondItem="MIY-NW-Joh" secondAttribute="top" id="Z4w-zP-8Bk"/>
+                            <constraint firstItem="JbV-y9-HBo" firstAttribute="top" secondItem="rI9-RR-sKP" secondAttribute="bottom" id="X6Z-Ta-uoQ"/>
+                            <constraint firstItem="gzF-B7-8pj" firstAttribute="top" secondItem="lsu-H8-wQc" secondAttribute="top" id="YYe-8d-Lnc"/>
+                            <constraint firstItem="gzF-B7-8pj" firstAttribute="leading" secondItem="lsu-H8-wQc" secondAttribute="leading" id="gQZ-gg-Opf"/>
+                            <constraint firstAttribute="trailing" secondItem="rI9-RR-sKP" secondAttribute="trailing" id="p51-up-UeV"/>
+                            <constraint firstItem="rI9-RR-sKP" firstAttribute="leading" secondItem="MIY-NW-Joh" secondAttribute="leading" id="uJM-3a-T9n"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="PressBackground"/>
                         </userDefinedRuntimeAttributes>
                     </view>
                     <connections>
+                        <outlet property="searchBar" destination="gzF-B7-8pj" id="X59-8C-1yC"/>
                         <outlet property="tableView" destination="JbV-y9-HBo" id="uQw-El-Xes"/>
                         <segue destination="Lfa-Zp-orR" kind="custom" identifier="CategorySelectorToEditorSegue" customClass="MWMSegue" id="gFM-Ca-ARt"/>
                     </connections>
@@ -692,7 +722,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="interactive" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="ina-WD-kps">
-                                <rect key="frame" x="0.0" y="88" width="1032" height="1243"/>
+                                <rect key="frame" x="0.0" y="80" width="1032" height="1251"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="TableView:PressBackground"/>
@@ -703,7 +733,7 @@
                                 </connections>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HEU-Bu-3wh" userLabel="Status Bar Background">
-                                <rect key="frame" x="0.0" y="-20" width="1032" height="108"/>
+                                <rect key="frame" x="0.0" y="-28" width="1032" height="108"/>
                                 <color key="backgroundColor" red="0.1215686275" green="0.59999999999999998" blue="0.32156862749999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
@@ -714,7 +744,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="z6s-26-dP6">
-                                <rect key="frame" x="0.0" y="24" width="1032" height="64"/>
+                                <rect key="frame" x="0.0" y="24" width="1032" height="56"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="UAk-z1-2EY"/>
@@ -1023,8 +1053,8 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="urr-1u-jhn"/>
-        <segue reference="gFM-Ca-ARt"/>
+        <segue reference="4Cc-99-mlN"/>
+        <segue reference="OEF-kR-jKi"/>
         <segue reference="0A8-4b-0A2"/>
     </inferredMetricsTieBreakers>
     <resources>


### PR DESCRIPTION
This PR reverts #11411 because the iOS Liquid Glass rollout should coincide with the CI migration to Xcode 26.
Since the app is currently built with Xcode 16, it should preserve the previous appearance.

iOS26 will look like:

<img width="300" height="819" alt="image" src="https://github.com/user-attachments/assets/11cdad63-fca2-4789-ac5e-5900dff0e5e7" />
<img width="300" height="819" alt="image" src="https://github.com/user-attachments/assets/f0b77c72-0c89-4339-92b7-8825d9bf19bf" />
<img width="300" height="819" alt="image" src="https://github.com/user-attachments/assets/3e2238f4-b197-40dd-8c7b-aec4fe973f81" />
<img width="300" height="819" alt="image" src="https://github.com/user-attachments/assets/679b6271-ca56-4043-a5ae-776e1b5bb784" />
