### PR TITLE
[android] AudioFocusManager fixes

### DIFF
--- a/android/sdk/src/main/java/app/organicmaps/sdk/sound/AudioFocusManagerImpl.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/sound/AudioFocusManagerImpl.java
@@ -1,0 +1,45 @@
+package app.organicmaps.sdk.sound;
+
+import static android.media.AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK;
+
+import android.content.Context;
+import android.media.AudioFocusRequest;
+import android.media.AudioManager;
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import app.organicmaps.sdk.util.log.Logger;
+
+@RequiresApi(26)
+final class AudioFocusManagerImpl extends AudioFocusManager
+{
+  private static final String TAG = AudioFocusManagerImpl.class.getSimpleName();
+
+  @NonNull
+  private final AudioFocusRequest mAudioFocusRequest;
+
+  public AudioFocusManagerImpl(@NonNull Context context, @NonNull OnAudioFocusLost onAudioFocusLost)
+  {
+    super(context, onAudioFocusLost);
+    mAudioFocusRequest = new AudioFocusRequest.Builder(AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+                             .setAudioAttributes(AUDIO_ATTRIBUTES)
+                             .setOnAudioFocusChangeListener(this::onAudioFocusChange)
+                             .build();
+  }
+
+  @Override
+  public boolean requestAudioFocus()
+  {
+    final int requestResult = mAudioManager.requestAudioFocus(mAudioFocusRequest);
+    mPlaybackAllowed = requestResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
+    if (!mPlaybackAllowed)
+      Logger.w(TAG, "Audio focus request failed");
+    return mPlaybackAllowed;
+  }
+
+  @Override
+  public void releaseAudioFocus()
+  {
+    mAudioManager.abandonAudioFocusRequest(mAudioFocusRequest);
+    mPlaybackAllowed = false;
+  }
+}

--- a/android/sdk/src/main/java/app/organicmaps/sdk/sound/AudioFocusManagerImplLegacy.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/sound/AudioFocusManagerImplLegacy.java
@@ -1,0 +1,34 @@
+package app.organicmaps.sdk.sound;
+
+import static android.media.AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK;
+
+import android.content.Context;
+import android.media.AudioManager;
+import androidx.annotation.NonNull;
+import app.organicmaps.sdk.util.log.Logger;
+
+final class AudioFocusManagerImplLegacy extends AudioFocusManager
+{
+  private static final String TAG = AudioFocusManagerImpl.class.getSimpleName();
+
+  public AudioFocusManagerImplLegacy(@NonNull Context context, @NonNull OnAudioFocusLost onAudioFocusLost)
+  {
+    super(context, onAudioFocusLost);
+  }
+
+  public boolean requestAudioFocus()
+  {
+    final int requestResult = mAudioManager.requestAudioFocus(this::onAudioFocusChange, AudioManager.STREAM_VOICE_CALL,
+                                                              AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK);
+    mPlaybackAllowed = requestResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
+    if (!mPlaybackAllowed)
+      Logger.w(TAG, "Audio focus request failed");
+    return mPlaybackAllowed;
+  }
+
+  public void releaseAudioFocus()
+  {
+    mAudioManager.abandonAudioFocus(this::onAudioFocusChange);
+    mPlaybackAllowed = false;
+  }
+}


### PR DESCRIPTION
Split legacy and new AudioFocusManager APIs into separate classes 
Correct handling of audio focus request:
* Stop playing when we loose audio focus
* Do not play anything when audio focus was not granted

Make AudioFocusManager classes package-private - do not expose it outside sdk module

Note:
I’m not sure that this change will resolve any existing issues
