### PR TITLE
[android] TTS fixes

### DIFF
--- a/android/sdk/src/main/java/app/organicmaps/sdk/sound/AudioFocusManager.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/sound/AudioFocusManager.java
@@ -2,8 +2,11 @@ package app.organicmaps.sdk.sound;
 
 import android.content.Context;
 import android.media.AudioAttributes;
+import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import app.organicmaps.sdk.util.log.Logger;
 
 abstract class AudioFocusManager
 {
@@ -17,6 +20,8 @@ abstract class AudioFocusManager
           .setUsage(AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE)
           .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
           .build();
+
+  private static final String TAG = AudioFocusManager.class.getSimpleName();
 
   @NonNull
   protected final AudioManager mAudioManager;
@@ -39,17 +44,52 @@ abstract class AudioFocusManager
       return new AudioFocusManagerImplLegacy(context, onAudioFocusLost);
   }
 
-  public abstract boolean requestAudioFocus();
+  public final boolean requestAudioFocus()
+  {
+    mPlaybackAllowed = requestAudioFocusImpl();
+    if (!mPlaybackAllowed)
+    {
+      Logger.w(TAG, "Audio focus request failed");
+      return false;
+    }
 
-  public abstract void releaseAudioFocus();
+    if (isBluetoothScoDeviceUsed())
+    {
+      Logger.d(TAG, "Bluetooth SCO device is used for audio output");
+      mAudioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
+    }
+    else
+      mAudioManager.setMode(AudioManager.MODE_NORMAL);
+    return mPlaybackAllowed;
+  }
+
+  public final void releaseAudioFocus()
+  {
+    releaseAudioFocusImpl();
+    mPlaybackAllowed = false;
+    mAudioManager.setMode(AudioManager.MODE_NORMAL);
+  }
 
   public boolean isMusicActive()
   {
     return mAudioManager.isMusicActive();
   }
 
+  public boolean isBluetoothScoDeviceUsed()
+  {
+    if (!mAudioManager.isBluetoothScoAvailableOffCall())
+      return false;
+
+    return android.os.Build.VERSION.SDK_INT >= 31 ? ImplApi31.isBluetoothScoOn(mAudioManager)
+                                                  : mAudioManager.isBluetoothScoOn();
+  }
+
+  protected abstract boolean requestAudioFocusImpl();
+  protected abstract void releaseAudioFocusImpl();
+
   protected void onAudioFocusChange(int focusChange)
   {
+    Logger.w(TAG, "Unexpected audio focus change: " + focusChange);
     if (focusChange == AudioManager.AUDIOFOCUS_GAIN || focusChange == AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
         || focusChange == AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
     {
@@ -60,6 +100,16 @@ abstract class AudioFocusManager
     {
       mPlaybackAllowed = false;
       mOnAudioFocusLost.onAudioFocusLost();
+    }
+  }
+
+  @RequiresApi(31)
+  private static class ImplApi31
+  {
+    private static boolean isBluetoothScoOn(@NonNull AudioManager audioManager)
+    {
+      final AudioDeviceInfo device = audioManager.getCommunicationDevice();
+      return device != null && device.getType() == AudioDeviceInfo.TYPE_BLUETOOTH_SCO;
     }
   }
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/sound/AudioFocusManagerImpl.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/sound/AudioFocusManagerImpl.java
@@ -7,13 +7,10 @@ import android.media.AudioFocusRequest;
 import android.media.AudioManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
-import app.organicmaps.sdk.util.log.Logger;
 
 @RequiresApi(26)
 final class AudioFocusManagerImpl extends AudioFocusManager
 {
-  private static final String TAG = AudioFocusManagerImpl.class.getSimpleName();
-
   @NonNull
   private final AudioFocusRequest mAudioFocusRequest;
 
@@ -27,19 +24,15 @@ final class AudioFocusManagerImpl extends AudioFocusManager
   }
 
   @Override
-  public boolean requestAudioFocus()
+  protected boolean requestAudioFocusImpl()
   {
     final int requestResult = mAudioManager.requestAudioFocus(mAudioFocusRequest);
-    mPlaybackAllowed = requestResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
-    if (!mPlaybackAllowed)
-      Logger.w(TAG, "Audio focus request failed");
-    return mPlaybackAllowed;
+    return requestResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
   }
 
   @Override
-  public void releaseAudioFocus()
+  protected void releaseAudioFocusImpl()
   {
     mAudioManager.abandonAudioFocusRequest(mAudioFocusRequest);
-    mPlaybackAllowed = false;
   }
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/sound/AudioFocusManagerImplLegacy.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/sound/AudioFocusManagerImplLegacy.java
@@ -5,30 +5,25 @@ import static android.media.AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK;
 import android.content.Context;
 import android.media.AudioManager;
 import androidx.annotation.NonNull;
-import app.organicmaps.sdk.util.log.Logger;
 
 final class AudioFocusManagerImplLegacy extends AudioFocusManager
 {
-  private static final String TAG = AudioFocusManagerImpl.class.getSimpleName();
-
   public AudioFocusManagerImplLegacy(@NonNull Context context, @NonNull OnAudioFocusLost onAudioFocusLost)
   {
     super(context, onAudioFocusLost);
   }
 
-  public boolean requestAudioFocus()
+  @Override
+  protected boolean requestAudioFocusImpl()
   {
     final int requestResult = mAudioManager.requestAudioFocus(this::onAudioFocusChange, AudioManager.STREAM_VOICE_CALL,
                                                               AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK);
-    mPlaybackAllowed = requestResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
-    if (!mPlaybackAllowed)
-      Logger.w(TAG, "Audio focus request failed");
-    return mPlaybackAllowed;
+    return requestResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
   }
 
-  public void releaseAudioFocus()
+  @Override
+  protected void releaseAudioFocusImpl()
   {
     mAudioManager.abandonAudioFocus(this::onAudioFocusChange);
-    mPlaybackAllowed = false;
   }
 }


### PR DESCRIPTION
Add check for bluetooth sco device.
If BleSCO is used we wait 1500 ms before playing sound Updated utterance listener
 * do not re-request audio focus for each string - we already requested it at start
 * abandon audio focus only after all strings are played

Added logs

Updated play logic to reset old request:
 * Each time we ask TTS to play strings (on speak() or on playTurnNotifications()) we flush the buffer
 * The first string in the queue flushes the buffer
 * Other strings are added to the buffer

Should be beta tested especially with bluetooth devices

Related issues:
https://github.com/organicmaps/organicmaps/issues/11429
https://github.com/organicmaps/organicmaps/issues/11339
https://github.com/organicmaps/organicmaps/issues/5176
https://github.com/organicmaps/organicmaps/issues/5661
https://github.com/organicmaps/organicmaps/issues/11369
https://github.com/organicmaps/organicmaps/issues/5109

Some of them may already be resolved by my other TTS fixes