### PR TITLE
Fix carplay audio ducking

### DIFF
--- a/iphone/Maps/Core/TextToSpeech/MWMTextToSpeech.h
+++ b/iphone/Maps/Core/TextToSpeech/MWMTextToSpeech.h
@@ -25,5 +25,6 @@
 - (instancetype)copyWithZone:(NSZone *)zone __attribute__((unavailable("call +tts instead")));
 + (instancetype)allocWithZone:(struct _NSZone *)zone __attribute__((unavailable("call +tts instead")));
 + (instancetype)new __attribute__((unavailable("call +tts instead")));
+@property(nonatomic, readonly) AVSpeechSynthesizer * speechSynthesizer;
 
 @end


### PR DESCRIPTION
Fixes #11650

### Problem
When navigation was stopped or finished during a voice direction announcement, the audio ducking (which lowers music/podcasts volume) was not restored, leaving CarPlay audio permanently quiet.

### Solution
- Added proper audio session cleanup in `CarPlayRouter.cancelTrip()` and `CarPlayRouter.finishTrip()`
- Immediately stops the speech synthesizer when navigation ends
- Deactivates the audio session with `notifyOthersOnDeactivation` flag to restore normal audio volume for other apps

### Testing
To test the fix:
1. Start navigation in CarPlay with music/podcast playing
2. Wait for a voice direction to start speaking
3. Stop navigation while TTS is still announcing
4. Verify that background audio returns to normal volume immediately