### PR TITLE
[android] Split "night mode" setting into "appearance" and "night navigation" options

### DIFF
--- a/android/app/src/main/java/app/organicmaps/car/util/ThemeUtils.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/ThemeUtils.java
@@ -16,11 +16,11 @@ public final class ThemeUtils
 {
   public enum ThemeMode
   {
-    AUTO(R.string.auto, Config.UiTheme.AUTO),
-    LIGHT(R.string.off, Config.UiTheme.DEFAULT),
-    NIGHT(R.string.on, Config.UiTheme.NIGHT);
+    AUTO(R.string.auto, Config.UiTheme.SYSTEM),
+    LIGHT(R.string.off, Config.UiTheme.LIGHT),
+    NIGHT(R.string.on, Config.UiTheme.DARK);
 
-    ThemeMode(@StringRes int titleId, @NonNull String config)
+    ThemeMode(@StringRes int titleId, @NonNull Config.UiTheme config)
     {
       mTitleId = titleId;
       mConfig = config;
@@ -33,7 +33,7 @@ public final class ThemeUtils
     }
 
     @NonNull
-    public String getConfig()
+    public Config.UiTheme getConfig()
     {
       return mConfig;
     }
@@ -41,7 +41,7 @@ public final class ThemeUtils
     @StringRes
     private final int mTitleId;
     @NonNull
-    private final String mConfig;
+    private final Config.UiTheme mConfig;
   }
 
   private static final String ANDROID_AUTO_PREFERENCES_FILE_KEY = "ANDROID_AUTO_PREFERENCES_FILE_KEY";
@@ -74,23 +74,22 @@ public final class ThemeUtils
   @UiThread
   public static void setThemeMode(@NonNull CarContext context, @NonNull ThemeMode themeMode)
   {
-    getSharedPreferences(context).edit().putString(THEME_KEY, themeMode.getConfig()).commit();
+    getSharedPreferences(context).edit().putString(THEME_KEY, themeMode.getConfig().value).commit();
     update(context, themeMode);
   }
 
   @NonNull
   public static ThemeMode getThemeMode(@NonNull CarContext context)
   {
-    final String themeMode = getSharedPreferences(context).getString(THEME_KEY, ThemeMode.AUTO.getConfig());
+    final var preferences = getSharedPreferences(context);
+    final var uiTheme = Config.UiTheme.ofValue(preferences.getString(THEME_KEY, Config.UiTheme.SYSTEM.value));
 
-    if (themeMode.equals(ThemeMode.AUTO.getConfig()))
-      return ThemeMode.AUTO;
-    else if (themeMode.equals(ThemeMode.LIGHT.getConfig()))
-      return ThemeMode.LIGHT;
-    else if (themeMode.equals(ThemeMode.NIGHT.getConfig()))
-      return ThemeMode.NIGHT;
-    else
-      throw new IllegalArgumentException("Unsupported value");
+    return switch (uiTheme)
+    {
+      case DARK -> ThemeMode.NIGHT;
+      case LIGHT -> ThemeMode.LIGHT;
+      case SYSTEM -> ThemeMode.AUTO;
+    };
   }
 
   @NonNull

--- a/android/app/src/main/java/app/organicmaps/util/ThemeUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/ThemeUtils.java
@@ -49,9 +49,4 @@ public final class ThemeUtils
     int nightFlag = context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
     return nightFlag == Configuration.UI_MODE_NIGHT_YES;
   }
-
-  public static boolean isNavAutoTheme()
-  {
-    return Config.UiTheme.isNavAuto(Config.UiTheme.getUiThemeSettings());
-  }
 }

--- a/android/app/src/main/res/values-af/strings.xml
+++ b/android/app/src/main/res/values-af/strings.xml
@@ -202,6 +202,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Knoppies + en - op die kaart</string>
     <string name="pref_zoom_summary">Vertoon op die kaart</string>
+    <string name="pref_auto_night_in_navigation_title">Nagstyl wanneer in die donker genavigeer word</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Nagmodus</string>
     <!-- Generic «On» string -->

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">أزرار + و- على الخريطة</string>
     <string name="pref_zoom_summary">عرض على الشاشة</string>
+    <string name="pref_auto_night_in_navigation_title">النمط الليلي عند التنقل في الظلام</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">الوضع الليلي</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">رمادي</string>
     <!-- blue gray color -->
     <string name="blue_gray">رمادي أزرق</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">المظهر</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">فاتح</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">داكن</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">اهْدِ خرائط مجانية بدون إعلانات لملايين المستخدمين!</string>
 

--- a/android/app/src/main/res/values-ast/strings.xml
+++ b/android/app/src/main/res/values-ast/strings.xml
@@ -136,6 +136,12 @@
     <string name="blue">Azul</string>
     <!-- green color -->
     <string name="green">Verde</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Aspeutu</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Claru</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Escuru</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">¡Regala mapes gratis y ensin anuncios a millones d\'usuarios!</string>
 

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">+ və - düymələri xəritədə</string>
     <string name="pref_zoom_summary">Xəritədə göstər</string>
