### PR TITLE
Revert "[android] Add missing service type to NavigationService"

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,7 +40,6 @@
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
   <!--
@@ -526,7 +525,7 @@
 
     <service
         android:name=".routing.NavigationService"
-        android:foregroundServiceType="location|mediaPlayback"
+        android:foregroundServiceType="location"
         android:exported="false"
         android:enabled="true"
         android:stopWithTask="false"/>

--- a/android/app/src/main/java/app/organicmaps/routing/NavigationService.java
+++ b/android/app/src/main/java/app/organicmaps/routing/NavigationService.java
@@ -227,9 +227,8 @@ public class NavigationService extends Service implements LocationListener
 
     Logger.i(TAG, "Starting Navigation Foreground service");
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-      ServiceCompat.startForeground(
-          this, NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build(),
-          ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION | ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
+      ServiceCompat.startForeground(this, NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build(),
+                                    ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
     else
       ServiceCompat.startForeground(this, NavigationService.NOTIFICATION_ID, getNotificationBuilder(this).build(), 0);
 


### PR DESCRIPTION
Looks like this fix doesn't work. Crashes are still there.

This reverts commit 65d9f7488afe3b001da6374373c2bc9c2dffb788.