### PR TITLE
Improve Opening Hours readability

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/data/TimeFormatUtils.java
+++ b/android/app/src/main/java/app/organicmaps/editor/data/TimeFormatUtils.java
@@ -4,6 +4,7 @@ import android.content.res.Resources;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import app.organicmaps.R;
+import app.organicmaps.sdk.editor.data.HoursMinutes;
 import app.organicmaps.sdk.editor.data.Timespan;
 import app.organicmaps.sdk.editor.data.Timetable;
 import app.organicmaps.utils.Utils;
@@ -80,9 +81,12 @@ public class TimeFormatUtils
 
   /**
    * Splits a working day into its open shifts around the closed (break) spans, joined by {@code separator}.
-   * OpenStreetMap stores a single working span with the closed (break) spans nested inside it, so N ordered
-   * closed spans yield N+1 open shifts; with no closed spans this is just the whole working span. E.g. a lunch
-   * break renders as "09:00—13:00" + separator + "16:00—20:00". Must not be called for full-day rows.
+   * A {@link Timetable} models a day as one working span with its breaks nested inside as closed spans (the
+   * C++ editor derives this from the parsed OpenStreetMap rules), so N ordered closed spans yield up to N+1
+   * open shifts, e.g. a lunch break gives "09:00—13:00" + separator + "16:00—20:00". Zero-length shifts (a
+   * break touching the working-span boundary or an adjacent break) are dropped, so a working span fully
+   * covered by breaks yields an empty string. A shift whose end is earlier than its start crosses midnight and
+   * is still open time. Must not be called for full-day rows.
    */
   @NonNull
   public static String formatOpenShifts(@NonNull Timetable tt, @NonNull String separator)
@@ -91,10 +95,22 @@ public class TimeFormatUtils
     var shiftStart = tt.workingTimespan.start;
     for (final Timespan closed : tt.closedTimespans)
     {
-      shifts.append(shiftStart).append('—').append(closed.start).append(separator);
+      appendShift(shifts, separator, shiftStart, closed.start);
       shiftStart = closed.end;
     }
-    return shifts.append(shiftStart).append('—').append(tt.workingTimespan.end).toString();
+    appendShift(shifts, separator, shiftStart, tt.workingTimespan.end);
+    return shifts.toString();
+  }
+
+  private static void appendShift(@NonNull StringBuilder shifts, @NonNull String separator, @NonNull HoursMinutes start,
+                                  @NonNull HoursMinutes end)
+  {
+    // Drop only truly empty shifts. A start later than end is a valid overnight shift, e.g. 23:00—04:00.
+    if (start.hours == end.hours && start.minutes == end.minutes)
+      return;
+    if (shifts.length() > 0)
+      shifts.append(separator);
+    shifts.append(start).append('—').append(end);
   }
 
   public static String formatTimetables(@NonNull Resources resources, String ohStr, Timetable[] timetables)
@@ -109,7 +125,9 @@ public class TimeFormatUtils
       Timetable tt = timetables[0];
       if (tt.isFullday)
         return resources.getString(R.string.twentyfour_seven);
-      return resources.getString(R.string.daily) + " " + formatOpenShifts(tt, ", ");
+      final String shifts = formatOpenShifts(tt, ", ");
+      final String openTime = shifts.isEmpty() ? Utils.unCapitalize(resources.getString(R.string.day_off)) : shifts;
+      return resources.getString(R.string.daily) + " " + openTime;
     }
 
     // Generate full week multiline string, one line per weekday group. E.g.
@@ -123,8 +141,11 @@ public class TimeFormatUtils
         weekSchedule.append('\n');
 
       final String weekdays = formatWeekdays(tt);
-      final String openTime = tt.isFullday ? Utils.unCapitalize(resources.getString(R.string.editor_time_allday))
-                                           : formatOpenShifts(tt, ", ");
+      String openTime = tt.isFullday ? Utils.unCapitalize(resources.getString(R.string.editor_time_allday))
+                                     : formatOpenShifts(tt, ", ");
+      // A working day fully covered by breaks has no open shift; show it as closed.
+      if (openTime.isEmpty())
+        openTime = Utils.unCapitalize(resources.getString(R.string.day_off));
       weekSchedule.append(weekdays).append(' ').append(openTime);
 
       firstRow = false;

--- a/android/app/src/main/java/app/organicmaps/editor/data/TimeFormatUtils.java
+++ b/android/app/src/main/java/app/organicmaps/editor/data/TimeFormatUtils.java
@@ -78,20 +78,23 @@ public class TimeFormatUtils
     return builder.toString();
   }
 
-  public static String formatNonBusinessTime(Timespan[] closedTimespans, String hoursClosedLabel)
+  /**
+   * Splits a working day into its open shifts around the closed (break) spans, joined by {@code separator}.
+   * OpenStreetMap stores a single working span with the closed (break) spans nested inside it, so N ordered
+   * closed spans yield N+1 open shifts; with no closed spans this is just the whole working span. E.g. a lunch
+   * break renders as "09:00—13:00" + separator + "16:00—20:00". Must not be called for full-day rows.
+   */
+  @NonNull
+  public static String formatOpenShifts(@NonNull Timetable tt, @NonNull String separator)
   {
-    StringBuilder closedTextBuilder = new StringBuilder();
-    boolean firstLine = true;
-
-    for (Timespan cts : closedTimespans)
+    final StringBuilder shifts = new StringBuilder();
+    var shiftStart = tt.workingTimespan.start;
+    for (final Timespan closed : tt.closedTimespans)
     {
-      if (!firstLine)
-        closedTextBuilder.append('\n');
-
-      closedTextBuilder.append(hoursClosedLabel).append(' ').append(cts.toWideString());
-      firstLine = false;
+      shifts.append(shiftStart).append('—').append(closed.start).append(separator);
+      shiftStart = closed.end;
     }
-    return closedTextBuilder.toString();
+    return shifts.append(shiftStart).append('—').append(tt.workingTimespan.end).toString();
   }
 
   public static String formatTimetables(@NonNull Resources resources, String ohStr, Timetable[] timetables)
@@ -99,22 +102,19 @@ public class TimeFormatUtils
     if (timetables == null || timetables.length == 0)
       return ohStr;
 
-    // Generate string "24/7" or "Daily HH:MM - HH:MM".
+    // Generate string "24/7" or "Daily HH:MM—HH:MM". Breaks split the day into open shifts, e.g.
+    // "Daily 09:00—13:00, 16:00—20:00".
     if (timetables[0].isFullWeek())
     {
       Timetable tt = timetables[0];
       if (tt.isFullday)
         return resources.getString(R.string.twentyfour_seven);
-      if (tt.closedTimespans == null || tt.closedTimespans.length == 0)
-        return resources.getString(R.string.daily) + " " + tt.workingTimespan.toWideString();
-      return resources.getString(R.string.daily) + " " + tt.workingTimespan.toWideString() + "\n"
-    + formatNonBusinessTime(tt.closedTimespans, resources.getString(R.string.editor_hours_closed));
+      return resources.getString(R.string.daily) + " " + formatOpenShifts(tt, ", ");
     }
 
-    // Generate full week multiline string. E.g.
-    // "Mon-Fri HH:MM - HH:MM
-    // Sat HH:MM - HH:MM
-    // Non-business Hours HH:MM - HH:MM"
+    // Generate full week multiline string, one line per weekday group. E.g.
+    // "Mo-Fr 09:00—13:00, 16:00—20:00
+    // Sa 10:00—16:00"
     StringBuilder weekSchedule = new StringBuilder();
     boolean firstRow = true;
     for (Timetable tt : timetables)
@@ -124,12 +124,8 @@ public class TimeFormatUtils
 
       final String weekdays = formatWeekdays(tt);
       final String openTime = tt.isFullday ? Utils.unCapitalize(resources.getString(R.string.editor_time_allday))
-                                           : tt.workingTimespan.toWideString();
-
+                                           : formatOpenShifts(tt, ", ");
       weekSchedule.append(weekdays).append(' ').append(openTime);
