### PR TITLE
[3party] Add support for public holidays in opening_hours lib

### DIFF
--- a/3party/opening_hours/opening_hours.cpp
+++ b/3party/opening_hours/opening_hours.cpp
@@ -883,6 +883,19 @@ OpeningHours::OpeningHours(TRuleSequences const & rule):
 {
 }
 
+OpeningHours::OpeningHours(std::string const & rule, THolidayDates const & holidays, std::string const & timezone)
+  : m_valid(Parse(rule, m_rule))
+  , m_holidays(holidays)
+  , m_timeZone(std::chrono::locate_zone(timezone))
+{}
+
+OpeningHours::OpeningHours(TRuleSequences const & rule, THolidayDates const & holidays, std::string const & timezone)
+  : m_rule(rule)
+  , m_valid(true)
+  , m_holidays(holidays)
+  , m_timeZone(std::chrono::locate_zone(timezone))
+{}
+
 bool OpeningHours::IsOpen(time_t const dateTime) const
 {
   return osmoh::IsOpen(m_rule, dateTime);
@@ -902,9 +915,13 @@ OpeningHours::InfoT OpeningHours::GetInfo(time_t const dateTime) const
 {
   InfoT info;
   info.state = GetState(m_rule, dateTime);
+
+  if (m_holidays.contains(dateTime))
+    info.isHoliday = true;
+
   if (info.state != RuleState::Unknown)
   {
-   if (info.state == RuleState::Open)
+    if (info.state == RuleState::Open)
       info.nextTimeOpen = dateTime;
     else
       info.nextTimeOpen = osmoh::GetNextTimeState(m_rule, dateTime, RuleState::Open);

--- a/3party/opening_hours/rules_evaluation.cpp
+++ b/3party/opening_hours/rules_evaluation.cpp
@@ -2,6 +2,7 @@
 #include "rules_evaluation_private.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdlib>
 #include <ctime>
 #include <iomanip>
@@ -257,19 +258,24 @@ bool IsActive(WeekdayRange const & range, std::tm const & date)
   return range.HasWday(wday);
 }
 
-bool IsActive(Holiday const & holiday, std::tm const & date)
+bool IsActive(Holiday const & holiday, std::tm const & date, THolidayDates const & holidays)
 {
+  std::time_t datetime = std::mktime(const_cast<std::tm *>(&date));
+
+  if (holiday.IsPlural() && holidays.contains(datetime))
+    return true;
+
   return false;
 }
 
-bool IsActive(Weekdays const & weekdays, std::tm const & date)
+bool IsActive(Weekdays const & weekdays, std::tm const & date, THolidayDates const & holidays)
 {
   for (auto const & wr : weekdays.GetWeekdayRanges())
     if (IsActive(wr, date))
       return true;
 
   for (auto const & hd : weekdays.GetHolidays())
-    if (IsActive(hd, date))
+    if (IsActive(hd, date, holidays))
       return true;
 
   return weekdays.GetWeekdayRanges().empty() &&

--- a/3party/opening_hours/rules_evaluation_private.hpp
+++ b/3party/opening_hours/rules_evaluation_private.hpp
@@ -8,8 +8,8 @@ namespace osmoh
 {
 bool IsActive(Timespan span, std::tm const & date);
 bool IsActive(WeekdayRange const & range, std::tm const & date);
-bool IsActive(Holiday const & holiday, std::tm const & date);
-bool IsActive(Weekdays const & weekdays, std::tm const & date);
+bool IsActive(Holiday const & holiday, std::tm const & date, THolidayDates const & holidays);
+bool IsActive(Weekdays const & weekdays, std::tm const & date, THolidayDates const & holidays = {});
 bool IsActive(MonthdayRange const & range, std::tm const & date);
 bool IsActive(YearRange const & range, std::tm const & date);
 bool IsActive(WeekRange const & range, std::tm const & date);


### PR DESCRIPTION

This PR adds support for public holidays in the `opening_hours` library:

- Added `THolidayDates` to store public holiday dates.
- Updated `OpeningHours` constructors and `IsActive`/`GetInfo` to consider holidays.
- Modified `opening_hours.hpp` and `rules_evaluation_private.hpp` for holiday evaluation.
- Added unit tests to verify correct behavior.