+    <string name="pref_auto_night_in_navigation_title">Qaranlıqda naviqasiya edərkən gecə üslubu</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Gecə rejimi</string>
     <!-- Generic «Off» string -->
@@ -335,6 +336,12 @@
     <string name="gray">Boz</string>
     <!-- blue gray color -->
     <string name="blue_gray">Mavi-boz</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Görünüş</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Parlaq</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Tünd</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Milyonlarla istifadəçiyə reklamsız, pulsuz xəritələr hədiyyə edin!</string>
 

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Кнопкі «+» і «-» на мапе</string>
     <string name="pref_zoom_summary">Адлюстраванне на карце</string>
+    <string name="pref_auto_night_in_navigation_title">Начны стыль пры навігацыі ў цемры</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Начны рэжым</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Шэры</string>
     <!-- blue gray color -->
     <string name="blue_gray">Блакітна-шэры</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Выгляд</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Светлы</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Цёмны</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Падарыце бясплатныя мапы без рэкламы мільёнам карыстальнікаў!</string>
 

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Бутони „+“ и „-“ на картата</string>
     <string name="pref_zoom_summary">Показване на картата</string>
+    <string name="pref_auto_night_in_navigation_title">Нощен стил при навигация на тъмно</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Нощен режим</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Сиво</string>
     <!-- blue gray color -->
     <string name="blue_gray">Синкаво Сиво</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Изглед</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Светъл</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Тъмен</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Подарете безплатни карти без реклами на милиони потребители!</string>
 

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Botons «+» i «-» al mapa</string>
     <string name="pref_zoom_summary">Mostra\'ls al mapa</string>
+    <string name="pref_auto_night_in_navigation_title">Estil nocturn quan es navega en la foscor</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Mode nocturn</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Gris</string>
     <!-- blue gray color -->
     <string name="blue_gray">Gris blavós</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Aspecte</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Clar</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Fosc</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Regala mapes gratuïts sense anuncis a milions d\'usuaris!</string>
 

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Tlačítka „+“ a „-“ na mapě</string>
     <string name="pref_zoom_summary">Zobrazit na obrazovce</string>
+    <string name="pref_auto_night_in_navigation_title">Noční styl při navigaci ve tmě</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Noční režim</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Šedá</string>
     <!-- blue gray color -->
     <string name="blue_gray">Modrošedá</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Vzhled</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Světlý</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Tmavý</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Darujte bezplatné mapy bez reklam milionům uživatelů!</string>
 

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Knapperne + og - på kortet</string>
     <string name="pref_zoom_summary">Vis på skærmen</string>
+    <string name="pref_auto_night_in_navigation_title">Nat-stil, når du navigerer i mørke</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Nattilstand</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Grå</string>
     <!-- blue gray color -->
     <string name="blue_gray">Blågrå</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Udseende</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Lys</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Mørk</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Giv gratis kort uden reklamer til millioner af brugere!</string>
 

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">„+“ und „-“ Knöpfe auf der Karte</string>
     <string name="pref_zoom_summary">Auf der Karte anzeigen</string>
+    <string name="pref_auto_night_in_navigation_title">Nacht-Stil beim Navigieren im Dunkeln</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Nachtmodus</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Grau</string>
     <!-- blue gray color -->
     <string name="blue_gray">Graublau</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Erscheinungsbild</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Hell</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Dunkel</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Schenke Millionen von Nutzern kostenlose und werbefreie Karten!</string>
 

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Πλήκτρα «+» και «-» στον χάρτη</string>
     <string name="pref_zoom_summary">Εμφάνιση στο χάρτη</string>
+    <string name="pref_auto_night_in_navigation_title">Νυχτερινό στυλ κατά την πλοήγηση στο σκοτάδι</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Νυχτερινή λειτουργία</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Γκρι</string>
     <!-- blue gray color -->
     <string name="blue_gray">Γκρίζο μπλε</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Εμφάνιση</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Ανοιχτόχρωμη</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Σκουρόχρωμη</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Χαρίστε δωρεάν χάρτες χωρίς διαφημίσεις σε εκατομμύρια χρήστες!</string>
 

--- a/android/app/src/main/res/values-es-rMX/strings.xml
+++ b/android/app/src/main/res/values-es-rMX/strings.xml
@@ -104,6 +104,7 @@
     <!-- Title for tracks category in bookmarks manager -->
     <string name="tracks_title">Rutas</string>
     <string name="pref_zoom_summary">Visualización en el mapa</string>
+    <string name="pref_auto_night_in_navigation_title">Estilo nocturno cuando se navega en la oscuridad</string>
     <!-- Settings «Map» category: «3D buildings» title -->
     <string name="pref_map_3d_buildings_title">Edificios 3D</string>
     <!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
@@ -169,6 +170,10 @@
     <string name="deep_orange">Naranja intenso</string>
     <!-- blue gray color -->
     <string name="blue_gray">Azul Gris</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Apariencia</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Luz</string>
 
     <!-- SECTION: Routing dialogs strings -->
     <string name="dialog_routing_disclaimer_title">Cuando siga la ruta, tenga en cuenta lo siguiente:</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Botones «+» y «-» en el mapa</string>
     <string name="pref_zoom_summary">Visualización en la pantalla</string>
