### PR TITLE
[android] Downgrade Crashlytics due to minSdk version increase

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -271,8 +271,10 @@ dependencies {
 
   // Google Firebase Services
   if (googleFirebaseServicesEnabled) {
-    // Import the BoM for the Firebase platform
-    implementation platform('com.google.firebase:firebase-bom:34.3.0')
+    // Import the BoM for the Firebase platform.
+    // firebase-crashlytics-ndk requires minSdkVersion 23 since 34.0.0
+    // See https://firebase.google.com/support/release-notes/android#crashlytics-ndk_v20-0-0
+    implementation platform('com.google.firebase:firebase-bom:33.16.0')
     // Add the dependencies for the Crashlytics and Analytics libraries
     // When using the BoM, you don't specify versions in Firebase library dependencies
     implementation 'com.google.firebase:firebase-crashlytics'


### PR DESCRIPTION
See https://firebase.google.com/support/release-notes/android#crashlytics-ndk_v20-0-0

Fixes failed Google beta/release builds:

```
 FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:processGoogleBetaMainManifest'.
> Manifest merger failed : uses-sdk:minSdkVersion 21 cannot be smaller than version 23 declared in library [com.google.firebase:firebase-crashlytics-ndk:20.0.2] /home/runner/.gradle/caches/8.14.3/transforms/c5cbc517a6ed9134194fe8dac4844b28/transformed/firebase-crashlytics-ndk-20.0.2/AndroidManifest.xml as the library might be using APIs not available in 21
  	Suggestion: use a compatible library with a minSdk of at most 21,
  		or increase this project's minSdk version to at least 23,
  		or use tools:overrideLibrary="com.google.firebase.crashlytics.ndk" to force usage (may lead to runtime failures)

```