### PR TITLE
[ios] Fix pp subtitle height compression bug

### DIFF
--- a/iphone/Maps/UI/PlacePage/PlacePage.storyboard
+++ b/iphone/Maps/UI/PlacePage/PlacePage.storyboard
@@ -1125,7 +1125,7 @@
                                                             <constraint firstItem="ct0-4B-Xfk" firstAttribute="top" secondItem="FPZ-be-cyu" secondAttribute="top" id="xto-UN-VQD"/>
                                                         </constraints>
                                                     </view>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4iT-AD-Eyf">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4iT-AD-Eyf">
                                                         <rect key="frame" x="0.0" y="34" width="277" height="0.0"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>


### PR DESCRIPTION
The subtitle compression resistance priority is increased to calculate the layout height properly.

Before / After

<img width="285" height="651" alt="image" src="https://github.com/user-attachments/assets/a75642bf-3920-4147-84b7-cb2744a036c8" />
<img width="285" height="651" alt="image" src="https://github.com/user-attachments/assets/6ee0221d-848d-405c-8be8-d9f7efecdb56" />