+    <string name="pref_auto_night_in_navigation_title">Estilo nocturno al navegar en la oscuridad</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Modo nocturno</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Gris</string>
     <!-- blue gray color -->
     <string name="blue_gray">Gris azulado</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Aspecto</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Claro</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Oscuro</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">¡Regala mapas gratis y sin anuncios a millones de usuarios!</string>
 

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Nupud „+” ja „-” kaardil</string>
     <string name="pref_zoom_summary">Kuva kaardil</string>
+    <string name="pref_auto_night_in_navigation_title">Öine stiil pimedas navigeerimisel</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Öörežiim</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Hall</string>
     <!-- blue gray color -->
     <string name="blue_gray">Sinakashall</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Välimus</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Hele kujundus</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Tume kujundus</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Kingi miljonitele kasutajatele tasuta ja reklaamideta kaardid!</string>
 

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Mapako “+” eta “-” botoiak</string>
     <string name="pref_zoom_summary">Erakutsi mapan</string>
+    <string name="pref_auto_night_in_navigation_title">Gau estiloa ilunpean nabigatzean</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Gaueko modua</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Grisa</string>
     <!-- blue gray color -->
     <string name="blue_gray">Gris urdinxka</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Itxura</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Argi</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Iluna</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Oparitu doako mapak iragarkirik gabe milioika erabiltzaileri!</string>
 

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">دکمه‌های + و - روی نقشه</string>
     <string name="pref_zoom_summary">نمایش بر روی نقشه</string>
+    <string name="pref_auto_night_in_navigation_title">سبک شب هنگام ناوبری در تاریکی</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">حالت شب</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">خاکستری</string>
     <!-- blue gray color -->
     <string name="blue_gray">خاکستری کبود</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">ظاهری</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">روشن</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">تیره</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">نقشه‌های رایگان و بدون تبلیغات را به میلیون‌ها کاربر هدیه دهید!</string>
 

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Painikkeet ”+” ja ”-” kartalla</string>
     <string name="pref_zoom_summary">Näytä kartalla</string>
+    <string name="pref_auto_night_in_navigation_title">Yötyyli, kun navigoidaan pimeässä</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Yötila</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Harmaa</string>
     <!-- blue gray color -->
     <string name="blue_gray">Siniharmaa</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Ulkoasu</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Vaalea</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Tumma</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Lahjoita ilmaiset ja mainoksettomat kartat miljoonille käyttäjille!</string>
 

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Boutons « + » et « - » sur la carte</string>
     <string name="pref_zoom_summary">Afficher à l\'écran</string>
+    <string name="pref_auto_night_in_navigation_title">Style nocturne lorsque vous naviguez dans l\'obscurité</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Mode nuit</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Gris</string>
     <!-- blue gray color -->
     <string name="blue_gray">Gris-bleu</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Apparence</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Claire</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Sombre</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Offrez des cartes gratuites et sans pub à des millions d\'utilisateurs !</string>
 

--- a/android/app/src/main/res/values-gl/strings.xml
+++ b/android/app/src/main/res/values-gl/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Botóns «+» e «-» no mapa</string>
     <string name="pref_zoom_summary">Mostrar no mapa</string>
+    <string name="pref_auto_night_in_navigation_title">Estilo nocturno ao navegar en escuro</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Modo nocturno</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Gris</string>
     <!-- blue gray color -->
     <string name="blue_gray">Gris azulado</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Aspecto</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Claro</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Escuro</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Regala mapas gratuítos e sen anuncios a millóns de usuarios!</string>
 

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -202,6 +202,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">मानचित्र पर + और - बटन</string>
     <string name="pref_zoom_summary">मानचित्र पर बटन प्रदर्शित करें</string>
+    <string name="pref_auto_night_in_navigation_title">अंधेरे में नेविगेट करते समय नाइट स्टाइल</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">रात का मोड</string>
     <!-- Generic «Off» string -->
@@ -278,6 +279,12 @@
     <string name="enable_location_services">कृपया स्थान सेवाएँ सक्षम करें</string>
     <string name="save">सहेजें</string>
     <string name="create">बनाएं</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">प्रकटन</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">हल्का</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">गहरा</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">लाखों उपयोगकर्ताओं को बिना विज्ञापनों वाले मुफ़्त नक्शे उपहार में दें!</string>
 

--- a/android/app/src/main/res/values-hr/strings.xml
+++ b/android/app/src/main/res/values-hr/strings.xml
@@ -130,6 +130,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Gumbi „+“ i „-“ na karti</string>
     <string name="pref_zoom_summary">Prikaži na karti</string>
+    <string name="pref_auto_night_in_navigation_title">Noćni stil pri navigaciji u mraku</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Noćni modus</string>
     <!-- Generic «Off» string -->

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">A térképen lévő + és - gombok</string>
     <string name="pref_zoom_summary">Megjelenítés a térképen</string>
