### PR TITLE
[ios] Add OM as default navigation app

### DIFF
--- a/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
+++ b/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
@@ -84,6 +84,13 @@
 
   private func handleDeepLink(url: URL) -> Bool {
     LOG(.info, "handleDeepLink: \(url)")
+
+    var url = url
+    if #available(iOS 18.4, *), let omURL = GeoNavigationToOMURLConverter.convert(url) {
+      LOG(.info, "Default navigation app link is converted from \(url) to \(omURL)")
+      url = omURL
+    }
+
     // TODO(AB): Rewrite API so iOS and Android will call only one C++ method to clear/set API state.
     // This call is also required for DeepLinkParser.showMap, and it also clears old API points...
     let urlType = DeepLinkParser.parseAndSetApiURL(url)
@@ -101,7 +108,7 @@
       MapsAppDelegate.theApp().showMap()
       return true
     case .search:
-      let sd = DeepLinkSearchData();
+      let sd = DeepLinkSearchData()
       let kSearchInViewportZoom: Int32 = 16;
       // Set viewport only when cll parameter was provided in url.
       // Equator and Prime Meridian are perfectly valid separately.

--- a/iphone/Maps/Core/DeepLink/GeoNavigationToOMURLConverter.swift
+++ b/iphone/Maps/Core/DeepLink/GeoNavigationToOMURLConverter.swift
@@ -1,0 +1,224 @@
+import CoreLocation
+
+@available(iOS 18.4, *)
+struct GeoNavigationToOMURLConverter {
+
+  private enum Scheme {
+    static let geoNavigation = "geo-navigation"
+    static let om = "om"
+  }
+
+  private enum GeoQueryKey {
+    static let source = "source"
+    static let destination = "destination"
+    static let coordinate = "coordinate"
+    static let address = "address"
+  }
+
+  private enum OMQueryKey {
+    static let sourceLatLon = "sll"
+    static let sourceAddress = "saddr"
+    static let destinationLatLon = "dll"
+    static let destinationAddress = "daddr"
+    static let routerType = "type"
+    static let version = "v"
+    static let latLon = "ll"
+    static let name = "n"
+    static let locale = "locale"
+    static let query = "query"
+  }
+
+  private enum OMQueryValue {
+    static let version1 = "1"
+  }
+
+  private enum GeoAction: String {
+    case direction = "/directions"
+    case place = "/place"
+  }
+
+  private enum OMAction {
+    case route(Route)
+    case map(Place)
+    case search(Place)
+
+    var path: String {
+      switch self {
+      case .route: "route"
+      case .map: "map"
+      case .search: "search"
+      }
+    }
+  }
+
+  struct Route {
+    var source: Place
+    var destination: Place
+  }
+
+  struct Place {
+    var coordinate: CLLocationCoordinate2D?
+    var name: String?
+  }
+
+  // MARK: - Public
+
+  static func convert(_ geoURL: URL) -> URL? {
+    guard geoURL.scheme?.lowercased() == Scheme.geoNavigation else {
+      LOG(.warning, "Not a geo-navigation URL: \(geoURL.absoluteString)")
+      return nil
+    }
+
+    guard let components = URLComponents(url: geoURL, resolvingAgainstBaseURL: false),
+          let geoAction = GeoAction(rawValue: components.path.lowercased()) else {
+      LOG(.warning, "Invalid URL: \(geoURL.absoluteString)")
+      return nil
+    }
+
+    func parseCoordinates(_ s: String) -> CLLocationCoordinate2D? {
+      let parts = s.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+      guard parts.count == 2,
+            let lat = Double(parts[0]),
+            let lon = Double(parts[1]),
+            abs(lat) <= 90, abs(lon) <= 180 else {
+        LOG(.warning, "Failed to parse coordinates: \(s)")
+        return nil
+      }
+      return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+    }
+
+    func parsePlace(_ s: String?) -> Place? {
+      let raw = s?.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard let raw, !raw.isEmpty else {
+        LOG(.warning, "Empty place string")
+        return nil
+      }
+      if let coordinates = parseCoordinates(raw) {
+        return Place(coordinate: coordinates, name: nil)
+      } else {
+        return Place(coordinate: nil, name: s)
+      }
+    }
+
+    var omAction: OMAction? = nil
+    switch geoAction {
+    case .direction:
+      let source = parsePlace(components.queryValue(for: GeoQueryKey.source))
+      let destination = parsePlace(components.queryValue(for: GeoQueryKey.destination))
+      if let destination {
+        if let source {
+          // TODO: (KK) Implement waypoints parsing when it will be supported by the core url parser.
+          if source.coordinate != nil && destination.coordinate != nil {
+            omAction = .route(Route(source: source, destination: destination))
+          } else {
+            LOG(.warning, "Source and destination must have coordinates to build a route: \(geoURL.absoluteString)")
+          }
+        } else {
+          if destination.coordinate != nil {
+            omAction = .map(destination)
+          } else {
+            omAction = .search(destination)
+          }
+        }
+      } else {
+        LOG(.warning, "Destination is missing: \(geoURL.absoluteString)")
+      }
+    case .place:
+      if let coordinates = components.queryValue(for: GeoQueryKey.coordinate).flatMap(parseCoordinates) {
+        omAction = .map(Place(coordinate: coordinates, name: components.queryValue(for: GeoQueryKey.address)))
+      } else if let addr = components.queryValue(for: GeoQueryKey.address) {
+        omAction = .search(Place(coordinate: nil, name: addr))
+      }
+    }
+
+    guard let omAction else {
+      LOG(.warning, "Unsupported geo-navigation action: \(geoURL.absoluteString)")
+      return nil
+    }
+    return buildOMURL(for: omAction)
+  }
+
+  static private func buildOMURL(for action: OMAction) -> URL? {
+    switch action {
+    case .route(let route):
+      return buildRouteURL(route, path: action.path)
+    case .map(let place):
+      return buildMapURL(place, path: action.path)
+    case .search(let place):
+      return buildSearchURL(place, path: action.path)
+    }
+  }
+
+  // MARK: - Builders
+
+  static private func buildRouteURL(_ route: Route, path: String) -> URL? {
+    var urlComponents = baseURLComponents(for: path)
+    var items: [URLQueryItem] = []
+
+    let source = route.source
+    if let coordinate = source.coordinate {
+      items.append(URLQueryItem(name: OMQueryKey.sourceLatLon, value: "\(coordinate.latitude),\(coordinate.longitude)"))
+      let n = source.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+      items.append(URLQueryItem(name: OMQueryKey.sourceAddress, value: n))
+    }
+
+    let destination = route.destination
+    if let coordinate = destination.coordinate {
+      items.append(URLQueryItem(name: OMQueryKey.destinationLatLon, value: "\(coordinate.latitude),\(coordinate.longitude)"))
+      let n = destination.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+      items.append(URLQueryItem(name: OMQueryKey.destinationAddress, value: n))
+    }
+
+    items.append(URLQueryItem(name: OMQueryKey.routerType, value: MWMRouter.string(from: MWMRouter.type())))
+    urlComponents.queryItems = items.isEmpty ? nil : items
+    return urlComponents.url
+  }
+
+  static private func buildMapURL(_ place: Place, path: String) -> URL? {
+    var urlComponents = baseURLComponents(for: path)
+    var items: [URLQueryItem] = [URLQueryItem(name: OMQueryKey.version, value: OMQueryValue.version1)]
+
+    if let coordinates = place.coordinate {
+      items.append(URLQueryItem(name: OMQueryKey.latLon, value: "\(coordinates.latitude),\(coordinates.longitude)"))
+    }
+    if let name = place.name?.nilIfEmpty {
+      items.append(URLQueryItem(name: OMQueryKey.name, value: name))
+    }
+
+    urlComponents.queryItems = items
+    return urlComponents.url
+  }
+
+  static private func buildSearchURL(_ place: Place, path: String) -> URL? {
+    var urlComponents = baseURLComponents(for: path)
+    var items: [URLQueryItem] = []
+
+    let locale = AppInfo.shared().twoLetterLanguageId
+    if !locale.isEmpty {
+      items.append(URLQueryItem(name: OMQueryKey.locale, value: locale))
+    }
+
+    guard let query = place.name?.nilIfEmpty else { return nil }
+    items.append(URLQueryItem(name: OMQueryKey.query, value: query))
+
+    urlComponents.queryItems = items.isEmpty ? nil : items
+    return urlComponents.url
+  }
+
+  static private func baseURLComponents(for host: String) -> URLComponents {
+    var c = URLComponents()
+    c.scheme = Scheme.om
+    c.host = host
+    return c
+  }
+}
+
+private extension String {
+  var nilIfEmpty: String? { isEmpty ? nil : self }
+}
+
+private extension URLComponents {
+  func queryValue(for name: String) -> String? {
+    queryItems?.first(where: { $0.name == name })?.value
+  }
+}

