### PR TITLE
[ios] Fix `download maps` button tinting

### DIFF
--- a/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
@@ -290,6 +290,8 @@ extension GlobalStyleSheet: IStyleSheet {
         s.cornerRadius = .buttonDefault
         s.clip = true
         s.fontColor = colors.whitePrimaryText
+        s.coloring = .whiteText
+        s.tintColor = colors.whitePrimaryText
         s.backgroundColor = colors.linkBlue
         s.fontColorHighlighted = colors.whitePrimaryTextHighlighted
         s.fontColorDisabled = colors.whitePrimaryTextHighlighted

--- a/iphone/Maps/UI/Storyboard/Main.storyboard
+++ b/iphone/Maps/UI/Storyboard/Main.storyboard
@@ -946,7 +946,7 @@
                                 </state>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="download_maps"/>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="FlatNormalButton:MWMWhite:regular17"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="FlatNormalButtonBig"/>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="downloadMaps" destination="3el-Zi-2E4" eventType="touchUpInside" id="gb5-gj-vlt"/>


### PR DESCRIPTION
Before/after

<img width="300" height="863" alt="image" src="https://github.com/user-attachments/assets/68a03487-1fa4-47fb-9b59-25964fc25a27" /> <img width="300" height="750" alt="image" src="https://github.com/user-attachments/assets/2d4524fc-43fc-4938-9e65-d68a8a526f70" />
