### PR TITLE
Denoised track ascent/descent calculation

### DIFF
--- a/libs/map/track_statistics.hpp
+++ b/libs/map/track_statistics.hpp
@@ -34,5 +34,6 @@ private:
   bool HasNoPoints() const;
 
   geometry::PointWithAltitude m_previousPoint;
+  geometry::Altitude m_lastValidAltitude;
   double m_previousTimestamp;
 };


### PR DESCRIPTION
Calculating elevation gain/loss is not nearly as straightforward as it might first seem. The original code simply calculated the delta from each point in a track to the next and added them up, but this approach is effected by noisy elevation data. I noticed that organicmaps was reporting elevation change for a track which was 70% greater than the value given by caltopo, alltrails, and several other sources.

I implemented the denoising technique described [here](https://www.gpsvisualizer.com/tutorials/elevation_gain.php), and organic maps now reports a very similar value to other software.

To test this, import a track (such as from a .gpx file) then select the track to view the elevation profile. The ascent and descent values should agree somewhat with other software such as [caltopo](https://caltopo.com/map.html) (this calculation is very approximate).