### PR TITLE
[ios] List deletion from `more` button now returns on the prev vc

### DIFF
--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListPresenter.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListPresenter.swift
@@ -178,7 +178,6 @@ final class BookmarksListPresenter {
                                            enabled: interactor.canDeleteGroup(),
                                            action: { [weak self] in
                                             self?.interactor.deleteBookmarksGroup()
-                                            self?.delegate?.bookmarksListDidDeleteGroup()
                                            }))
     view.showMenu(moreItems, from: .more)
   }


### PR DESCRIPTION
Fixes https://github.com/organicmaps/organicmaps/issues/8966

Follow up to https://github.com/organicmaps/organicmaps/pull/11575 and https://github.com/organicmaps/organicmaps/pull/11503 , thanks to @pavannani99

![Simulator Screen Recording - iPhone 16e - 2025-10-27 at 11 46 21](https://github.com/user-attachments/assets/63b8f5d2-904d-4511-9057-5e926307497d)