--- a/iphone/Maps/Core/Routing/MWMRouter.h
+++ b/iphone/Maps/Core/Routing/MWMRouter.h
@@ -32,6 +32,7 @@ typedef void (^MWMImageHeightBlock)(UIImage *, NSString *, NSString *);
 
 + (void)setType:(MWMRouterType)type;
 + (MWMRouterType)type;
++ (NSString *)stringFromRouterType:(MWMRouterType)type;
 
 + (void)disableFollowMode;
 

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -14,6 +14,7 @@
 #import "UIImage+RGBAData.h"
 
 #include <CoreApi/Framework.h>
+#include <CoreApi/StringUtils.h>
 
 #include "platform/distance.hpp"
 #include "platform/local_country_file_utils.hpp"
@@ -191,6 +192,12 @@ char const * kRenderAltitudeImagesQueueLabel = "mapsme.mwmrouter.renderAltitudeI
 {
   return routerType(GetFramework().GetRoutingManager().GetRouter());
 }
+
++ (NSString *)stringFromRouterType:(MWMRouterType)type
+{
+  return ToNSString(ToString(coreRouterType(type)).c_str());
+}
+
 + (void)disableFollowMode
 {
   GetFramework().GetRoutingManager().DisableFollowMode();

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -489,6 +489,7 @@
 		ED914AB22D35063A00973C45 /* TextColorStyleSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED914AB12D35063A00973C45 /* TextColorStyleSheet.swift */; };
 		ED914AB82D351DF000973C45 /* StyleApplicable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED914AB72D351DF000973C45 /* StyleApplicable.swift */; };
 		ED914ABE2D351FF800973C45 /* UILabel+SetFontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED914ABD2D351FF800973C45 /* UILabel+SetFontStyle.swift */; };
