### PR TITLE
[api] Parse search query from OpenStreetMap URLs

### DIFF
--- a/libs/ge0/ge0_tests/geo_url_tests.cpp
+++ b/libs/ge0/ge0_tests/geo_url_tests.cpp
@@ -259,9 +259,7 @@ UNIT_TEST(GeoURL_OpenStreetMap)
   TEST_ALMOST_EQUAL_ABS(info.m_zoom, 16.0, kEps, ());
 
   TEST(parser.Parse("https://www.openstreetmap.org/search?query=Falafel%20Sahyoun#map=16/33.89041/35.50664", info), ());
-  TEST_ALMOST_EQUAL_ABS(info.m_lat, 33.89041, kEps, ());
-  TEST_ALMOST_EQUAL_ABS(info.m_lon, 35.50664, kEps, ());
-  TEST_ALMOST_EQUAL_ABS(info.m_zoom, 16.0, kEps, ());
+  TEST_EQUAL(info.m_query, "Falafel Sahyoun", ());
 
   TEST(parser.Parse("https://www.openstreetmap.org/#map=21/53.90323/-27.55806", info), ());
   TEST_ALMOST_EQUAL_ABS(info.m_lat, 53.90323, kEps, ());

--- a/libs/ge0/geo_url_parser.cpp
+++ b/libs/ge0/geo_url_parser.cpp
@@ -311,8 +311,18 @@ bool OpenStreetMapParser::Parse(url::Url const & url, GeoURLInfo & info) const
 {
   info.Reset();
 
-  auto const * mapV = url.GetParamValue("map");
-  return (mapV && MatchLatLonZoom(*mapV, m_regex, 2, 3, 1, info));
+  auto const * queryParam = url.GetParamValue("query");
+  if (!queryParam || queryParam->empty())
+    queryParam = url.GetParamValue("q");
+
+  if (queryParam && !queryParam->empty())
+  {
+    info.m_query = *queryParam;
+    return true;
+  }
+
+  auto const * mapParam = url.GetParamValue("map");
+  return mapParam && MatchLatLonZoom(*mapParam, m_regex, 2, 3, 1, info);
 }
 
 GeoURLInfo::GeoURLInfo()


### PR DESCRIPTION
Clicking on links like https://www.openstreetmap.org/search?query=StreetName%20HouseNumber,%20POSTALCODE%20CITY,%20COUNTRY now opens the search in Organic Maps with this string in it.

Fixes #12132
