### PR TITLE
Fix annoying Github dependabot warning for python dependencies

### DIFF
--- a/tools/python/maps_generator/requirements.txt
+++ b/tools/python/maps_generator/requirements.txt
@@ -2,7 +2,7 @@ omim-data-all
 omim-data-files
 omim-descriptions
 omim-post_generation
-filelock==3.20.1
+filelock==3.20.3
 beautifulsoup4==4.9.1
 requests>=2.31.0
 requests_file==1.5.1

--- a/tools/python/maps_generator/requirements_dev.txt
+++ b/tools/python/maps_generator/requirements_dev.txt
@@ -1,6 +1,6 @@
 -r ../post_generation/requirements_dev.txt
 -r ../descriptions/requirements_dev.txt
-filelock==3.20.1
+filelock==3.20.3
 beautifulsoup4==4.9.1
 requests>=2.31.0
 requests_file==1.5.1


### PR DESCRIPTION
https://github.com/organicmaps/organicmaps/security/dependabot

They're crazy there with vulnerabilities, a follow-up to https://github.com/organicmaps/organicmaps/pull/11929/