### PR TITLE
[drape] Adjust route colors according to the current theme.

### DIFF
--- a/libs/drape/CMakeLists.txt
+++ b/libs/drape/CMakeLists.txt
@@ -13,6 +13,7 @@ set(DRAPE_TESTABLE_SRC
   binding_info.hpp
   buffer_base.cpp
   buffer_base.hpp
+  color.cpp
   color.hpp
   constants.hpp
   cpu_buffer.cpp

--- a/libs/drape/color.cpp
+++ b/libs/drape/color.cpp
@@ -1,0 +1,89 @@
+#include "drape/color.hpp"
+
+#include <algorithm>
+
+namespace dp
+{
+
+bool HSL::AdjustLightness(bool isLightTheme)
+{
+  // Possible alternatives:
+  // Inverse: l = 1.0f - l;
+  // Also reduce saturaton: s = std::max(0, s - 0.1f);
+
+  if (isLightTheme && l > 0.8f)
+  {
+    l = 0.2f;
+    return true;
+  }
+  else if (!isLightTheme && l < 0.2f)
+  {
+    l = 0.8f;
+    return true;
+  }
+
+  return false;
+}
+
+HSL Color2HSL(Color c)
+{
+  float const r = c.GetRedF();
+  float const g = c.GetGreenF();
+  float const b = c.GetBlueF();
+
+  float const max = std::max({r, g, b});
+  float const min = std::min({r, g, b});
+  float const d = max - min;
+
+  HSL hsl;
+  hsl.l = (max + min) / 2.0f;
+
+  if (d == 0)
+    hsl.h = hsl.s = 0;  // gray
+  else
+  {
+    hsl.s = hsl.l > 0.5f ? d / (2.0f - max - min) : d / (max + min);
+
+    if (max == r)
+      hsl.h = (g - b) / d + (g < b ? 6.0f : 0.0f);
+    else if (max == g)
+      hsl.h = (b - r) / d + 2.0f;
+    else
+      hsl.h = (r - g) / d + 4.0f;
+
+    hsl.h *= 60.0f;
+  }
+
+  return hsl;
+}
+
+float hue2rgb(float p, float q, float t)
+{
+  if (t < 0.0f)
+    t += 1.0f;
+  if (t > 1.0f)
+    t -= 1.0f;
+  if (t < 1.0f / 6.0f)
+    return p + (q - p) * 6.0f * t;
+  if (t < 1.0f / 2.0f)
+    return q;
+  if (t < 2.0f / 3.0f)
+    return p + (q - p) * (2.0f / 3.0f - t) * 6.0f;
+  return p;
+}
+
+Color HSL2Color(HSL const & hsl)
+{
+  float const h = hsl.h / 360.0f;
+
+  if (hsl.s == 0)
+    return Color::FromFloat(hsl.l, hsl.l, hsl.l);  // gray
+  else
+  {
+    float q = hsl.l < 0.5f ? hsl.l * (1.0f + hsl.s) : hsl.l + hsl.s - hsl.l * hsl.s;
+    float p = 2.0f * hsl.l - q;
+    return Color::FromFloat(hue2rgb(p, q, h + 1.0f / 3.0f), hue2rgb(p, q, h), hue2rgb(p, q, h - 1.0f / 3.0f));
+  }
+}
+
+}  // namespace dp

--- a/libs/drape/color.hpp
+++ b/libs/drape/color.hpp
@@ -63,6 +63,10 @@ struct Color
   {
     return {ExtractByte(rgba, 3), ExtractByte(rgba, 2), ExtractByte(rgba, 1), ExtractByte(rgba, 0)};
   }
+  constexpr static Color FromFloat(float red, float green, float blue)
+  {
+    return {uint8_t(red * kMaxChannelValue), uint8_t(green * kMaxChannelValue), uint8_t(blue * kMaxChannelValue)};
+  }
 
 private:
   constexpr static uint8_t ExtractByte(uint32_t number, uint8_t byteIdx) { return (number >> (8 * byteIdx)) & 0xFF; }
@@ -83,4 +87,17 @@ inline std::string DebugPrint(Color const & c)
       << ", B = " << static_cast<uint32_t>(c.GetBlue()) << ", A = " << static_cast<uint32_t>(c.GetAlpha()) << "]";
   return out.str();
 }
