### PR TITLE
Fix street name clipping in navigation header

### DIFF
--- a/android/app/src/main/res/layout-land/layout_nav_top.xml
+++ b/android/app/src/main/res/layout-land/layout_nav_top.xml
@@ -16,21 +16,17 @@
     app:layout_constraintTop_toTopOf="parent"
     android:clickable="true"
     android:background="?cardBackground">
-    <RelativeLayout
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      tools:ignore="UselessParent">
-      <TextView
+    <TextView
         android:id="@+id/street"
         style="@style/MwmWidget.TextView.NavStreet"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:minHeight="@dimen/nav_street_height"
         android:layout_marginStart="@dimen/nav_street_left"
         android:maxLines="2"
-        android:layout_gravity="center_horizontal"
+        android:layout_gravity="center_vertical"
         android:gravity="center"
         tools:text="Sample street name.\nLong looooooooong!!!!"/>
-    </RelativeLayout>
   </FrameLayout>
 
   <RelativeLayout

--- a/android/app/src/main/res/layout/layout_nav_top.xml
+++ b/android/app/src/main/res/layout/layout_nav_top.xml
@@ -16,21 +16,17 @@
     app:layout_constraintTop_toTopOf="parent"
     android:clickable="true"
     android:background="?cardBackground">
-    <RelativeLayout
-      android:layout_width="match_parent"
-      android:layout_height="@dimen/nav_street_height"
-      tools:ignore="UselessParent">
-      <TextView
+    <TextView
         android:id="@+id/street"
         style="@style/MwmWidget.TextView.NavStreet"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="@dimen/nav_street_height"
         android:layout_marginStart="@dimen/nav_street_left"
         android:maxLines="2"
         android:layout_gravity="center_vertical"
         android:gravity="center"
         tools:text="Sample street name.\nLong looooooooong!!!!"/>
-    </RelativeLayout>
   </FrameLayout>
 
   <RelativeLayout


### PR DESCRIPTION
What was done:
- Removed fixed-height wrapper around the street name TextView
- Switched to wrap_content with minHeight to preserve original layout size
- Applied the fix to both portrait and landscape layouts

Test:
- Tested on physical Android device.

Fixes #11964
