### PR TITLE
Fix/per mode routing options

### DIFF
--- a/iphone/Maps/Classes/CarPlay/Template Builders/SettingsTemplateBuilder.swift
+++ b/iphone/Maps/Classes/CarPlay/Template Builders/SettingsTemplateBuilder.swift
@@ -12,7 +12,7 @@ final class SettingsTemplateBuilder {
   }
 
   private class func buildGridButtons() -> [CPGridButton] {
-    let options = RoutingOptions()
+    let options = RoutingOptions(routerType: .vehicle)
     return [createUnpavedButton(options: options),
             createTollButton(options: options),
             createFerryButton(options: options),

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardInteractor.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardInteractor.swift
@@ -105,7 +105,7 @@ extension NavigationDashboard {
         return .updateSearchState(state)
 
       case .updateDrivingOptionsState:
-        let routingOptions = RoutingOptions()
+        let routingOptions = RoutingOptions(routerType: router.type())
         return .updateDrivingOptionsState(routingOptions)
 
       case .moveRoutePoint(let from, let to):

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewModel.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewModel.swift
@@ -34,7 +34,7 @@ extension NavigationDashboard.ViewModel {
       routePoints: .empty,
       routerType: MWMRouter.type(),
       entity: MWMNavigationDashboardEntity(),
-      routingOptions: RoutingOptions(),
+      routingOptions: RoutingOptions(routerType: MWMRouter.type()),
       elevationInfo: nil,
       navigationInfo: .hidden,
       estimates: NSAttributedString(),

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -161,7 +161,7 @@ char const * kRenderAltitudeImagesQueueLabel = "mapsme.mwmrouter.renderAltitudeI
     [MWMLocationManager addObserver:self];
     [MWMFrameworkListener addObserver:self];
     _canAutoAddLastLocation = YES;
-    _routingOptions = [MWMRoutingOptions new];
+    _routingOptions = [[MWMRoutingOptions alloc] initWithRouterType:[MWMRouter type]];
     _isRestoreProcessCompleted = NO;
   }
   return self;
@@ -550,7 +550,7 @@ char const * kRenderAltitudeImagesQueueLabel = "mapsme.mwmrouter.renderAltitudeI
 
 - (void)onRouteReady:(BOOL)hasWarnings
 {
-  self.routingOptions = [MWMRoutingOptions new];
+  self.routingOptions = [[MWMRoutingOptions alloc] initWithRouterType:[MWMRouter type]];
 
   auto startPoint = [MWMRouter startPoint];
   if (!startPoint || !startPoint.isMyPosition)
@@ -573,7 +573,8 @@ char const * kRenderAltitudeImagesQueueLabel = "mapsme.mwmrouter.renderAltitudeI
   case routing::RouterResultCode::NeedMoreMaps:
   case routing::RouterResultCode::FileTooOld:
   case routing::RouterResultCode::RouteNotFound:
-    self.routingOptions = [MWMRoutingOptions new];
+    self.routingOptions = [[MWMRoutingOptions alloc] initWithRouterType:[MWMRouter type]];
+
     [self presentDownloaderAlert:code countries:absentCountries];
     [[MWMNavigationDashboardManager sharedManager] onRouteError:L(@"routing_planning_error")];
     break;
@@ -693,19 +694,20 @@ char const * kRenderAltitudeImagesQueueLabel = "mapsme.mwmrouter.renderAltitudeI
 
 + (void)updateRoute
 {
-  MWMRoutingOptions * newOptions = [MWMRoutingOptions new];
+  MWMRoutingOptions * newOptions = [[MWMRoutingOptions alloc] initWithRouterType:self.type];
   if ((self.isRoutingActive && !self.isOnRoute) && ![newOptions isEqual:[self router].routingOptions])
     [self rebuildWithBestRouter:YES];
 }
 
 + (BOOL)hasActiveDrivingOptions
 {
-  return [MWMRoutingOptions new].hasOptions && self.type != MWMRouterTypeRuler;
+  return [[MWMRoutingOptions alloc] initWithRouterType:self.type].hasOptions
+  && self.type != MWMRouterTypeRuler;
 }
 
 + (void)avoidRoadTypeAndRebuild:(MWMRoadType)type
 {
-  MWMRoutingOptions * options = [MWMRoutingOptions new];
+  MWMRoutingOptions * options = [[MWMRoutingOptions alloc] initWithRouterType:self.type];
   switch (type)
   {
   case MWMRoadTypeToll: options.avoidToll = YES; break;

--- a/iphone/Maps/Core/Settings/MWMRoutingOptions.h
+++ b/iphone/Maps/Core/Settings/MWMRoutingOptions.h
@@ -1,4 +1,6 @@
 #import <Foundation/Foundation.h>
+#import "MWMRouterType.h"
+
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,7 +13,10 @@ NS_SWIFT_NAME(RoutingOptions)
 @property(nonatomic) BOOL avoidMotorway;
 @property(nonatomic, readonly) BOOL hasOptions;
 
+- (instancetype)initWithRouterType:(MWMRouterType)type;
 - (void)save;
+
+
 
 @end
 

--- a/iphone/Maps/Core/Settings/MWMRoutingOptions.h
+++ b/iphone/Maps/Core/Settings/MWMRoutingOptions.h
@@ -1,7 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "MWMRouterType.h"
 
-
 NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(RoutingOptions)
@@ -15,8 +14,6 @@ NS_SWIFT_NAME(RoutingOptions)
 
 - (instancetype)initWithRouterType:(MWMRouterType)type;
 - (void)save;
-
-
 
 @end
 

--- a/iphone/Maps/Core/Settings/MWMRoutingOptions.mm
+++ b/iphone/Maps/Core/Settings/MWMRoutingOptions.mm
@@ -1,10 +1,12 @@
 #import "MWMRoutingOptions.h"
 
 #include "routing/routing_options.hpp"
+#import "MWMRouterType.h"
 
 @interface MWMRoutingOptions ()
 {
   routing::RoutingOptions _options;
+  MWMRouterType _routerType;
 }
 
 @end
@@ -13,10 +15,29 @@
 
 - (instancetype)init
 {
-  self = [super init];
-  if (self)
-    _options = routing::RoutingOptions::LoadCarOptionsFromSettings();
+  return [self initWithRouterType:MWMRouterTypeVehicle];
+}
 
+- (instancetype)initWithRouterType:(MWMRouterType)type
+{
+  self = [super init];
+  if (self) {
+    _routerType = type;
+    switch (type) {
+      case MWMRouterTypeVehicle:
+        _options = routing::RoutingOptions::LoadCarOptionsFromSettings();
+        break;
+      case MWMRouterTypePedestrian:
+        _options = routing::RoutingOptions::LoadPedestrianOptionsFromSettings();
+        break;
+      case MWMRouterTypeBicycle:
+        _options = routing::RoutingOptions::LoadBicycleOptionsFromSettings();
+        break;
+      default:
+        _options = routing::RoutingOptions::LoadCarOptionsFromSettings();
+        break;
+    }
+  }
   return self;
 }
 
@@ -67,7 +88,20 @@
 
 - (void)save
 {
-  routing::RoutingOptions::SaveCarOptionsToSettings(_options);
+  switch (_routerType) {
+    case MWMRouterTypeVehicle:
+      routing::RoutingOptions::SaveCarOptionsToSettings(_options);
+      break;
+    case MWMRouterTypePedestrian:
+      routing::RoutingOptions::SavePedestrianOptionsToSettings(_options);
+      break;
+    case MWMRouterTypeBicycle:
+      routing::RoutingOptions::SaveBicycleOptionsToSettings(_options);
+      break;
+    default:
+      routing::RoutingOptions::SaveCarOptionsToSettings(_options);
+      break;
+  }
 }
 
 - (void)setOption:(routing::RoutingOptions::Road)option enabled:(BOOL)enabled

--- a/iphone/Maps/UI/Settings/DrivingOptionsViewController.swift
+++ b/iphone/Maps/UI/Settings/DrivingOptionsViewController.swift
@@ -1,6 +1,6 @@
 
 class DrivingOptionsViewController: MWMTableViewController {
-  let options = RoutingOptions(routerType: .vehicle)
+  lazy var options = RoutingOptions(routerType: MWMRouter.type())
   @IBOutlet var tollRoadsCell: SettingsTableViewSwitchCell!
   @IBOutlet var unpavedRoadsCell: SettingsTableViewSwitchCell!
   @IBOutlet var ferryCrossingsCell: SettingsTableViewSwitchCell!

--- a/iphone/Maps/UI/Settings/DrivingOptionsViewController.swift
+++ b/iphone/Maps/UI/Settings/DrivingOptionsViewController.swift
@@ -1,6 +1,6 @@
 
 class DrivingOptionsViewController: MWMTableViewController {
-  let options = RoutingOptions()
+  let options = RoutingOptions(routerType: .vehicle)
   @IBOutlet var tollRoadsCell: SettingsTableViewSwitchCell!
   @IBOutlet var unpavedRoadsCell: SettingsTableViewSwitchCell!
   @IBOutlet var ferryCrossingsCell: SettingsTableViewSwitchCell!

--- a/libs/routing/index_router.cpp
+++ b/libs/routing/index_router.cpp
@@ -1062,8 +1062,24 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints, m2::P
 
 unique_ptr<WorldGraph> IndexRouter::MakeWorldGraph()
 {
-  // Use saved routing options for all types (car, bicycle, pedestrian).
-  RoutingOptions const routingOptions = RoutingOptions::LoadCarOptionsFromSettings();
+  // Use saved routing options based on the current vehicle type.
+  RoutingOptions routingOptions;
+  switch (m_vehicleType)
+  {
+  case VehicleType::Car:
+    routingOptions = RoutingOptions::LoadCarOptionsFromSettings();
+    break;
+  case VehicleType::Pedestrian:
+  case VehicleType::Transit:
+    routingOptions = RoutingOptions::LoadPedestrianOptionsFromSettings();
+    break;
+  case VehicleType::Bicycle:
+    routingOptions = RoutingOptions::LoadBicycleOptionsFromSettings();
+    break;
+  default:
+    routingOptions = RoutingOptions::LoadCarOptionsFromSettings();
+    break;
+  }
   /// @DebugNote
   // Add avoid roads here for debug purpose.
   // routingOptions.Add(RoutingOptions::Road::Motorway);

--- a/libs/routing/routing_options.cpp
+++ b/libs/routing/routing_options.cpp
@@ -17,6 +17,8 @@ using namespace std;
 // RoutingOptions -------------------------------------------------------------------------------------
 
 std::string_view constexpr kAvoidRoutingOptionSettingsForCar = "avoid_routing_options_car";
+std::string_view constexpr kAvoidRoutingOptionSettingsForPedestrian = "avoid_routing_options_pedestrian";
+std::string_view constexpr kAvoidRoutingOptionSettingsForBicycle = "avoid_routing_options_bicycle";
 
 // static
 RoutingOptions RoutingOptions::LoadCarOptionsFromSettings()
@@ -32,6 +34,37 @@ RoutingOptions RoutingOptions::LoadCarOptionsFromSettings()
 void RoutingOptions::SaveCarOptionsToSettings(RoutingOptions options)
 {
   settings::Set(kAvoidRoutingOptionSettingsForCar, strings::to_string(static_cast<int32_t>(options.GetOptions())));
+}
+// static
+RoutingOptions RoutingOptions::LoadPedestrianOptionsFromSettings()
+{
+  uint32_t mode = 0;
+  if (!settings::Get(kAvoidRoutingOptionSettingsForPedestrian, mode))
+    mode = 0;
+
+  return RoutingOptions(base::checked_cast<RoadType>(mode));
+}
+
+// static
+void RoutingOptions::SavePedestrianOptionsToSettings(RoutingOptions options)
+{
+  settings::Set(kAvoidRoutingOptionSettingsForPedestrian, strings::to_string(static_cast<int32_t>(options.GetOptions())));
+}
+
+// static
+RoutingOptions RoutingOptions::LoadBicycleOptionsFromSettings()
+{
+  uint32_t mode = 0;
+  if (!settings::Get(kAvoidRoutingOptionSettingsForBicycle, mode))
+    mode = 0;
+
+  return RoutingOptions(base::checked_cast<RoadType>(mode));
+}
+
+// static
+void RoutingOptions::SaveBicycleOptionsToSettings(RoutingOptions options)
+{
+  settings::Set(kAvoidRoutingOptionSettingsForBicycle, strings::to_string(static_cast<int32_t>(options.GetOptions())));
 }
 
 void RoutingOptions::Add(RoutingOptions::Road type)

--- a/libs/routing/routing_options.cpp
+++ b/libs/routing/routing_options.cpp
@@ -20,51 +20,56 @@ std::string_view constexpr kAvoidRoutingOptionSettingsForCar = "avoid_routing_op
 std::string_view constexpr kAvoidRoutingOptionSettingsForPedestrian = "avoid_routing_options_pedestrian";
 std::string_view constexpr kAvoidRoutingOptionSettingsForBicycle = "avoid_routing_options_bicycle";
 
+namespace
+{
+RoutingOptions LoadOptionsFromSettings(std::string_view key)
+{
+  uint32_t mode = 0;
+  if (!settings::Get(key, mode))
+    mode = 0;
+  return RoutingOptions(base::checked_cast<RoutingOptions::RoadType>(mode));
+}
+
+void SaveOptionsToSettings(std::string_view key, RoutingOptions options)
+{
+  settings::Set(key, strings::to_string(static_cast<int32_t>(options.GetOptions())));
+}
+}  // namespace
+
 // static
 RoutingOptions RoutingOptions::LoadCarOptionsFromSettings()
 {
-  uint32_t mode = 0;
-  if (!settings::Get(kAvoidRoutingOptionSettingsForCar, mode))
-    mode = 0;
-
-  return RoutingOptions(base::checked_cast<RoadType>(mode));
+  return LoadOptionsFromSettings(kAvoidRoutingOptionSettingsForCar);
 }
 
 // static
 void RoutingOptions::SaveCarOptionsToSettings(RoutingOptions options)
 {
-  settings::Set(kAvoidRoutingOptionSettingsForCar, strings::to_string(static_cast<int32_t>(options.GetOptions())));
+  SaveOptionsToSettings(kAvoidRoutingOptionSettingsForCar, options);
 }
+
 // static
 RoutingOptions RoutingOptions::LoadPedestrianOptionsFromSettings()
 {
-  uint32_t mode = 0;
-  if (!settings::Get(kAvoidRoutingOptionSettingsForPedestrian, mode))
-    mode = 0;
-
-  return RoutingOptions(base::checked_cast<RoadType>(mode));
+  return LoadOptionsFromSettings(kAvoidRoutingOptionSettingsForPedestrian);
 }
 
 // static
 void RoutingOptions::SavePedestrianOptionsToSettings(RoutingOptions options)
 {
-  settings::Set(kAvoidRoutingOptionSettingsForPedestrian, strings::to_string(static_cast<int32_t>(options.GetOptions())));
+  SaveOptionsToSettings(kAvoidRoutingOptionSettingsForPedestrian, options);
 }
 
 // static
 RoutingOptions RoutingOptions::LoadBicycleOptionsFromSettings()
 {
-  uint32_t mode = 0;
-  if (!settings::Get(kAvoidRoutingOptionSettingsForBicycle, mode))
-    mode = 0;
-
-  return RoutingOptions(base::checked_cast<RoadType>(mode));
+  return LoadOptionsFromSettings(kAvoidRoutingOptionSettingsForBicycle);
 }
 
 // static
 void RoutingOptions::SaveBicycleOptionsToSettings(RoutingOptions options)
 {
-  settings::Set(kAvoidRoutingOptionSettingsForBicycle, strings::to_string(static_cast<int32_t>(options.GetOptions())));
+  SaveOptionsToSettings(kAvoidRoutingOptionSettingsForBicycle, options);
 }
 
 void RoutingOptions::Add(RoutingOptions::Road type)

--- a/libs/routing/routing_options.hpp
+++ b/libs/routing/routing_options.hpp
@@ -29,6 +29,10 @@ public:
 
   static RoutingOptions LoadCarOptionsFromSettings();
   static void SaveCarOptionsToSettings(RoutingOptions options);
+  static RoutingOptions LoadPedestrianOptionsFromSettings();
+  static void SavePedestrianOptionsToSettings(RoutingOptions options);
+  static RoutingOptions LoadBicycleOptionsFromSettings();
+  static void SaveBicycleOptionsToSettings(RoutingOptions options);
 
   void Add(Road type);
   void Remove(Road type);


### PR DESCRIPTION
**ISSUE** : Routing options (avoid tolls, ferries, etc.) were shared 
across all transportation modes. Enabling "avoid tolls" 
for car routing incorrectly applied to walking/cycling too.

**CHANGES** : C++: Added separate storage keys and load/save 
  functions per routing mode
- Objective-C: Updated MWMRoutingOptions to accept 
  router type parameter. Fixed 6 instances in MWMRouter.mm 
  that always loaded car settings
- Swift: Updated all instantiation points to pass 
  current routing mode dynamically
  
  
 Each routing mode (car/pedestrian/bicycle) now maintains
completely independent routing option settings.

**After changes**

https://github.com/user-attachments/assets/223f29e4-a836-4773-bf4a-b9d8fb216aaa
fixes #5656 

Please let me know if any further changes are needed here
thank you.