-      if (tt.closedTimespans != null && tt.closedTimespans.length > 0)
-        weekSchedule.append('\n').append(
-            formatNonBusinessTime(tt.closedTimespans, resources.getString(R.string.editor_hours_closed)));
 
       firstRow = false;
     }

--- a/android/app/src/main/java/app/organicmaps/editor/data/TimeFormatUtils.java
+++ b/android/app/src/main/java/app/organicmaps/editor/data/TimeFormatUtils.java
@@ -4,8 +4,6 @@ import android.content.res.Resources;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import app.organicmaps.R;
-import app.organicmaps.sdk.editor.data.HoursMinutes;
-import app.organicmaps.sdk.editor.data.Timespan;
 import app.organicmaps.sdk.editor.data.Timetable;
 import app.organicmaps.utils.Utils;
 import java.text.DateFormatSymbols;
@@ -79,40 +77,6 @@ public class TimeFormatUtils
     return builder.toString();
   }
 
-  /**
-   * Splits a working day into its open shifts around the closed (break) spans, joined by {@code separator}.
-   * A {@link Timetable} models a day as one working span with its breaks nested inside as closed spans (the
-   * C++ editor derives this from the parsed OpenStreetMap rules), so N ordered closed spans yield up to N+1
-   * open shifts, e.g. a lunch break gives "09:00—13:00" + separator + "16:00—20:00". Zero-length shifts (a
-   * break touching the working-span boundary or an adjacent break) are dropped, so a working span fully
-   * covered by breaks yields an empty string. A shift whose end is earlier than its start crosses midnight and
-   * is still open time. Must not be called for full-day rows.
-   */
-  @NonNull
-  public static String formatOpenShifts(@NonNull Timetable tt, @NonNull String separator)
-  {
-    final StringBuilder shifts = new StringBuilder();
-    var shiftStart = tt.workingTimespan.start;
-    for (final Timespan closed : tt.closedTimespans)
-    {
-      appendShift(shifts, separator, shiftStart, closed.start);
-      shiftStart = closed.end;
-    }
-    appendShift(shifts, separator, shiftStart, tt.workingTimespan.end);
-    return shifts.toString();
-  }
-
-  private static void appendShift(@NonNull StringBuilder shifts, @NonNull String separator, @NonNull HoursMinutes start,
-                                  @NonNull HoursMinutes end)
-  {
-    // Drop only truly empty shifts. A start later than end is a valid overnight shift, e.g. 23:00—04:00.
-    if (start.hours == end.hours && start.minutes == end.minutes)
-      return;
-    if (shifts.length() > 0)
-      shifts.append(separator);
-    shifts.append(start).append('—').append(end);
-  }
-
   public static String formatTimetables(@NonNull Resources resources, String ohStr, Timetable[] timetables)
   {
     if (timetables == null || timetables.length == 0)
@@ -125,7 +89,7 @@ public class TimeFormatUtils
       Timetable tt = timetables[0];
       if (tt.isFullday)
         return resources.getString(R.string.twentyfour_seven);
-      final String shifts = formatOpenShifts(tt, ", ");
+      final String shifts = tt.formatOpenShifts(", ");
       final String openTime = shifts.isEmpty() ? Utils.unCapitalize(resources.getString(R.string.day_off)) : shifts;
       return resources.getString(R.string.daily) + " " + openTime;
     }
@@ -142,7 +106,7 @@ public class TimeFormatUtils
 
       final String weekdays = formatWeekdays(tt);
       String openTime = tt.isFullday ? Utils.unCapitalize(resources.getString(R.string.editor_time_allday))
-                                     : formatOpenShifts(tt, ", ");
+                                     : tt.formatOpenShifts(", ");
       // A working day fully covered by breaks has no open shift; show it as closed.
       if (openTime.isEmpty())
         openTime = Utils.unCapitalize(resources.getString(R.string.day_off));

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
@@ -1,6 +1,6 @@
 package app.organicmaps.widget.placepage.sections;
 
-import static app.organicmaps.editor.data.TimeFormatUtils.formatNonBusinessTime;
+import static app.organicmaps.editor.data.TimeFormatUtils.formatOpenShifts;
 import static app.organicmaps.editor.data.TimeFormatUtils.formatWeekdaysRange;
 
 import android.view.LayoutInflater;
@@ -10,9 +10,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import app.organicmaps.R;
-import app.organicmaps.sdk.editor.data.Timespan;
 import app.organicmaps.sdk.editor.data.Timetable;
-import app.organicmaps.util.UiUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -103,33 +101,17 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
     final WeekScheduleData schedule = mWeekSchedule.get(position);
 
     holder.setBoldStyle(schedule.isBold);
-
-    if (schedule.isClosed)
-    {
-      holder.setWeekdays(formatWeekdaysRange(schedule.startWeekDay, schedule.endWeekDay));
-      holder.setOpenTime(holder.itemView.getResources().getString(R.string.day_off));
-      holder.hideNonBusinessTime();
-      return;
-    }
-
-    final Timetable tt = schedule.timetable;
-
-    String workingTime = tt.isFullday ? holder.itemView.getResources().getString(R.string.editor_time_allday)
-                                      : tt.workingTimespan.toWideString();
-
     holder.setWeekdays(formatWeekdaysRange(schedule.startWeekDay, schedule.endWeekDay));
-    holder.setOpenTime(workingTime);
 
-    final Timespan[] closedTime = tt.closedTimespans;
-    if (closedTime == null || closedTime.length == 0)
-    {
-      holder.hideNonBusinessTime();
-    }
+    final String openTime;
+    if (schedule.isClosed)
+      openTime = holder.itemView.getResources().getString(R.string.day_off);
+    else if (schedule.timetable.isFullday)
+      openTime = holder.itemView.getResources().getString(R.string.editor_time_allday);
     else
-    {
-      final String hoursNonBusinessLabel = holder.itemView.getResources().getString(R.string.editor_hours_closed);
-      holder.setNonBusinessTime(formatNonBusinessTime(closedTime, hoursNonBusinessLabel));
-    }
+      openTime = formatOpenShifts(schedule.timetable, "\n");
+
+    holder.setOpenTime(openTime);
   }
 
   @Override
@@ -160,14 +142,12 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
   {
     private final TextView mWeekdays;
     private final TextView mOpenTime;
-    private final TextView mNonBusinessTime;
 
     public ViewHolder(@NonNull View itemView)
     {
       super(itemView);
       mWeekdays = itemView.findViewById(R.id.tv__opening_hours_weekdays);
       mOpenTime = itemView.findViewById(R.id.tv__opening_hours_time);
-      mNonBusinessTime = itemView.findViewById(R.id.tv__opening_hours_nonbusiness_time);
       itemView.setVisibility(View.VISIBLE);
     }
 
@@ -186,16 +166,6 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
     public void setOpenTime(String openTime)
     {
       mOpenTime.setText(openTime);
-    }
-
-    public void setNonBusinessTime(String nonBusinessTime)
-    {
-      UiUtils.setTextAndShow(mNonBusinessTime, nonBusinessTime);
-    }
-
-    public void hideNonBusinessTime()
-    {
-      UiUtils.clearTextAndHide(mNonBusinessTime);
     }
   }
 }

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
@@ -109,7 +109,11 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
     else if (schedule.timetable.isFullday)
       openTime = holder.itemView.getResources().getString(R.string.editor_time_allday);
     else
-      openTime = formatOpenShifts(schedule.timetable, "\n");
+    {
+      final String shifts = formatOpenShifts(schedule.timetable, "\n");
+      // A working day fully covered by breaks has no open shift; show it as closed.
+      openTime = shifts.isEmpty() ? holder.itemView.getResources().getString(R.string.day_off) : shifts;
+    }
 
     holder.setOpenTime(openTime);
   }

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
@@ -1,6 +1,5 @@
 package app.organicmaps.widget.placepage.sections;
 
