### PR TITLE
[android] Keep debug symbols in debug apk

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -176,6 +176,13 @@ android {
       signingConfig = signingConfigs.debug
       resValue 'string', 'app_name', 'Debug Organic Maps'
 
+      packagingOptions {
+        doNotStrip "*/arm64-v8a/*.so"
+        doNotStrip "*/armeabi-v7a/*.so"
+        doNotStrip "*/x86/*.so"
+        doNotStrip "*/x86_64/*.so"
+      }
+
       if (googleFirebaseServicesEnabled) {
         firebaseCrashlytics {
           nativeSymbolUploadEnabled true


### PR DESCRIPTION
- Adds ~65Mb to the debug apk size.
- Helps to see stack traces in adb logcat.