### PR TITLE
fix cycling navigation

### DIFF
--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -3340,7 +3340,8 @@ void Framework::OnRouteFollow(routing::RouterType type)
   // TODO. We need to sync two enums VehicleType and RouterType to be able to pass
   // GetRoutingSettings(type).m_matchRoute to the FollowRoute() instead of |isPedestrianRoute|.
   // |isArrowGlued| parameter fully corresponds to |m_matchRoute| in RoutingSettings.
-  m_drapeEngine->FollowRoute(scale, scale3d, enableAutoZoom, !isPedestrianRoute /* isArrowGlued */);
+  // For pedestrian and bicycle modes, use compass heading when stopped (isArrowGlued = false).
+  m_drapeEngine->FollowRoute(scale, scale3d, enableAutoZoom, !(isPedestrianRoute || isBicycleRoute) /* isArrowGlued */);
 }
 
 // RoutingManager::Delegate


### PR DESCRIPTION
Closes #12083

This PR fixes an issue in Cycling navigation where the map orientation would remain locked to the GPS course even when the user is stopped.



Tested on physical device:

https://drive.google.com/file/d/1IpuQxgNKa2iknbl1wVW1lpvg9FzxGI7J/view?usp=drivesdk 