+    <string name="pref_auto_night_in_navigation_title">Éjszakai stílus sötétben történő navigáláskor</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Éjszakai mód</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Szürke</string>
     <!-- blue gray color -->
     <string name="blue_gray">Kékes szürke</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Megjelenés</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Világos</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Sötét</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Ajándékozzon ingyenes, hirdetésmentes térképeket felhasználók millióinak!</string>
 

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Tombol + dan - pada peta</string>
     <string name="pref_zoom_summary">Tampilkan pada layar</string>
+    <string name="pref_auto_night_in_navigation_title">Gaya malam saat menavigasi dalam gelap</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Mode Malam</string>
     <!-- Generic «Off» string -->
@@ -335,6 +336,12 @@
     <string name="gray">Abu-abu</string>
     <!-- blue gray color -->
     <string name="blue_gray">Biru Keabu-abuan</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Tampilan</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Terang</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Gelap</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Hadiahkan peta gratis tanpa iklan untuk jutaan pengguna!</string>
 

--- a/android/app/src/main/res/values-is/strings.xml
+++ b/android/app/src/main/res/values-is/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Hnapparnir „+“ og „-“ á kortinu</string>
     <string name="pref_zoom_summary">Birta á kortinu</string>
+    <string name="pref_auto_night_in_navigation_title">Næturstíll þegar siglt er í myrkri</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Næturhamur</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Grátt</string>
     <!-- blue gray color -->
     <string name="blue_gray">Blágrátt</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Útlit</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Ljóst</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Dökkt</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Gefðu milljónum notenda ókeypis kort án auglýsinga!</string>
 

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Pulsanti «+» e «-» sulla mappa</string>
     <string name="pref_zoom_summary">Mostra sulla mappa</string>
+    <string name="pref_auto_night_in_navigation_title">Stile notturno quando naviga al buio</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Modalità notte</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Grigio</string>
     <!-- blue gray color -->
     <string name="blue_gray">Grigiazzurro</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Aspetto</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Chiaro</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Scuro</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Regala mappe gratuite e senza pubblicità a milioni di utenti!</string>
 

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">כפתורי + ו- על המפה</string>
     <string name="pref_zoom_summary">הצג על המסך</string>
+    <string name="pref_auto_night_in_navigation_title">סגנון לילה בעת ניווט בחושך</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">מצב לילה</string>
     <!-- Generic «Off» string -->
@@ -331,6 +332,12 @@
     <string name="gray">אפור</string>
     <!-- blue gray color -->
     <string name="blue_gray">כחול אפרפר</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">מראה</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">בהיר</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">כהה</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">העניקו במתנה מפות חינמיות וללא פרסומות למיליוני משתמשים!</string>
 

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">地図上の「+」と「-」ボタン</string>
     <string name="pref_zoom_summary">画面上に表示</string>
+    <string name="pref_auto_night_in_navigation_title">暗闇でナビゲートする際のナイトスタイル</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">夜間モード</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">灰色</string>
     <!-- blue gray color -->
     <string name="blue_gray">青灰色</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">外観</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">ライト</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">ダーク</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">何百万人ものユーザーに広告なしの無料地図を贈ろう！</string>
 

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">지도에서 + 및 - 버튼</string>
     <string name="pref_zoom_summary">화면에 표시</string>
+    <string name="pref_auto_night_in_navigation_title">어두운 곳에서 내비게이션할 때의 야간 스타일</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">나이트 모드</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">회색</string>
     <!-- blue gray color -->
     <string name="blue_gray">청회색</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">모양</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">라이트</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">다크</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">수백만 명의 사용자에게 광고 없는 무료 지도를 선물하세요!</string>
 

--- a/android/app/src/main/res/values-lt/strings.xml
+++ b/android/app/src/main/res/values-lt/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Mygtukai „+“ ir „-“ žemėlapyje</string>
     <string name="pref_zoom_summary">Rodyti žemėlapyje</string>
+    <string name="pref_auto_night_in_navigation_title">Naktinis stilius, kai navigacija vykdoma tamsoje</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Nakties veiksena</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Pilkas</string>
     <!-- blue gray color -->
     <string name="blue_gray">Mėlynai pilkas</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Išvaizda</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Šviesi</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Tamsi</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Padovanokite nemokamus žemėlapius be skelbimų milijonams vartotojų!</string>
 

--- a/android/app/src/main/res/values-lv/strings.xml
+++ b/android/app/src/main/res/values-lv/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Pogas \"+\" un \"-\" kartē</string>
     <string name="pref_zoom_summary">Rādīt kartē</string>
+    <string name="pref_auto_night_in_navigation_title">Nakts stils, ja navigācija notiek tumsā</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Tumšais motīvs</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Pelēka</string>
     <!-- blue gray color -->
     <string name="blue_gray">Zilpelēka</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Izskats</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Gaišs</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Tumšs</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Dāviniet bezmaksas kartes bez reklāmām miljoniem lietotāju!</string>
 

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -196,6 +196,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">नकाशावर + आणि - बटणे</string>
     <string name="pref_zoom_summary">नकाशावर दाखवा</string>
