### PR TITLE
[ios] Undo blue FAQ hint in About for new users

### DIFF
--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarInteractor.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarInteractor.swift
@@ -2,7 +2,6 @@ protocol BottomTabBarInteractorProtocol: AnyObject {
   func configureTabBar()
   func openSearch()
   func openHelp()
-  func openFaq()
   func openBookmarks()
   func openMenu()
 }
@@ -35,24 +34,16 @@ extension BottomTabBarInteractor: BottomTabBarInteractorProtocol {
   func openSearch() {
     searchManager.isSearching ? searchManager.close() : searchManager.startSearching(isRouting: false)
   }
-  
+
   func openHelp() {
     let aboutViewController = AboutController(onDidAppearCompletionHandler: configureTabBar)
     MapViewController.shared()?.navigationController?.pushViewController(aboutViewController, animated: true)
   }
-  
-  func openFaq() {
-    guard let navigationController = MapViewController.shared()?.navigationController else { return }
-    let aboutController = AboutController(onDidAppearCompletionHandler: {
-      navigationController.pushViewController(FaqController(), animated: true)
-    })
-    navigationController.pushViewController(aboutController, animated: true)
-  }
-  
+
   func openBookmarks() {
     mapViewController?.bookmarksCoordinator.open()
   }
-  
+
   func openMenu() {
     guard let state = controlsManager?.menuState else {
       fatalError("ERROR: Failed to retrieve the current MapViewControlsManager's state.")

--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarPresenter.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarPresenter.swift
@@ -1,14 +1,14 @@
 protocol BottomTabBarPresenterProtocol: AnyObject {
   func viewWillAppear()
   func onSearchButtonPressed()
-  func onHelpButtonPressed(withBadge: Bool)
+  func onHelpButtonPressed()
   func onBookmarksButtonPressed()
   func onMenuButtonPressed()
 }
 
 class BottomTabBarPresenter: NSObject {
   private let interactor: BottomTabBarInteractorProtocol
-  
+
   init(interactor: BottomTabBarInteractorProtocol) {
     self.interactor = interactor
   }
@@ -23,8 +23,8 @@ extension BottomTabBarPresenter: BottomTabBarPresenterProtocol {
     interactor.openSearch()
   }
 
-  func onHelpButtonPressed(withBadge: Bool) {
-    withBadge ? interactor.openFaq() : interactor.openHelp()
+  func onHelpButtonPressed() {
+    interactor.openHelp()
   }
 
   func onBookmarksButtonPressed() {

--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.swift
@@ -1,16 +1,12 @@
-
-private let kUDDidShowFirstTimeRoutingEducationalHint = "kUDDidShowFirstTimeRoutingEducationalHint"
-
 class BottomTabBarViewController: UIViewController {
   var presenter: BottomTabBarPresenterProtocol!
-  
+
   @IBOutlet var searchButton: MWMButton!
   @IBOutlet var helpButton: MWMButton!
   @IBOutlet var bookmarksButton: MWMButton!
   @IBOutlet var moreButton: MWMButton!
   @IBOutlet var downloadBadge: UIView!
-  @IBOutlet var helpBadge: UIView!
-  
+
   private var avaliableArea = CGRect.zero
   @objc var isHidden: Bool = false {
     didSet {
@@ -28,12 +24,12 @@ class BottomTabBarViewController: UIViewController {
 
   @objc static var controller: BottomTabBarViewController? { MWMMapViewControlsManager.manager()?.tabBarController }
 
-  
+
   override func viewDidLoad() {
     super.viewDidLoad()
     view.alpha = 0 // Hide the view until it receives a first available area update.
   }
-  
+
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     presenter.viewWillAppear()
@@ -51,24 +47,19 @@ class BottomTabBarViewController: UIViewController {
   static func updateAvailableArea(_ frame: CGRect) {
     BottomTabBarViewController.controller?.updateAvailableArea(frame)
   }
-  
+
   @IBAction func onSearchButtonPressed(_ sender: Any) {
     presenter.onSearchButtonPressed()
   }
-  
+
   @IBAction func onHelpButtonPressed(_ sender: Any) {
-    if !helpBadge.isHidden {
-      presenter.onHelpButtonPressed(withBadge: true)
-      setHelpBadgeShown()
-    } else {
-      presenter.onHelpButtonPressed(withBadge: false)
-    }
+    presenter.onHelpButtonPressed()
   }
-  
+
   @IBAction func onBookmarksButtonPressed(_ sender: Any) {
     presenter.onBookmarksButtonPressed()
   }
-  
+
   @IBAction func onMenuButtonPressed(_ sender: Any) {
     presenter.onMenuButtonPressed()
   }
@@ -78,7 +69,7 @@ class BottomTabBarViewController: UIViewController {
     updateFrame(animated: false)
     self.view.layoutIfNeeded()
   }
-  
+
   private func updateFrame(animated: Bool) {
     if avaliableArea == .zero {
       return
@@ -101,20 +92,8 @@ class BottomTabBarViewController: UIViewController {
       self.view.alpha = alpha
     }
   }
-  
+
   private func updateBadge() {
     downloadBadge.isHidden = isApplicationBadgeHidden
-    helpBadge.isHidden = !needsToShowHelpBadge()
-  }
-}
-
-// MARK: - Help badge
-private extension BottomTabBarViewController {
-  private func needsToShowHelpBadge() -> Bool {
-    !UserDefaults.standard.bool(forKey: kUDDidShowFirstTimeRoutingEducationalHint)
-  }
-  
-  private func setHelpBadgeShown() {
-    UserDefaults.standard.set(true, forKey: kUDDidShowFirstTimeRoutingEducationalHint)
   }
 }

--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.xib
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23091" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23079"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -12,7 +12,6 @@
             <connections>
                 <outlet property="bookmarksButton" destination="dgG-ki-3tB" id="md5-3T-9tb"/>
                 <outlet property="downloadBadge" destination="uDI-ZC-4wx" id="fAf-cy-Ozn"/>
-                <outlet property="helpBadge" destination="0pe-0n-d1F" id="pua-oN-kIZ"/>
                 <outlet property="helpButton" destination="dzf-7Z-N6a" id="ORg-VO-5ar"/>
                 <outlet property="moreButton" destination="svD-yi-GrZ" id="kjk-ZW-nZN"/>
                 <outlet property="searchButton" destination="No0-ld-JX3" id="m5F-UT-j94"/>
@@ -90,27 +89,12 @@
                                 <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Badge"/>
                             </userDefinedRuntimeAttributes>
                         </view>
-                        <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0pe-0n-d1F" userLabel="HelpBadge">
-                            <rect key="frame" x="49.5" y="11" width="10" height="10"/>
-                            <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <accessibility key="accessibilityConfiguration">
-                                <accessibilityTraits key="traits" notEnabled="YES"/>
-                            </accessibility>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="10" id="FgD-lk-SxR"/>
-                                <constraint firstAttribute="width" constant="10" id="OwT-jV-hqZ"/>
-                            </constraints>
-                            <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Badge"/>
-                            </userDefinedRuntimeAttributes>
-                        </view>
                     </subviews>
                     <accessibility key="accessibilityConfiguration" identifier="MainButtons"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="48" id="69A-eu-uLp"/>
                         <constraint firstItem="No0-ld-JX3" firstAttribute="centerY" secondItem="vum-s3-PHx" secondAttribute="centerY" id="8nL-zT-Y7b"/>
                         <constraint firstItem="No0-ld-JX3" firstAttribute="height" secondItem="vum-s3-PHx" secondAttribute="height" id="9eR-I7-7at"/>
-                        <constraint firstItem="0pe-0n-d1F" firstAttribute="centerX" secondItem="dzf-7Z-N6a" secondAttribute="centerX" constant="8" id="Ab0-g9-N4P"/>
                         <constraint firstItem="svD-yi-GrZ" firstAttribute="height" secondItem="vum-s3-PHx" secondAttribute="height" id="Fde-um-JL6"/>
                         <constraint firstItem="dgG-ki-3tB" firstAttribute="centerX" secondItem="vum-s3-PHx" secondAttribute="centerX" multiplier="1.25" id="Jc7-nc-elY"/>
                         <constraint firstItem="dgG-ki-3tB" firstAttribute="centerY" secondItem="vum-s3-PHx" secondAttribute="centerY" id="JjT-sc-hIY"/>
@@ -118,7 +102,6 @@
                         <constraint firstItem="dgG-ki-3tB" firstAttribute="height" secondItem="vum-s3-PHx" secondAttribute="height" id="Rs8-Hl-CAc"/>
                         <constraint firstItem="uDI-ZC-4wx" firstAttribute="centerX" secondItem="svD-yi-GrZ" secondAttribute="centerX" constant="8" id="XNb-Ba-Hn7"/>
                         <constraint firstItem="dzf-7Z-N6a" firstAttribute="centerY" secondItem="vum-s3-PHx" secondAttribute="centerY" id="Zug-zY-KIX"/>
-                        <constraint firstItem="0pe-0n-d1F" firstAttribute="centerY" secondItem="dzf-7Z-N6a" secondAttribute="centerY" constant="-8" id="pgw-rN-LCe"/>
                         <constraint firstItem="svD-yi-GrZ" firstAttribute="centerY" secondItem="vum-s3-PHx" secondAttribute="centerY" id="sja-hO-YY3"/>
                         <constraint firstItem="No0-ld-JX3" firstAttribute="centerX" secondItem="vum-s3-PHx" secondAttribute="centerX" multiplier="0.75" id="tDb-w1-ueQ"/>
                         <constraint firstItem="dzf-7Z-N6a" firstAttribute="centerX" secondItem="vum-s3-PHx" secondAttribute="centerX" multiplier="0.25" id="u3G-gY-98J"/>
@@ -145,9 +128,9 @@
         </view>
     </objects>
     <resources>
-        <image name="ic_menu" width="48" height="48"/>
-        <image name="ic_menu_bookmark_list" width="48" height="48"/>
-        <image name="ic_menu_search" width="48" height="48"/>
-        <image name="logo" width="512" height="512"/>
+        <image name="ic_menu" width="24" height="24"/>
+        <image name="ic_menu_bookmark_list" width="24" height="24"/>
+        <image name="ic_menu_search" width="24" height="24"/>
+        <image name="logo" width="462" height="512"/>
     </resources>
 </document>


### PR DESCRIPTION
As discussed in the chat. It is now replaced with a gift icon.

Tested on iPad 26 sim.

Reverts https://github.com/organicmaps/organicmaps/pull/6446/ and https://github.com/organicmaps/organicmaps/pull/6573/