### PR TITLE
[android] Fix wrong Not Enough Free Space

### DIFF
--- a/libs/storage/storage.cpp
+++ b/libs/storage/storage.cpp
@@ -383,7 +383,7 @@ LocalAndRemoteSize Storage::CountrySizeInBytes(CountryId const & countryId) cons
   CountryFile const & countryFile = GetCountryFile(countryId);
   LocalAndRemoteSize sizes(0, GetRemoteSize(countryFile));
 
-  if (!IsCountryInQueue(countryId) && !IsDiffApplyingInProgressToCountry(countryId))
+  if (!IsDiffApplyingInProgressToCountry(countryId))
     sizes.first = localFile ? localFile->GetSize(MapFileType::Map) : 0;
 
   auto const it = m_downloadingCountries.find(countryId);

--- a/libs/storage/storage_helpers.cpp
+++ b/libs/storage/storage_helpers.cpp
@@ -47,7 +47,7 @@ bool IsEnoughSpaceForUpdate(CountryId const & countryId, Storage const & storage
   // - max MWM file size to apply diff patch (patches are applying one-by-one) = m_maxFileSizeInBytes
   // - final size difference between old and new MWMs = m_sizeDifference
 
-  [[maybe_unused]] MwmSize const diff = updateInfo.m_sizeDifference > 0 ? updateInfo.m_sizeDifference : 0;
+  [[maybe_unused]] MwmSize const diff = std::max(updateInfo.m_sizeDifference, int64_t{0});
   //  return IsEnoughSpaceForDownload(std::max(diff, updateInfo.m_totalDownloadSizeInBytes) +
   //                                  updateInfo.m_maxFileSizeInBytes);
 


### PR DESCRIPTION
…when retrying the download with the outdated countries in the download queue.

Fixes https://github.com/organicmaps/organicmaps/issues/2969
