### PR TITLE
[ios] Update OSM login buttons style

### DIFF
--- a/iphone/Maps/UI/Storyboard/Authorization.storyboard
+++ b/iphone/Maps/UI/Storyboard/Authorization.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24128" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2p5-BG-sgS">
-                                <rect key="frame" x="0.0" y="68" width="414" height="88"/>
+                                <rect key="frame" x="0.0" y="116" width="414" height="88"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8t7-Lb-1dX" userLabel="Separator #1">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="1"/>
@@ -100,21 +100,21 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QoF-Wv-nc2">
-                                <rect key="frame" x="16" y="176" width="382" height="44"/>
+                                <rect key="frame" x="16" y="224" width="382" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="g9P-gK-jg8"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <state key="normal" title="Log In"/>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="FlatNormalButton"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="FlatNormalButtonBig"/>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="login" destination="4R7-Vk-fQr" eventType="touchUpInside" id="IIp-Wz-gj1"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dOX-WF-oyI">
-                                <rect key="frame" x="16" y="232" width="382" height="44"/>
+                                <rect key="frame" x="16" y="280" width="382" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="SFg-uo-s0U"/>
                                 </constraints>
@@ -129,7 +129,7 @@
                                 </connections>
                             </button>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jMt-5d-INe">
-                                <rect key="frame" x="197" y="188" width="20" height="20"/>
+                                <rect key="frame" x="197" y="236" width="20" height="20"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="9HJ-T7-PfS"/>
@@ -184,7 +184,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S0n-BM-V4o" userLabel="Auth view">
-                                <rect key="frame" x="20" y="144" width="374" height="194"/>
+                                <rect key="frame" x="20" y="192" width="374" height="194"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tzz-yF-441">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="41"/>
@@ -207,9 +207,10 @@
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="BfT-9z-7iV"/>
                                         </constraints>
-                                        <state key="normal" title="OpenStreetMap"/>
+                                        <state key="normal" title="Log inOpenStreetMap"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="FlatNormalButtonBig"/>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="login_osm"/>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
                                             <action selector="loginOSM" destination="iZ6-Zi-bkZ" eventType="touchUpInside" id="U8A-dL-xzX"/>
@@ -224,7 +225,7 @@
                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                         <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular14:whitePrimaryText"/>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="medium17:whitePrimaryText"/>
                                             <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="no_osm_account"/>
                                         </userDefinedRuntimeAttributes>
                                     </label>
@@ -236,7 +237,7 @@
                                         </constraints>
                                         <state key="normal" title="Sign Up Now"/>
                                         <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular17:whitePrimaryText"/>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="FlatNormalButtonBig"/>
                                             <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="register_at_openstreetmap"/>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
@@ -262,7 +263,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qZp-mj-lui" userLabel="Account view">
-                                <rect key="frame" x="0.0" y="48" width="414" height="814"/>
+                                <rect key="frame" x="0.0" y="96" width="414" height="732"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WGF-rs-oH8" userLabel="Main view">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="212"/>
@@ -325,7 +326,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="bottom" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7m7-zW-Tcq">
-                                        <rect key="frame" x="20" y="774" width="374" height="20"/>
+                                        <rect key="frame" x="20" y="692" width="374" height="20"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="20" id="Z6L-ma-g9a"/>
                                         </constraints>


### PR DESCRIPTION
Small buttons style fixes

| Before | After |
| ------ | ----- |
| <img width="300" height="801" alt="image" src="https://github.com/user-attachments/assets/d88e9be0-5e3b-4ff7-9200-bdd0b2163d28" /> | <img width="300" height="801" alt="image" src="https://github.com/user-attachments/assets/33b9dc3b-e78b-4c9a-bb6c-54ea0f951bfd" /> |
|  <img width="300" height="801" alt="image" src="https://github.com/user-attachments/assets/32d9e87d-e51b-485a-b466-db502ef6d837" /> | <img width="300" height="801" alt="image" src="https://github.com/user-attachments/assets/5399c337-6f49-4685-90be-be84e671d41e" /> |
