### PR TITLE
Fix race condition in SplashActivity

### DIFF
--- a/android/app/src/main/java/app/organicmaps/SplashActivity.java
+++ b/android/app/src/main/java/app/organicmaps/SplashActivity.java
@@ -154,12 +154,11 @@ public class SplashActivity extends AppCompatActivity
   @SuppressWarnings({"unused", "unchecked"})
   public void processNavigation()
   {
-    if (isDestroyed())
+    if (isFinishing() || isDestroyed())
     {
-      Logger.w(TAG, "Ignore late callback from core because activity is already destroyed");
+      Logger.w(TAG, "Ignore late callback from core because activity is already finishing or destroyed");
       return;
     }
-
     // Re-use original intent with the known safe subset of flags to retain security permissions.
     // https://github.com/organicmaps/organicmaps/issues/6944
     final Intent intent = Objects.requireNonNull(getIntent());
@@ -188,7 +187,7 @@ public class SplashActivity extends AppCompatActivity
 
     Config.setFirstStartDialogSeen(this);
     startActivity(intent);
-    finish();
+    new android.os.Handler(android.os.Looper.getMainLooper()).post(this::finish);
   }
 
   private boolean isManageSpaceActivity(@NonNull Intent intent)


### PR DESCRIPTION
This pull request resolves a race condition in SplashActivity that triggers a java.lang.IllegalArgumentException: Activity client record must not be null crash when processNavigation() is invoked on a destroyed activity. By implementing a guard clause that checks isFinishing() or isDestroyed() before executing navigation transactions, the application now safely aborts the initialization process if the activity context is no longer valid.
Fixes #11938 