### PR TITLE
Hint to UI when the first info cell should be displayed

### DIFF
--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -736,7 +736,10 @@ void Framework::FillInfoFromFeatureType(FeatureType & ft, place_page::Info & inf
 
   info.SetFromFeatureType(ft);
 
-  FillDescriptions(ft, info);
+  bool const hasWikiOrOsmDescription = FillDescriptions(ft, info);
+
+  if (hasWikiOrOsmDescription || info.HasRouteRefs() || !info.GetOpeningHours().empty())
+    info.SetOpeningMode(place_page::OpeningMode::PreviewPlus);
 
   auto const mwmInfo = ft.GetID().m_mwmId.GetInfo();
   bool const isMapVersionEditable = CanEditMapForPosition(info.GetMercator());
@@ -3364,26 +3367,27 @@ void Framework::SetPlacePageLocation(place_page::Info & info)
   }
 }
 
-void Framework::FillDescriptions(FeatureType & ft, place_page::Info & info) const
+bool Framework::FillDescriptions(FeatureType & ft, place_page::Info & info) const
 {
   if (!ft.GetID().m_mwmId.IsAlive())
-    return;
+    return false;
 
   auto const & regionData = ft.GetID().m_mwmId.GetInfo()->GetRegionData();
   auto const deviceLang = StringUtf8Multilang::GetLangIndex(languages::GetCurrentMapLanguage());
   auto const langPriority = feature::GetDescriptionLangPriority(regionData, deviceLang);
 
+  bool hasDescription = false;
+
   std::string wikiDescription = m_descriptionsLoader->GetWikiDescription(ft.GetID(), langPriority);
   if (!wikiDescription.empty())
   {
     info.SetWikiDescription(std::move(wikiDescription));
-    info.SetOpeningMode(m_routingManager.IsRoutingActive() ? place_page::OpeningMode::Preview
-                                                           : place_page::OpeningMode::PreviewPlus);
+    hasDescription = true;
   }
 
   std::string_view const osmDescriptionValue = ft.GetMetadata(feature::Metadata::FMD_DESCRIPTION);
   if (osmDescriptionValue.empty())
-    return;
+    return hasDescription;
 
   buffer_vector<int8_t, 4> langCodes;
   for (auto const & lang : languages::GetSystemPreferred())
@@ -3400,6 +3404,7 @@ void Framework::FillDescriptions(FeatureType & ft, place_page::Info & info) cons
   if (osmDescription.empty())
     osmDescription = osmDescriptionMultilang.GetFirstString();
   info.SetOSMDescription(std::string(osmDescription));
+  return true;
 }
 
 void Framework::OnPowerFacilityChanged(power_management::Facility const facility, bool enabled)

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -635,7 +635,8 @@ private:
   void FillBookmarkInfo(Bookmark const & bmk, place_page::Info & info) const;
   void FillTrackInfo(Track const & track, m2::PointD const & trackPoint, place_page::Info & info) const;
   void SetPlacePageLocation(place_page::Info & info);
-  void FillDescriptions(FeatureType & ft, place_page::Info & info) const;
+  /// @returns true if either Wiki or OSM descriptions were found and set to place page info.
+  bool FillDescriptions(FeatureType & ft, place_page::Info & info) const;
 
 public:
   search::ReverseGeocoder::Address GetAddressAtPoint(m2::PointD const & pt) const;

--- a/libs/map/place_page_info.hpp
+++ b/libs/map/place_page_info.hpp
@@ -216,6 +216,7 @@ public:
   void SetSelectedObject(df::SelectionShape::ESelectedObject selectedObject) { m_selectedObject = selectedObject; }
   df::SelectionShape::ESelectedObject GetSelectedObject() const { return m_selectedObject; }
 
+  bool HasRouteRefs() const { return !m_routes.empty(); }
   std::string FormatRouteRefs() const;
 
 private:


### PR DESCRIPTION
For OpeningHours, Stops with routes, Wiki and OSM descriptions.

Required for other PRs, including upcoming PT schedules.

Need to fix Android and test/fix for iOS before merging.

CC @rovertrack 