### PR TITLE
[ios] Fix `CarPlay clientTripAlreadyStartedException` crash

### DIFF
--- a/iphone/Maps/Classes/CarPlay/CarPlayRouter.swift
+++ b/iphone/Maps/Classes/CarPlay/CarPlayRouter.swift
@@ -204,6 +204,12 @@ final class CarPlayRouter: NSObject {
 // MARK: - Navigation session management
 extension CarPlayRouter {
   func startNavigationSession(forTrip trip: CPTrip, template: CPMapTemplate) {
+    guard routeSession == nil else {
+      let errorMessage = "Route session is already running."
+      LOG(.error, errorMessage)
+      Toast.show(withText: errorMessage, alignment: .top)
+      return
+    }
     routeSession = template.startNavigationSession(for: trip)
     routeSession?.pauseTrip(for: .loading, description: nil)
     updateUpcomingManeuvers()
@@ -212,11 +218,15 @@ extension CarPlayRouter {
     }
   }
 
-  func cancelTrip() {
+  func cancelNavigationSession() {
     routeSession?.cancelTrip()
     routeSession = nil
-    completeRouteAndRemovePoints()
     RoutingManager.routingManager.resetOnNewTurnCallback()
+  }
+
+  func cancelTrip() {
+    cancelNavigationSession()
+    completeRouteAndRemovePoints()
   }
 
   func finishTrip() {

--- a/iphone/Maps/Classes/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Classes/CarPlay/CarPlayService.swift
@@ -67,13 +67,14 @@ final class CarPlayService: NSObject {
   }
 
   private var savedInterfaceController: CPInterfaceController?
-  @objc func showOnPhone() {
+
+  func showOnPhone() {
     savedInterfaceController = interfaceController
     switchScreenToPhone()
     showPhoneModeAlert()
   }
 
-  @objc func showOnCarplay() {
+  private func showOnCarplay() {
     if let window, let savedInterfaceController {
       setup(window: window, interfaceController: savedInterfaceController)
     }
@@ -114,6 +115,7 @@ final class CarPlayService: NSObject {
     } else if router?.previewTrip != nil {
       MWMRouter.rebuild(withBestRouter: true)
     }
+    router?.cancelNavigationSession()
     searchService = nil
     router = nil
     sessionConfiguration = nil


### PR DESCRIPTION
This PR is an attempt to fix the quite frequent CarPlay crashes:

<img width="800" height="873" alt="image" src="https://github.com/user-attachments/assets/8e47f362-6059-409c-86a5-a2b0e97333fa" />

I couldn't reproduce the exact flow that causes the crash while switching/launching the CP. But double call of `startNavigationSession` method produces exactly the same crash with `clientTripAlreadyStartedException`. 

The new session should not be created while the previous one is active/not cleared. 

The fix contains 2 parts:
1. Clean up the active CarPlay session explicitly when switching to the iPhone from the car
2. Guard the new session creation when the previous one exists

We should test it and see how it works. 

If someone has faced and can reproduce the bug while using the CarPlay, please help me to test it!