### PR TITLE
[iOS] Standalone notes and anonymous notes.

### DIFF
--- a/iphone/Maps/Core/Editor/MWMEditorHelper.mm
+++ b/iphone/Maps/Core/Editor/MWMEditorHelper.mm
@@ -8,8 +8,7 @@
 
 + (void)uploadEdits:(void (^)(UIBackgroundFetchResult))completionHandler
 {
-  if (!osm_auth_ios::AuthorizationHaveCredentials() ||
-      Platform::EConnectionType::CONNECTION_NONE == Platform::ConnectionStatus())
+  if (Platform::EConnectionType::CONNECTION_NONE == Platform::ConnectionStatus())
   {
     completionHandler(UIBackgroundFetchResultFailed);
   }

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -1116,3 +1116,5 @@
 
 /* Login to OSM button text */
 "login_osm_browser" = "Login using Browser";
+"editor_note_placeholder" = "Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.";
+"editor_note_submit_button" = "Send";

--- a/libs/editor/editor_notes.cpp
+++ b/libs/editor/editor_notes.cpp
@@ -176,7 +176,8 @@ void Notes::Upload(osm::OsmOAuth const & auth)
         /// @todo It looks like a race, but we do push_back (and getters) only in other _modifying_ places.
         /// size can only increase, front is not changed and list doesn't have reallocs.
         /// As I said before, refactor in a more _natural_ way with producer-consumer on a circular buffer pattern.
-        auto const id = api.CreateNote(notes.front().m_point, notes.front().m_note);
+        bool const isAnonymous = !auth.IsAuthorized();
+        auto const id = api.CreateNote(notes.front().m_point, notes.front().m_note, isAnonymous);
         ulock.lock();
 
         LOG(LINFO, ("A note uploaded with id", id));

--- a/libs/editor/osm_auth.cpp
+++ b/libs/editor/osm_auth.cpp
@@ -383,10 +383,14 @@ OsmOAuth::Response OsmOAuth::Request(string const & method, string const & httpM
   return {request.ErrorCode(), request.ServerResponse()};
 }
 
-OsmOAuth::Response OsmOAuth::DirectRequest(string const & method, bool api) const
+OsmOAuth::Response OsmOAuth::DirectRequest(string const & method, bool api, string const & httpMethod,
+                                           string const & body) const
 {
   string const url = api ? m_apiUrl + kApiVersion + method : m_baseUrl + method;
   HttpClient request(url);
+
+  if (httpMethod != "GET")
+    request.SetBodyData(body, "application/xml", httpMethod);
   if (!request.RunHttpRequest())
     MYTHROW(NetworkError, ("DirectRequest Network error while connecting to", url));
   if (request.WasRedirected())

--- a/libs/editor/osm_auth.hpp
+++ b/libs/editor/osm_auth.hpp
@@ -89,9 +89,10 @@ public:
   /// @param[method] The API method, must start with a forward slash.
   Response Request(std::string const & method, std::string const & httpMethod = "GET",
                    std::string const & body = "") const;
-  /// Tokenless GET request, for convenience.
+  /// Tokenless request.
   /// @param[api] If false, request is made to m_baseUrl.
-  Response DirectRequest(std::string const & method, bool api = true) const;
+  Response DirectRequest(std::string const & method, bool api = true, std::string const & httpMethod = "GET",
+                         std::string const & body = "") const;
 
   // Getters
   std::string GetBaseUrl() const { return m_baseUrl; }

--- a/libs/editor/osm_editor.cpp
+++ b/libs/editor/osm_editor.cpp
@@ -586,6 +586,9 @@ void Editor::UploadChanges(string const & oauthToken, ChangesetTags tags, Finish
 {
   m_notes->Upload(OsmOAuth::ServerAuth(oauthToken));
 
+  if (!OsmOAuth::ServerAuth(oauthToken).IsAuthorized())
+    return;
+
   if (m_isUploadingNow)
     return;
 

--- a/libs/editor/server_api.cpp
+++ b/libs/editor/server_api.cpp
@@ -117,13 +117,14 @@ void ServerApi06::CloseChangeSet(uint64_t changesetId) const
     MYTHROW(ErrorClosingChangeSet, ("CloseChangeSet request has failed:", response));
 }
 
-uint64_t ServerApi06::CreateNote(ms::LatLon const & ll, std::string const & message) const
+uint64_t ServerApi06::CreateNote(ms::LatLon const & ll, std::string const & message, bool isAnonymous) const
 {
   CHECK(!message.empty(), ("Note content should not be empty."));
   std::string const params =
       "?lat=" + strings::to_string_dac(ll.m_lat, 7) + "&lon=" + strings::to_string_dac(ll.m_lon, 7) +
       "&text=" + url::UrlEncode(message + " #organicmaps " + OMIM_OS_NAME + " " + GetPlatform().Version());
-  OsmOAuth::Response const response = m_auth.Request("/notes" + params, "POST");
+  OsmOAuth::Response const response =
+      isAnonymous ? m_auth.DirectRequest("/notes" + params, true, "POST") : m_auth.Request("/notes" + params, "POST");
   if (response.first != OsmOAuth::HTTP::OK)
     MYTHROW(ErrorAddingNote, ("Could not post a new note:", response));
   pugi::xml_document details;

--- a/libs/editor/server_api.hpp
+++ b/libs/editor/server_api.hpp
@@ -73,7 +73,7 @@ public:
   void UpdateChangeSet(uint64_t changesetId, KeyValueTags const & kvTags) const;
   void CloseChangeSet(uint64_t changesetId) const;
   /// @returns id of a created note.
-  uint64_t CreateNote(ms::LatLon const & ll, std::string const & message) const;
+  uint64_t CreateNote(ms::LatLon const & ll, std::string const & message, bool isAnonymous = false) const;
   void CloseNote(uint64_t const id) const;
 
   /// @returns OSM xml string with features in the bounding box or empty string on error.

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -3265,6 +3265,11 @@ void Framework::CreateNote(osm::MapObject const & mapObject, osm::Editor::NotePr
     DeactivateMapSelection();
 }
 
+void Framework::CreateStandaloneNote(ms::LatLon const & latLon, string const & note)
+{
+  osm::Editor::Instance().CreateStandaloneNote(latLon, note);
+}
+
 void Framework::RunUITask(function<void()> fn)
 {
   GetPlatform().RunTask(Platform::Thread::Gui, std::move(fn));

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -767,6 +767,7 @@ public:
   osm::NewFeatureCategories GetEditorCategories() const;
   bool RollBackChanges(FeatureID const & fid);
   void CreateNote(osm::MapObject const & mapObject, osm::Editor::NoteProblemType const type, std::string const & note);
+  void CreateStandaloneNote(ms::LatLon const & latLon, std::string const & note);
 
 private:
   settings::UsageStats m_usageStats;


### PR DESCRIPTION
@biodranik 

Fixes: https://github.com/organicmaps/organicmaps/issues/11853 ,  https://github.com/organicmaps/organicmaps/issues/7620,
https://github.com/organicmaps/organicmaps/issues/266
 
Fixes:
1. Added a standalone notes section when category/type results are not found while adding a POI.
2. Sending anonymous notes.

I did not find any instance of code which uses anonymous uploads, so i removed the authentication in the UploadEdits function and added auth check while creating the note. pls point me the code if there is any usage of anonymous edits

We can consider implementing:
1. Trimming the ends of the notes if it has whitespaces.
2. Right now unauthorized editing of a POI will not prompt a login popup.
4. Showing a toast message after adding a POI. 
5. Creating a new parser debug command` ?notes` which returns a list of all uploaded and non-uploaded notes.