### PR TITLE
Avoid stripping debug symbols for debug builds

### DIFF
--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -69,14 +69,10 @@ android {
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
-  buildTypes {
-    debug {
-    }
-  }
-  packagingOptions {
-    doNotStrip "**/liborganicmaps.so"
-  }
 
+  packagingOptions{
+      doNotStrip "**/liborganicmaps.so"
+  }
 
   externalNativeBuild {
     cmake {


### PR DESCRIPTION
Updates the SDK build.gradle to preserve native debug symbols, fixing unreadable C++ crash logs in debug builds
Fixes: #10835 