-import static app.organicmaps.editor.data.TimeFormatUtils.formatOpenShifts;
 import static app.organicmaps.editor.data.TimeFormatUtils.formatWeekdaysRange;
 
 import android.view.LayoutInflater;
@@ -110,7 +109,7 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
       openTime = holder.itemView.getResources().getString(R.string.editor_time_allday);
     else
     {
-      final String shifts = formatOpenShifts(schedule.timetable, "\n");
+      final String shifts = schedule.timetable.formatOpenShifts("\n");
       // A working day fully covered by breaks has no open shift; show it as closed.
       openTime = shifts.isEmpty() ? holder.itemView.getResources().getString(R.string.day_off) : shifts;
     }

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageOpeningHoursFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageOpeningHoursFragment.java
@@ -1,19 +1,24 @@
 package app.organicmaps.widget.placepage.sections;
 
+import static app.organicmaps.editor.data.TimeFormatUtils.formatWeekdaysRange;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
 import android.animation.ValueAnimator;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
+import androidx.core.widget.TextViewCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.recyclerview.widget.RecyclerView;
 import app.organicmaps.R;
 import app.organicmaps.editor.data.TimeFormatUtils;
 import app.organicmaps.sdk.bookmarks.data.MapObject;
@@ -37,11 +42,12 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
   private TextView mTvSchedulePreviewOpenIndicator;
   private TextView mTvSchedulePreviewDescription;
   private TextView mTvSingleLineOpeningHours;
-  private RecyclerView mFullWeekOpeningHours;
-  private PlaceOpeningHoursAdapter mOpeningHoursAdapter;
+  private LinearLayout mFullWeekOpeningHours;
+  private WeekScheduleBuilder mScheduleBuilder;
   private View dropDownIcon;
   private View mOhContainer;
   private boolean isOhExpanded;
+  private ValueAnimator mDropdownAnimator;
 
   private PlacePageViewModel mViewModel;
 
@@ -59,35 +65,19 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
   {
     super.onViewCreated(view, savedInstanceState);
     mFrame = view;
-    mFullWeekOpeningHours = view.findViewById(R.id.rw__full_opening_hours);
+    mFullWeekOpeningHours = view.findViewById(R.id.full_opening_hours);
     mSchedulePreviewContainer = view.findViewById(R.id.schedule_preview_container);
     mTvSchedulePreviewOpenIndicator = view.findViewById(R.id.tv__schedule_preview_open_indicator);
     mTvSchedulePreviewDescription = view.findViewById(R.id.tv__schedule_preview_description);
     mTvSingleLineOpeningHours = view.findViewById(R.id.tv__single_line_opening_hours);
     mDropdownContent = view.findViewById(R.id.dropdown_content);
-    mOpeningHoursAdapter = new PlaceOpeningHoursAdapter();
-    mFullWeekOpeningHours.setAdapter(mOpeningHoursAdapter);
+    mScheduleBuilder = new WeekScheduleBuilder();
     dropDownIcon = view.findViewById(R.id.dropdown_icon);
     mDropdownContent.getLayoutParams().height = 0;
     UiUtils.hide(dropDownIcon);
     isOhExpanded = false;
     mOhContainer = mFrame.findViewById(R.id.oh_container);
-    var touchListener = new RecyclerView.OnItemTouchListener() {
-      @Override
-      public boolean onInterceptTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e)
-      {
-        if (e.getAction() == MotionEvent.ACTION_UP)
-          expandOpeningHours();
-        return false;
-      }
-      @Override
-      public void onTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e)
-      {}
-      @Override
-      public void onRequestDisallowInterceptTouchEvent(boolean disallowIntercept)
-      {}
-    };
-    mFullWeekOpeningHours.addOnItemTouchListener(touchListener);
+    mFullWeekOpeningHours.setOnClickListener(v -> expandOpeningHours());
   }
 
   private void refreshOpeningHours(MapObject mapObject)
@@ -136,26 +126,68 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
       {
         UiUtils.show(mFullWeekOpeningHours);
         int currentDayOfWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        mOpeningHoursAdapter.setTimetables(timetables, currentDayOfWeek);
+        mScheduleBuilder.setTimetables(timetables, currentDayOfWeek);
+        populateWeekSchedule();
         enableDropdownContent();
       }
     }
   }
 
+  private void populateWeekSchedule()
+  {
+    mFullWeekOpeningHours.removeAllViews();
+    final LayoutInflater inflater = LayoutInflater.from(requireContext());
+    for (final WeekScheduleBuilder.WeekScheduleData schedule : mScheduleBuilder.getWeekSchedule())
+    {
+      final View row = inflater.inflate(R.layout.place_page_opening_hours_item, mFullWeekOpeningHours, false);
+      bindScheduleRow(row, schedule);
+      mFullWeekOpeningHours.addView(row);
+    }
+  }
+
+  private void bindScheduleRow(@NonNull View row, @NonNull WeekScheduleBuilder.WeekScheduleData schedule)
+  {
+    final TextView weekdays = row.findViewById(R.id.tv__opening_hours_weekdays);
+    final TextView openTime = row.findViewById(R.id.tv__opening_hours_time);
+
+    final int style = schedule.isBold ? R.style.MwmTextAppearance_PlacePage : R.style.MwmTextAppearance_Body3;
+    TextViewCompat.setTextAppearance(weekdays, style);
+    TextViewCompat.setTextAppearance(openTime, style);
+
+    weekdays.setText(formatWeekdaysRange(schedule.startWeekDay, schedule.endWeekDay));
+    openTime.setText(formatOpenTime(schedule));
+  }
+
+  @NonNull
+  private String formatOpenTime(@NonNull WeekScheduleBuilder.WeekScheduleData schedule)
+  {
+    final Resources res = getResources();
+    if (schedule.isClosed)
+      return res.getString(R.string.day_off);
+    if (schedule.timetable.isFullday)
+      return res.getString(R.string.editor_time_allday);
+
+    final String shifts = schedule.timetable.formatOpenShifts("\n");
+    return shifts.isEmpty() ? res.getString(R.string.day_off) : shifts;
+  }
+
   private void expandOpeningHours()
   {
+    if (mDropdownAnimator != null)
+      mDropdownAnimator.cancel();
+
     int targetHeight, startHeight;
     if (!isOhExpanded)
     {
       UiUtils.show(mDropdownContent);
       startHeight = 0;
-      targetHeight = getDropdownContentHeight();
+      targetHeight = measureDropdownContentHeight();
       dropDownIcon.animate().rotation(-180f).setDuration(200).start();
       isOhExpanded = true;
     }
     else
     {
-      startHeight = getDropdownContentHeight();
+      startHeight = measureDropdownContentHeight();
       targetHeight = 0;
       dropDownIcon.animate().rotation(0f).setDuration(200).start();
       isOhExpanded = false;
@@ -166,10 +198,39 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
     va.addUpdateListener(animation -> {
       mDropdownContent.getLayoutParams().height = (int) animation.getAnimatedValue();
       mDropdownContent.requestLayout();
-      if (mFrame.getParent() instanceof View)
-        ((View) mFrame.getParent()).requestLayout();
+      requestParentLayout();
     });
+    // Snap to wrap_content once expanded: the measured height can fall short and there is no inner scroll.
+    if (isOhExpanded)
+      va.addListener(new AnimatorListenerAdapter() {
+        private boolean mCancelled;
+        @Override
+        public void onAnimationCancel(Animator animation)
+        {
+          mCancelled = true;
+        }
+        @Override
+        public void onAnimationEnd(Animator animation)
+        {
+          if (!mCancelled && isOhExpanded)
+            setDropdownContentWrapHeight();
+        }
+      });
+    mDropdownAnimator = va;
     va.start();
+  }
+
+  private void setDropdownContentWrapHeight()
+  {
+    mDropdownContent.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
+    mDropdownContent.requestLayout();
+    requestParentLayout();
+  }
+
+  private void requestParentLayout()
+  {
+    if (mFrame.getParent() instanceof View)
+      ((View) mFrame.getParent()).requestLayout();
   }
 
   @Override
@@ -204,6 +265,7 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
     UiUtils.hide(mDropdownContent);
     UiUtils.hide(mTvSingleLineOpeningHours);
     UiUtils.hide(mFullWeekOpeningHours);
+    mFullWeekOpeningHours.removeAllViews();
   }
 
   private void enableDropdownContent()
