### PR TITLE
[android] Fix deprecated edge-to-edge API usage in MwmActivity

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -270,6 +270,7 @@ dependencies {
   // > A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable
   // We don't use Kotlin, but some dependencies are actively using it.
   // See https://stackoverflow.com/a/75719642
+  implementation 'androidx.activity:activity-ktx:1.11.0'
   implementation 'androidx.core:core:1.17.0'
   implementation(platform('org.jetbrains.kotlin:kotlin-bom:2.2.20'))
   implementation 'androidx.annotation:annotation:1.9.1'

--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -29,6 +29,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.Window;
+import android.view.WindowInsetsController; 
 import android.view.WindowManager;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -2377,11 +2378,31 @@ public class MwmActivity extends BaseMwmFragmentActivity
   }
 
   private void makeNavigationBarTransparentInLightMode()
+{
+  if (!app.organicmaps.sdk.util.Utils.isDarkMode(this)) // if light mode
   {
-    int nightMask = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
-    if (nightMask == Configuration.UI_MODE_NIGHT_NO) // if light mode
+    Window window = getWindow();
+    
+    // Use WindowInsetsController (Android 11+)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) 
     {
-      Window window = getWindow();
+      // Modern edge-to-edge approach
+      window.setDecorFitsSystemWindows(false);
+      
+      WindowInsetsController controller = window.getInsetsController();
+      if (controller != null) 
+      {
+       
+        controller.setSystemBarsAppearance(
+          WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS,
+          WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS
+        );
+      }
+    } 
+    else 
+    {
+      // Fallback for older Android versions (still uses deprecated APIs)
+      
       window.setNavigationBarColor(Color.TRANSPARENT);
       window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
 
@@ -2397,6 +2418,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
         window.setNavigationBarContrastEnforced(false);
     }
   }
+}
 
   private void reportUnsupported()
   {


### PR DESCRIPTION
### Summary
Replaced deprecated `setNavigationBarColor` and related system UI flag usage with the modern `WindowInsetsController` API for Android 11+ (`Build.VERSION_CODES.R`).

This fixes Android 15 deprecation warnings while maintaining transparent navigation bars in light mode.

### Changes
- Updated `MwmActivity.makeNavigationBarTransparentInLightMode()`
- Added `WindowInsetsController` for modern Android
- Kept fallback for older versions

### Fixes
#11424
