### PR TITLE
[ios] Fix async pp raw data access crash during the country downloading update

### DIFF
--- a/iphone/CoreApi/CoreApi/PlacePageData/PlacePageData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/PlacePageData.mm
@@ -171,8 +171,9 @@ static PlacePageRoadType convertRoadType(RoadWarningMarkType roadType)
   if ([countryId isEqualToString:self.mapNodeAttributes.countryId])
   {
     _mapNodeAttributes = [[MWMStorage sharedStorage] attributesForCountry:countryId];
-    _osmContributionData = [[PlacePageOSMContributionData alloc] initWithRawData:rawData()
-                                                                   mapAttributes:_mapNodeAttributes];
+    if ([PlacePageData hasData])
+      _osmContributionData = [[PlacePageOSMContributionData alloc] initWithRawData:rawData()
+                                                                     mapAttributes:_mapNodeAttributes];
     if (self.onMapNodeStatusUpdate != nil)
       self.onMapNodeStatusUpdate();
   }


### PR DESCRIPTION
The crash was caused by the 5d2f06022c5cb4ed13c7d7c2d27058d0036316b9

At some point in time, the iOS `PlacePageData` object can receive an update during the map downloading, but the core pp data is already deinitialized (for example, during some animation). The downloading status update for the place page data can rely **only** on the valid cpp data object state, so the `rawData` existence should be checked before the access.
This PR adds a `hasData` check to avoid accessing the deinitialized cpp data object.

<img width="1360" height="874" alt="image" src="https://github.com/user-attachments/assets/1e018e9b-a932-4c8e-91b0-4b8f26f321a0" />