@@ -213,19 +275,14 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
     mOhContainer.setOnClickListener((v) -> expandOpeningHours());
 
     if (isOhExpanded)
-    {
-      mDropdownContent.getLayoutParams().height = getDropdownContentHeight();
-      mDropdownContent.requestLayout();
-    }
+      setDropdownContentWrapHeight();
   }
 
-  private int getDropdownContentHeight()
+  // Measure at the dropdown's own width so multi-line shifts wrap exactly as they render.
+  private int measureDropdownContentHeight()
   {
-    // request a layout with dropdown content at its full size to make sure mFrame.getWidth() returns the right result
-    mDropdownContent.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
-    mFrame.requestLayout();
-
-    mDropdownContent.measure(View.MeasureSpec.makeMeasureSpec(mFrame.getWidth(), View.MeasureSpec.EXACTLY),
+    final int width = mDropdownContent.getWidth() > 0 ? mDropdownContent.getWidth() : mFrame.getWidth();
+    mDropdownContent.measure(View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
                              View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
     return mDropdownContent.getMeasuredHeight();
   }

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/WeekScheduleBuilder.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/WeekScheduleBuilder.java
@@ -1,25 +1,17 @@
 package app.organicmaps.widget.placepage.sections;
 
-import static app.organicmaps.editor.data.TimeFormatUtils.formatWeekdaysRange;
-
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.TextView;
 import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.RecyclerView;
-import app.organicmaps.R;
 import app.organicmaps.sdk.editor.data.Timetable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
-public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningHoursAdapter.ViewHolder>
+
+// Groups per-working-day timetables into the weekly schedule rows shown on the place page.
+public class WeekScheduleBuilder
 {
   private List<WeekScheduleData> mWeekSchedule = Collections.emptyList();
-
-  public PlaceOpeningHoursAdapter() {}
 
   public void setTimetables(Timetable[] timetables, int currentDayOfWeek)
   {
@@ -59,8 +51,12 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
     }
 
     mWeekSchedule = scheduleData;
+  }
 
-    notifyDataSetChanged();
+  @NonNull
+  public List<WeekScheduleData> getWeekSchedule()
+  {
+    return mWeekSchedule;
   }
 
   public static List<Integer> buildWeekByFirstDay(int firstDayOfWeek)
@@ -83,46 +79,6 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
     return null;
   }
 
-  @NonNull
-  @Override
-  public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType)
-  {
-    return new ViewHolder(
-        LayoutInflater.from(parent.getContext()).inflate(R.layout.place_page_opening_hours_item, parent, false));
-  }
-
-  @Override
-  public void onBindViewHolder(@NonNull ViewHolder holder, int position)
-  {
-    if (mWeekSchedule == null || position >= mWeekSchedule.size() || position < 0)
-      return;
-
-    final WeekScheduleData schedule = mWeekSchedule.get(position);
-
-    holder.setBoldStyle(schedule.isBold);
-    holder.setWeekdays(formatWeekdaysRange(schedule.startWeekDay, schedule.endWeekDay));
-
-    final String openTime;
-    if (schedule.isClosed)
-      openTime = holder.itemView.getResources().getString(R.string.day_off);
-    else if (schedule.timetable.isFullday)
-      openTime = holder.itemView.getResources().getString(R.string.editor_time_allday);
-    else
-    {
-      final String shifts = schedule.timetable.formatOpenShifts("\n");
-      // A working day fully covered by breaks has no open shift; show it as closed.
-      openTime = shifts.isEmpty() ? holder.itemView.getResources().getString(R.string.day_off) : shifts;
-    }
-
-    holder.setOpenTime(openTime);
-  }
-
-  @Override
-  public int getItemCount()
-  {
-    return (mWeekSchedule != null ? mWeekSchedule.size() : 0);
-  }
-
   public static class WeekScheduleData
   {
     public final int startWeekDay;
@@ -138,37 +94,6 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
       this.isClosed = timetable == null;
       this.timetable = timetable;
       this.isBold = isBold;
-    }
-  }
-
-  public static class ViewHolder extends RecyclerView.ViewHolder
-  {
-    private final TextView mWeekdays;
-    private final TextView mOpenTime;
-
-    public ViewHolder(@NonNull View itemView)
-    {
-      super(itemView);
-      mWeekdays = itemView.findViewById(R.id.tv__opening_hours_weekdays);
-      mOpenTime = itemView.findViewById(R.id.tv__opening_hours_time);
-      itemView.setVisibility(View.VISIBLE);
-    }
-
-    public void setBoldStyle(boolean isBold)
-    {
-      final int style = isBold ? R.style.MwmTextAppearance_PlacePage : R.style.MwmTextAppearance_Body3;
-      mWeekdays.setTextAppearance(itemView.getContext(), style);
-      mOpenTime.setTextAppearance(itemView.getContext(), style);
-    }
-
-    public void setWeekdays(String weekdays)
-    {
-      mWeekdays.setText(weekdays);
-    }
-
-    public void setOpenTime(String openTime)
-    {
-      mOpenTime.setText(openTime);
     }
   }
 }

--- a/android/app/src/main/res/layout/place_page_opening_hours_fragment.xml
+++ b/android/app/src/main/res/layout/place_page_opening_hours_fragment.xml
@@ -74,7 +74,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_below="@id/schedule_preview_container"
-      android:layout_alignStart="@id/icon">
+      android:layout_toEndOf="@id/icon">
 
       <TextView
         android:id="@+id/tv__single_line_opening_hours"
@@ -84,12 +84,12 @@
         android:textAppearance="@style/MwmTextAppearance.Body3"
         tools:text="Very very ugly timetable format with very very very long text..." />
 
-      <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rw__full_opening_hours"
+      <LinearLayout
+        android:id="@+id/full_opening_hours"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+        android:orientation="vertical" />
 
     </RelativeLayout>
 

--- a/android/app/src/main/res/layout/place_page_opening_hours_item.xml
+++ b/android/app/src/main/res/layout/place_page_opening_hours_item.xml
@@ -1,36 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<!-- Layout, width and gravity (center_vertical) come from @style/PlacePageOpeningHoursItem.
+     gravity=top overrides it so the weekday label lines up with the first shift when the
+     hours column spans several lines (split shifts). Weekday/hours use fixed 0.4/0.6 weights
+     so the hours column starts at the same x across all rows. -->
+<LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/ll__place_opening_hours_item"
   style="@style/PlacePageOpeningHoursItem"
-  android:visibility="visible">
+  android:baselineAligned="false"
+  android:gravity="top">
 
   <TextView
     android:id="@+id/tv__opening_hours_weekdays"
+    android:layout_width="0dp"
     android:layout_height="wrap_content"
-    android:layout_width="wrap_content"
-    android:layout_alignParentStart="true"
+    android:layout_weight="0.4"
     android:textAppearance="@style/MwmTextAppearance.Body3"
     tools:text="Mo-Fr"/>
 
+  <!-- One or more open shifts, one per line (e.g. "09:00—13:00\n16:00—20:00"). -->
   <TextView
     android:id="@+id/tv__opening_hours_time"
+    android:layout_width="0dp"
     android:layout_height="wrap_content"
-    android:layout_width="wrap_content"
-    android:layout_alignParentEnd="true"
-    android:layout_toEndOf="@id/tv__opening_hours_weekdays"
+    android:layout_weight="0.6"
     android:textAppearance="@style/MwmTextAppearance.Body3"
-    android:textAlignment="viewEnd"
-    tools:text="08:00 - 19:00"/>
+    tools:text="09:00—13:00"/>
 
