### PR TITLE
[Android] Guess file type from content

### DIFF
--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/BookmarkManager.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/BookmarkManager.java
@@ -377,7 +377,7 @@ public enum BookmarkManager {
 
       // ZIP (first two bytes are 'PK')
       if (buf[0] == 0x50 && buf[1] == 0x4B)
-        return ".zip";
+        return ".kmz";
 
       // Skip UTF-8 BOM
       int i = (len >= 3 && buf[0] == (byte) 0xEF && buf[1] == (byte) 0xBB && buf[2] == (byte) 0xBF) ? 3 : 0;
@@ -390,7 +390,7 @@ public enum BookmarkManager {
 
       // JSON
       if (buf[i] == '{' || buf[i] == '[')
-        return ".json";
+        return ".geojson";
 
       // XML-based (KML, GPX)
       if (buf[i] == '<')


### PR DESCRIPTION
Importing from WhatsApp is broken because we get no file extension and no mime type from WhatsApp. Implemented function "guessFileExtensionByContent" to search common markers in imported files.

If file starts with `{` then it's probably Json.
If file starts with `PK` then it's probably ZIP.
If starts with `<` and contains `<kml` then it's probably KML.
If starts with `<` and contains `<gpx` then it's probably GPX.

This should fix bookmakrs import from WhatsApp.