### PR TITLE
[ios] Recover the place page previous content offset after the bookmark title editing

### DIFF
--- a/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderViewController.swift
@@ -1,6 +1,7 @@
 protocol PlacePageHeaderViewProtocol: AnyObject {
   var presenter: PlacePageHeaderPresenterProtocol? { get set }
-  var onEditingTitle: ((Bool) -> Void)? { get set }
+  var didStartEditingTitle: ((Bool) -> Void)? { get set }
+  var didChangeEditedTitle: (() -> Void)? { get set }
 
   func setShadowHidden(_ hidden: Bool)
   func setTitle(_ title: String?, secondaryTitle: String?)
@@ -29,10 +30,11 @@ final class PlacePageHeaderViewController: UIViewController {
   var presenter: PlacePageHeaderPresenterProtocol?
   var isEditingTitle: Bool = false {
     didSet {
-      onEditingTitle?(isEditingTitle)
+      didStartEditingTitle?(isEditingTitle)
     }
   }
-  var onEditingTitle: ((Bool) -> Void)?
+  var didStartEditingTitle: ((Bool) -> Void)?
+  var didChangeEditedTitle: (() -> Void)?
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -212,6 +214,7 @@ extension PlacePageHeaderViewController: UITextViewDelegate {
 
   func textViewDidChange(_ textView: UITextView) {
     clearTitleTextButton.isHidden = textView.text.isEmpty
+    didChangeEditedTitle?()
   }
 
   func textViewDidEndEditing(_ textView: UITextView) {


### PR DESCRIPTION
### Issue description
During the bookmark/track name editing, the PP is raised up to be visible over the keyboard. But some place page screens have a height that is less than keyboard height. After the keyboard was dismissed, the pp wasn't returned to the state before the editing. It produces a bug when the PP's offset is incorrect.

It is mostly related to the tracks without altitudes:
<img width="250" height="711" alt="image" src="https://github.com/user-attachments/assets/983940ea-181e-498d-81fe-0ca559d99774" />


### Solution
Store the PP's offset before editing in the separate property and recover the offset to the previous state after editing is finished.

![Simulator Screen Recording - iPhone 16e - 2025-12-01 at 14 50 46](https://github.com/user-attachments/assets/98dc8a5c-192e-4f9f-ba6e-d06152b3a2ac)

https://github.com/user-attachments/assets/e3bffbfc-a132-48e6-8eb2-13ee90533285

---

Also fixed the issue when the user is typing the long title - the PP changes its height when the text increases/decreases in height:

![Simulator Screen Recording - iPhone 15 Pro - 2025-12-01 at 18 27 02](https://github.com/user-attachments/assets/bbc7d785-857f-4026-8e82-42078d56c66c)