+    <string name="pref_auto_night_in_navigation_title">अंधारात नेव्हिगेट करताना रात्रीची शैली</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">रात्र मोड</string>
     <!-- Generic «Off» string -->
@@ -329,6 +330,12 @@
     <string name="gray">राखाडी</string>
     <!-- blue gray color -->
     <string name="blue_gray">निळा राखाडी</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">दर्शनी रूप</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">प्रकाश</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">अंधार</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">लाखो वापरकर्त्यांना जाहिरातीशिवाय विनामूल्य नकाशे भेट द्या!</string>
 

--- a/android/app/src/main/res/values-mt/strings.xml
+++ b/android/app/src/main/res/values-mt/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Il-buttuni + u - fuq il-mappa</string>
     <string name="pref_zoom_summary">Uri fuq il-mappa</string>
+    <string name="pref_auto_night_in_navigation_title">Stil bil-lejl meta tkun qed tinnaviga fid-dlam</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Il-mod ta’ bil-lejl</string>
     <!-- Generic «Off» string -->
@@ -333,6 +334,8 @@
     <string name="gray">Griż</string>
     <!-- blue gray color -->
     <string name="blue_gray">Blu Griż</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Dehra</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Agħti mapep b\'xejn u bla reklami lil miljuni ta\' utenti!</string>
 

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Knappene + og - på kartet</string>
     <string name="pref_zoom_summary">Vis på skjermen</string>
+    <string name="pref_auto_night_in_navigation_title">Nattstil når du navigerer i mørket</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Nattmodus</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Grå</string>
     <!-- blue gray color -->
     <string name="blue_gray">Gråblå</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Utseende</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Lys</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Mørke</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Gi gratis kart uten reklame til millioner av brukere!</string>
 

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">‘+’ en ‘-’ knoppen op de kaart</string>
     <string name="pref_zoom_summary">Toon op de kaart</string>
+    <string name="pref_auto_night_in_navigation_title">Nachtstijl bij navigeren in het donker</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Nachtmodus</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Grijs</string>
     <!-- blue gray color -->
     <string name="blue_gray">Grijsblauw</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Weergave</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Licht</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Donker</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Geef gratis kaarten zonder advertenties aan miljoenen gebruikers!</string>
 

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Przyciski „+” i „-” na mapie</string>
     <string name="pref_zoom_summary">Wyświetla na ekranie</string>
+    <string name="pref_auto_night_in_navigation_title">Styl nocny podczas nawigacji w ciemności</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Tryb nocny</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Szary</string>
     <!-- blue gray color -->
     <string name="blue_gray">Szaroniebieski</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Wygląd</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Jasny</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Ciemny</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Podaruj darmowe mapy bez reklam milionom użytkowników!</string>
 

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -133,6 +133,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Botões \"+\" e \"-\" no mapa</string>
     <string name="pref_zoom_summary">Mostrar na tela</string>
+    <string name="pref_auto_night_in_navigation_title">Estilo noturno ao navegar no escuro</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Modo Noturno</string>
     <!-- Generic «Off» string -->
@@ -226,6 +227,12 @@
     <string name="lime">Verde limão</string>
     <!-- blue gray color -->
     <string name="blue_gray">Azul escuro</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Aparência</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Clara</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Escura</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Ofereça mapas gratuitos e sem anúncios a milhões de usuários!</string>
 

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Botões «+» e «-» no mapa</string>
     <string name="pref_zoom_summary">Mostrar no ecrã</string>
+    <string name="pref_auto_night_in_navigation_title">Estilo noturno quando navega no escuro</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Modo noturno</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Cinza</string>
     <!-- blue gray color -->
     <string name="blue_gray">Azul-cinza</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Apresentação</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Tons claros</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Tons escuros</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Ofereça mapas gratuitos e sem anúncios a milhões de utilizadores!</string>
 

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Butoanele „+” și „-” pe hartă</string>
     <string name="pref_zoom_summary">Arată pe hartă</string>
+    <string name="pref_auto_night_in_navigation_title">Stil de noapte atunci când navigați în întuneric</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Mod nocturn</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Gri</string>
     <!-- blue gray color -->
     <string name="blue_gray">Gri albăstriu</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Aspect</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Luminos</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Întunecat</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Oferiți hărți gratuite fără reclame pentru milioane de utilizatori!</string>
 

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Кнопки «+» и «-» на карте</string>
     <string name="pref_zoom_summary">Показать на карте</string>
+    <string name="pref_auto_night_in_navigation_title">Ночной стиль при навигации в темноте</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Ночной режим</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Серый</string>
     <!-- blue gray color -->
     <string name="blue_gray">Серо-голубой</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Оформление</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Светлое</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Темное</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Подарите миллионам пользователей бесплатные карты без рекламы!</string>
 

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Tlačidlá „+“ a „-“ na mape</string>
     <string name="pref_zoom_summary">Zobraziť na obrazovke</string>