-  <TextView
-    android:id="@+id/tv__opening_hours_nonbusiness_time"
-    android:layout_height="wrap_content"
-    android:layout_width="wrap_content"
-    android:layout_alignParentEnd="true"
-    android:layout_below="@id/tv__opening_hours_weekdays"
-    android:textAppearance="@style/MwmTextAppearance.Body4"
-    android:textAlignment="viewEnd"
-    android:visibility="gone"/>
-</RelativeLayout>
+</LinearLayout>

--- a/android/app/src/main/res/layout/place_page_opening_hours_item.xml
+++ b/android/app/src/main/res/layout/place_page_opening_hours_item.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Layout, width and gravity (center_vertical) come from @style/PlacePageOpeningHoursItem.
-     gravity=top overrides it so the weekday label lines up with the first shift when the
-     hours column spans several lines (split shifts). Weekday/hours use fixed 0.4/0.6 weights
-     so the hours column starts at the same x across all rows. -->
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
@@ -19,12 +15,12 @@
     android:textAppearance="@style/MwmTextAppearance.Body3"
     tools:text="Mo-Fr"/>
 
-  <!-- One or more open shifts, one per line (e.g. "09:00—13:00\n16:00—20:00"). -->
   <TextView
     android:id="@+id/tv__opening_hours_time"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:layout_weight="0.6"
+    android:textAlignment="viewStart"
     android:textAppearance="@style/MwmTextAppearance.Body3"
     tools:text="09:00—13:00"/>
 

--- a/android/app/src/test/java/app/organicmaps/editor/data/TimeFormatUtilsTest.java
+++ b/android/app/src/test/java/app/organicmaps/editor/data/TimeFormatUtilsTest.java
@@ -33,6 +33,15 @@ public class TimeFormatUtilsTest
   }
 
   @Test
