### PR TITLE
[android] Fix speed camera warning sound when set to “Never warn”

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/NavigationService.java
+++ b/android/app/src/main/java/app/organicmaps/routing/NavigationService.java
@@ -291,7 +291,8 @@ public class NavigationService extends Service implements LocationListener
     if (routingInfo == null)
       return;
 
-    if (routingInfo.shouldPlayWarningSignal())
+    if (routingInfo.shouldPlayWarningSignal()
+        && app.organicmaps.sdk.settings.SpeedCameraMode.NEVER != Framework.getSpeedCamerasMode())
       mPlayer.playback(R.raw.speed_cams_beep);
 
     // Don't spend time on updating RemoteView if notifications are not allowed.

--- a/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
@@ -88,6 +88,16 @@ public class Framework
     nativeSetSpeedCamManagerMode(mode.ordinal());
   }
 
+  @NonNull
+  public static SpeedCameraMode getSpeedCamerasMode()
+  {
+    final int nativeMode = nativeGetSpeedCamManagerMode();
+    final SpeedCameraMode[] values = SpeedCameraMode.values();
+    if (nativeMode < 0 || nativeMode >= values.length)
+      return SpeedCameraMode.AUTO;
+    return values[nativeMode];
+  }
+
   public static native void nativeRestoreDownloadQueue();
 
   public static native void nativeShowTrackRect(long track);
@@ -221,6 +231,8 @@ public class Framework
   public static native String[] nativeGenerateNotifications(boolean announceStreets);
 
   private static native void nativeSetSpeedCamManagerMode(int mode);
+
+  private static native int nativeGetSpeedCamManagerMode();
 
   public static native void nativeSetRoutingListener(@NonNull RoutingListener listener);
 


### PR DESCRIPTION
 - Fixes #11736

## Changes made
- Added `getSpeedCamerasMode()` in `Framework.java` to expose `nativeGetSpeedCamManagerMode()` to Java.
- Used this method to check the active speed camera mode before playing the warning sound, ensuring no beep is played when the mode is set to **NEVER**.
