### PR TITLE
[android] Fix place page subtitle text cutoff Fixes #12107

### DIFF
--- a/android/app/src/main/res/layout/place_page_preview.xml
+++ b/android/app/src/main/res/layout/place_page_preview.xml
@@ -75,6 +75,7 @@
         android:layout_marginTop="@dimen/margin_quarter"
         android:ellipsize="end"
         android:fontFamily="@font/organic_maps_emoji"
+        android:lineSpacingExtra="@dimen/line_spacing_extra_1"
         android:textAppearance="@style/MwmTextAppearance.Body3"
         tools:background="#300000F0"
         tools:text="Subtitle, very very very very very very very long" />


### PR DESCRIPTION
Add lineSpacingExtra to the subtitle TextView in place_page_preview.xml to prevent letters with descenders (g, y, p) and emoji characters from being clipped when using the custom emoji font.

Fixes #12107