+    <string name="pref_auto_night_in_navigation_title">Nočný štýl pri navigácii v tme</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Nočný režim</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Sivá</string>
     <!-- blue gray color -->
     <string name="blue_gray">Modro sivá</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Vzhľad</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Svetlý</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Tmavý</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Darujte bezplatné mapy bez reklám miliónom používateľov!</string>
 

--- a/android/app/src/main/res/values-sl/strings.xml
+++ b/android/app/src/main/res/values-sl/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Gumbi „+“ in „-“ na zemljevidu</string>
     <string name="pref_zoom_summary">Prikaži na zemljevidu</string>
+    <string name="pref_auto_night_in_navigation_title">Nočni slog pri navigaciji v temi</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Nočni način</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Siva</string>
     <!-- blue gray color -->
     <string name="blue_gray">Modro siva</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Videz</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Svetla</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Temna</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Podarite brezplačne zemljevide brez oglasov milijonom uporabnikov!</string>
 

--- a/android/app/src/main/res/values-sq/strings.xml
+++ b/android/app/src/main/res/values-sq/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Butonat “+” dhe “-” në hartë</string>
     <string name="pref_zoom_summary">Shfaq në hartë</string>
+    <string name="pref_auto_night_in_navigation_title">Stili nate kur navigoni në errësirë</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Modaliteti i Natës</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Gri</string>
     <!-- blue gray color -->
     <string name="blue_gray">Gri Blu</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Pamja</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Dritë</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Errësirë</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Dhuroni harta falas pa reklama për miliona përdorues!</string>
 

--- a/android/app/src/main/res/values-sr/strings.xml
+++ b/android/app/src/main/res/values-sr/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Дугмад „+” и „-” на мапи</string>
     <string name="pref_zoom_summary">Прикажи на мапи</string>
+    <string name="pref_auto_night_in_navigation_title">Ноћни стил приликом навигације у мраку</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Ноћни режим</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Сива</string>
     <!-- blue gray color -->
     <string name="blue_gray">Плаво сива</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Изглед</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Светло</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Тамно</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Поклоните бесплатне мапе без огласа милионима корисника!</string>
 

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Knapparna + och - på kartan</string>
     <string name="pref_zoom_summary">Visa på kartan</string>
+    <string name="pref_auto_night_in_navigation_title">Nattstil när du navigerar i mörkret</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Nattläge</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Grå</string>
     <!-- blue gray color -->
     <string name="blue_gray">Ljusblå grå</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Utseende</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Ljust</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Mörkt</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Ge bort gratis kartor utan annonser till miljontals användare!</string>
 

--- a/android/app/src/main/res/values-sw/strings.xml
+++ b/android/app/src/main/res/values-sw/strings.xml
@@ -56,6 +56,7 @@
     <string name="data_version">Data ya OpenStreetMap: %s</string>
     <!-- Confirmation for OpenStreetMap log out. -->
     <string name="osm_log_out_confirmation">Je, una uhakika unataka kuondoka kwenye akaunti yako ya OpenStreetMap?</string>
+    <string name="pref_auto_night_in_navigation_title">Mtindo wa usiku unapovinjari gizani</string>
     <!-- Generic «Auto» string -->
     <string name="auto">Auto</string>
     <!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -195,6 +195,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">ปุ่ม + และ - บนแผนที่</string>
     <string name="pref_zoom_summary">แสดงบนหน้าจอ</string>
+    <string name="pref_auto_night_in_navigation_title">สไตล์กลางคืนเมื่อนำทางในที่มืด</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">โหมดกลางคืน</string>
     <!-- Generic «Off» string -->
@@ -326,6 +327,12 @@
     <string name="gray">สีเทา</string>
     <!-- blue gray color -->
     <string name="blue_gray">สีฟ้าอมเทา</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">รูปแบบ</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">สว่าง</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">มืด</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">มอบแผนที่ฟรีไม่มีโฆษณาให้แก่ผู้ใช้นับล้าน!</string>
 

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Haritadaki + ve - düğmeleri</string>
     <string name="pref_zoom_summary">Haritada göster</string>
+    <string name="pref_auto_night_in_navigation_title">Karanlıkta navigasyon yaparken gece stili</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Gece Modu</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Gri</string>
     <!-- blue gray color -->
     <string name="blue_gray">Mavi Gri</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Görünüm</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Açık</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Koyu</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Milyonlarca kullanıcıya reklamsız ve ücretsiz haritalar hediye edin!</string>
 

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Кнопки «+» і «-» на мапі</string>
     <string name="pref_zoom_summary">Відображення на екрані</string>
+    <string name="pref_auto_night_in_navigation_title">Нічний стиль під час навігації в темряві</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Нічний режим</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Сірий</string>
     <!-- blue gray color -->
     <string name="blue_gray">Сіро-блакитний</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Вигляд</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Світлий</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Темний</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Подаруйте мільйонам користувачів безкоштовні мапи без реклами!</string>
 

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -195,6 +195,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">Nút + và - trên bản đồ</string>
     <string name="pref_zoom_summary">Hiển thị trên màn hình</string>
