### PR TITLE
Fix crash on network error during note upload

### DIFF
--- a/libs/editor/editor_notes.cpp
+++ b/libs/editor/editor_notes.cpp
@@ -181,22 +181,9 @@ void Notes::Upload(osm::OsmOAuth const & auth)
 
         LOG(LINFO, ("A note uploaded with id", id));
       }
-      catch (osm::OsmOAuth::NetworkError const & e)
+      catch (RootException const & e)
       {
-        ulock.lock();  // important: restore mutex before returning
-        LOG(LWARNING, ("Network error while uploading note:", e.what()));
-        return;
-      }
-      catch (osm::ServerApi06::ServerApi06Exception const & e)
-      {
-        LOG(LERROR, ("Can't upload note.", e.Msg()));
-        // We believe that next iterations will suffer from the same error.
-        return;
-      }
-      catch (std::exception const & e)
-      {
-        ulock.lock();
-        LOG(LERROR, ("Unexpected exception while uploading note:", e.what()));
+        LOG(LERROR, ("Error while uploading note:", e.Msg()));
         return;
       }
 


### PR DESCRIPTION
Fixes a crash caused by uncaught osm::OsmOAuth::NetworkError thrown from
OsmOAuth::Request() when uploading notes in Notes::Upload().

The exception could escape the network thread and trigger std::terminate().
This change catches network and standard exceptions inside the worker
lambda, logs the error, and prevents application termination.

Related to issue #11939.
https://github.com/organicmaps/organicmaps/issues/11939