### PR TITLE
[ios] Fix visible area frame during the navigation for iPad

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
@@ -165,9 +165,8 @@ final class NavigationDashboardViewController: UIViewController {
 
   private func visibleAreaInsets(for frame: CGRect) -> UIEdgeInsets {
     let isCompact = traitCollection.verticalSizeClass == .compact
-    let bottom = (isCompact || isiPad) ? 0 : frame.height - frame.origin.y
-    let left = isiPad ? frame.origin.x + frame.width : 0
-    return UIEdgeInsets(top: 0, left: left, bottom: bottom, right: 0)
+    let bottom = isCompact ? 0 : frame.height - frame.origin.y
+    return UIEdgeInsets(top: 0, left: 0, bottom: bottom, right: 0)
   }
 
   private func setupGestureRecognizers() {


### PR DESCRIPTION
The f2eec28 changes the route-building screen layout from the `side panel` to the `bottom sheet` (like on the iPhone). But the available area calculation wasn't updated. It produces incorrect viewport updates during route building and navigation. 

This PR fixes this bug.

Before:
<img width="500" height="874" alt="image" src="https://github.com/user-attachments/assets/ec5d4682-dfc2-4d61-bb82-352ac521c596" />

After:
<img width="500" height="909" alt="image" src="https://github.com/user-attachments/assets/39dcad8b-efa6-4505-ab41-ab28eda87c1d" />
