### PR TITLE
[android] Set AudioAttributes in TTS

### DIFF
--- a/android/sdk/src/main/java/app/organicmaps/sdk/sound/AudioFocusManager.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/sound/AudioFocusManager.java
@@ -11,6 +11,12 @@ import androidx.annotation.Nullable;
 
 public class AudioFocusManager
 {
+  public static final AudioAttributes AUDIO_ATTRIBUTES =
+      new AudioAttributes.Builder()
+          .setUsage(AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE)
+          .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+          .build();
+
   @Nullable
   private AudioManager mAudioManager = null;
   @Nullable
@@ -27,10 +33,7 @@ public class AudioFocusManager
       mOnFocusChange = focusGain -> {};
     else
       mAudioFocusRequest = new AudioFocusRequest.Builder(AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
-                               .setAudioAttributes(new AudioAttributes.Builder()
-                                                       .setUsage(AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE)
-                                                       .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                                                       .build())
+                               .setAudioAttributes(AUDIO_ATTRIBUTES)
                                .build();
   }
 

--- a/android/sdk/src/main/java/app/organicmaps/sdk/sound/TtsPlayer.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/sound/TtsPlayer.java
@@ -163,6 +163,7 @@ public enum TtsPlayer
       }
       refreshLanguages();
       mTts.setSpeechRate(SPEECH_RATE);
+      mTts.setAudioAttributes(AudioFocusManager.AUDIO_ATTRIBUTES);
       mTts.setOnUtteranceProgressListener(new UtteranceProgressListener() {
         @Override
         public void onStart(String utteranceId)


### PR DESCRIPTION
I have noticed that we're not setting audio attributes in our TTS.
This may explain some issues with sound
https://github.com/organicmaps/organicmaps/issues/7684
https://github.com/organicmaps/organicmaps/issues/7006
But I'm not sure if it fixes them or not

We're telling the system that we're going to play something for navigation with `CONTENT_TYPE_SPEECH` but we're not telling the TTS engine to actually play it with those parameters