### PR TITLE
Android search parking emoji

### DIFF
--- a/android/app/src/main/res/layout/item_search_result.xml
+++ b/android/app/src/main/res/layout/item_search_result.xml
@@ -29,6 +29,7 @@
       android:layout_toStartOf="@id/open"
       android:layout_marginEnd="@dimen/margin_half"
       android:layout_marginTop="@dimen/margin_quarter"
+      android:fontFamily="@font/organic_maps_emoji"
       android:textAppearance="@style/MwmTextAppearance.Body3"
       android:maxLines="2"
       android:ellipsize="end"


### PR DESCRIPTION
## Changes
- Applied custom emoji font to search result description TextView in `\item_search_result.xml\`
- Parking capacity now displays with 🚘 (car) and 🚲 (bicycle) emoji

## Related
- Implements Android version of feature from #11689
- Builds on emoji font infrastructure from #11769

## Testing
Tested on Android emulator - parking search results correctly display capacity with emoji (e.g., \"10 🚗\", \"6 🚗\")

cc @biodranik @dvdmrtnz"