### PR TITLE
Fix login error dialog disappearing on rotation

### DIFF
--- a/android/app/src/main/res/layout-land/fragment_osm_login.xml
+++ b/android/app/src/main/res/layout-land/fragment_osm_login.xml
@@ -104,6 +104,16 @@
               android:hint="@string/password"
               android:inputType="textPassword" />
           </com.google.android.material.textfield.TextInputLayout>
+          <TextView
+              android:id="@+id/tv_error"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_marginTop = "@dimen/margin_base"
+              android:gravity="center"
+              android:text = "Login failed"
+              android:textColor="@color/base_red"
+              android:visibility="gone"
+              tools:visibility="visible"/>
           <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/android/app/src/main/res/layout/fragment_osm_login.xml
+++ b/android/app/src/main/res/layout/fragment_osm_login.xml
@@ -88,6 +88,17 @@
           android:hint="@string/password"
           android:inputType="textPassword" />
       </com.google.android.material.textfield.TextInputLayout>
+      <TextView
+          android:id="@+id/tv_error"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginTop = "@dimen/margin_base"
+          android:gravity="center"
+          android:text = "Login failed"
+          android:textColor="@color/base_red"
+          android:visibility="gone"
+          tools:visibility="visible"/>
+
       <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Fixed a bug where the login error dialog disappeared during screen rotation using the onSaveInstanceState API to persist and restore the dialog state. I verified the fix on various Android versions (5, 6, 10, 11, and 12), ensuring it works perfectly across both legacy and modern devices.
Fixes #11668
Portrait
<img width="333" height="748" alt="Organic Maps – OsmLoginFragment java  Organic_Maps app main  16-01-2026 07_19_27" src="https://github.com/user-attachments/assets/8e0909e0-b297-4ccd-814a-f68845f4acd2" />
Landscape
<img width="436" height="182" alt="Organic Maps – OsmLoginFragment java  Organic_Maps app main  16-01-2026 07_19_32" src="https://github.com/user-attachments/assets/43f4969d-c4c3-4aae-a586-18ea508e6c33" />

