### PR TITLE
[ios] Avoid redundant downloadAllView state updates

### DIFF
--- a/iphone/Maps/UI/Downloader/DownloadMapsViewController.swift
+++ b/iphone/Maps/UI/Downloader/DownloadMapsViewController.swift
@@ -443,9 +443,12 @@ extension DownloadMapsViewController: StorageObserver {
     if countryId == dataSource.getParentCountryId() {
       downloadAllView.downloadProgress = CGFloat(downloadedBytes) / CGFloat(totalBytes)
       downloadAllView.downloadSize = totalBytes
-    } else if dataSource.isRoot && dataSource is DownloadedMapsDataSource {
-      downloadAllView.state = .dowloading
-      downloadAllView.isSizeHidden = true
+    } 
+    else if dataSource.isRoot && dataSource is DownloadedMapsDataSource {
+      if downloadAllView.state != .dowloading { 
+        downloadAllView.state = .dowloading
+        downloadAllView.isSizeHidden = true
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes UI flashing of download progress icons when multiple
map downloads are running and one of them finishes.

The issue was caused by repeatedly setting
`downloadAllView.state` during progress updates, which
triggered unnecessary UI refreshes and restarted animations
on visible cells.

## Changes

- Guard `downloadAllView.state` assignment so it is only
  updated when the state actually changes
- Prevent redundant layout and animation resets during
  concurrent downloads

## Testing

⚠️ I do not currently have access to a macOS/iOS development
environment, so this change has not been tested locally.

The fix is minimal, scoped to UI state handling, and does not
affect download logic. Verification on macOS/iOS would be
appreciated.

Fixes #11248

**Note: LLM tools (ChatGPT, Claude, Gemini) were used for
analysis and assistance while developing this change.**