+  public void formatOpenShifts_overnightNoBreak_isWholeWorkingSpan()
+  {
+    // "Mo 20:00-04:00" -> a single overnight shift, not a fully closed day.
+    final Timetable tt = workingDay(span(20, 0, 4, 0));
+    assertEquals("20:00—04:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
+    assertEquals("20:00—04:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+  }
+
+  @Test
   public void formatOpenShifts_oneBreak_isTwoShifts()
   {
     // "Mo 09:00-13:00,16:00-20:00" -> working 09:00-20:00 with one lunch break -> two shifts.
@@ -48,5 +57,60 @@ public class TimeFormatUtilsTest
     final Timetable tt = workingDay(span(8, 0, 19, 0), span(12, 0, 13, 0), span(15, 0, 16, 0));
     assertEquals("08:00—12:00\n13:00—15:00\n16:00—19:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
     assertEquals("08:00—12:00, 13:00—15:00, 16:00—19:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+  }
+
+  @Test
+  public void formatOpenShifts_overnightWithBreak_keepsPostMidnightShift()
+  {
+    // Working 20:00-03:00 with a 22:00-23:00 break leaves a valid overnight 23:00—03:00 shift.
+    final Timetable tt = workingDay(span(20, 0, 3, 0), span(22, 0, 23, 0));
+    assertEquals("20:00—22:00\n23:00—03:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
+    assertEquals("20:00—22:00, 23:00—03:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+  }
+
+  @Test
+  public void formatOpenShifts_breakAtStart_dropsEmptyLeadingShift()
+  {
+    // "Mo 11:00-17:00; Mo 11:00-13:00 off" parses to working 11:00-17:00, exclude 11:00-13:00.
+    // The 11:00—11:00 shift is empty and must not be emitted.
+    final Timetable tt = workingDay(span(11, 0, 17, 0), span(11, 0, 13, 0));
+    assertEquals("13:00—17:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
+    assertEquals("13:00—17:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+  }
+
+  @Test
+  public void formatOpenShifts_breakAtEnd_dropsEmptyTrailingShift()
+  {
+    // Working 11:00-17:00 with a break 15:00-17:00 up to the closing time -> the 17:00—17:00 shift is dropped.
+    final Timetable tt = workingDay(span(11, 0, 17, 0), span(15, 0, 17, 0));
+    assertEquals("11:00—15:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
+    assertEquals("11:00—15:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+  }
+
+  @Test
+  public void formatOpenShifts_adjacentBreaks_dropEmptyMiddleShift()
+  {
+    // Working 09:00-18:00 with back-to-back breaks 12:00-13:00 and 13:00-15:00 -> the 13:00—13:00 shift is dropped.
+    final Timetable tt = workingDay(span(9, 0, 18, 0), span(12, 0, 13, 0), span(13, 0, 15, 0));
+    assertEquals("09:00—12:00\n15:00—18:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
+    assertEquals("09:00—12:00, 15:00—18:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+  }
+
+  @Test
+  public void formatOpenShifts_fullyCovered_isEmpty()
+  {
+    // Working 11:00-17:00 fully covered by a 11:00-17:00 break -> no open shift; callers render this as closed.
+    final Timetable tt = workingDay(span(11, 0, 17, 0), span(11, 0, 17, 0));
+    assertEquals("", TimeFormatUtils.formatOpenShifts(tt, "\n"));
+    assertEquals("", TimeFormatUtils.formatOpenShifts(tt, ", "));
+  }
+
+  @Test
+  public void formatOpenShifts_overnightFullyCovered_isEmpty()
+  {
+    // Working 20:00-04:00 fully covered by a 20:00-04:00 break -> no open shift.
+    final Timetable tt = workingDay(span(20, 0, 4, 0), span(20, 0, 4, 0));
+    assertEquals("", TimeFormatUtils.formatOpenShifts(tt, "\n"));
+    assertEquals("", TimeFormatUtils.formatOpenShifts(tt, ", "));
   }
 }

--- a/android/app/src/test/java/app/organicmaps/editor/data/TimeFormatUtilsTest.java
+++ b/android/app/src/test/java/app/organicmaps/editor/data/TimeFormatUtilsTest.java
@@ -1,0 +1,52 @@
+package app.organicmaps.editor.data;
+
+import static org.junit.Assert.assertEquals;
+
+import app.organicmaps.sdk.editor.data.HoursMinutes;
+import app.organicmaps.sdk.editor.data.Timespan;
+import app.organicmaps.sdk.editor.data.Timetable;
+import org.junit.Test;
+
+public class TimeFormatUtilsTest
+{
+  private static Timespan span(int fromH, int fromM, int toH, int toM)
+  {
+    return new Timespan(new HoursMinutes(fromH, fromM, true), new HoursMinutes(toH, toM, true));
+  }
+
+  private static Timetable workingDay(Timespan working, Timespan... closed)
+  {
+    return new Timetable(working, closed, false, new int[] {2});
+  }
+
+  // The UI (place page rows) stacks shifts with "\n"; long-press-to-copy joins them inline with ", ".
+  // Both go through formatOpenShifts, so a break renders the same way in both, never as a labelled
+  // "Non-Business Hours" line.
+
+  @Test
+  public void formatOpenShifts_noBreak_isWholeWorkingSpan()
+  {
+    // "Mo 09:00-18:00" -> a single shift, separator unused.
+    final Timetable tt = workingDay(span(9, 0, 18, 0));
+    assertEquals("09:00—18:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
+    assertEquals("09:00—18:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+  }
+
+  @Test
+  public void formatOpenShifts_oneBreak_isTwoShifts()
+  {
+    // "Mo 09:00-13:00,16:00-20:00" -> working 09:00-20:00 with one lunch break -> two shifts.
+    final Timetable tt = workingDay(span(9, 0, 20, 0), span(13, 0, 16, 0));
+    assertEquals("09:00—13:00\n16:00—20:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
+    assertEquals("09:00—13:00, 16:00—20:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+  }
+
+  @Test
+  public void formatOpenShifts_twoBreaks_isThreeShifts()
+  {
+    // "Mo 08:00-12:00,13:00-15:00,16:00-19:00" -> working 08:00-19:00 with two breaks -> three shifts.
+    final Timetable tt = workingDay(span(8, 0, 19, 0), span(12, 0, 13, 0), span(15, 0, 16, 0));
+    assertEquals("08:00—12:00\n13:00—15:00\n16:00—19:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
+    assertEquals("08:00—12:00, 13:00—15:00, 16:00—19:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+  }
+}

--- a/android/app/src/test/java/app/organicmaps/widget/placepage/sections/WeekScheduleBuilderTest.java
+++ b/android/app/src/test/java/app/organicmaps/widget/placepage/sections/WeekScheduleBuilderTest.java
@@ -5,68 +5,65 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.spy;
 
 import app.organicmaps.sdk.editor.data.HoursMinutes;
 import app.organicmaps.sdk.editor.data.Timespan;
 import app.organicmaps.sdk.editor.data.Timetable;
-import app.organicmaps.widget.placepage.sections.PlaceOpeningHoursAdapter.WeekScheduleData;
+import app.organicmaps.widget.placepage.sections.WeekScheduleBuilder.WeekScheduleData;
 import java.lang.reflect.Field;
 import java.util.Calendar;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PlaceOpeningHoursAdapterTest
+public class WeekScheduleBuilderTest
 {
-  PlaceOpeningHoursAdapter adapter;
+  WeekScheduleBuilder builder;
   Field mWeekScheduleField;
 
   @Before
   public void setUp() throws NoSuchFieldException
   {
-    adapter = spy(new PlaceOpeningHoursAdapter());
-    doNothing().when(adapter).notifyDataSetChanged();
+    builder = new WeekScheduleBuilder();
 
-    mWeekScheduleField = PlaceOpeningHoursAdapter.class.getDeclaredField("mWeekSchedule");
+    mWeekScheduleField = WeekScheduleBuilder.class.getDeclaredField("mWeekSchedule");
     mWeekScheduleField.setAccessible(true);
   }
 
   @Test
   public void test_build_week_from_sunday()
   {
-    List<Integer> weekDays = PlaceOpeningHoursAdapter.buildWeekByFirstDay(Calendar.SUNDAY);
+    List<Integer> weekDays = WeekScheduleBuilder.buildWeekByFirstDay(Calendar.SUNDAY);
     assertEquals(weekDays, List.of(1, 2, 3, 4, 5, 6, 7));
   }
 
   @Test
   public void test_build_week_from_monday()
   {
-    List<Integer> weekDays = PlaceOpeningHoursAdapter.buildWeekByFirstDay(Calendar.MONDAY);
+    List<Integer> weekDays = WeekScheduleBuilder.buildWeekByFirstDay(Calendar.MONDAY);
     assertEquals(weekDays, List.of(2, 3, 4, 5, 6, 7, 1));
   }
 
   @Test
   public void test_build_week_from_saturday()
   {
-    List<Integer> weekDays = PlaceOpeningHoursAdapter.buildWeekByFirstDay(Calendar.SATURDAY);
+    List<Integer> weekDays = WeekScheduleBuilder.buildWeekByFirstDay(Calendar.SATURDAY);
     assertEquals(weekDays, List.of(7, 1, 2, 3, 4, 5, 6));
   }
 
   @Test
   public void test_build_week_from_friday()
   {
-    List<Integer> weekDays = PlaceOpeningHoursAdapter.buildWeekByFirstDay(Calendar.FRIDAY);
+    List<Integer> weekDays = WeekScheduleBuilder.buildWeekByFirstDay(Calendar.FRIDAY);
     assertEquals(weekDays, List.of(6, 7, 1, 2, 3, 4, 5));
   }
 
   @Test
   public void test_build_week_errors()
   {
-    assertThrows(IllegalArgumentException.class, () -> PlaceOpeningHoursAdapter.buildWeekByFirstDay(-1));
-    assertThrows(IllegalArgumentException.class, () -> PlaceOpeningHoursAdapter.buildWeekByFirstDay(0));
-    assertThrows(IllegalArgumentException.class, () -> PlaceOpeningHoursAdapter.buildWeekByFirstDay(8));
+    assertThrows(IllegalArgumentException.class, () -> WeekScheduleBuilder.buildWeekByFirstDay(-1));
+    assertThrows(IllegalArgumentException.class, () -> WeekScheduleBuilder.buildWeekByFirstDay(0));
+    assertThrows(IllegalArgumentException.class, () -> WeekScheduleBuilder.buildWeekByFirstDay(8));
   }
 
   @Test
@@ -80,7 +77,7 @@ public class PlaceOpeningHoursAdapterTest
     timetables[1] = new Timetable(new Timespan(new HoursMinutes(12, 0, true), new HoursMinutes(14, 0, true)),
                                   new Timespan[0], false, new int[] {7});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY);
+    builder.setTimetables(timetables, Calendar.MONDAY);
 
     /* Expected parsed schedule (today = Mo):
      *  0 - Mo-Fr, open, bold
@@ -88,7 +85,7 @@ public class PlaceOpeningHoursAdapterTest
      *  2 - Su,    closed
      * */
 
-    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(builder);
     assertNotNull(schedule);
     assertEquals(3, schedule.size());
     assertFalse(schedule.get(0).isClosed); // Mo-Fr - open
@@ -115,7 +112,7 @@ public class PlaceOpeningHoursAdapterTest
     timetables[2] = new Timetable(new Timespan(new HoursMinutes(11, 0, true), new HoursMinutes(18, 0, true)),
                                   new Timespan[0], false, new int[] {6});
 
-    adapter.setTimetables(timetables, Calendar.THURSDAY);
+    builder.setTimetables(timetables, Calendar.THURSDAY);
 
     /* Expected parsed schedule (today = Th):
      *  0 - Th,    closed, bold
@@ -126,7 +123,7 @@ public class PlaceOpeningHoursAdapterTest
      *  5 - We,    open
      * */
 
-    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(builder);
     assertNotNull(schedule);
     assertEquals(6, schedule.size());
     assertTrue(schedule.get(0).isClosed); //  Th    - closed
@@ -153,7 +150,7 @@ public class PlaceOpeningHoursAdapterTest
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(18, 0, true)),
                                   new Timespan[0], false, new int[] {2, 4, 6});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY);
+    builder.setTimetables(timetables, Calendar.MONDAY);
 
     /* Expected parsed schedule (today = Mo):
      *  0 - Mo,    open, bold
@@ -164,7 +161,7 @@ public class PlaceOpeningHoursAdapterTest
      *  5 - Sa-Su, closed
      * */
 
-    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(builder);
     assertNotNull(schedule);
     assertEquals(6, schedule.size());
     assertFalse(schedule.get(0).isClosed); // Mo    - open
@@ -191,7 +188,7 @@ public class PlaceOpeningHoursAdapterTest
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(18, 0, true)),
                                   new Timespan[0], false, new int[] {2, 4, 6});
 
-    adapter.setTimetables(timetables, Calendar.SUNDAY);
+    builder.setTimetables(timetables, Calendar.SUNDAY);
 
     /* Expected parsed schedule (today = Su):
      *  0 - Su, closed, bold
@@ -203,7 +200,7 @@ public class PlaceOpeningHoursAdapterTest
      *  6 - Sa, closed
      * */
 
-    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(builder);
     assertNotNull(schedule);
     assertEquals(7, schedule.size());
     assertTrue(schedule.get(0).isClosed); // Su - closed
@@ -232,14 +229,14 @@ public class PlaceOpeningHoursAdapterTest
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
                                   new Timespan[0], false, new int[] {1, 7});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY);
+    builder.setTimetables(timetables, Calendar.MONDAY);
 
     /* Expected parsed schedule (today = Mo):
      *  0 - Mo-Fr, closed, bold
      *  1 - Sa-Su, open
      * */
 
-    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(builder);
     assertNotNull(schedule);
     assertEquals(2, schedule.size());
     assertTrue(schedule.get(0).isClosed); //  Mo-Fr - closed
@@ -260,7 +257,7 @@ public class PlaceOpeningHoursAdapterTest
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
                                   new Timespan[0], false, new int[] {1, 7});
 
-    adapter.setTimetables(timetables, Calendar.SUNDAY);
+    builder.setTimetables(timetables, Calendar.SUNDAY);
 
     /* Expected parsed schedule (today = Su):
      *  0 - Su,    open, bold
@@ -268,7 +265,7 @@ public class PlaceOpeningHoursAdapterTest
      *  2 - Sa,    open
      * */
 
-    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(builder);
     assertNotNull(schedule);
     assertEquals(3, schedule.size());
     assertFalse(schedule.get(0).isClosed); // Su    - open
@@ -293,14 +290,14 @@ public class PlaceOpeningHoursAdapterTest
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
                                   new Timespan[0], false, new int[] {1, 7});
 
-    adapter.setTimetables(timetables, Calendar.SATURDAY);
+    builder.setTimetables(timetables, Calendar.SATURDAY);
 
     /* Expected parsed schedule (today = Sa):
      *  0 - Sa-Su, open, bold (wrap start=7 end=1)
      *  1 - Mo-Fr, closed
      * */
 
-    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(builder);
     assertNotNull(schedule);
     assertEquals(2, schedule.size());
     assertFalse(schedule.get(0).isClosed); // Sa-Su - open
@@ -321,13 +318,13 @@ public class PlaceOpeningHoursAdapterTest
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
                                   new Timespan[0], false, new int[] {1, 2, 3, 4, 5, 6, 7});
 
-    adapter.setTimetables(timetables, Calendar.FRIDAY);
+    builder.setTimetables(timetables, Calendar.FRIDAY);
 
     /* Expected parsed schedule (today = Fr):
      *  0 - Fr-Th, open, bold (wrap start=6 end=5)
      * */
 
-    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(builder);
     assertNotNull(schedule);
     assertEquals(1, schedule.size());
     assertFalse(schedule.get(0).isClosed); // Fr-Th - open
@@ -345,9 +342,9 @@ public class PlaceOpeningHoursAdapterTest
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(18, 0, true)),
                                   new Timespan[0], false, new int[] {Calendar.THURSDAY}); // open only today
 
-    adapter.setTimetables(timetables, Calendar.THURSDAY);
+    builder.setTimetables(timetables, Calendar.THURSDAY);
 
-    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(builder);
     assertNotNull(schedule);
     assertEquals(2, schedule.size());
     WeekScheduleData today = schedule.get(0); // today is first

--- a/android/libs/car/src/main/java/app/organicmaps/car/util/UiHelpers.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/util/UiHelpers.java
@@ -132,7 +132,11 @@ public final class UiHelpers
       if (timetables[0].isFullday)
         builder.setTitle(context.getString(R.string.twentyfour_seven));
       else
-        builder.setTitle(timetables[0].workingTimespan.toWideString());
+      {
+        final String shifts = timetables[0].formatOpenShifts(", ");
+        // A day fully covered by breaks has no open shift; the place is closed.
+        builder.setTitle(shifts.isEmpty() ? context.getString(R.string.day_off_today) : shifts);
+      }
     }
     else
     {
@@ -148,8 +152,11 @@ public final class UiHelpers
           if (tt.isFullday)
             openTime = Utils.unCapitalize(context.getString(R.string.editor_time_allday));
           else
-            openTime = tt.workingTimespan.toWideString();
+            openTime = tt.formatOpenShifts(", ");
 
+          // A day fully covered by breaks has no open shift; the place is closed today.
+          if (openTime.isEmpty())
+            openTime = context.getString(R.string.day_off_today);
           builder.setTitle(openTime);
 
           break;

--- a/android/sdk/src/main/java/app/organicmaps/sdk/editor/data/HoursMinutes.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/editor/data/HoursMinutes.java
@@ -44,7 +44,8 @@ public class HoursMinutes implements Parcelable
 
     // Formatting a string here with hours outside of 0-23 range causes DateTimeException.
     final LocalTime localTime = LocalTime.of((int) hours % 24, (int) minutes);
-    return localTime.format(DateTimeFormatter.ofPattern("hh:mm a"));
+    // \u00A0 is a non-breaking space: keep the time glued to AM/PM so the marker never wraps to its own line.
+    return localTime.format(DateTimeFormatter.ofPattern("hh:mm\u00A0a"));
   }
 
   @Override

--- a/android/sdk/src/main/java/app/organicmaps/sdk/editor/data/Timespan.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/editor/data/Timespan.java
@@ -21,9 +21,4 @@ public class Timespan
   {
     return start + "-" + end;
   }
-
-  public String toWideString()
-  {
-    return start + "\u2014" + end;
-  }
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/editor/data/Timetable.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/editor/data/Timetable.java
@@ -39,6 +39,40 @@ public class Timetable
     return weekdays.length == 7;
   }
 
+  /**
+   * Splits this working day into its open shifts around the closed (break) spans, joined by {@code separator}.
+   * The day is modelled as one working span with its breaks nested inside as closed spans (the C++ editor
+   * derives this from the parsed OpenStreetMap rules), so N ordered closed spans yield up to N+1 open shifts,
+   * e.g. a lunch break gives "09:00—13:00" + separator + "16:00—20:00". Zero-length shifts (a break touching
+   * the working-span boundary or an adjacent break) are dropped, so a day fully covered by breaks yields an
+   * empty string. A shift whose end is earlier than its start crosses midnight and is still open time. Must not
+   * be called for full-day rows.
+   */
+  @NonNull
+  public String formatOpenShifts(@NonNull String separator)
+  {
+    final StringBuilder shifts = new StringBuilder();
+    HoursMinutes shiftStart = workingTimespan.start;
+    for (final Timespan closed : closedTimespans)
+    {
+      appendShift(shifts, separator, shiftStart, closed.start);
+      shiftStart = closed.end;
+    }
+    appendShift(shifts, separator, shiftStart, workingTimespan.end);
+    return shifts.toString();
+  }
+
+  private static void appendShift(@NonNull StringBuilder shifts, @NonNull String separator, @NonNull HoursMinutes start,
+                                  @NonNull HoursMinutes end)
+  {
+    // Drop only truly empty shifts. A start later than end is a valid overnight shift, e.g. 23:00—04:00.
+    if (start.hours == end.hours && start.minutes == end.minutes)
+      return;
+    if (shifts.length() > 0)
+      shifts.append(separator);
+    shifts.append(start).append('—').append(end);
+  }
+
   @Override
   public String toString()
   {

--- a/android/sdk/src/main/java/app/organicmaps/sdk/editor/data/Timetable.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/editor/data/Timetable.java
@@ -40,13 +40,9 @@ public class Timetable
   }
 
   /**
-   * Splits this working day into its open shifts around the closed (break) spans, joined by {@code separator}.
-   * The day is modelled as one working span with its breaks nested inside as closed spans (the C++ editor
-   * derives this from the parsed OpenStreetMap rules), so N ordered closed spans yield up to N+1 open shifts,
-   * e.g. a lunch break gives "09:00—13:00" + separator + "16:00—20:00". Zero-length shifts (a break touching
-   * the working-span boundary or an adjacent break) are dropped, so a day fully covered by breaks yields an
-   * empty string. A shift whose end is earlier than its start crosses midnight and is still open time. Must not
-   * be called for full-day rows.
+   * Splits the working span into open shifts around its nested breaks, joined by {@code separator},
+   * e.g. a lunch break gives "09:00—13:00" + separator + "16:00—20:00". A day fully covered by breaks
+   * yields an empty string (caller shows it as closed). Not for full-day rows.
    */
   @NonNull
   public String formatOpenShifts(@NonNull String separator)

--- a/android/sdk/src/test/java/app/organicmaps/sdk/editor/data/TimetableTest.java
+++ b/android/sdk/src/test/java/app/organicmaps/sdk/editor/data/TimetableTest.java
@@ -1,13 +1,10 @@
-package app.organicmaps.editor.data;
+package app.organicmaps.sdk.editor.data;
 
 import static org.junit.Assert.assertEquals;
 
-import app.organicmaps.sdk.editor.data.HoursMinutes;
-import app.organicmaps.sdk.editor.data.Timespan;
-import app.organicmaps.sdk.editor.data.Timetable;
 import org.junit.Test;
 
-public class TimeFormatUtilsTest
+public class TimetableTest
 {
   private static Timespan span(int fromH, int fromM, int toH, int toM)
   {
@@ -19,17 +16,17 @@ public class TimeFormatUtilsTest
     return new Timetable(working, closed, false, new int[] {2});
   }
 
-  // The UI (place page rows) stacks shifts with "\n"; long-press-to-copy joins them inline with ", ".
-  // Both go through formatOpenShifts, so a break renders the same way in both, never as a labelled
-  // "Non-Business Hours" line.
+  // The place-page rows stack shifts with "\n"; copy text and Android Auto join them inline with ", ".
+  // Both go through formatOpenShifts, so a break renders the same way everywhere, never as a continuous
+  // span plus a labelled "Non-Business Hours" line.
 
   @Test
   public void formatOpenShifts_noBreak_isWholeWorkingSpan()
   {
     // "Mo 09:00-18:00" -> a single shift, separator unused.
     final Timetable tt = workingDay(span(9, 0, 18, 0));
-    assertEquals("09:00—18:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
-    assertEquals("09:00—18:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+    assertEquals("09:00—18:00", tt.formatOpenShifts("\n"));
+    assertEquals("09:00—18:00", tt.formatOpenShifts(", "));
   }
 
   @Test
@@ -37,8 +34,8 @@ public class TimeFormatUtilsTest
   {
     // "Mo 20:00-04:00" -> a single overnight shift, not a fully closed day.
     final Timetable tt = workingDay(span(20, 0, 4, 0));
-    assertEquals("20:00—04:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
-    assertEquals("20:00—04:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+    assertEquals("20:00—04:00", tt.formatOpenShifts("\n"));
+    assertEquals("20:00—04:00", tt.formatOpenShifts(", "));
   }
 
   @Test
@@ -46,8 +43,8 @@ public class TimeFormatUtilsTest
   {
     // "Mo 09:00-13:00,16:00-20:00" -> working 09:00-20:00 with one lunch break -> two shifts.
     final Timetable tt = workingDay(span(9, 0, 20, 0), span(13, 0, 16, 0));
-    assertEquals("09:00—13:00\n16:00—20:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
-    assertEquals("09:00—13:00, 16:00—20:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+    assertEquals("09:00—13:00\n16:00—20:00", tt.formatOpenShifts("\n"));
+    assertEquals("09:00—13:00, 16:00—20:00", tt.formatOpenShifts(", "));
   }
 
   @Test
@@ -55,8 +52,8 @@ public class TimeFormatUtilsTest
   {
     // "Mo 08:00-12:00,13:00-15:00,16:00-19:00" -> working 08:00-19:00 with two breaks -> three shifts.
     final Timetable tt = workingDay(span(8, 0, 19, 0), span(12, 0, 13, 0), span(15, 0, 16, 0));
-    assertEquals("08:00—12:00\n13:00—15:00\n16:00—19:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
-    assertEquals("08:00—12:00, 13:00—15:00, 16:00—19:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+    assertEquals("08:00—12:00\n13:00—15:00\n16:00—19:00", tt.formatOpenShifts("\n"));
+    assertEquals("08:00—12:00, 13:00—15:00, 16:00—19:00", tt.formatOpenShifts(", "));
   }
 
   @Test
@@ -64,8 +61,8 @@ public class TimeFormatUtilsTest
   {
     // Working 20:00-03:00 with a 22:00-23:00 break leaves a valid overnight 23:00—03:00 shift.
     final Timetable tt = workingDay(span(20, 0, 3, 0), span(22, 0, 23, 0));
-    assertEquals("20:00—22:00\n23:00—03:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
-    assertEquals("20:00—22:00, 23:00—03:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+    assertEquals("20:00—22:00\n23:00—03:00", tt.formatOpenShifts("\n"));
+    assertEquals("20:00—22:00, 23:00—03:00", tt.formatOpenShifts(", "));
   }
 
   @Test
@@ -74,8 +71,8 @@ public class TimeFormatUtilsTest
     // "Mo 11:00-17:00; Mo 11:00-13:00 off" parses to working 11:00-17:00, exclude 11:00-13:00.
     // The 11:00—11:00 shift is empty and must not be emitted.
     final Timetable tt = workingDay(span(11, 0, 17, 0), span(11, 0, 13, 0));
-    assertEquals("13:00—17:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
-    assertEquals("13:00—17:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+    assertEquals("13:00—17:00", tt.formatOpenShifts("\n"));
+    assertEquals("13:00—17:00", tt.formatOpenShifts(", "));
   }
 
   @Test
@@ -83,8 +80,8 @@ public class TimeFormatUtilsTest
   {
     // Working 11:00-17:00 with a break 15:00-17:00 up to the closing time -> the 17:00—17:00 shift is dropped.
     final Timetable tt = workingDay(span(11, 0, 17, 0), span(15, 0, 17, 0));
-    assertEquals("11:00—15:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
-    assertEquals("11:00—15:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+    assertEquals("11:00—15:00", tt.formatOpenShifts("\n"));
+    assertEquals("11:00—15:00", tt.formatOpenShifts(", "));
   }
 
   @Test
@@ -92,8 +89,8 @@ public class TimeFormatUtilsTest
   {
     // Working 09:00-18:00 with back-to-back breaks 12:00-13:00 and 13:00-15:00 -> the 13:00—13:00 shift is dropped.
     final Timetable tt = workingDay(span(9, 0, 18, 0), span(12, 0, 13, 0), span(13, 0, 15, 0));
-    assertEquals("09:00—12:00\n15:00—18:00", TimeFormatUtils.formatOpenShifts(tt, "\n"));
-    assertEquals("09:00—12:00, 15:00—18:00", TimeFormatUtils.formatOpenShifts(tt, ", "));
+    assertEquals("09:00—12:00\n15:00—18:00", tt.formatOpenShifts("\n"));
+    assertEquals("09:00—12:00, 15:00—18:00", tt.formatOpenShifts(", "));
   }
 
   @Test
@@ -101,8 +98,8 @@ public class TimeFormatUtilsTest
   {
     // Working 11:00-17:00 fully covered by a 11:00-17:00 break -> no open shift; callers render this as closed.
     final Timetable tt = workingDay(span(11, 0, 17, 0), span(11, 0, 17, 0));
-    assertEquals("", TimeFormatUtils.formatOpenShifts(tt, "\n"));
-    assertEquals("", TimeFormatUtils.formatOpenShifts(tt, ", "));
+    assertEquals("", tt.formatOpenShifts("\n"));
+    assertEquals("", tt.formatOpenShifts(", "));
   }
 
   @Test
@@ -110,7 +107,7 @@ public class TimeFormatUtilsTest
   {
     // Working 20:00-04:00 fully covered by a 20:00-04:00 break -> no open shift.
     final Timetable tt = workingDay(span(20, 0, 4, 0), span(20, 0, 4, 0));
-    assertEquals("", TimeFormatUtils.formatOpenShifts(tt, "\n"));
-    assertEquals("", TimeFormatUtils.formatOpenShifts(tt, ", "));
+    assertEquals("", tt.formatOpenShifts("\n"));
+    assertEquals("", tt.formatOpenShifts(", "));
   }
 }


### PR DESCRIPTION
Refactored the opening hours layout to align days and hours in columns, displaying split shifts instead of break times for better readability. The desired proposal design is achieved, matching the visual requirements of the Issue.
Fixes: #12044,#12104

Before|After
------|-----
<img src="https://github.com/user-attachments/assets/2fa4ff8e-ab71-406c-9743-ce3889c932e6" width="360" />|<img src="https://github.com/user-attachments/assets/13391566-e4ee-447a-890a-29be2a73c901" width="360" />