+		ED9837CB2E97ADE100739B1D /* GeoNavigationToOMURLConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9837CA2E97ADE100739B1D /* GeoNavigationToOMURLConverter.swift */; };
 		ED9857082C4ED02D00694F6C /* MailComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9857072C4ED02D00694F6C /* MailComposer.swift */; };
 		ED9966802B94FBC20083CE55 /* ColorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED99667D2B94FBC20083CE55 /* ColorPicker.swift */; };
 		ED9DDF882D6F151000645BC8 /* PlacePageTrackRecordingLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9DDF872D6F151000645BC8 /* PlacePageTrackRecordingLayout.swift */; };
@@ -498,6 +499,7 @@
 		EDB71D8C2D8474A0004A6A7F /* CornerRadius.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB71D8B2D8474A0004A6A7F /* CornerRadius.swift */; };
 		EDB71E002D8B0338004A6A7F /* ModalPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB71DFF2D8B0338004A6A7F /* ModalPresentationAnimator.swift */; };
 		EDB71E042D8B0943004A6A7F /* SearchOnMapAreaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB71E032D8B0943004A6A7F /* SearchOnMapAreaView.swift */; };
+		EDBAB6F52E980421007962B5 /* GeoNavigationToOMURLConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBAB6F42E980421007962B5 /* GeoNavigationToOMURLConverterTests.swift */; };
 		EDBD68072B625724005DD151 /* LocationServicesDisabledAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */; };
 		EDBD680B2B62572E005DD151 /* LocationServicesDisabledAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */; };
 		EDC3573B2B7B5029001AE9CA /* CALayer+SetCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3573A2B7B5029001AE9CA /* CALayer+SetCorner.swift */; };
