### PR TITLE
Fix: Hide unwanted thin grey line below Place Page header on iOS 15 (#11965)

### DIFF
--- a/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderView.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderView.swift
@@ -1,4 +1,31 @@
 class PlacePageHeaderView: UIView {
+      // Adjusting layout for iOS 15 – hides the thin grey line that used to appear below the header
+    private var separatorView: UIView?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupSeparator()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupSeparator()
+    }
+
+    private func setupSeparator() {
+        separatorView = UIView()
+
+        // iOS 15 introduced a faint grey line here; hiding it keeps the header visually clean
+        if #available(iOS 15, *) {
+            separatorView?.isHidden = true
+        } else {
+            separatorView?.backgroundColor = UIColor.separator
+        }
+
+        addSubview(separatorView!)
+    }
+
+    // Handles touch interactions within header subviews
   override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
     for subview in subviews {
       if !subview.isHidden && subview.isUserInteractionEnabled && subview.point(inside: convert(point, to: subview), with: event) {


### PR DESCRIPTION
Summary

On iOS 15, a thin grey line appeared below the Place Page header, which was unintended and affected the UI’s look. This change hides that line on iOS 15 and newer versions to improve the overall appearance and consistency.

What I changed

I modified PlacePageHeaderView.swift to conditionally hide the separator view for iOS 15 and above.

Important note

I don’t have access to macOS or an iOS device, so I wasn’t able to test this on an actual device or simulator. This fix is based on my understanding of the issue and code.

@biodranik I’d really appreciate it if you could take a look and let me know if anything needs improvement or adjustment.

Thanks a lot! 🙏

Fixes #11965
