### PR TITLE
[android] Fix deadlock when editing POIs with invalid phones

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
@@ -269,13 +269,6 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
       }
     }
 
-    if (!Editor.nativeIsPhoneValid(mPhone.getText().toString()))
-    {
-      mPhone.requestFocus();
-      InputUtils.showKeyboard(mPhone);
-      return false;
-    }
-
     return validateNames();
   }
 


### PR DESCRIPTION
Debugged by: @biodranik

Fixes: #12014

**The Problem:**
The `EditorFragment` validates all fields before allowing a user to open any sub-editor window. If validation fails, it attempts to `requestFocus()` on the invalid field. However the phone number is displayed in a non-focusable `TextView` on the main screen. This results in a deadlock where the user cannot open any sub-fragment.

**The Solution:**
Removed the redundant check from `EditorFragment.java`. Validation is already handled in `PhoneListAdapter`.
```java
mInput = itemView.findViewById(R.id.input);
final TextInputLayout phoneInput = itemView.findViewById(R.id.phone_input);
mInput.addTextChangedListener(new StringUtils.SimpleTextWatcher() {
  @Override
  public void onTextChanged(CharSequence s, int start, int before, int count)
  {
    UiUtils.setInputError(phoneInput,
                          Editor.nativeIsPhoneValid(s.toString()) ? 0 : R.string.error_enter_correct_phone);
    PhoneListAdapter.this.updatePhoneItem(mPosition, mInput.getText().toString());
  }
});
```
**Testing**
Tested on POI with invalid phone numbers and POI with valid phone numbers.