### PR TITLE
Desktop: remove hardcoded black text color

### DIFF
--- a/qt/mainwindow.cpp
+++ b/qt/mainwindow.cpp
@@ -84,7 +84,6 @@ template <class T>
 T * CreateBlackControl(QString const & name)
 {
   T * p = new T(name);
-  p->setStyleSheet("color: black;");
   return p;
 }
 


### PR DESCRIPTION
### Summary
Removes a hardcoded `color: black;` stylesheet from `CreateBlackControl()` in `qt/mainwindow.cpp`.

### Reason
Forcing black text ignores the system/Qt palette and can make text unreadable in dark mode.  
Letting Qt handle the text color ensures correct appearance across light/dark themes and custom styles.

### Changes
- Removed `p->setStyleSheet("color: black;");` from `CreateBlackControl()`