+    <string name="pref_auto_night_in_navigation_title">Chế độ ban đêm khi điều hướng trong điều kiện thiếu sáng</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Chế độ ban đêm</string>
     <!-- Generic «Off» string -->
@@ -326,6 +327,12 @@
     <string name="gray">Xám</string>
     <!-- blue gray color -->
     <string name="blue_gray">Xám xanh da trời</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Giao diện</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Sáng</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Tối</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Tặng bản đồ miễn phí không có quảng cáo cho hàng triệu người dùng!</string>
 

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">地圖上的「+」和「-」按鈕</string>
     <string name="pref_zoom_summary">在螢幕上顯示</string>
+    <string name="pref_auto_night_in_navigation_title">在黑暗中導航時的夜間風格</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">夜間模式</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">灰色</string>
     <!-- blue gray color -->
     <string name="blue_gray">藍灰色</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">外觀</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">淺色</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">深色</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">向數百萬使用者贈送無廣告的免費地圖！</string>
 

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">地图上的“+”和“-”按钮</string>
     <string name="pref_zoom_summary">在屏幕上显示</string>
+    <string name="pref_auto_night_in_navigation_title">黑暗中导航时的夜间风格</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">夜间模式</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">灰色</string>
     <!-- blue gray color -->
     <string name="blue_gray">蓝灰色</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">外观</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">浅色</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">深色</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">向数百万用户赠送无广告的免费地图！</string>
 

--- a/android/app/src/main/res/values/donottranslate.xml
+++ b/android/app/src/main/res/values/donottranslate.xml
@@ -14,7 +14,8 @@
   <string name="pref_emulate_bad_external_storage" translatable="false">EmulateBadExternalStorage</string>
   <string name="pref_about" translatable="false">AboutOrganicMaps</string>
   <string name="pref_help" translatable="false">Help</string>
-  <string name="pref_map_style" translatable="false">MapStyle</string>
+  <string name="pref_map_appearance" translatable="false">MapStyle</string>
+  <string name="pref_auto_night_in_navigation" translatable="false">AutoNightInNavigation</string>
   <string name="pref_tts_screen" translatable="false">TtsScreen</string>
   <string name="pref_tts_enabled" translatable="false">TtsEnabled</string>
   <string name="pref_tts_street_names" translatable="false">TtsStreetNames</string>

--- a/android/app/src/main/res/values/string-arrays.xml
+++ b/android/app/src/main/res/values/string-arrays.xml
@@ -24,11 +24,10 @@
     <item>1</item>
   </string-array>
 
-  <string-array name="map_style">
-    <item>@string/off</item>
-    <item>@string/on</item>
+  <string-array name="map_appearance">
     <item>@string/follow_system</item>
-    <item>@string/nav_auto</item>
+    <item>@string/pref_appearance_light</item>
+    <item>@string/pref_appearance_dark</item>
   </string-array>
 
   <string-array name="speed_cameras">

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -204,6 +204,7 @@
     <!-- Setting name which enables or disables zoom buttons on the map screen. -->
     <string name="pref_zoom_title">“+” and “-” buttons on the map</string>
     <string name="pref_zoom_summary">Display on the map</string>
+    <string name="pref_auto_night_in_navigation_title">Night style when navigating in the dark</string>
     <!-- Settings «Map» category: «Night style» title -->
     <string name="pref_map_style_title">Night Mode</string>
     <!-- Generic «Off» string -->
@@ -337,6 +338,12 @@
     <string name="gray">Gray</string>
     <!-- blue gray color -->
     <string name="blue_gray">Blue Gray</string>
+    <!-- Settings «Map» category: «Appearance» title -->
+    <string name="pref_appearance_title">Appearance</string>
+    <!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_light">Light</string>
+    <!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
+    <string name="pref_appearance_dark">Dark</string>
     <!-- Tex label above the Donate button -->
     <string name="donate_description">Gift free maps with no ads to millions of users!</string>
 

--- a/android/app/src/main/res/xml/prefs_main.xml
+++ b/android/app/src/main/res/xml/prefs_main.xml
@@ -15,6 +15,12 @@
     android:title="@string/prefs_group_general"
     android:order="2">
     <ListPreference
+      android:key="@string/pref_map_appearance"
+      android:title="@string/pref_appearance_title"
+      app:singleLineTitle="false"
+      android:entries="@array/map_appearance"
+      android:order="0" />
+    <ListPreference
       android:key="@string/pref_munits"
       android:title="@string/measurement_units"
       app:singleLineTitle="false"
@@ -126,11 +132,10 @@
     android:key="@string/pref_navigation"
     android:title="@string/prefs_group_route"
     android:order="3">
-    <ListPreference
-      android:key="@string/pref_map_style"
-      android:title="@string/pref_map_style_title"
+    <SwitchPreferenceCompat
+      android:key="@string/pref_auto_night_in_navigation"
+      android:title="@string/pref_auto_night_in_navigation_title"
       app:singleLineTitle="false"