+
+// Hue, Saturation, Lightness
+struct HSL
+{
+  float h, s, l;  // h: 0-360, s/l: 0-1
+
+  bool IsDark() const { return l < 0.4f; }
+  bool AdjustLightness(bool isLightTheme);
+};
+
+HSL Color2HSL(Color c);
+Color HSL2Color(HSL const & hsl);
+
 }  // namespace dp

--- a/libs/drape/drape_tests/CMakeLists.txt
+++ b/libs/drape/drape_tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SRC
   batcher_tests.cpp
   bingind_info_tests.cpp
   buffer_tests.cpp
+  color_tests.cpp
   dummy_texture.hpp
   font_texture_tests.cpp
   gl_functions.cpp

--- a/libs/drape/drape_tests/color_tests.cpp
+++ b/libs/drape/drape_tests/color_tests.cpp
@@ -1,0 +1,28 @@
+#include "testing/testing.hpp"
+
+#include "drape/color.hpp"
+
+using namespace dp;
+
+UNIT_TEST(Color_HSL)
+{
+  {
+    Color const black = Color::Black();
+    HSL hsl = Color2HSL(black);
+    TEST(hsl.IsDark(), ());
+    TEST_EQUAL(HSL2Color(hsl), black, ());
+
+    TEST(hsl.AdjustLightness(false), ());
+    TEST_EQUAL(HSL2Color(hsl), Color(204, 204, 204), ());
+  }
+
+  {
+    Color const white = Color::White();
+    HSL hsl = Color2HSL(white);
+    TEST(!hsl.IsDark(), ());
+    TEST_EQUAL(HSL2Color(hsl), white, ());
+
+    TEST(hsl.AdjustLightness(true), ());
+    TEST_EQUAL(HSL2Color(hsl), Color(51, 51, 51), ());
+  }
+}

--- a/libs/drape_frontend/color_constants.cpp
+++ b/libs/drape_frontend/color_constants.cpp
@@ -22,8 +22,7 @@ class TransitColorsHolder
 public:
   dp::Color GetColor(std::string const & name) const
   {
-    auto const style = GetStyleReader().GetCurrentStyle();
-    auto const isDarkStyle = style == MapStyle::MapStyleDefaultDark || style == MapStyle::MapStyleVehicleDark;
+    auto const isDarkStyle = MapStyleIsDark(GetStyleReader().GetCurrentStyle());
     auto const & colors = isDarkStyle ? m_nightColors : m_clearColors;
     auto const it = colors.find(name);
     if (it == colors.cend())

--- a/libs/drape_frontend/relations_draw_info.cpp
+++ b/libs/drape_frontend/relations_draw_info.cpp
@@ -1,11 +1,11 @@
 #include "relations_draw_info.hpp"
 
 #include "indexer/feature.hpp"
+#include "indexer/map_style_reader.hpp"
 
 namespace df
 {
 
-dp::Color constexpr kDefaultTextColor = dp::Color::Blue();
 dp::Color constexpr kDefaultRouteColor{128, 0, 128};  // purple
 
 bool RelationsDrawInfo::HasHikingOrCycling(FeatureType & ft) const
@@ -71,6 +71,15 @@ void RelationsDrawInfo::Init(FeatureType & ft)
   if (m_colors.empty())
     return;
 
+  // Adjust colors to the current theme for readability.
+  bool const isLightTheme = !MapStyleIsDark(GetStyleReader().GetCurrentStyle());
+  for (auto & [c, _] : m_colors)
+  {
+    dp::HSL hsl = dp::Color2HSL(c);
+    if (hsl.AdjustLightness(isLightTheme))
+      c = dp::HSL2Color(hsl);
+  }
+
   // Most used color first.
   std::sort(m_colors.begin(), m_colors.end(), [](auto const & r1, auto const & r2) { return r1.second > r2.second; });
 
@@ -100,14 +109,7 @@ void RelationsDrawInfo::Init(FeatureType & ft)
 
 dp::Color RelationsDrawInfo::GetTextColor() const
 {
-  /// A simple patch, because white text looks strange.
-  /// @todo Take into account dark theme and other constrains,
-  /// something like ReadableTextColor(GetStyleReader().GetCurrentStyle(), color).
-
-  auto res = m_colors.front().first;
-  if (res == dp::Color::White())
-    res = m_colors.size() > 1 ? m_colors[1].first : kDefaultTextColor;
-  return res;
+  return m_colors.front().first;
 }
 
 }  // namespace df

--- a/xcode/drape/drape.xcodeproj/project.pbxproj
+++ b/xcode/drape/drape.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		6743D3451C3533AE0095054B /* support_manager.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 6743D3431C3533AE0095054B /* support_manager.hpp */; };
 		675D21991BFB876E00717E4F /* projection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 675D21971BFB876E00717E4F /* projection.cpp */; };
 		675D219A1BFB876E00717E4F /* projection.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 675D21981BFB876E00717E4F /* projection.hpp */; };