@@ -1501,6 +1503,7 @@
 		ED914AB12D35063A00973C45 /* TextColorStyleSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextColorStyleSheet.swift; sourceTree = "<group>"; };
 		ED914AB72D351DF000973C45 /* StyleApplicable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleApplicable.swift; sourceTree = "<group>"; };
 		ED914ABD2D351FF800973C45 /* UILabel+SetFontStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+SetFontStyle.swift"; sourceTree = "<group>"; };
+		ED9837CA2E97ADE100739B1D /* GeoNavigationToOMURLConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoNavigationToOMURLConverter.swift; sourceTree = "<group>"; };
 		ED9857072C4ED02D00694F6C /* MailComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailComposer.swift; sourceTree = "<group>"; };
 		ED99667D2B94FBC20083CE55 /* ColorPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorPicker.swift; sourceTree = "<group>"; };
 		ED9DDF872D6F151000645BC8 /* PlacePageTrackRecordingLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacePageTrackRecordingLayout.swift; sourceTree = "<group>"; };
@@ -1510,6 +1513,7 @@
 		EDB71D8B2D8474A0004A6A7F /* CornerRadius.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerRadius.swift; sourceTree = "<group>"; };
 		EDB71DFF2D8B0338004A6A7F /* ModalPresentationAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPresentationAnimator.swift; sourceTree = "<group>"; };
 		EDB71E032D8B0943004A6A7F /* SearchOnMapAreaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchOnMapAreaView.swift; sourceTree = "<group>"; };
+		EDBAB6F42E980421007962B5 /* GeoNavigationToOMURLConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoNavigationToOMURLConverterTests.swift; sourceTree = "<group>"; };
 		EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LocationServicesDisabledAlert.xib; sourceTree = "<group>"; };
 		EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServicesDisabledAlert.swift; sourceTree = "<group>"; };
 		EDC3573A2B7B5029001AE9CA /* CALayer+SetCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+SetCorner.swift"; sourceTree = "<group>"; };
@@ -2762,6 +2766,7 @@
 		4B4153B62BF9709100EE4B02 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				EDBAB6F12E980415007962B5 /* GeoNavigationToOMURLConverterTests */,
 				ED9DDF982D6F6D8000645BC8 /* TrackRecorder */,
 				EDF838AB2C00B9C7007E4E67 /* iCloudTests */,
 				4B4153B72BF970A000EE4B02 /* TextToSpeech */,
@@ -2919,6 +2924,7 @@
 			children = (
 				993F54F7237C622700545511 /* Strategies */,
 				993F5505237C622700545511 /* DeepLinkHandler.swift */,
+				ED9837CA2E97ADE100739B1D /* GeoNavigationToOMURLConverter.swift */,
 			);
 			path = DeepLink;
 			sourceTree = "<group>";
@@ -3355,6 +3361,14 @@
 				ED9DDF9B2D6F6DA300645BC8 /* TrackRecordingManagerTests.swift */,
 			);
 			path = TrackRecorder;
