### PR TITLE
[tests] Wait for python server to finish startup before running platform_tests

### DIFF
--- a/cmake/OmimTesting.cmake
+++ b/cmake/OmimTesting.cmake
@@ -8,12 +8,12 @@ endif()
 # TestServer fixture configuration
 add_test(
   NAME OmimStartTestServer
-  COMMAND start_server.py
+  COMMAND Python3::Interpreter start_server.py
   WORKING_DIRECTORY ${OMIM_ROOT}/tools/python/test_server
 )
 add_test(
   NAME OmimStopTestServer
-  COMMAND stop_server.py
+  COMMAND Python3::Interpreter stop_server.py
   WORKING_DIRECTORY ${OMIM_ROOT}/tools/python/test_server
 )
 set_tests_properties(OmimStartTestServer PROPERTIES FIXTURES_SETUP TestServer)

--- a/tools/python/test_server/start_server.py
+++ b/tools/python/test_server/start_server.py
@@ -1,7 +1,35 @@
 #!/usr/bin/env python3
 
+import os
+import socket
 import subprocess
+import sys
+import time
 
-SERVER_RUNNABLE = 'server/testserver.py'
+from pathlib import Path
 
-subprocess.Popen(['python3', SERVER_RUNNABLE], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+SCRIPT_DIR = Path(os.path.dirname(__file__))
+SERVER_RUNNABLE = SCRIPT_DIR / 'server/testserver.py'
+
+subprocess.Popen([sys.executable, SERVER_RUNNABLE], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+# Now wait until the server actually starts.
+
+HOST='localhost'
+PORT=34568  # Should match config.py
+TIMEOUT_SECONDS=3.0
+
+# Source: https://gist.github.com/butla/2d9a4c0f35ea47b7452156c96a4e7b12
+start_time = time.perf_counter()
+while True:
+    try:
+        with socket.create_connection((HOST, PORT), timeout=TIMEOUT_SECONDS):
+            break
+    except OSError as ex:
+        time.sleep(0.01)
+        if time.perf_counter() - start_time >= TIMEOUT_SECONDS:
+            raise TimeoutError(
+                "Waited too long for the port {} on host {} to start accepting connections.".format(
+                    PORT, HOST
+                )
+            ) from ex


### PR DESCRIPTION
Fixes random CI test failures like this one: https://github.com/organicmaps/organicmaps/actions/runs/20181757268/job/57943609822#step:13:77