+		AC5F32772F41D0DB00176C2A /* color.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AC5F32762F41D0DB00176C2A /* color.cpp */; };
 		BB035F6C1E3A2A5C00519962 /* drape_diagnostics.hpp in Headers */ = {isa = PBXBuildFile; fileRef = BB035F6B1E3A2A5C00519962 /* drape_diagnostics.hpp */; };
 		BBAD59F821258812005543FC /* debug_renderer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = BBAD59F721258812005543FC /* debug_renderer.hpp */; };
 		BBB72E902110AF0F00249D4F /* oglcontext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BBB72E8F2110AF0F00249D4F /* oglcontext.cpp */; };
@@ -287,6 +288,7 @@
 		6743D3431C3533AE0095054B /* support_manager.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = support_manager.hpp; sourceTree = "<group>"; };
 		675D21971BFB876E00717E4F /* projection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = projection.cpp; sourceTree = "<group>"; };
 		675D21981BFB876E00717E4F /* projection.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = projection.hpp; sourceTree = "<group>"; };
+		AC5F32762F41D0DB00176C2A /* color.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = color.cpp; sourceTree = "<group>"; };
 		BB035F6B1E3A2A5C00519962 /* drape_diagnostics.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = drape_diagnostics.hpp; sourceTree = "<group>"; };
 		BBAD59F721258812005543FC /* debug_renderer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = debug_renderer.hpp; sourceTree = "<group>"; };
 		BBB72E8F2110AF0F00249D4F /* oglcontext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = oglcontext.cpp; sourceTree = "<group>"; };
@@ -399,6 +401,7 @@
 				6729A50A1A69213A007D5872 /* buffer_base.hpp */,
 				6729A5091A69213A007D5872 /* buffer_base.cpp */,
 				6729A50C1A69213A007D5872 /* color.hpp */,
+				AC5F32762F41D0DB00176C2A /* color.cpp */,
 				45201E941CE605B1008A4842 /* constants.hpp */,
 				6729A50E1A69213A007D5872 /* cpu_buffer.hpp */,
 				6729A50D1A69213A007D5872 /* cpu_buffer.cpp */,
@@ -712,6 +715,7 @@
 				6729A5B21A69213A007D5872 /* vertex_decl.cpp in Sources */,
 				6729A5A81A69213A007D5872 /* texture_of_colors.cpp in Sources */,
 				6729A5AC1A69213A007D5872 /* uniform_value.cpp in Sources */,
+				AC5F32772F41D0DB00176C2A /* color.cpp in Sources */,
 				6729A5961A69213A007D5872 /* overlay_tree.cpp in Sources */,
 				4577B26021F2035D00864FAC /* vulkan_mesh_object_impl.cpp in Sources */,
 				6729A5651A69213A007D5872 /* attribute_provider.cpp in Sources */,


### PR DESCRIPTION
Example of how a black route is shown in the dark theme:

![telegram-cloud-photo-size-2-5226567379662345276-y](https://github.com/user-attachments/assets/c64961e5-53d2-420b-989b-f2b1d3885833)

![telegram-cloud-photo-size-2-5226567379662345275-y](https://github.com/user-attachments/assets/f2a092ec-0278-4cac-938b-167c10363d17)

