### PR TITLE
[ios] Fix logging: write all logs < LINFO on the main thread

### DIFF
--- a/iphone/CoreApi/CoreApi/Logger/Logger.mm
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.mm
@@ -242,7 +242,7 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
   // Log the message into the system log.
   os_log([self logger].osLogger, "%{public}s", logString.c_str());
 
-  if (level < base::GetDefaultLogAbortLevel())
+  if (level < LINFO)
     dispatch_async([self fileLoggingQueue], ^{ [self tryWriteToFile:logString]; });
   else
     [self tryWriteToFile:logString];


### PR DESCRIPTION
When logging is enabled in the settings, all logs < LINFO are written on the main thread to avoid losing logs before a possible crash.