### PR TITLE
[ios] Fix side buttons animation

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/Navigation/NavigationControlView.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/Navigation/NavigationControlView.swift
@@ -119,7 +119,7 @@ final class NavigationControlView: SolidTouchView {
   private func updateVisibleViewportArea(onClose: Bool = false) {
     let bottom = frame.height / 2
     let insets = UIEdgeInsets(top: 0, left: 0, bottom: onClose ? 0 : bottom, right: 0)
-    MapViewController.shared()?.updateVisibleAreaInsets(for: self, insets: insets)
+    MapViewController.shared()?.updateVisibleAreaInsets(for: self, insets: insets, updatingViewport: true)
   }
 
   private func updateLegendSize() {

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardInteractor.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardInteractor.swift
@@ -118,7 +118,7 @@ extension NavigationDashboard {
         return .show(points: router.points(), routerType: router.type())
 
       case .updateVisibleAreaInsets(let insets):
-        mapViewController.updateVisibleAreaInsets(for: self, insets: insets)
+        mapViewController.updateVisibleAreaInsets(for: self, insets: insets, updatingViewport: true)
         return .none
 
       case .setHidden(let hidden):

--- a/iphone/Maps/Classes/MapViewController.h
+++ b/iphone/Maps/Classes/MapViewController.h
@@ -44,7 +44,8 @@
 /// - Parameters:
 ///   - object: The source object for which the visible area is being set.
 ///   - insets: The insets defining the portion of the map that is not covered or obstructed by the source object's view.
-- (void)updateVisibleAreaInsetsFor:(NSObject * _Nonnull)object insets:(UIEdgeInsets)insets;
+///   - updatingViewport: Should the core be notified to uptade a viewport.
+- (void)updateVisibleAreaInsetsFor:(NSObject * _Nonnull)object insets:(UIEdgeInsets)insets updatingViewport:(BOOL)updateViewport;
 
 + (void)setViewport:(double)lat lon:(double)lon zoomLevel:(int)zoomlevel;
 

--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -889,12 +889,24 @@ NSString * const kSettingsSegue = @"Map2Settings";
   return _downloadDialog;
 }
 
-- (void)updateVisibleAreaInsetsFor:(NSObject *)object insets:(UIEdgeInsets)insets
+- (void)updateVisibleAreaInsetsFor:(NSObject * _Nonnull)object
+                            insets:(UIEdgeInsets)insets
+                  updatingViewport:(BOOL)updateViewport
 {
   if (object == nil)
     return;
   [self.availableAreaInsetsMap setObject:[NSValue valueWithUIEdgeInsets:insets] forKey:object];
-  [self updateVisibleAreaBounds];
+
+  UIEdgeInsets availableAreaInsets = [self availableAreaInsets];
+
+  if (updateViewport)
+  {
+    self.visibleAreaBottom.constant = availableAreaInsets.bottom;
+    self.visibleAreaLeading.constant = availableAreaInsets.left;
+    self.visibleAreaTrailing.constant = availableAreaInsets.right;
+  }
+  self.sideButtonsAreaBottom.constant = availableAreaInsets.bottom;
+  self.sideButtonsAreaCompactBottom.constant = availableAreaInsets.bottom;
 }
 
 - (UIEdgeInsets)availableAreaInsets
@@ -924,17 +936,6 @@ NSString * const kSettingsSegue = @"Map2Settings";
     return UIEdgeInsetsZero;
 
   return UIEdgeInsetsMake(top, left, bottom, right);
-}
-
-- (void)updateVisibleAreaBounds
-{
-  UIEdgeInsets availableAreaInsets = [self availableAreaInsets];
-
-  self.visibleAreaBottom.constant = availableAreaInsets.bottom;
-  self.visibleAreaLeading.constant = availableAreaInsets.left;
-  self.visibleAreaTrailing.constant = availableAreaInsets.right;
-  self.sideButtonsAreaBottom.constant = availableAreaInsets.bottom;
-  self.sideButtonsAreaCompactBottom.constant = availableAreaInsets.bottom;
 }
 
 + (void)setViewport:(double)lat lon:(double)lon zoomLevel:(int)zoomLevel

--- a/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
@@ -1,6 +1,6 @@
 protocol PlacePageInteractorProtocol: AnyObject {
   func viewWillDisappear()
-  func updateVisibleAreaInsets(_ insets: UIEdgeInsets)
+  func updateVisibleAreaInsets(_ insets: UIEdgeInsets, updatingViewport: Bool)
   func close()
 }
 
@@ -79,8 +79,8 @@ extension PlacePageInteractor: PlacePageInteractorProtocol {
     unsubscribeFromTrackActivePointUpdates()
   }
 
-  func updateVisibleAreaInsets(_ insets: UIEdgeInsets) {
-    presenter?.updateVisibleAreaInsets(insets)
+  func updateVisibleAreaInsets(_ insets: UIEdgeInsets, updatingViewport: Bool) {
+    presenter?.updateVisibleAreaInsets(insets, updatingViewport: updatingViewport)
   }
 
   func close() {

--- a/iphone/Maps/UI/PlacePage/PlacePagePresenter.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePagePresenter.swift
@@ -1,6 +1,6 @@
 protocol PlacePagePresenterProtocol: AnyObject {
   func layoutIfNeeded()
-  func updateVisibleAreaInsets(_ insets: UIEdgeInsets)
+  func updateVisibleAreaInsets(_ insets: UIEdgeInsets, updatingViewport: Bool)
   func showNextStop()
   func openURL(_ path: String)
   func showActivity(_ activity: ActivityViewController, from sourceView: UIView)
@@ -32,8 +32,8 @@ extension PlacePagePresenter: PlacePagePresenterProtocol {
     view.layoutIfNeeded()
   }
 
-  func updateVisibleAreaInsets(_ insets: UIEdgeInsets) {
-    mapViewController.updateVisibleAreaInsets(for: self, insets: insets)
+  func updateVisibleAreaInsets(_ insets: UIEdgeInsets, updatingViewport: Bool) {
+    mapViewController.updateVisibleAreaInsets(for: self, insets: insets, updatingViewport: updatingViewport)
   }
 
   func showNextStop() {

--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -302,11 +302,11 @@ final class PlacePageScrollView: UIScrollView {
     }
   }
 
-  private func updateTopBound(_ bound: CGFloat) {
+  private func updateTopBound(_ bound: CGFloat, updatingViewport: Bool = true) {
     alternativeSizeClass(iPhone: {
       let isCompact = traitCollection.verticalSizeClass == .compact
       let insets = UIEdgeInsets(top: 0, left: 0, bottom: isCompact ? 0 : bound, right: 0)
-      self.interactor?.updateVisibleAreaInsets(insets)
+      self.interactor?.updateVisibleAreaInsets(insets, updatingViewport: updatingViewport)
     }, iPad: {})
   }
 }
@@ -395,6 +395,8 @@ extension PlacePageViewController: UIScrollViewDelegate {
     if scrollView.contentOffset.y < -scrollView.height + 1 && beginDragging {
       interactor?.close()
     }
+    let bound = view.height + scrollView.contentOffset.y
+    updateTopBound(bound, updatingViewport: false) // Skip updating viewport on every drag.
     onOffsetChanged(scrollView.contentOffset.y)
   }
 

--- a/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapInteractor.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapInteractor.swift
@@ -64,7 +64,7 @@ final class SearchOnMapInteractor: NSObject {
       return .updatePresentationStep(step)
 
     case .updateVisibleAreaInsets(let insets):
-      MapViewController.shared()!.updateVisibleAreaInsets(for: self, insets: insets)
+      MapViewController.shared()!.updateVisibleAreaInsets(for: self, insets: insets, updatingViewport: true)
       return .none
     case .closeSearch:
       return closeSearch()


### PR DESCRIPTION
The side buttons' position is tightened to the available area updates. During the refactoring in the a0d464d the `intermediate` updates were removed to skip excessive viewport updates when the user drags the Place Page screen. This refactoring breaks the side buttons' animations. The PR adds a flag to the viewport updating method, indicating whether the viewport should be updated or not. During the dragging the `false` will be passed to the flag and only the side buttons' position will be updated.

Before

https://github.com/user-attachments/assets/30663bf2-5eb4-4345-ba05-49907c31ea9c

After

https://github.com/user-attachments/assets/c9d530ea-ea7f-47a8-a093-4271ca03f178

