### PR TITLE
[map] Remove debug timeout for the `rate us` prompt

### DIFF
--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -3565,11 +3565,7 @@ bool Framework::CanShowRateUsRequest() const
   if (!settings::Get(kLastAskedForRateUsTimeKey, lastAskedForRateUsTime))
     return true;
 
-#ifdef DEBUG
-  uint32_t constexpr kLastAskedForRateUsTimeout = 30;
-#else
   uint32_t constexpr kLastAskedForRateUsTimeout = 60 * 60 * 24 * 90;  // 90 days
-#endif
 
   bool const timeoutExpired = lastAskedForRateUsTime + kLastAskedForRateUsTimeout < base::SecondsSinceEpoch();
   if (!timeoutExpired)


### PR DESCRIPTION
To not spam during the development.

Closes https://github.com/organicmaps/organicmaps/issues/11794