-      android:entries="@array/map_style"
       android:order="1" />
     <SwitchPreferenceCompat
       android:key="@string/pref_3d"

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -5976,6 +5976,62 @@ vi = Hiển thị trên màn hình
 zh-Hans = 在屏幕上显示
 zh-Hant = 在螢幕上顯示
 
+[pref_auto_night_in_navigation_title]
+tags = android-app
+en = Night style when navigating in the dark
+af = Nagstyl wanneer in die donker genavigeer word
+ar = النمط الليلي عند التنقل في الظلام
+az = Qaranlıqda naviqasiya edərkən gecə üslubu
+be = Начны стыль пры навігацыі ў цемры
+bg = Нощен стил при навигация на тъмно
+bn = অন্ধকারে নেভিগেট করার সময় নাইট স্টাইল
+ca = Estil nocturn quan es navega en la foscor
+cs = Noční styl při navigaci ve tmě
+da = Nat-stil, når du navigerer i mørke
+de = Nacht-Stil beim Navigieren im Dunkeln
+el = Νυχτερινό στυλ κατά την πλοήγηση στο σκοτάδι
+es = Estilo nocturno al navegar en la oscuridad
+es-MX = Estilo nocturno cuando se navega en la oscuridad
+et = Öine stiil pimedas navigeerimisel
+eu = Gau estiloa ilunpean nabigatzean
+fa = سبک شب هنگام ناوبری در تاریکی
+fi = Yötyyli, kun navigoidaan pimeässä
+fr = Style nocturne lorsque vous naviguez dans l'obscurité
+gl = Estilo nocturno ao navegar en escuro
+he = סגנון לילה בעת ניווט בחושך
+hi = अंधेरे में नेविगेट करते समय नाइट स्टाइल
+hr = Noćni stil pri navigaciji u mraku
+hu = Éjszakai stílus sötétben történő navigáláskor
+id = Gaya malam saat menavigasi dalam gelap
+is = Næturstíll þegar siglt er í myrkri
+it = Stile notturno quando naviga al buio
+ja = 暗闇でナビゲートする際のナイトスタイル
+ko = 어두운 곳에서 내비게이션할 때의 야간 스타일
+lt = Naktinis stilius, kai navigacija vykdoma tamsoje
+lv = Nakts stils, ja navigācija notiek tumsā
+mr = अंधारात नेव्हिगेट करताना रात्रीची शैली
+mt = Stil bil-lejl meta tkun qed tinnaviga fid-dlam
+nb = Nattstil når du navigerer i mørket
+nl = Nachtstijl bij navigeren in het donker
+pa = ਅੰਧੇਰੇ ਵਿੱਚ ਨੈਵੀਗੇਸ਼ਨ ਕਰਦਿਆਂ ਰਾਤ ਦੀ ਸ਼ੈਲੀ
+pl = Styl nocny podczas nawigacji w ciemności
+pt = Estilo noturno quando navega no escuro
+pt-BR = Estilo noturno ao navegar no escuro
+ro = Stil de noapte atunci când navigați în întuneric
+ru = Ночной стиль при навигации в темноте
+sk = Nočný štýl pri navigácii v tme
+sl = Nočni slog pri navigaciji v temi
+sq = Stili nate kur navigoni në errësirë
+sr = Ноћни стил приликом навигације у мраку
+sv = Nattstil när du navigerar i mörkret
+sw = Mtindo wa usiku unapovinjari gizani
+th = สไตล์กลางคืนเมื่อนำทางในที่มืด
+tr = Karanlıkta navigasyon yaparken gece stili
+uk = Нічний стиль під час навігації в темряві
+vi = Chế độ ban đêm khi điều hướng trong điều kiện thiếu sáng
+zh-Hans = 黑暗中导航时的夜间风格
+zh-Hant = 在黑暗中導航時的夜間風格
+
 [pref_map_style_title]
 comment = Settings «Map» category: «Night style» title
 tags = android-app
@@ -9892,7 +9948,7 @@ zh-Hant = Organic Maps 版本：%@
 
 [pref_appearance_title]
 comment = Settings «Map» category: «Appearance» title
-tags = apple-maps
+tags = android-app,apple-maps
 en = Appearance
 ar = المظهر
 ast = Aspeutu
@@ -9945,7 +10001,7 @@ zh-Hant = 外觀
 
 [pref_appearance_light]
 comment = Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation.
-tags = apple-maps
+tags = android-app,apple-maps
 en = Light
 ar = فاتح
 ast = Claru
@@ -9997,7 +10053,7 @@ zh-Hant = 淺色
 
 [pref_appearance_dark]
 comment = Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation.
-tags = apple-maps
+tags = android-app,apple-maps
 en = Dark
 ar = داكن
 ast = Escuru


### PR DESCRIPTION
The previous "Night mode" setting is now split into 2:
- "Appearance" controls the preferred theme for the app - Light/Dark/Follow the system
- "Force dark during night navigation" replaces the old "Auto in navigation"

Simplified theme handling: instead of multiple enums/constants, there is now only one for preference + one for Android Auto.

References #11994