### PR TITLE
Fix visibility icon glitch on Android 5 (API 21)

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/Holders.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/Holders.java
@@ -258,7 +258,7 @@ public class Holders
     @NonNull
     private final TextView mName;
     @NonNull
-    CheckBox mVisibilityMarker;
+    ImageView mVisibilityMarker;
     @NonNull
     ImageView mMoreButton;
 
@@ -272,7 +272,10 @@ public class Holders
 
     void setVisibilityState(boolean visible)
     {
-      mVisibilityMarker.setChecked(visible);
+      if (visible)
+        mVisibilityMarker.setImageResource(R.drawable.ic_show);
+      else
+        mVisibilityMarker.setImageResource(R.drawable.ic_hide);
     }
 
     void setVisibilityListener(@Nullable View.OnClickListener listener)

--- a/android/app/src/main/res/layout/item_bookmark_category.xml
+++ b/android/app/src/main/res/layout/item_bookmark_category.xml
@@ -6,16 +6,17 @@
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:background="@drawable/bg_clickable_card">
-  <CheckBox
+  <ImageView
     android:id="@+id/checkbox"
     android:layout_width="@dimen/margin_double_plus"
     android:layout_height="wrap_content"
     android:layout_centerVertical="true"
     android:layout_alignParentTop="true"
     android:layout_alignBottom="@id/bottom_line_container"
-    android:background="@null"
-    android:button="@drawable/button_visibility_centre_inset"
-    android:buttonTint="?accentColorSelector" />
+    android:background="?selectableItemBackgroundBorderless"
+    app:srcCompat="@drawable/button_visibility_centre_inset"
+    android:scaleType="center"
+    app:tint="?colorAccent" />
   <TextView
     android:id="@+id/name"
     android:layout_width="wrap_content"
@@ -55,6 +56,7 @@
     android:layout_alignParentTop="true"
     android:layout_alignBottom="@id/bottom_line_container"
     android:background="?selectableItemBackgroundBorderless"
+    android:scaleType="center"
     android:importantForAccessibility="no"
     android:paddingHorizontal="@dimen/margin_half"
     app:srcCompat="@drawable/ic_more"


### PR DESCRIPTION
The app showed a visual glitch on older devices because the app icon used a modern file format that Android 5 could not read correctly.
Fixes: #12091

https://github.com/user-attachments/assets/7e85d7c4-6c86-4ba8-ad40-92b7cab8d2f2


