### PR TITLE
[android] Prepare task to publish sdk

### DIFF
--- a/.github/workflows/android-release.yaml
+++ b/.github/workflows/android-release.yaml
@@ -274,3 +274,9 @@ jobs:
             ./android/app/build/outputs/apk/web/release/OrganicMaps-${{ needs.tag.outputs.code }}-web-release.apk
             ./android/app/build/outputs/apk/web/release/OrganicMaps-${{ needs.tag.outputs.code }}-web-release.apk.sha256sum
           fail_on_unmatched_files: true
+
+  android-sdk-release:
+    uses: ./.github/workflows/android-sdk.yaml
+    needs: tag
+    with:
+      tag: ${{ needs.tag.outputs.tag }}

--- a/.github/workflows/android-release.yaml
+++ b/.github/workflows/android-release.yaml
@@ -280,3 +280,6 @@ jobs:
     needs: tag
     with:
       tag: ${{ needs.tag.outputs.tag }}
+    # The reusable workflow reads the Maven Central and signing secrets directly, so the
+    # caller must forward them; without this they would be empty on the release path.
+    secrets: inherit

--- a/.github/workflows/android-release.yaml
+++ b/.github/workflows/android-release.yaml
@@ -274,12 +274,3 @@ jobs:
             ./android/app/build/outputs/apk/web/release/OrganicMaps-${{ needs.tag.outputs.code }}-web-release.apk
             ./android/app/build/outputs/apk/web/release/OrganicMaps-${{ needs.tag.outputs.code }}-web-release.apk.sha256sum
           fail_on_unmatched_files: true
-
-  android-sdk-release:
-    uses: ./.github/workflows/android-sdk.yaml
-    needs: tag
-    with:
-      tag: ${{ needs.tag.outputs.tag }}
-    # The reusable workflow reads the Maven Central and signing secrets directly, so the
-    # caller must forward them; without this they would be empty on the release path.
-    secrets: inherit

--- a/.github/workflows/android-sdk.yaml
+++ b/.github/workflows/android-sdk.yaml
@@ -1,12 +1,7 @@
 name: Android SDK Release
 on:
-  workflow_dispatch:  # Manual trigger
-    inputs:
-      tag:
-        description: 'Release tag'
-        required: true
-        type: string
-  workflow_call: # For calling from another workflow
+  # SDK releases are intentionally decoupled from app releases and triggered manually.
+  workflow_dispatch:
     inputs:
       tag:
         description: 'Release tag'

--- a/.github/workflows/android-sdk.yaml
+++ b/.github/workflows/android-sdk.yaml
@@ -1,0 +1,90 @@
+name: Android SDK Release
+on:
+  workflow_dispatch:  # Manual trigger
+    inputs:
+      tag:
+        description: 'Release tag'
+        required: true
+        type: string
+  workflow_call: # For calling from another workflow
+    inputs:
+      tag:
+        description: 'Release tag'
+        required: true
+        type: string
+  pull_request: # TODO: For testing purposes, remove before merge
+
+env:
+  JAVA_HOME: /usr/lib/jvm/temurin-17-jdk-amd64  # Java 17 is required for Android Gradle 8 plugin
+
+jobs:
+  android-sdk-release:
+    name: Android SDK Release
+    runs-on: ubuntu-latest
+    # TODO: Commented for testing purposes, uncomment before merge
+    # environment: production
+    steps:
+      - name: Install build tools and dependencies
+        shell: bash
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y ninja-build
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 100 # enough to get all commits for the current day
+          # TODO: Commented for testing purposes, uncomment before merge
+          # ref: 'refs/tags/${{ inputs.tag }}'
+
+# TODO: Commented for testing purposes, uncomment before merge
+#      - name: Check tag
+#        shell: bash
+#        run: |
+#          git show HEAD
+#          test -n "${{ inputs.tag }}"
+#          test "$(git tag --points-at HEAD)" = "${{ inputs.tag }}"
+
+      - name: Restore Boost submodule from cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            3party/boost
+            .git/modules/3party/boost
+          key: boost-submodule
+
+      - name: Parallel submodules checkout
+        shell: bash
+        run: git submodule update --depth 1 --init --recursive --jobs=$(($(nproc) * 20))
+
+# TODO: Commented for testing purposes, uncomment before merge
+#      - name: Restore release keys
+#        shell: bash
+#        run: |
+#          echo "$PRIVATE_H" | base64 -d > private.h
+#        env:
+#          PRIVATE_H: ${{ secrets.PRIVATE_H }}
+
+      - name: Configure repository
+        shell: bash
+        run: ./configure.sh
+
+      - name: Set up SDK
+        shell: bash
+        run: echo "sdk.dir=$ANDROID_SDK_ROOT" > android/local.properties
+
+      - name: Publish Android SDK to local Maven repo
+        shell: bash
+        working-directory: android
+        run: ./gradlew publishSdk
+
+      - name: Deploy Android SDK artifacts to Maven Central
+        shell: bash
+        working-directory: android
+        env:
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME }}
+          JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD }}
+        run: ./gradlew jreleaserDeploy

--- a/.github/workflows/android-sdk.yaml
+++ b/.github/workflows/android-sdk.yaml
@@ -59,14 +59,9 @@ jobs:
       - name: Build and deploy the Android SDK to Maven Central
         shell: bash
         working-directory: android
-        # The SDK is built with the repository's default private.h (public keys); the app's
-        # production secrets are intentionally not injected into the published artifacts.
-        # nmcp bundles all SDK modules into one deployment that must be released manually
-        # from the Central Portal (publishingType = USER_MANAGED in settings.gradle).
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_KEY }}
-          #ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.MAVEN_SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_SIGNING_KEY_PASSWORD }}
         run: ./gradlew publishAggregationToCentralPortal

--- a/.github/workflows/android-sdk.yaml
+++ b/.github/workflows/android-sdk.yaml
@@ -12,7 +12,6 @@ on:
         description: 'Release tag'
         required: true
         type: string
