### PR TITLE
Fixed be as the main OSM language for Belarus since 2022

### DIFF
--- a/data/countries_meta.txt
+++ b/data/countries_meta.txt
@@ -93,7 +93,7 @@
  "languages": ["bn"]
 },
 "Belarus": {
- "languages": ["ru"]
+ "languages": ["be", "ru"]
 },
 "Belgium": {
  "languages": ["fr", "de", "nl"]


### PR DESCRIPTION
https://wiki.openstreetmap.org/wiki/Be:Belarus_language_issues