### PR TITLE
1.5x wider bicycle route

### DIFF
--- a/libs/drape_frontend/route_renderer.cpp
+++ b/libs/drape_frontend/route_renderer.cpp
@@ -59,19 +59,27 @@ double GetPreviewGlobalEps(ScreenBase const & screen)
   return std::max(screen.GetScale() * kPreviewScreenPositionEpsInPixels, 1e-12);
 }
 
+std::array<float, 20> const & GetRouteHalfWidthInPixel(RouteType routeType)
+{
+  switch (routeType)
+  {
+  case RouteType::Car:
+  case RouteType::Taxi: return kRouteHalfWidthInPixelCar;
+  case RouteType::Bicycle: return kRouteHalfWidthInPixelBicycle;
+  case RouteType::Transit: return kRouteHalfWidthInPixelTransit;
+  case RouteType::Pedestrian:
+  case RouteType::Ruler: return kRouteHalfWidthInPixelOthers;
+  }
+  UNREACHABLE();
+}
+
 void InterpolateByZoom(SubrouteConstPtr const & subroute, ScreenBase const & screen, float & halfWidth, double & zoom)
 {
   int index = 0;
   float lerpCoef = 0.0f;
   ExtractZoomFactors(screen, zoom, index, lerpCoef);
 
-  std::array<float, 20> const * halfWidthInPixel = &kRouteHalfWidthInPixelOthers;
-  if (subroute->m_routeType == RouteType::Car || subroute->m_routeType == RouteType::Taxi)
-    halfWidthInPixel = &kRouteHalfWidthInPixelCar;
-  else if (subroute->m_routeType == RouteType::Transit)
-    halfWidthInPixel = &kRouteHalfWidthInPixelTransit;
-
-  halfWidth = InterpolateByZoomLevels(index, lerpCoef, *halfWidthInPixel);
+  halfWidth = InterpolateByZoomLevels(index, lerpCoef, GetRouteHalfWidthInPixel(subroute->m_routeType));
   halfWidth *= static_cast<float>(df::VisualParams::Instance().GetVisualScale());
 }
 

--- a/libs/drape_frontend/route_shape.cpp
+++ b/libs/drape_frontend/route_shape.cpp
@@ -25,20 +25,27 @@ namespace df
 std::array<float, 20> const kRouteHalfWidthInPixelCar = {
     // 1   2     3     4     5     6     7     8     9     10
     1.0f, 1.2f, 1.5f, 1.5f, 1.7f, 2.0f, 2.0f, 2.3f, 2.5f, 2.7f,
-    // 11   12    13    14    15   16    17    18    19     20
-    3.0f, 3.5f, 4.5f, 5.5f, 7.0, 9.0f, 10.0f, 14.0f, 22.0f, 27.0f};
+    // 11   12    13    14    15    16    17    18    19     20
+    3.0f, 3.5f, 4.5f, 5.5f, 7.0f, 9.0f, 10.0f, 14.0f, 22.0f, 27.0f};
+
+// 1.5x of kRouteHalfWidthInPixelOthers to make turn arrows visible on light-colored roads.
+std::array<float, 20> const kRouteHalfWidthInPixelBicycle = {
+    // 1   2     3     4     5     6     7     8      9     10
+    1.5f, 1.5f, 1.5f, 1.5f, 1.5f, 1.5f, 1.5f, 1.65f, 1.8f, 1.95f,
+    // 11     12     13     14     15     16     17    18     19     20
+    2.25f, 2.55f, 3.45f, 4.05f, 5.25f, 6.75f, 7.5f, 10.5f, 16.5f, 19.5f};
 
 std::array<float, 20> const kRouteHalfWidthInPixelTransit = {
     // 1   2     3     4     5     6     7     8     9     10
     1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.7f,
     // 11   12    13    14    15   16    17    18    19     20
-    1.8f, 2.1f, 2.5f, 2.8f, 3.5, 4.5f, 5.0f, 7.0f, 11.0f, 13.0f};
+    1.8f, 2.1f, 2.5f, 2.8f, 3.5f, 4.5f, 5.0f, 7.0f, 11.0f, 13.0f};
 
 std::array<float, 20> const kRouteHalfWidthInPixelOthers = {
     // 1   2     3     4     5     6     7     8     9     10
     1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.1f, 1.2f, 1.3f,
     // 11   12    13    14    15   16    17    18    19     20
-    1.5f, 1.7f, 2.3f, 2.7f, 3.5, 4.5f, 5.0f, 7.0f, 11.0f, 13.0f};
+    1.5f, 1.7f, 2.3f, 2.7f, 3.5f, 4.5f, 5.0f, 7.0f, 11.0f, 13.0f};
 // clang-format on
 
 namespace rs

--- a/libs/drape_frontend/route_shape.hpp
+++ b/libs/drape_frontend/route_shape.hpp
@@ -35,6 +35,7 @@ double const kArrowHeightFactor = kArrowTextureHeight / kArrowBodyHeight;
 double const kArrowAspect = kArrowTextureWidth / kArrowTextureHeight;
 
 extern std::array<float, 20> const kRouteHalfWidthInPixelCar;
+extern std::array<float, 20> const kRouteHalfWidthInPixelBicycle;
 extern std::array<float, 20> const kRouteHalfWidthInPixelTransit;
 extern std::array<float, 20> const kRouteHalfWidthInPixelOthers;
 


### PR DESCRIPTION
It should help a bit with the visibility of the route without breaking other things.

Related to https://github.com/organicmaps/organicmaps/issues/1086

3D buildings | No 3D buildings
-------------|----------------
![telegram-cloud-photo-size-2-5307932429823708979-y](https://github.com/user-attachments/assets/f4a52786-6654-41c9-85a5-afafa603b5ce)|![telegram-cloud-photo-size-2-5307932429823708978-y](https://github.com/user-attachments/assets/6abc9f83-2f12-401f-8753-11544179d01c)