-  pull_request: # TODO: For testing purposes, remove before merge
 
 env:
   JAVA_HOME: /usr/lib/jvm/temurin-17-jdk-amd64  # Java 17 is required for Android Gradle 8 plugin
@@ -21,8 +20,7 @@ jobs:
   android-sdk-release:
     name: Android SDK Release
     runs-on: ubuntu-latest
-    # TODO: Commented for testing purposes, uncomment before merge
-    # environment: production
+    environment: android-sdk-release
     steps:
       - name: Install build tools and dependencies
         shell: bash
@@ -31,22 +29,20 @@ jobs:
           sudo apt-get install -y ninja-build
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 100 # enough to get all commits for the current day
-          # TODO: Commented for testing purposes, uncomment before merge
-          # ref: 'refs/tags/${{ inputs.tag }}'
+          ref: 'refs/tags/${{ inputs.tag }}'
 
-# TODO: Commented for testing purposes, uncomment before merge
-#      - name: Check tag
-#        shell: bash
-#        run: |
-#          git show HEAD
-#          test -n "${{ inputs.tag }}"
-#          test "$(git tag --points-at HEAD)" = "${{ inputs.tag }}"
+      - name: Check tag
+        shell: bash
+        run: |
+          git show HEAD
+          test -n "${{ inputs.tag }}"
+          test "$(git tag --points-at HEAD)" = "${{ inputs.tag }}"
 
       - name: Restore Boost submodule from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v5
         with:
           path: |
             3party/boost
@@ -57,14 +53,6 @@ jobs:
         shell: bash
         run: git submodule update --depth 1 --init --recursive --jobs=$(($(nproc) * 20))
 
-# TODO: Commented for testing purposes, uncomment before merge
-#      - name: Restore release keys
-#        shell: bash
-#        run: |
-#          echo "$PRIVATE_H" | base64 -d > private.h
-#        env:
-#          PRIVATE_H: ${{ secrets.PRIVATE_H }}
-
       - name: Configure repository
         shell: bash
         run: ./configure.sh
@@ -73,18 +61,17 @@ jobs:
         shell: bash
         run: echo "sdk.dir=$ANDROID_SDK_ROOT" > android/local.properties
 
-      - name: Publish Android SDK to local Maven repo
+      - name: Build and deploy the Android SDK to Maven Central
         shell: bash
         working-directory: android
-        run: ./gradlew publishSdk
-
-      - name: Deploy Android SDK artifacts to Maven Central
-        shell: bash
-        working-directory: android
+        # The SDK is built with the repository's default private.h (public keys); the app's
+        # production secrets are intentionally not injected into the published artifacts.
+        # nmcp bundles all SDK modules into one deployment that must be released manually
+        # from the Central Portal (publishingType = USER_MANAGED in settings.gradle).
         env:
