### PR TITLE
[android] Fixed crash in Editor Profile

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/ProfileFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/ProfileFragment.java
@@ -98,14 +98,15 @@ public class ProfileFragment extends BaseMwmToolbarFragment
   {
     if (OsmOAuth.isAuthorized())
     {
+      if (mEditsSent.getText().length() == 0)
+      {
+        UiUtils.show(mProfileInfoLoading);
+        UiUtils.hide(mUserInfoBlock);
+      }
+      final FragmentManager fm = getParentFragmentManager();
       // Update the number of uploaded changesets from OSM.
       ThreadPool.getWorker().execute(() -> {
-        if (mEditsSent.getText().equals(""))
-        {
-          UiUtils.show(mProfileInfoLoading);
-          UiUtils.hide(mUserInfoBlock);
-        }
-        final int profileEditCount = OsmOAuth.getOsmChangesetsCount(mDialogPresenter, getParentFragmentManager());
+        final int profileEditCount = OsmOAuth.getOsmChangesetsCount(mDialogPresenter, fm);
         final String profileUsername = OsmOAuth.getUsername();
         final Bitmap profilePicture = OsmOAuth.getProfilePicture();
 


### PR DESCRIPTION
```
Exception java.lang.IllegalStateException:
  at androidx.fragment.app.Fragment.getParentFragmentManager (Fragment.java:1117)
  at app.organicmaps.editor.ProfileFragment.lambda$refreshViews$5 (ProfileFragment.java:108)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1156)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:651)
  at java.lang.Thread.run (Thread.java:1119)
```