### PR TITLE
[ios] Update route building screen layout on iPad

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
@@ -70,10 +70,7 @@
 {
   if (self.state == MWMNavigationDashboardStateClosed || self.state == MWMNavigationDashboardStateNavigation)
     return;
-  if (selected && !IPAD)
-    self.state = MWMNavigationDashboardStateHidden;
-  else
-    self.state = MWMNavigationDashboardStateReady;
+  self.state = selected ? MWMNavigationDashboardStateHidden : MWMNavigationDashboardStateReady;
 }
 
 - (void)onNavigationInfoUpdated:(MWMNavigationDashboardEntity *)entity

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardModalPresentationStepStrategy.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardModalPresentationStepStrategy.swift
@@ -8,6 +8,7 @@ enum NavigationDashboardModalPresentationStep: Int, ModalPresentationStep {
 final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationStepStrategy {
   private enum Constants {
     static let iPadWidth: CGFloat = 350
+    static let iPadLeadingOffset: CGFloat = 20
     static let compactHeightOffset: CGFloat = 300
     static let fullScreenHeightFactorPortrait: CGFloat = 0.1
     static let halfScreenHeightFactorPortrait: CGFloat = 0.55
@@ -67,26 +68,15 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
     let traitCollection = containerViewController.traitCollection
     var frame = CGRect(origin: .zero, size: containerSize)
 
-    if isIPad {
+    func iPadFrame() -> CGRect {
       frame.size.width = Constants.iPadWidth
-      switch step {
-      case .hidden:
-        frame.origin.x = -Constants.iPadWidth
-      default:
-        frame.origin.x = .zero
-      }
-      return frame
-    }
-
-    let isPortraitOrientation = traitCollection.verticalSizeClass == .regular
-    if isPortraitOrientation {
+      frame.origin.x = Constants.iPadLeadingOffset
       switch step {
       case .expanded:
         frame.origin.y = safeAreaInsets.top + Constants.topInset
       case .regular:
-        let maxHeight = safeAreaInsets.top + Constants.topInset
         if regularHeigh != 0 {
-          frame.origin.y = max(containerSize.height - regularHeigh, maxHeight)
+          frame.origin.y = max(containerSize.height - regularHeigh, safeAreaInsets.top + Constants.topInset)
         } else {
           frame.origin.y = containerSize.height * Constants.halfScreenHeightFactorPortrait
         }
@@ -99,18 +89,45 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
       case .hidden:
         frame.origin.y = containerSize.height
       }
-    } else {
-      frame.size.width = Constants.iPadWidth
-      frame.origin.x = safeAreaInsets.left
-      switch step {
-      case .expanded, .regular:
-        frame.origin.y = Constants.topInset
-      case .compact:
-        frame.origin.y = containerSize.height - (compactHeight != 0 ? compactHeight : Constants.compactHeightOffset)
-      case .hidden:
-        frame.origin.y = containerSize.height
-      }
+      return frame
     }
-    return frame
+
+    func iPhoneFrame() -> CGRect {
+      let isPortraitOrientation = traitCollection.verticalSizeClass == .regular
+      if isPortraitOrientation {
+        switch step {
+        case .expanded:
+          frame.origin.y = safeAreaInsets.top + Constants.topInset
+        case .regular:
+          if regularHeigh != 0 {
+            frame.origin.y = max(containerSize.height - regularHeigh, safeAreaInsets.top + Constants.topInset)
+          } else {
+            frame.origin.y = containerSize.height * Constants.halfScreenHeightFactorPortrait
+          }
+        case .compact:
+          if compactHeight != 0 {
+            frame.origin.y = containerSize.height - compactHeight
+          } else {
+            frame.origin.y = containerSize.height * Constants.halfScreenHeightFactorPortrait
+          }
+        case .hidden:
+          frame.origin.y = containerSize.height
+        }
+      } else {
+        frame.size.width = Constants.iPadWidth
+        frame.origin.x = safeAreaInsets.left
+        switch step {
+        case .expanded, .regular:
+          frame.origin.y = Constants.topInset
+        case .compact:
+          frame.origin.y = containerSize.height - (compactHeight != 0 ? compactHeight : Constants.compactHeightOffset)
+        case .hidden:
+          frame.origin.y = containerSize.height
+        }
+      }
+      return frame
+    }
+
+    return isIPad ? iPadFrame() : iPhoneFrame()
   }
 }

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardPresenter.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardPresenter.swift
@@ -2,7 +2,7 @@ extension NavigationDashboard {
   final class Presenter: NSObject {
     private weak var view: NavigationDashboardViewController?
     private var viewModel: ViewModel = .initial
-    private var latestVisiblePresentationStep: NavigationDashboardModalPresentationStep = .compact
+    private var latestVisiblePresentationStep: NavigationDashboardModalPresentationStep = isiPad ? .regular : .compact
     private var isSearchOpened: Bool = false
     private let placePageManagerHelper: MWMPlacePageManagerHelper.Type
 

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
@@ -108,9 +108,9 @@ final class NavigationDashboardViewController: UIViewController {
   override func viewWillTransition(to size: CGSize, with coordinator: any UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
     routePointsView.viewWillTransition(to: size, with: coordinator)
-    if #available(iOS 14.0, *), ProcessInfo.processInfo.isiOSAppOnMac {
-      updateFrameOfPresentedViewInContainerView()
-    }
+    coordinator.animate(alongsideTransition: { _ in
+      self.updateFrameOfPresentedViewInContainerView()
+    })
   }
 
   func add(to parentViewController: MapViewController) {
@@ -171,11 +171,9 @@ final class NavigationDashboardViewController: UIViewController {
   }
 
   private func setupGestureRecognizers() {
-    iPhoneSpecific {
-      let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
-      panGestureRecognizer.delegate = self
-      availableAreaView.addGestureRecognizer(panGestureRecognizer)
-    }
+    let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+    panGestureRecognizer.delegate = self
+    availableAreaView.addGestureRecognizer(panGestureRecognizer)
   }
 
   @objc

--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -223,14 +223,6 @@ NSString * const kSettingsSegue = @"Map2Settings";
       leadingToSearchConstraint.priority = UILayoutPriorityDefaultHigh;
       leadingToSearchConstraint.active = isLimitedWidth;
     }
-    else if (self.navigationDashboardViewAvailableArea)
-    {
-      NSLayoutConstraint * leadingToNavigationDashboardConstraint = [self.placePageContainer.leadingAnchor
-          constraintGreaterThanOrEqualToAnchor:self.navigationDashboardViewAvailableArea.trailingAnchor
-                                      constant:kPlacePageLeadingOffset];
-      leadingToNavigationDashboardConstraint.priority = UILayoutPriorityDefaultHigh;
-      leadingToNavigationDashboardConstraint.active = isLimitedWidth;
-    }
   }
 
   [self.placePageWidthConstraint setActive:isLimitedWidth];
@@ -867,11 +859,6 @@ NSString * const kSettingsSegue = @"Map2Settings";
 - (UIView * _Nullable)searchViewAvailableArea
 {
   return self.searchManager.viewController.availableAreaView;
-}
-
-- (UIView * _Nullable)navigationDashboardViewAvailableArea
-{
-  return [self navigationDashboardManager].availableAreaView;
 }
 
 - (BOOL)hasNavigationBar

--- a/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
@@ -478,7 +478,7 @@ extension GlobalStyleSheet: IStyleSheet {
         s.shadowRadius = 6
         s.cornerRadius = .modalSheet
         s.clip = false
-        s.maskedCorners = isiPad ? [] : [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        s.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
       }
     case .modalSheetContent:
       return .addFrom(Self.modalSheetBackground) { s in

--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -375,8 +375,6 @@ extension PlacePageViewController: PlacePageViewProtocol {
           let frame = self.view.frame.offsetBy(dx: 0, dy: self.view.height - self.stackView.convert(self.stackView.origin, to: self.view).y)
           self.view.frame = frame
         }, iPad: {
-          let frame = self.view.frame
-          self.view.minX = frame.minX - frame.width
           self.view.alpha = 0
         })
       },


### PR DESCRIPTION
Changes:
1. Now it behaves like on the iPhone - the modal draggable screen with regular, compact and expanded detents. 
2. Significantly increases the visible map area
3. The PP opening(closing) hides (shows) the route builder

![Simulator Screen Recording - iPad Air 11-inch (M3) - 2025-10-23 at 17 54 10](https://github.com/user-attachments/assets/abf8b57f-97ce-44a7-a26f-c243d1cb7f45)

![Simulator Screen Recording - iPad Air 11-inch (M3) - 2025-10-23 at 17 54 24](https://github.com/user-attachments/assets/ea45db01-c2ed-4f7b-b1fa-bff5429d3140)
