### PR TITLE
Fix search URL handling

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -411,7 +411,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     startActivity(intent);
   }
 
-  private void showSearch(String query)
+  public void showSearch(String query)
   {
     closeSearchToolbar(false, true);
     if (mIsTabletLayout)


### PR DESCRIPTION
This update ensures that web search links are processed correctly by the app's search engine
I am testing with this link https://www.openstreetmap.org/search?query=Berlin
Fixes: #12132

https://github.com/user-attachments/assets/22fe968a-2a4f-4aa8-89e2-15dae11669c8



https://github.com/user-attachments/assets/a79b06b3-7857-4e07-9c2e-47d23d53a229