+			sourceTree = "<group>";
+		};
+		EDBAB6F12E980415007962B5 /* GeoNavigationToOMURLConverterTests */ = {
+			isa = PBXGroup;
+			children = (
+				EDBAB6F42E980421007962B5 /* GeoNavigationToOMURLConverterTests.swift */,
+			);
+			path = GeoNavigationToOMURLConverterTests;
 			sourceTree = "<group>";
 		};
 		EDC4E3422C5D1BD3009286A2 /* RecentlyDeletedTests */ = {
@@ -4571,6 +4585,7 @@
 				993DF0B523F6B2EF00AC231A /* PlacePageTrackLayout.swift in Sources */,
 				44360A0D2A7D34990016F412 /* TransportRuler.swift in Sources */,
 				CD6E8677226774C700D1EDF7 /* CPConstants.swift in Sources */,
+				ED9837CB2E97ADE100739B1D /* GeoNavigationToOMURLConverter.swift in Sources */,
 				F6791B141C43DF0B007A8A6E /* MWMStartButton.m in Sources */,
 				9977E6A12480E1EE0073780C /* BottomMenuLayerButton.swift in Sources */,
 				471527372491C20500E91BBA /* SelectBookmarkGroupViewController.swift in Sources */,
@@ -4954,6 +4969,7 @@
 				EDC4E3612C5E2576009286A2 /* RecentlyDeletedCategoriesViewModelTests.swift in Sources */,
 				4B4153B52BF9695500EE4B02 /* MWMTextToSpeechTests.mm in Sources */,
 				EDF838C42C00B9D6007E4E67 /* FileManagerMock.swift in Sources */,
+				EDBAB6F52E980421007962B5 /* GeoNavigationToOMURLConverterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iphone/Maps/OMaps-Debug.entitlements
+++ b/iphone/Maps/OMaps-Debug.entitlements
@@ -19,6 +19,8 @@
 		<string>CloudDocuments</string>
 		<string>CloudKit</string>
 	</array>
+	<key>com.apple.developer.navigation-app</key>
+	<true/>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
 	<array>
 		<string>iCloud.app.organicmaps.debug</string>

--- a/iphone/Maps/OMaps-Release.entitlements
+++ b/iphone/Maps/OMaps-Release.entitlements
@@ -19,6 +19,8 @@
 		<string>CloudDocuments</string>
 		<string>CloudKit</string>
 	</array>
+	<key>com.apple.developer.navigation-app</key>
+	<true/>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
 	<array>
 		<string>iCloud.app.organicmaps</string>

--- a/iphone/Maps/OMaps.plist
+++ b/iphone/Maps/OMaps.plist
@@ -99,6 +99,7 @@
 				<string>geo</string>
 				<string>om</string>
 				<string>mapswithmepro</string>
+                <string>geo-navigation</string>
 			</array>
 		</dict>
 	</array>

--- a/iphone/Maps/Tests/Core/GeoNavigationToOMURLConverterTests/GeoNavigationToOMURLConverterTests.swift
+++ b/iphone/Maps/Tests/Core/GeoNavigationToOMURLConverterTests/GeoNavigationToOMURLConverterTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+@testable import Organic_Maps__Debug_
+
+@available(iOS 18.4, *)
+final class GeoNavigationToOMURLConverterTests: XCTestCase {
+
+  private let converter = GeoNavigationToOMURLConverter.self
+
+  private let coordinate1 = "1.1,2.2"
+  private let coordinate2 = "3.3,4.4"
+
+  // MARK: - Directions tests
+
+  func testDirections_GivenSourceAndDestination_WhenNoWaypoints_ThenBuildRoute() throws {
+    let geoUrl = geoURLStub("geo-navigation:///directions?source=\(coordinate1)&destination=\(coordinate2)")
+    let omUrl = try XCTUnwrap(converter.convert(geoUrl))
+    let routingType = MWMRouter.type()
+    XCTAssertEqual(omUrl.absoluteString, "om://route?sll=\(coordinate1)&saddr=&dll=\(coordinate2)&daddr=&type=\(MWMRouter.string(from: routingType)!)")
+    let urlType = DeepLinkParser.parseAndSetApiURL(omUrl)
+    switch urlType {
+    case .route:
+      let adapter = try XCTUnwrap(DeepLinkRouteStrategyAdapter(omUrl))
+      CheckAlmostEqual(adapter.p1.latitude, 1.1)
+      CheckAlmostEqual(adapter.p1.longitude, 2.2)
+      XCTAssertEqual(adapter.p1.type, .start)
+      XCTAssertFalse(adapter.p1.isMyPosition)
+      CheckAlmostEqual(adapter.p2.latitude, 3.3)
+      CheckAlmostEqual(adapter.p2.longitude, 4.4)
+      XCTAssertFalse(adapter.p2.isMyPosition)
+      XCTAssertEqual(adapter.type, routingType)
+    default:
+      XCTFail("Unexpected url type")
+    }
+  }
+
+  func test_GivenDirections_WhenSourceDestinationAnd2Waypoints_ThenBuildRouteWithoutWaypoints() throws {
+    let geoUrl = geoURLStub("geo-navigation:///directions?source=\(coordinate1)&destination=\(coordinate2)&waypoint=48.0,8.0&waypoint=47.0,8.0")
+    let omUrl = try XCTUnwrap(converter.convert(geoUrl))
+    let routingType = MWMRouter.type()
+    XCTAssertEqual(omUrl.absoluteString, "om://route?sll=\(coordinate1)&saddr=&dll=\(coordinate2)&daddr=&type=vehicle")
+    let urlType = DeepLinkParser.parseAndSetApiURL(omUrl)
+    switch urlType {
+    case .route:
+      let adapter = try XCTUnwrap(DeepLinkRouteStrategyAdapter(omUrl))
+      CheckAlmostEqual(adapter.p1.latitude, 1.1)
+      CheckAlmostEqual(adapter.p1.longitude, 2.2)
+      XCTAssertEqual(adapter.p1.type, .start)
+      XCTAssertFalse(adapter.p1.isMyPosition)
+      CheckAlmostEqual(adapter.p2.latitude, 3.3)
+      CheckAlmostEqual(adapter.p2.longitude, 4.4)
+      XCTAssertFalse(adapter.p2.isMyPosition)
+      XCTAssertEqual(adapter.type, routingType)
+    default:
+      XCTFail("Unexpected url type")
+    }
+  }
+
+  func test_GivenDirections_WhenSourceWithoutDestination_ThenFail() {
+    let geoUrl = geoURLStub("geo-navigation:///directions?source=\(coordinate1)")
+    XCTAssertNil(converter.convert(geoUrl))
+  }
+
+  func test_GivenDirections_WhenDestinationIsCoordinatesWithoutSource_ThenShowPlace() throws {
+    let geoUrl = geoURLStub("geo-navigation:///directions?destination=\(coordinate1)")
+    let omUrl = try XCTUnwrap(converter.convert(geoUrl))
+    XCTAssertEqual(omUrl.absoluteString, "om://map?v=1&ll=\(coordinate1)")
+    XCTAssertEqual(DeepLinkParser.parseAndSetApiURL(omUrl), .map)
+  }
+
+  func test_GivenDirections_WhenDestinationIsNameWithoutSource_ThenSearch() throws {
+    let address = "PlaceName"
+    let geoUrl = geoURLStub("geo-navigation:///directions?destination=\(address)")
+    let omUrl = try XCTUnwrap(converter.convert(geoUrl))
+    XCTAssertEqual(DeepLinkParser.parseAndSetApiURL(omUrl), .search)
+    let sd = DeepLinkSearchData()
+    XCTAssertEqual(sd.query.trimmingCharacters(in: .whitespacesAndNewlines), address)
+    XCTAssertEqual(sd.locale, AppInfo.shared().twoLetterLanguageId)
+  }
+
+  func test_GivenDirections_WhenSourceAndDestinationUseNamesInsteadOfCoordinates_ThenFail() {
+    let geoUrl = geoURLStub("geo-navigation:///directions?source=StartPoint&destination=EndPoint")
+    XCTAssertNil(converter.convert(geoUrl))
+  }
+
+  // MARK: - Place tests
+
+  func test_GivenPlace_WhenHasCoordinatesWithoutAddress_ThenShowPlace() throws {
+    let geoUrl = geoURLStub("geo-navigation:///place?coordinate=\(coordinate1)")
+    let omUrl = try XCTUnwrap(converter.convert(geoUrl))
+    XCTAssertEqual(omUrl.absoluteString, "om://map?v=1&ll=\(coordinate1)")
+    XCTAssertEqual(DeepLinkParser.parseAndSetApiURL(omUrl), .map)
+  }
+
+  func test_GivenPlace_WhenHasCoordinatesAndAddress_ThenShowPlace() throws {
+    let address = "Address"
+    let geoUrl = geoURLStub("geo-navigation:///place?coordinate=\(coordinate1)&address=\(address)")
+    let omUrl = try XCTUnwrap(converter.convert(geoUrl))
+    XCTAssertEqual(omUrl.absoluteString, "om://map?v=1&ll=\(coordinate1)&n=\(address)")
+  }
+
+  func test_GivenPlace_WhenNoAddressNoCoordinates_ThenFail() throws {
+    let geoUrl = geoURLStub("geo-navigation:///place?coordinate=&address=")
+    XCTAssertNil(converter.convert(geoUrl))
+  }
+
+  func test_GivenPlace_WhenBrokenCoordinates_ThenFail() throws {
+    let geoUrl = geoURLStub("geo-navigation:///place?coordinate=1.1")
+    XCTAssertNil(converter.convert(geoUrl))
+  }
+
+  func test_GivenPlace_WhenHasAddressWithoutCoordinates_ThenSearch() throws {
+    let address = "Address"
+    let geoUrl = geoURLStub("geo-navigation:///place?address=\(address)")
+    let omUrl = try XCTUnwrap(converter.convert(geoUrl))
+    let locale = AppInfo.shared().twoLetterLanguageId
+    XCTAssertEqual(omUrl.absoluteString, "om://search?locale=\(locale)&query=\(address)")
+    let urlType = DeepLinkParser.parseAndSetApiURL(omUrl)
+    switch urlType {
+    case .search:
+      let sd = DeepLinkSearchData()
+      XCTAssertEqual(sd.query.trimmingCharacters(in: .whitespacesAndNewlines), address)
+      XCTAssertEqual(sd.locale, AppInfo.shared().twoLetterLanguageId)
+    default:
+      XCTFail("Unexpected url type")
+    }
+  }
+
+  private func geoURLStub(_ s: String) -> URL {
+    guard let url = URL(string: s) else {
+      XCTFail("Bad URL: \(s)")
+      fatalError()
+    }
+    return url
+  }
+
+  private func CheckAlmostEqual(_ lhs: Double, _ rhs: Double, tolerance: Double = 1e-6) {
+    XCTAssertTrue(lhs - rhs < tolerance)
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/organicmaps/organicmaps/issues/10310

Apple's geo-navigation API is described here:
https://developer.apple.com/documentation/MapKit/preparing-your-app-to-be-the-default-navigation-app#Adopt-the-geonavigation-URL-scheme 

### TODO:
- [x] Add support for the default navigation app
- [x] Map `geo-navigation` to the `om` URL
This mapping is tricky because  the APIs are quite different:
1. Routing: OM doesn't support waypoints, so they will be skipped
2. Routing: OM source and destination points should **always** have not only coords but **names** too (even empty). But `geo-navigation` can have in this argument `coord` OR `place name` OR `address`, so there can only be mapping: `coordinate` -> `coordinate` with empty name like `saddr=`. The `place name` or `address` as a source/destination will be skipped.
3. Place: if Apple provides `coordinate/coordinate+address` the `map` api request will be triggered.
4. Place:  if Apple provides only `address` without the coordinates, the `search` api request will be triggered with the `address` as a query.
- [x] Unit tests
- [x] Test on real device. For some reason, testing on the simulator doesn't work for me (maybe because the entitlements aren't properly updated in the dev account), but the `geo-navigation` scheme **deeplinking** works as expected - see results. The `location` buttons on the calendar and reminder in the simulator always open the Apple Maps as before implementation. The correct behavior should be checked for another default app on the real device in EU.
In the Notes app if the address can be parsed by the apple the link will be opened by default app:

### Results  

From the Notes app

https://github.com/user-attachments/assets/8e574956-956f-42bb-9115-7d7608456e6f

geo-navigation support

https://github.com/user-attachments/assets/716ca42f-6ef7-4e5f-b2f6-1f50542d176e


https://github.com/user-attachments/assets/83d6b6c5-18a9-4822-b3d5-8bb5f2815a14


https://github.com/user-attachments/assets/4acaeb7a-32aa-4b99-a947-9acfda36effb