-          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
-          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
-          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
-          JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME }}
-          JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD }}
-        run: ./gradlew jreleaserDeploy
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_KEY }}
+          #ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.MAVEN_SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_SIGNING_KEY_PASSWORD }}
+        run: ./gradlew publishAggregationToCentralPortal

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,13 @@
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
+buildscript {
+    dependencies {
+        classpath libs.activation
+        classpath libs.jakarta.xml.bind.api
+        classpath libs.jaxb.impl
+    }
+}
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias libs.plugins.android.application apply false
@@ -11,6 +19,8 @@ plugins {
 
     alias libs.plugins.triplet.play apply false
     alias libs.plugins.huawei.plugin apply false
+
+    alias libs.plugins.jreleaser apply false
 }
 
 def run(cmd) {
@@ -89,4 +99,17 @@ tasks.register("detektCheckAll") {
     dependsOn(subprojects.collectMany { p ->
         p.tasks.matching { it.name == "detektCheck" }
     })
+}
+
+tasks.register('publishSdk') {
+    group = 'publishing'
+    description = 'Publishes the SDK modules'
+
+    def sdkModules = subprojects.findAll { project ->
+        project.projectDir.toPath().startsWith(rootProject.projectDir.toPath().resolve("sdk"))
+    }
+
+    dependsOn sdkModules.collect { sub ->
+        sub.tasks.matching { it.name == "publish" }
+    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,13 +1,5 @@
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
-buildscript {
-    dependencies {
-        classpath libs.activation
-        classpath libs.jakarta.xml.bind.api
-        classpath libs.jaxb.impl
-    }
-}
-
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias libs.plugins.android.application apply false
@@ -20,7 +12,13 @@ plugins {
     alias libs.plugins.triplet.play apply false
     alias libs.plugins.huawei.plugin apply false
 
-    alias libs.plugins.jreleaser apply false
+    alias libs.plugins.vanniktech.maven.publish apply false
+
+    // nmcp aggregates the per-module publications into one Maven Central Portal deployment.
+    // The base plugin is only put on the classpath (each SDK module applies it, see
+    // groovy/publishing.gradle); the aggregation plugin is applied to this root project.
+    alias libs.plugins.nmcp apply false
+    alias libs.plugins.nmcp.aggregation
 }
 
 def run(cmd) {
@@ -101,15 +99,30 @@ tasks.register("detektCheckAll") {
     })
 }
 
-tasks.register('publishSdk') {
-    group = 'publishing'
-    description = 'Publishes the SDK modules'
-
-    def sdkModules = subprojects.findAll { project ->
-        project.projectDir.toPath().startsWith(rootProject.projectDir.toPath().resolve("sdk"))
+// Aggregate every SDK module's publication into a single atomic Maven Central Portal
+// deployment via `./gradlew publishAggregationToCentralPortal`. Only the modules listed
+// below are bundled; the deployment is uploaded but must be released manually from the
+// Central Portal UI (publishingType = USER_MANAGED). Credentials come from the CI
+// environment and are empty locally, where the deploy task is never run.
+nmcpAggregation {
+    // ':sdk:car' and ':libs:car' share the simple name 'car'. Aggregation is declared by
+    // explicit project path below, so resolution is unambiguous; this only opts out of
+    // nmcp's defensive global name-uniqueness check (gradle/gradle#36167).
+    allowDuplicateProjectNames.set(true)
+    centralPortal {
+        username = providers.environmentVariable('MAVEN_CENTRAL_USERNAME').getOrElse('')
+        password = providers.environmentVariable('MAVEN_CENTRAL_PASSWORD').getOrElse('')
+        publishingType = 'USER_MANAGED'
     }
+}
 
-    dependsOn sdkModules.collect { sub ->
-        sub.tasks.matching { it.name == "publish" }
-    }
+dependencies {
+    nmcpAggregation project(':sdk')
+    nmcpAggregation project(':sdk:car')
+    nmcpAggregation project(':sdk:location:core')
+    nmcpAggregation project(':sdk:location:gms:google')
+    nmcpAggregation project(':sdk:location:gms:foss')
+    nmcpAggregation project(':sdk:maps:world')
+    nmcpAggregation project(':sdk:widgets:lanes')
+    nmcpAggregation project(':sdk:widgets:speedlimit')
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,9 +14,6 @@ plugins {
 
     alias libs.plugins.vanniktech.maven.publish apply false
 
-    // nmcp aggregates the per-module publications into one Maven Central Portal deployment.
-    // The base plugin is only put on the classpath (each SDK module applies it, see
-    // groovy/publishing.gradle); the aggregation plugin is applied to this root project.
     alias libs.plugins.nmcp apply false
     alias libs.plugins.nmcp.aggregation
 }
@@ -99,15 +96,8 @@ tasks.register("detektCheckAll") {
     })
 }
 
-// Aggregate every SDK module's publication into a single atomic Maven Central Portal
-// deployment via `./gradlew publishAggregationToCentralPortal`. Only the modules listed
-// below are bundled; the deployment is uploaded but must be released manually from the
-// Central Portal UI (publishingType = USER_MANAGED). Credentials come from the CI
-// environment and are empty locally, where the deploy task is never run.
 nmcpAggregation {
-    // ':sdk:car' and ':libs:car' share the simple name 'car'. Aggregation is declared by
-    // explicit project path below, so resolution is unambiguous; this only opts out of
-    // nmcp's defensive global name-uniqueness check (gradle/gradle#36167).
+    // :libs:car and :sdk:car share the simple name 'car'; opt out of nmcp's global unique-name check.
     allowDuplicateProjectNames.set(true)
     centralPortal {
         username = providers.environmentVariable('MAVEN_CENTRAL_USERNAME').getOrElse('')

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+activation = "1.1.1"
 agp = "9.2.1"
 detekt = "1.23.8"
 ktlint = "1.8.0"
@@ -43,6 +44,13 @@ google-material = "1.13.0"
 
 huawei-plugin = "1.5.0"
 
+# We need exactly those versions for jreleaser
+# noinspection NewerVersionAvailable
+jakarta-xml-bind-api = "2.3.3"
+# noinspection NewerVersionAvailable
+jaxb-impl = "2.3.3"
+jreleaser = "1.23.0"
+
 microg-gms-location = "0.3.14.250932"
 
 mockito-core = "5.23.0"
@@ -53,6 +61,8 @@ okhttp = "5.3.2"
 triplet-play-publisher = "4.0.0"
 
 [libraries]
+activation = { module = "javax.activation:activation", version.ref = "activation" }
+
 android-tools-desugaring = { module = "com.android.tools:desugar_jdk_libs", version.ref = "android-tools-desugaring" }
 
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
@@ -82,6 +92,9 @@ google-firebase-crashlytics = { module = "com.google.firebase:firebase-crashlyti
 # Version managed by firebase-bom
 google-firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-ndk" }
 
+jakarta-xml-bind-api = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version.ref = "jakarta-xml-bind-api" }
+jaxb-impl = { module = "com.sun.xml.bind:jaxb-impl", version.ref = "jaxb-impl" }
+
 google-gms-location = { module = "com.google.android.gms:play-services-location", version.ref = "google-gms-location" }
 google-material = { module = "com.google.android.material:material", version.ref = "google-material" }
 
@@ -103,5 +116,7 @@ google-firebase-appdistribution = { id = "com.google.firebase.appdistribution", 
 google-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "google-firebase-crashlytics" }
 
 huawei-plugin = { id = "ru.cian.huawei-publish-gradle-plugin", version.ref = "huawei-plugin" }
+
+jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
 
 triplet-play = { id = "com.github.triplet.play", version.ref = "triplet-play-publisher" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-activation = "1.1.1"
 agp = "9.2.1"
 detekt = "1.23.8"
 ktlint = "1.8.0"
@@ -44,25 +43,20 @@ google-material = "1.13.0"
 
 huawei-plugin = "1.5.0"
 
-# We need exactly those versions for jreleaser
-# noinspection NewerVersionAvailable
-jakarta-xml-bind-api = "2.3.3"
-# noinspection NewerVersionAvailable
-jaxb-impl = "2.3.3"
-jreleaser = "1.23.0"
-
 microg-gms-location = "0.3.14.250932"
 
 mockito-core = "5.23.0"
 mockito-inline = "5.2.0"
 
+nmcp = "1.4.4"
+
 okhttp = "5.3.2"
 
 triplet-play-publisher = "4.0.0"
 
-[libraries]
-activation = { module = "javax.activation:activation", version.ref = "activation" }
+vanniktech-maven-publish = "0.36.0"
 
+[libraries]
 android-tools-desugaring = { module = "com.android.tools:desugar_jdk_libs", version.ref = "android-tools-desugaring" }
 
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
@@ -92,9 +86,6 @@ google-firebase-crashlytics = { module = "com.google.firebase:firebase-crashlyti
 # Version managed by firebase-bom
 google-firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-ndk" }
 
-jakarta-xml-bind-api = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version.ref = "jakarta-xml-bind-api" }
-jaxb-impl = { module = "com.sun.xml.bind:jaxb-impl", version.ref = "jaxb-impl" }
-
 google-gms-location = { module = "com.google.android.gms:play-services-location", version.ref = "google-gms-location" }
 google-material = { module = "com.google.android.material:material", version.ref = "google-material" }
 
@@ -117,6 +108,9 @@ google-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.
 
 huawei-plugin = { id = "ru.cian.huawei-publish-gradle-plugin", version.ref = "huawei-plugin" }
 
-jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
+nmcp = { id = "com.gradleup.nmcp", version.ref = "nmcp" }
+nmcp-aggregation = { id = "com.gradleup.nmcp.aggregation", version.ref = "nmcp" }
 
 triplet-play = { id = "com.github.triplet.play", version.ref = "triplet-play-publisher" }
+
+vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech-maven-publish" }

--- a/android/groovy/publishing.gradle
+++ b/android/groovy/publishing.gradle
@@ -1,0 +1,121 @@
+ext.Publish = { Project project, Map<String, Object> props ->
+  apply plugin: 'maven-publish'
+  apply plugin: 'signing'
+  apply plugin: 'org.jreleaser'
+
+  android {
+    version = rootProject.ext.versionName
+    defaultConfig {
+      aarMetadata {
+        minCompileSdk = propMinSdkVersion.toInteger()
+      }
+    }
+
+    publishing {
+      singleVariant('release') {
+        withSourcesJar()
+        withJavadocJar()
+      }
+    }
+  }
+
+  publishing {
+    publications {
+      release(MavenPublication) {
+        groupId = 'app.organicmaps.sdk'
+        artifactId = props['artifactId']
+        version = rootProject.ext.versionName
+        project.afterEvaluate {
+          from project.components.release
+        }
+        pom {
+          packaging = 'aar'
+          name = props['name']
+          description = props['description']
+          url = 'https://github.com/organicmaps/organicmaps.git'
+          inceptionYear = props['inceptionYear']
+
+          licenses {
+            license {
+              name = 'The Apache License, Version 2.0'
+              url = 'https://github.com/organicmaps/organicmaps/blob/master/LICENSE'
+              distribution = 'manual'
+            }
+            license {
+              name = 'Organic Maps Binary Data License'
+              url = 'https://github.com/organicmaps/organicmaps/blob/master/DATA_LICENSE.txt'
+              distribution = 'manual'
+            }
+          }
+
+          organization {
+            name = 'Organic Maps'
+            url = 'https://organicmaps.app'
+          }
+
+          developers {
+            developer {
+              id = 'OrganicMaps'
+              name = 'Organic Maps Team'
+              email = 'sdk@organicmaps.app'
+              organizationUrl = 'https://organicmaps.app'
+            }
+          }
+
+          scm {
+            connection = 'scm:git:git://github.com/organicmaps/organicmaps'
+            developerConnection = 'scm:git:ssh://github.com:organicmaps/organicmaps.git'
+            url = 'https://github.com/organicmaps/organicmaps.git'
+          }
+
+          ciManagement {
+            system = 'GitHub Actions'
+            url = 'https://github.com/organicmaps/organicmaps/actions'
+          }
+
+          issueManagement {
+            system = 'GitHub Issues'
+            url = 'https://github.com/organicmaps/organicmaps/issues'
+          }
+        }
+      }
+    }
+    repositories {
+      mavenLocal {
+        name = 'mavenLocal'
+        url = rootProject.layout.buildDirectory.dir('publications/mavenLocal')
+      }
+    }
+  }
+
+  jreleaser { it ->
+    gitRootSearch = true
+    it.project {
+      versionPattern = 'CALVER:YYYY.0M.0D-MICRO'
+    }
+    release {
+      github {
+        skipRelease = true
+        token = '...'
+      }
+    }
+    signing {
+      pgp {
+        active = 'ALWAYS'
+        armored = true
+      }
+    }
+    deploy {
+      maven {
+        mavenCentral {
+          sonatype {
+            active = 'ALWAYS'
+            url = 'https://central.sonatype.com/api/v1/publisher'
+            stagingRepository(rootProject.layout.buildDirectory.dir('publications/mavenLocal').get())
+            verifyPom = false
+          }
+        }
+      }
+    }
+  }
+}

--- a/android/groovy/publishing.gradle
+++ b/android/groovy/publishing.gradle
@@ -1,120 +1,80 @@
 ext.Publish = { Project project, Map<String, Object> props ->
-  apply plugin: 'maven-publish'
-  apply plugin: 'signing'
-  apply plugin: 'org.jreleaser'
+  apply plugin: 'com.vanniktech.maven.publish'
+  // Exposes this module's publication to the root nmcp aggregation (see android/build.gradle).
+  apply plugin: 'com.gradleup.nmcp'
 
   android {
-    version = rootProject.ext.versionName
     defaultConfig {
       aarMetadata {
-        minCompileSdk = propMinSdkVersion.toInteger()
-      }
-    }
-
-    publishing {
-      singleVariant('release') {
-        withSourcesJar()
-        withJavadocJar()
+        // Consumers must compile against at least the SDK version this library was built
+        // with, so every API referenced in its public surface is available to them.
+        minCompileSdk = propCompileSdkVersion.toInteger()
       }
     }
   }
 
-  publishing {
-    publications {
-      release(MavenPublication) {
-        groupId = 'app.organicmaps.sdk'
-        artifactId = props['artifactId']
-        version = rootProject.ext.versionName
-        project.afterEvaluate {
-          from project.components.release
+  mavenPublishing {
+    // The vanniktech plugin auto-creates the release publication (AAR + sources + javadoc)
+    // for the com.android.library plugin. nmcp (see android/build.gradle) then aggregates
+    // every SDK module into one atomic Maven Central Portal deployment, so this script
+    // intentionally does not configure any per-module remote upload.
+    coordinates('app.organicmaps.sdk', props['artifactId'], rootProject.ext.versionName)
+
+    // Sign only when a signing key is provided (in CI, for the Central Portal upload).
+    // Otherwise signMavenPublication has no signatory and would fail local tasks such as
+    // publishToMavenLocal, blocking local publication and consumer smoke testing.
+    if (project.findProperty('signingInMemoryKey') != null) {
+      signAllPublications()
+    }
+
+    pom {
+      name = props['name']
+      description = props['description']
+      url = 'https://github.com/organicmaps/organicmaps'
+      // Year the Organic Maps SDK modules were first created.
+      inceptionYear = '2026'
+
+      licenses {
+        license {
+          name = 'The Apache License, Version 2.0'
+          url = 'https://github.com/organicmaps/organicmaps/blob/master/LICENSE'
+          distribution = 'repo'
         }
-        pom {
-          packaging = 'aar'
-          name = props['name']
-          description = props['description']
-          url = 'https://github.com/organicmaps/organicmaps.git'
-          inceptionYear = props['inceptionYear']
-
-          licenses {
-            license {
-              name = 'The Apache License, Version 2.0'
-              url = 'https://github.com/organicmaps/organicmaps/blob/master/LICENSE'
-              distribution = 'manual'
-            }
-            license {
-              name = 'Organic Maps Binary Data License'
-              url = 'https://github.com/organicmaps/organicmaps/blob/master/DATA_LICENSE.txt'
-              distribution = 'manual'
-            }
-          }
-
-          organization {
-            name = 'Organic Maps'
-            url = 'https://organicmaps.app'
-          }
-
-          developers {
-            developer {
-              id = 'OrganicMaps'
-              name = 'Organic Maps Team'
-              email = 'sdk@organicmaps.app'
-              organizationUrl = 'https://organicmaps.app'
-            }
-          }
-
-          scm {
-            connection = 'scm:git:git://github.com/organicmaps/organicmaps'
-            developerConnection = 'scm:git:ssh://github.com:organicmaps/organicmaps.git'
-            url = 'https://github.com/organicmaps/organicmaps.git'
-          }
-
-          ciManagement {
-            system = 'GitHub Actions'
-            url = 'https://github.com/organicmaps/organicmaps/actions'
-          }
-
-          issueManagement {
-            system = 'GitHub Issues'
-            url = 'https://github.com/organicmaps/organicmaps/issues'
-          }
+        license {
+          name = 'Organic Maps Binary Data License'
+          url = 'https://github.com/organicmaps/organicmaps/blob/master/DATA_LICENSE.txt'
+          distribution = 'repo'
         }
       }
-    }
-    repositories {
-      mavenLocal {
-        name = 'mavenLocal'
-        url = rootProject.layout.buildDirectory.dir('publications/mavenLocal')
-      }
-    }
-  }
 
-  jreleaser { it ->
-    gitRootSearch = true
-    it.project {
-      versionPattern = 'CALVER:YYYY.0M.0D-MICRO'
-    }
-    release {
-      github {
-        skipRelease = true
-        token = '...'
+      organization {
+        name = 'Organic Maps'
+        url = 'https://organicmaps.app'
       }
-    }
-    signing {
-      pgp {
-        active = 'ALWAYS'
-        armored = true
-      }
-    }
-    deploy {
-      maven {
-        mavenCentral {
-          sonatype {
-            active = 'ALWAYS'
-            url = 'https://central.sonatype.com/api/v1/publisher'
-            stagingRepository(rootProject.layout.buildDirectory.dir('publications/mavenLocal').get())
-            verifyPom = false
-          }
+
+      developers {
+        developer {
+          id = 'OrganicMaps'
+          name = 'Organic Maps Team'
+          email = 'sdk@organicmaps.app'
+          organizationUrl = 'https://organicmaps.app'
         }
+      }
+
+      scm {
+        connection = 'scm:git:https://github.com/organicmaps/organicmaps.git'
+        developerConnection = 'scm:git:ssh://git@github.com/organicmaps/organicmaps.git'
+        url = 'https://github.com/organicmaps/organicmaps'
+      }
+
+      ciManagement {
+        system = 'GitHub Actions'
+        url = 'https://github.com/organicmaps/organicmaps/actions'
+      }
+
+      issueManagement {
+        system = 'GitHub Issues'
+        url = 'https://github.com/organicmaps/organicmaps/issues'
       }
     }
   }

--- a/android/groovy/publishing.gradle
+++ b/android/groovy/publishing.gradle
@@ -1,28 +1,19 @@
 ext.Publish = { Project project, Map<String, Object> props ->
   apply plugin: 'com.vanniktech.maven.publish'
-  // Exposes this module's publication to the root nmcp aggregation (see android/build.gradle).
   apply plugin: 'com.gradleup.nmcp'
 
   android {
     defaultConfig {
       aarMetadata {
-        // Consumers must compile against at least the SDK version this library was built
-        // with, so every API referenced in its public surface is available to them.
         minCompileSdk = propCompileSdkVersion.toInteger()
       }
     }
   }
 
   mavenPublishing {
-    // The vanniktech plugin auto-creates the release publication (AAR + sources + javadoc)
-    // for the com.android.library plugin. nmcp (see android/build.gradle) then aggregates
-    // every SDK module into one atomic Maven Central Portal deployment, so this script
-    // intentionally does not configure any per-module remote upload.
     coordinates('app.organicmaps.sdk', props['artifactId'], rootProject.ext.versionName)
 
-    // Sign only when a signing key is provided (in CI, for the Central Portal upload).
-    // Otherwise signMavenPublication has no signatory and would fail local tasks such as
-    // publishToMavenLocal, blocking local publication and consumer smoke testing.
+    // Sign only when a key is configured; local tasks (e.g. publishToMavenLocal) run without one.
     if (project.findProperty('signingInMemoryKey') != null) {
       signAllPublications()
     }
@@ -31,7 +22,6 @@ ext.Publish = { Project project, Map<String, Object> props ->
       name = props['name']
       description = props['description']
       url = 'https://github.com/organicmaps/organicmaps'
-      // Year the Organic Maps SDK modules were first created.
       inceptionYear = '2026'
 
       licenses {

--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 apply from: "${rootProject.rootDir}/groovy/common-config.gradle"
+apply from: "${rootProject.rootDir}/groovy/publishing.gradle"
 
 android {
   namespace = 'app.organicmaps.sdk'
@@ -116,3 +117,10 @@ project.afterEvaluate {
     }
   }
 }
+
+Publish(project, [
+    "artifactId"   : "sdk",
+    'name'         : 'Organic Maps SDK',
+    'description'  : 'An open-source Android library for building fully offline, privacy-respecting map and navigation applications powered by OpenStreetMap data',
+    'inceptionYear': '2026'
+])

--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -86,15 +86,19 @@ android {
 }
 
 dependencies {
+  // Types from these dependencies appear in the SDK's public API (e.g. MapController and
+  // OrganicMaps implement DefaultLifecycleObserver, CategoryDataSource extends
+  // RecyclerView.AdapterDataObserver, NetworkPolicy exposes FragmentManager), so they are
+  // exposed transitively (api) for consumers to compile against.
   api project(':sdk:location:core')
+  api libs.androidx.lifecycle
+  api libs.androidx.recyclerview
+  api libs.androidx.fragment
 
   coreLibraryDesugaring libs.android.tools.desugaring
 
   implementation libs.androidx.annotation
   implementation libs.androidx.core
-  implementation libs.androidx.recyclerview
-  implementation libs.androidx.fragment
-  implementation libs.androidx.lifecycle
   implementation libs.androidx.media
   implementation libs.okhttp
 
@@ -119,8 +123,7 @@ project.afterEvaluate {
 }
 
 Publish(project, [
-    "artifactId"   : "sdk",
-    'name'         : 'Organic Maps SDK',
-    'description'  : 'An open-source Android library for building fully offline, privacy-respecting map and navigation applications powered by OpenStreetMap data',
-    'inceptionYear': '2026'
+    'artifactId' : 'sdk',
+    'name'       : 'Organic Maps SDK',
+    'description': 'An open-source Android library for building fully offline, privacy-respecting map and navigation applications powered by OpenStreetMap data and Organic Maps'
 ])

--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -86,10 +86,6 @@ android {
 }
 
 dependencies {
-  // Types from these dependencies appear in the SDK's public API (e.g. MapController and
-  // OrganicMaps implement DefaultLifecycleObserver, CategoryDataSource extends
-  // RecyclerView.AdapterDataObserver, NetworkPolicy exposes FragmentManager), so they are
-  // exposed transitively (api) for consumers to compile against.
   api project(':sdk:location:core')
   api libs.androidx.lifecycle
   api libs.androidx.recyclerview

--- a/android/sdk/car/build.gradle
+++ b/android/sdk/car/build.gradle
@@ -11,16 +11,17 @@ android {
 }
 
 dependencies {
-  implementation project(':sdk')
+  // CarContext and :sdk types (Map, MapController, LocationHelper) appear in this module's
+  // public API, so expose them as api for consumers.
+  api project(':sdk')
+  api libs.androidx.car.app
+
   implementation project(':sdk:widgets:speedlimit')
   implementation project(':sdk:widgets:lanes')
-
-  implementation libs.androidx.car.app
 }
 
 Publish(project, [
-    'artifactId'   : 'car',
-    'name'         : 'Organic Maps SDK for Android Auto and Android Automotive',
-    'description'  : 'A library that provides OM integration for Android Auto and Android Automotive',
-    'inceptionYear': '2026'
+    'artifactId' : 'car',
+    'name'       : 'Organic Maps SDK for Android Auto and Android Automotive',
+    'description': 'A library that provides Organic Maps integration for Android Auto and Android Automotive'
 ])

--- a/android/sdk/car/build.gradle
+++ b/android/sdk/car/build.gradle
@@ -11,8 +11,6 @@ android {
 }
 
 dependencies {
-  // CarContext and :sdk types (Map, MapController, LocationHelper) appear in this module's
-  // public API, so expose them as api for consumers.
   api project(':sdk')
   api libs.androidx.car.app
 

--- a/android/sdk/car/build.gradle
+++ b/android/sdk/car/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 apply from: "${rootProject.rootDir}/groovy/common-config.gradle"
+apply from: "${rootProject.rootDir}/groovy/publishing.gradle"
 
 android {
   namespace 'app.organicmaps.sdk.car'
@@ -16,3 +17,10 @@ dependencies {
 
   implementation libs.androidx.car.app
 }
+
+Publish(project, [
+    'artifactId'   : 'car',
+    'name'         : 'Organic Maps SDK for Android Auto and Android Automotive',
+    'description'  : 'A library that provides OM integration for Android Auto and Android Automotive',
+    'inceptionYear': '2026'
+])

--- a/android/sdk/location/core/build.gradle
+++ b/android/sdk/location/core/build.gradle
@@ -16,8 +16,7 @@ dependencies {
 }
 
 Publish(project, [
-    'artifactId'   : 'location-core',
-    'name'         : 'Organic Maps SDK. Location module',
-    'description'  : 'A library that provides core location services for the app',
-    'inceptionYear': '2026'
+    'artifactId' : 'location-core',
+    'name'       : 'Organic Maps SDK. Location module',
+    'description': 'A library that provides core location services for the Organic Maps SDK'
 ])

--- a/android/sdk/location/core/build.gradle
+++ b/android/sdk/location/core/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 apply from: "${rootProject.rootDir}/groovy/common-config.gradle"
+apply from: "${rootProject.rootDir}/groovy/publishing.gradle"
 
 android {
   namespace = 'app.organicmaps.sdk.location'
@@ -13,3 +14,10 @@ dependencies {
   implementation libs.androidx.annotation
   implementation libs.androidx.core
 }
+
+Publish(project, [
+    'artifactId'   : 'location-core',
+    'name'         : 'Organic Maps SDK. Location module',
+    'description'  : 'A library that provides core location services for the app',
+    'inceptionYear': '2026'
+])

--- a/android/sdk/location/gms/foss/build.gradle
+++ b/android/sdk/location/gms/foss/build.gradle
@@ -20,7 +20,6 @@ android {
 
 dependencies {
   implementation project(':sdk')
-  // BaseLocationProvider (from location:core) is returned by the public provider factory.
   api project(':sdk:location:core')
 
   implementation libs.androidx.annotation

--- a/android/sdk/location/gms/foss/build.gradle
+++ b/android/sdk/location/gms/foss/build.gradle
@@ -20,7 +20,8 @@ android {
 
 dependencies {
   implementation project(':sdk')
-  implementation project(':sdk:location:core')
+  // BaseLocationProvider (from location:core) is returned by the public provider factory.
+  api project(':sdk:location:core')
 
   implementation libs.androidx.annotation
   // This is the microG project's re-implementation which is permissible on
@@ -29,8 +30,7 @@ dependencies {
 }
 
 Publish(project, [
-    'artifactId'   : 'location-foss',
-    'name'         : 'Organic Maps SDK. Google Fused Location (FOSS)',
-    'description'  : 'A library that provides FOSS implementation of google gms location services for the app',
-    'inceptionYear': '2026'
+    'artifactId' : 'location-foss',
+    'name'       : 'Organic Maps SDK. Google Fused Location (FOSS)',
+    'description': 'A library that provides a FOSS implementation of Google fused location services for the Organic Maps SDK'
 ])

--- a/android/sdk/location/gms/foss/build.gradle
+++ b/android/sdk/location/gms/foss/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 apply from: "${rootProject.rootDir}/groovy/common-config.gradle"
+apply from: "${rootProject.rootDir}/groovy/publishing.gradle"
 
 android {
   namespace = 'app.organicmaps.sdk.location.gms'
@@ -26,3 +27,10 @@ dependencies {
   // F-droid because it's Apache-2.0.
   implementation libs.microg.gms.location
 }
+
+Publish(project, [
+    'artifactId'   : 'location-foss',
+    'name'         : 'Organic Maps SDK. Google Fused Location (FOSS)',
+    'description'  : 'A library that provides FOSS implementation of google gms location services for the app',
+    'inceptionYear': '2026'
+])

--- a/android/sdk/location/gms/google/build.gradle
+++ b/android/sdk/location/gms/google/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 apply from: "${rootProject.rootDir}/groovy/common-config.gradle"
+apply from: "${rootProject.rootDir}/groovy/publishing.gradle"
 
 android {
   namespace = 'app.organicmaps.sdk.location.gms'
@@ -16,3 +17,10 @@ dependencies {
   implementation libs.androidx.annotation
   implementation libs.google.gms.location
 }
+
+Publish(project, [
+    'artifactId'   : 'location-google',
+    'name'         : 'Organic Maps SDK. Google Fused Location',
+    'description'  : 'A library that provides google gms location services for the app',
+    'inceptionYear': '2026'
+])

--- a/android/sdk/location/gms/google/build.gradle
+++ b/android/sdk/location/gms/google/build.gradle
@@ -12,7 +12,6 @@ android {
 
 dependencies {
   implementation project(':sdk')
-  // BaseLocationProvider (from location:core) is returned by the public provider factory.
   api project(':sdk:location:core')
 
   implementation libs.androidx.annotation

--- a/android/sdk/location/gms/google/build.gradle
+++ b/android/sdk/location/gms/google/build.gradle
@@ -12,15 +12,15 @@ android {
 
 dependencies {
   implementation project(':sdk')
-  implementation project(':sdk:location:core')
+  // BaseLocationProvider (from location:core) is returned by the public provider factory.
+  api project(':sdk:location:core')
 
   implementation libs.androidx.annotation
   implementation libs.google.gms.location
 }
 
 Publish(project, [
-    'artifactId'   : 'location-google',
-    'name'         : 'Organic Maps SDK. Google Fused Location',
-    'description'  : 'A library that provides google gms location services for the app',
-    'inceptionYear': '2026'
+    'artifactId' : 'location-google',
+    'name'       : 'Organic Maps SDK. Google Fused Location',
+    'description': 'A library that provides Google fused location services for the Organic Maps SDK'
 ])

--- a/android/sdk/maps/world/build.gradle
+++ b/android/sdk/maps/world/build.gradle
@@ -11,8 +11,7 @@ android {
 }
 
 Publish(project, [
-    'artifactId'   : 'maps-world',
-    'name'         : 'Organic Maps SDK. World Maps',
-    'description'  : 'A library that provides world maps for the app',
-    'inceptionYear': '2026'
+    'artifactId' : 'maps-world',
+    'name'       : 'Organic Maps SDK. World Maps',
+    'description': 'A library that provides world maps for the Organic Maps SDK'
 ])

--- a/android/sdk/maps/world/build.gradle
+++ b/android/sdk/maps/world/build.gradle
@@ -3,8 +3,16 @@ plugins {
 }
 
 apply from: "${rootProject.rootDir}/groovy/common-config.gradle"
+apply from: "${rootProject.rootDir}/groovy/publishing.gradle"
 
 android {
   namespace = 'app.organicmaps.sdk.maps.world'
   // enableKotlin = true  // see app/build.gradle
 }
+
+Publish(project, [
+    'artifactId'   : 'maps-world',
+    'name'         : 'Organic Maps SDK. World Maps',
+    'description'  : 'A library that provides world maps for the app',
+    'inceptionYear': '2026'
+])

--- a/android/sdk/widgets/lanes/build.gradle
+++ b/android/sdk/widgets/lanes/build.gradle
@@ -11,15 +11,15 @@ android {
 }
 
 dependencies {
-  implementation project(':sdk')
+  // LaneInfo/LaneWay (from :sdk) appear in the LanesView/LanesDrawable public API.
+  api project(':sdk')
 
   implementation libs.androidx.annotation
   implementation libs.androidx.appcompat
 }
 
 Publish(project, [
-    'artifactId'   : 'widgets-lanes',
-    'name'         : 'Organic Maps SDK. Lanes widget',
-    'description'  : 'A library that provides lanes widget for the app',
-    'inceptionYear': '2026'
+    'artifactId' : 'widgets-lanes',
+    'name'       : 'Organic Maps SDK. Lanes widget',
+    'description': 'A library that provides a lanes widget for the Organic Maps SDK'
 ])

--- a/android/sdk/widgets/lanes/build.gradle
+++ b/android/sdk/widgets/lanes/build.gradle
@@ -11,7 +11,6 @@ android {
 }
 
 dependencies {
-  // LaneInfo/LaneWay (from :sdk) appear in the LanesView/LanesDrawable public API.
   api project(':sdk')
 
   implementation libs.androidx.annotation

--- a/android/sdk/widgets/lanes/build.gradle
+++ b/android/sdk/widgets/lanes/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 apply from: "${rootProject.rootDir}/groovy/common-config.gradle"
+apply from: "${rootProject.rootDir}/groovy/publishing.gradle"
 
 android {
   namespace 'app.organicmaps.sdk.widgets.lanes'
@@ -15,3 +16,10 @@ dependencies {
   implementation libs.androidx.annotation
   implementation libs.androidx.appcompat
 }
+
+Publish(project, [
+    'artifactId'   : 'widgets-lanes',
+    'name'         : 'Organic Maps SDK. Lanes widget',
+    'description'  : 'A library that provides lanes widget for the app',
+    'inceptionYear': '2026'
+])

--- a/android/sdk/widgets/speedlimit/build.gradle
+++ b/android/sdk/widgets/speedlimit/build.gradle
@@ -15,8 +15,7 @@ dependencies {
 }
 
 Publish(project, [
-    'artifactId'   : 'widgets-speedlimit',
-    'name'         : 'Organic Maps SDK. SpeedLimit widget',
-    'description'  : 'A library that provides speed limit widget for the app',
-    'inceptionYear': '2026'
+    'artifactId' : 'widgets-speedlimit',
+    'name'       : 'Organic Maps SDK. SpeedLimit widget',
+    'description': 'A library that provides a speed limit widget for the Organic Maps SDK'
 ])

--- a/android/sdk/widgets/speedlimit/build.gradle
+++ b/android/sdk/widgets/speedlimit/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 apply from: "${rootProject.rootDir}/groovy/common-config.gradle"
+apply from: "${rootProject.rootDir}/groovy/publishing.gradle"
 
 android {
   namespace 'app.organicmaps.sdk.widgets.speedlimit'
@@ -12,3 +13,10 @@ android {
 dependencies {
   implementation libs.androidx.annotation
 }
+
+Publish(project, [
+    'artifactId'   : 'widgets-speedlimit',
+    'name'         : 'Organic Maps SDK. SpeedLimit widget',
+    'description'  : 'A library that provides speed limit widget for the app',
+    'inceptionYear': '2026'
+])


### PR DESCRIPTION
## What this does

Publishes the Organic Maps Android SDK modules to Maven Central (Central Portal) under the `app.organicmaps.sdk` group:

`sdk`, `car`, `location-core`, `location-google`, `location-foss`, `maps-world`, `widgets-lanes`, `widgets-speedlimit`

(e.g. `app.organicmaps.sdk:sdk:<version>`). The version is the app's date-based version from `tools/unix/version.sh android_name` (e.g. `2026.06.06-3`).

> Supersedes the original JReleaser-based approach in this PR.

## How it's published

- Each module uses the **vanniktech maven-publish** plugin (`0.36.0`) to produce a signed `release` publication (AAR + sources jar + javadoc jar + POM).
- **GradleUp nmcp** (`1.4.4`) aggregates all modules into a **single atomic Central Portal deployment** via `./gradlew publishAggregationToCentralPortal`.
- The deployment is **`USER_MANAGED`** — uploaded and validated automatically, but **released manually** from the Central Portal UI.
- Dependencies that appear in a module's public API are exposed as `api` so consumers compile against them (e.g. `androidx.lifecycle`/`recyclerview`/`fragment` in `:sdk`, `androidx.car.app` + `:sdk` in `:car`, `location:core` in the location modules).
- The SDK is built with the repository's default `private.h` (public keys); the app's production secrets are intentionally **not** baked into the published artifacts.

## Releasing (manual, decoupled from app releases)

SDK releases are independent of app releases and triggered manually:

1. Run the **Android SDK Release** workflow (`.github/workflows/android-sdk.yaml`) via *Run workflow* (`workflow_dispatch`) with the release `tag`.
2. It builds all ABIs, signs the artifacts, and uploads one aggregated deployment.
3. Review and **release** the deployment in the Central Portal.

Local equivalents:
- `./gradlew publishToMavenLocal` — build + install all modules to `~/.m2` (no signing key required).
- `./gradlew nmcpZipAggregation` — produce the exact deployment bundle (signed if a key is configured) for inspection.
- `./gradlew publishAggregationToCentralPortal` — upload to the Portal (needs credentials).

## Required configuration

The release job runs in the **`android-sdk-release`** GitHub environment, which holds the secrets and gates which refs may deploy. Secrets:

| Secret | Purpose |
|---|---|
| `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` | Central Portal publisher token |
| `MAVEN_SIGNING_KEY` | Armored **RSA** secret key (in-memory signing) |
| `MAVEN_SIGNING_KEY_PASSWORD` | Key passphrase (empty if none); `MAVEN_SIGNING_KEY_ID` optional |

Prerequisites:
- The signing key must be **RSA** — Gradle's signing (Bouncy Castle) cannot read ed25519 keys (fails with `Could not read PGP secret key`).
- The signing **public** key must be published to a keyserver so Central can verify signatures.
- The `app.organicmaps` namespace must be verified on the Central Portal (DNS TXT on `organicmaps.app`).

## Testing

- **Local:** `publishToMavenLocal` + `nmcpZipAggregation` produce a single signed bundle of all 8 modules (`.aar`/`-sources.jar`/`-javadoc.jar`/`.pom`/`.module`, each with a `.asc`); generated POMs verified for coordinates and `compile`/`runtime` (api/implementation) scopes.
- **CI:** the `android-sdk.yaml` workflow runs end-to-end — all ABIs built, all modules signed and aggregated, and uploaded as one `USER_MANAGED` deployment.

---
*The publishing setup was reworked with assistance from Claude Code.*
