### PR TITLE
[android-auto] Fix navigation template background color

### DIFF
--- a/android/app/src/main/java/app/organicmaps/car/util/Colors.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/Colors.java
@@ -11,7 +11,7 @@ public final class Colors
   public static final CarColor OPENING_HOURS_CLOSES_SOON = CarColor.YELLOW;
   public static final CarColor OPENING_HOURS_CLOSED = CarColor.RED;
   public static final CarColor START_NAVIGATION = CarColor.GREEN;
-  public static final CarColor NAVIGATION_TEMPLATE_BACKGROUND = CarColor.GREEN;
+  public static final CarColor NAVIGATION_TEMPLATE_BACKGROUND = CarColor.createCustom(0xFF313538, 0xFF252728);
   public static final CarColor BUTTON_ACCEPT = CarColor.GREEN;
 
   private Colors() {}


### PR DESCRIPTION
<img width="500" src="https://github.com/user-attachments/assets/fa1f1b39-9aa3-4d16-aa89-2b28273aff1b" />
<img width="500" src="https://github.com/user-attachments/assets/18e9c74e-432b-45ec-ade9-4459f4cec108" />

Closes https://github.com/organicmaps/organicmaps/issues/11601