### PR TITLE
Bookmark and Track new edit timestamp field

### DIFF
--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/Bookmark.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/Bookmark.cpp
@@ -59,7 +59,7 @@ JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeSetColor(J
   auto const newColor = dp::Color::FromARGB(color);
 
   if (mark->GetColorForRendering() == newColor)
-    return; // New color is the same as existing color. Nothing to update.
+    return;  // New color is the same as existing color. Nothing to update.
 
   // initialize new bookmark
   kml::BookmarkData bmData(mark->GetData());
@@ -80,7 +80,7 @@ JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeUpdatePara
 
   if (mark->GetPreferredName() == bmName && mark->GetDescription() == bmDescr &&
       mark->GetColorForRendering() == newColor)
-    return; // New bookmark parameters match existing params. Nothing to update.
+    return;  // New bookmark parameters match existing params. Nothing to update.
 
   // initialize new bookmark
   kml::BookmarkData bmData(mark->GetData());

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/Bookmark.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/Bookmark.cpp
@@ -56,10 +56,14 @@ extern "C"
 JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeSetColor(JNIEnv *, jclass, jlong bmk, jint color)
 {
   auto const * mark = getBookmark(bmk);
+  auto const newColor = dp::Color::FromARGB(color);
+
+  if (mark->GetColorForRendering() == newColor)
+    return; // New color is the same as existing color. Nothing to update.
 
   // initialize new bookmark
   kml::BookmarkData bmData(mark->GetData());
-  bmData.m_color = kml::MakeCustomBookmarkColorData(dp::Color::FromARGB(color));
+  bmData.m_color = kml::MakeCustomBookmarkColorData(newColor);
 
   g_framework->ReplaceBookmark(static_cast<kml::MarkId>(bmk), bmData);
 }
@@ -70,14 +74,21 @@ JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeUpdatePara
 {
   auto const * mark = getBookmark(bmk);
 
+  auto const bmName = jni::ToNativeString(env, name);
+  auto const bmDescr = jni::ToNativeString(env, descr);
+  auto const newColor = dp::Color::FromARGB(color);
+
+  if (mark->GetPreferredName() == bmName && mark->GetDescription() == bmDescr &&
+      mark->GetColorForRendering() == newColor)
+    return; // New bookmark parameters match existing params. Nothing to update.
+
   // initialize new bookmark
   kml::BookmarkData bmData(mark->GetData());
-  auto const bmName = jni::ToNativeString(env, name);
+
   if (mark->GetPreferredName() != bmName)
     kml::SetDefaultStr(bmData.m_customName, bmName);
-  if (descr)
-    kml::SetDefaultStr(bmData.m_description, jni::ToNativeString(env, descr));
-  bmData.m_color = kml::MakeCustomBookmarkColorData(dp::Color::FromARGB(color));
+  kml::SetDefaultStr(bmData.m_description, bmDescr);
+  bmData.m_color = kml::MakeCustomBookmarkColorData(newColor);
 
   g_framework->ReplaceBookmark(static_cast<kml::MarkId>(bmk), bmData);
 }

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/Track.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/Track.cpp
@@ -131,21 +131,32 @@ JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_Track_nativeSetParams(JNI
   auto const * nTrack = frm()->GetBookmarkManager().GetTrack(static_cast<kml::TrackId>(id));
   CHECK(nTrack, ("Track must not be null with id:", id));
 
-  kml::TrackData trackData(nTrack->GetData());
   auto const trkName = jni::ToNativeString(env, name);
-  kml::SetDefaultStr(trackData.m_name, trkName);
-  kml::SetDefaultStr(trackData.m_description, jni::ToNativeString(env, descr));
-
+  auto const trkDescr = jni::ToNativeString(env, descr);
   uint8_t alpha = ExtractByte(color, 3);
-  trackData.m_layers[0].m_color.m_rgba = static_cast<uint32_t>(shift(color, 8) + alpha);
+  auto const trkColor = static_cast<dp::Color>(shift(color, 8) + alpha);
+
+  if (nTrack->GetName() == trkName && nTrack->GetDescription() == trkDescr && \
+    nTrack->GetColor(0) == trkColor)
+    return; // New parameters match existing track params. Nothing to update.
+
+  kml::TrackData trackData(nTrack->GetData());
+  kml::SetDefaultStr(trackData.m_name, trkName);
+  kml::SetDefaultStr(trackData.m_description, trkDescr);
+  trackData.m_layers[0].m_color.m_rgba = trkColor.GetRGBA();
 
   g_framework->ReplaceTrack(static_cast<kml::TrackId>(id), trackData);
 }
 
 JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_Track_nativeChangeColor(JNIEnv *, jclass, jlong id, jint color)
 {
-  uint8_t const alpha = ExtractByte(color, 3);
-  g_framework->ChangeTrackColor(static_cast<kml::TrackId>(id), static_cast<dp::Color>(shift(color, 8) + alpha));
+  auto const * nTrack = frm()->GetBookmarkManager().GetTrack(static_cast<kml::TrackId>(id));
+  uint8_t alpha = ExtractByte(color, 3);
+  auto const trkColor = static_cast<dp::Color>(shift(color, 8) + alpha);
+  if (nTrack->GetColor(0) == trkColor)
+    return; // New color is the same as old one.
+
+  g_framework->ChangeTrackColor(static_cast<kml::TrackId>(id), static_cast<dp::Color>(trkColor));
 }
 
 JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_Track_nativeChangeCategory(JNIEnv *, jclass, jlong oldCat,

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/Track.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/Track.cpp
@@ -136,9 +136,8 @@ JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_Track_nativeSetParams(JNI
   uint8_t alpha = ExtractByte(color, 3);
   auto const trkColor = static_cast<dp::Color>(shift(color, 8) + alpha);
 
-  if (nTrack->GetName() == trkName && nTrack->GetDescription() == trkDescr && \
-    nTrack->GetColor(0) == trkColor)
-    return; // New parameters match existing track params. Nothing to update.
+  if (nTrack->GetName() == trkName && nTrack->GetDescription() == trkDescr && nTrack->GetColor(0) == trkColor)
+    return;  // New parameters match existing track params. Nothing to update.
 
   kml::TrackData trackData(nTrack->GetData());
   kml::SetDefaultStr(trackData.m_name, trkName);
@@ -154,7 +153,7 @@ JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_Track_nativeChangeColor(J
   uint8_t alpha = ExtractByte(color, 3);
   auto const trkColor = static_cast<dp::Color>(shift(color, 8) + alpha);
   if (nTrack->GetColor(0) == trkColor)
-    return; // New color is the same as old one.
+    return;  // New color is the same as old one.
 
   g_framework->ChangeTrackColor(static_cast<kml::TrackId>(id), static_cast<dp::Color>(trkColor));
 }

--- a/data/test_data/kml/generated.kml
+++ b/data/test_data/kml/generated.kml
@@ -270,6 +270,47 @@
     </ExtendedData>
   </Placemark>
   <Placemark>
+    <name>Хочу побывать</name>
+    <description>Test bookmark description</description>
+    <TimeStamp>
+        <when>1970-01-01T00:26:40Z</when>
+        <modified>1970-01-01T00:40:00Z</modified>
+    </TimeStamp>
+    <styleUrl>#placemark-red</styleUrl>
+    <Point><coordinates>-80.12702,25.79145</coordinates></Point>
+    <ExtendedData xmlns:mwm="https://omaps.app">
+      <mwm:name>
+        <mwm:lang code="ru">Маями</mwm:lang>
+        <mwm:lang code="default">Miami Beach</mwm:lang>
+      </mwm:name>
+      <mwm:description>
+        <mwm:lang code="ru">Отличное место для солнечных ванн</mwm:lang>
+        <mwm:lang code="default">Nice place to tan</mwm:lang>
+      </mwm:description>
+      <mwm:featureTypes>
+        <mwm:value>historic-castle</mwm:value>
+        <mwm:value>historic-memorial</mwm:value>
+      </mwm:featureTypes>
+      <mwm:customName>
+        <mwm:lang code="en">Place I want to visit</mwm:lang>
+        <mwm:lang code="default">Хочу побывать</mwm:lang>
+      </mwm:customName>
+      <mwm:scale>15</mwm:scale>
+      <mwm:boundTracks>
+        <mwm:value>0</mwm:value>
+      </mwm:boundTracks>
+      <mwm:visibility>1</mwm:visibility>
+      <mwm:nearestToponym>Miami</mwm:nearestToponym>
+      <mwm:minZoom>10</mwm:minZoom>
+      <mwm:properties>
+        <mwm:value key="om_property1">value1</mwm:value>
+        <mwm:value key="om_property2">value2</mwm:value>
+        <mwm:value key="score">A</mwm:value>
+      </mwm:properties>
+      <mwm:compilations>1,3,5</mwm:compilations>
+    </ExtendedData>
+  </Placemark>
+  <Placemark>
     <name>Test track</name>
     <description>Test track description</description>
     <Style><LineStyle>

--- a/data/test_data/kml/generated.kml
+++ b/data/test_data/kml/generated.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://earth.google.com/kml/2.2">
+<kml xmlns="http://earth.google.com/kml/2.2" xmlns:om="https://omaps.app">
 <Document>
   <Style id="placemark-red">
     <IconStyle>
@@ -296,7 +296,7 @@
         <mwm:value>0</mwm:value>
       </mwm:boundTracks>
       <mwm:visibility>1</mwm:visibility>
-      <mwm:modifiedTimestamp>1970-01-01T00:40:00Z</mwm:modifiedTimestamp>
+      <om:modified>1970-01-01T00:40:00Z</om:modified>
       <mwm:nearestToponym>Miami</mwm:nearestToponym>
       <mwm:minZoom>10</mwm:minZoom>
       <mwm:properties>
@@ -333,7 +333,7 @@
         </mwm:additionalLineStyle>
       </mwm:additionalStyle>
       <mwm:visibility>0</mwm:visibility>
-      <mwm:modifiedTimestamp>1970-01-01T00:20:00Z</mwm:modifiedTimestamp>
+      <om:modified>1970-01-01T00:20:00Z</om:modified>
       <mwm:nearestToponyms>
         <mwm:value>12345</mwm:value>
         <mwm:value>54321</mwm:value>

--- a/data/test_data/kml/generated.kml
+++ b/data/test_data/kml/generated.kml
@@ -317,7 +317,7 @@
       <color>FF0000FF</color>
       <width>6</width>
     </LineStyle></Style>
-    <TimeStamp><when>1970-01-01T00:15:00Z</when></TimeStamp>
+    <TimeStamp><when>1970-01-01T00:15:00Z</when><modified>1970-01-01T00:20:00Z</modified></TimeStamp>
     <LineString><coordinates>45.9242,49.3268593,1 45.2244,48.9412882,2 45.1964,49.4019479,3</coordinates></LineString>
     <ExtendedData xmlns:mwm="https://omaps.app">
       <mwm:name>

--- a/data/test_data/kml/generated.kml
+++ b/data/test_data/kml/generated.kml
@@ -272,10 +272,7 @@
   <Placemark>
     <name>Хочу побывать</name>
     <description>Test bookmark description</description>
-    <TimeStamp>
-        <when>1970-01-01T00:26:40Z</when>
-        <modified>1970-01-01T00:40:00Z</modified>
-    </TimeStamp>
+    <TimeStamp><when>1970-01-01T00:26:40Z</when></TimeStamp>
     <styleUrl>#placemark-red</styleUrl>
     <Point><coordinates>-80.12702,25.79145</coordinates></Point>
     <ExtendedData xmlns:mwm="https://omaps.app">
@@ -300,6 +297,7 @@
         <mwm:value>0</mwm:value>
       </mwm:boundTracks>
       <mwm:visibility>1</mwm:visibility>
+      <mwm:modifiedTimestamp>1970-01-01T00:40:00Z</mwm:modifiedTimestamp>
       <mwm:nearestToponym>Miami</mwm:nearestToponym>
       <mwm:minZoom>10</mwm:minZoom>
       <mwm:properties>
@@ -317,7 +315,7 @@
       <color>FF0000FF</color>
       <width>6</width>
     </LineStyle></Style>
-    <TimeStamp><when>1970-01-01T00:15:00Z</when><modified>1970-01-01T00:20:00Z</modified></TimeStamp>
+    <TimeStamp><when>1970-01-01T00:15:00Z</when></TimeStamp>
     <LineString><coordinates>45.9242,49.3268593,1 45.2244,48.9412882,2 45.1964,49.4019479,3</coordinates></LineString>
     <ExtendedData xmlns:mwm="https://omaps.app">
       <mwm:name>
@@ -336,6 +334,7 @@
         </mwm:additionalLineStyle>
       </mwm:additionalStyle>
       <mwm:visibility>0</mwm:visibility>
+      <mwm:modifiedTimestamp>1970-01-01T00:20:00Z</mwm:modifiedTimestamp>
       <mwm:nearestToponyms>
         <mwm:value>12345</mwm:value>
         <mwm:value>54321</mwm:value>

--- a/data/test_data/kml/generated.kml
+++ b/data/test_data/kml/generated.kml
@@ -285,8 +285,7 @@
         <mwm:lang code="default">Nice place to tan</mwm:lang>
       </mwm:description>
       <mwm:featureTypes>
-        <mwm:value>historic-castle</mwm:value>
-        <mwm:value>historic-memorial</mwm:value>
+        <mwm:value>leisure-beach_resort</mwm:value>
       </mwm:featureTypes>
       <mwm:customName>
         <mwm:lang code="en">Place I want to visit</mwm:lang>

--- a/data/test_data/kml/generated_mixed_tracks.kml
+++ b/data/test_data/kml/generated_mixed_tracks.kml
@@ -270,6 +270,47 @@
     </ExtendedData>
   </Placemark>
   <Placemark>
+    <name>Хочу побывать</name>
+    <description>Test bookmark description</description>
+    <TimeStamp>
+        <when>1970-01-01T00:26:40Z</when>
+        <modified>1970-01-01T00:40:00Z</modified>
+    </TimeStamp>
+    <styleUrl>#placemark-red</styleUrl>
+    <Point><coordinates>-80.12702,25.79145</coordinates></Point>
+    <ExtendedData xmlns:mwm="https://omaps.app">
+      <mwm:name>
+        <mwm:lang code="ru">Маями</mwm:lang>
+        <mwm:lang code="default">Miami Beach</mwm:lang>
+      </mwm:name>
+      <mwm:description>
+        <mwm:lang code="ru">Отличное место для солнечных ванн</mwm:lang>
+        <mwm:lang code="default">Nice place to tan</mwm:lang>
+      </mwm:description>
+      <mwm:featureTypes>
+        <mwm:value>historic-castle</mwm:value>
+        <mwm:value>historic-memorial</mwm:value>
+      </mwm:featureTypes>
+      <mwm:customName>
+        <mwm:lang code="en">Place I want to visit</mwm:lang>
+        <mwm:lang code="default">Хочу побывать</mwm:lang>
+      </mwm:customName>
+      <mwm:scale>15</mwm:scale>
+      <mwm:boundTracks>
+        <mwm:value>0</mwm:value>
+      </mwm:boundTracks>
+      <mwm:visibility>1</mwm:visibility>
+      <mwm:nearestToponym>Miami</mwm:nearestToponym>
+      <mwm:minZoom>10</mwm:minZoom>
+      <mwm:properties>
+        <mwm:value key="om_property1">value1</mwm:value>
+        <mwm:value key="om_property2">value2</mwm:value>
+        <mwm:value key="score">A</mwm:value>
+      </mwm:properties>
+      <mwm:compilations>1,3,5</mwm:compilations>
+    </ExtendedData>
+  </Placemark>
+  <Placemark>
     <name>Test track</name>
     <description>Test track description</description>
     <Style><LineStyle>

--- a/data/test_data/kml/generated_mixed_tracks.kml
+++ b/data/test_data/kml/generated_mixed_tracks.kml
@@ -317,7 +317,7 @@
       <color>FF0000FF</color>
       <width>6</width>
     </LineStyle></Style>
-    <TimeStamp><when>1970-01-01T00:15:00Z</when></TimeStamp>
+    <TimeStamp><when>1970-01-01T00:15:00Z</when><modified>1970-01-01T00:20:00Z</modified></TimeStamp>
     <LineString><coordinates>45.9242,49.326859,1 45.2244,48.941288,2 45.1964,49.401948,3</coordinates></LineString>
     <gx:MultiTrack>
       <gx:Track>

--- a/data/test_data/kml/generated_mixed_tracks.kml
+++ b/data/test_data/kml/generated_mixed_tracks.kml
@@ -272,10 +272,7 @@
   <Placemark>
     <name>Хочу побывать</name>
     <description>Test bookmark description</description>
-    <TimeStamp>
-        <when>1970-01-01T00:26:40Z</when>
-        <modified>1970-01-01T00:40:00Z</modified>
-    </TimeStamp>
+    <TimeStamp><when>1970-01-01T00:26:40Z</when></TimeStamp>
     <styleUrl>#placemark-red</styleUrl>
     <Point><coordinates>-80.12702,25.79145</coordinates></Point>
     <ExtendedData xmlns:mwm="https://omaps.app">
@@ -300,6 +297,7 @@
         <mwm:value>0</mwm:value>
       </mwm:boundTracks>
       <mwm:visibility>1</mwm:visibility>
+      <mwm:modifiedTimestamp>1970-01-01T00:40:00Z</mwm:modifiedTimestamp>
       <mwm:nearestToponym>Miami</mwm:nearestToponym>
       <mwm:minZoom>10</mwm:minZoom>
       <mwm:properties>
@@ -317,7 +315,7 @@
       <color>FF0000FF</color>
       <width>6</width>
     </LineStyle></Style>
-    <TimeStamp><when>1970-01-01T00:15:00Z</when><modified>1970-01-01T00:20:00Z</modified></TimeStamp>
+    <TimeStamp><when>1970-01-01T00:15:00Z</when></TimeStamp>
     <LineString><coordinates>45.9242,49.326859,1 45.2244,48.941288,2 45.1964,49.401948,3</coordinates></LineString>
     <gx:MultiTrack>
       <gx:Track>
@@ -352,6 +350,7 @@
         </mwm:additionalLineStyle>
       </mwm:additionalStyle>
       <mwm:visibility>0</mwm:visibility>
+      <mwm:modifiedTimestamp>1970-01-01T00:20:00Z</mwm:modifiedTimestamp>
       <mwm:nearestToponyms>
         <mwm:value>12345</mwm:value>
         <mwm:value>54321</mwm:value>

--- a/data/test_data/kml/generated_mixed_tracks.kml
+++ b/data/test_data/kml/generated_mixed_tracks.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:om="https://omaps.app">
 <Document>
   <Style id="placemark-red">
     <IconStyle>
@@ -296,7 +296,7 @@
         <mwm:value>0</mwm:value>
       </mwm:boundTracks>
       <mwm:visibility>1</mwm:visibility>
-      <mwm:modifiedTimestamp>1970-01-01T00:40:00Z</mwm:modifiedTimestamp>
+      <om:modified>1970-01-01T00:40:00Z</om:modified>
       <mwm:nearestToponym>Miami</mwm:nearestToponym>
       <mwm:minZoom>10</mwm:minZoom>
       <mwm:properties>
@@ -349,7 +349,7 @@
         </mwm:additionalLineStyle>
       </mwm:additionalStyle>
       <mwm:visibility>0</mwm:visibility>
-      <mwm:modifiedTimestamp>1970-01-01T00:20:00Z</mwm:modifiedTimestamp>
+      <om:modified>1970-01-01T00:20:00Z</om:modified>
       <mwm:nearestToponyms>
         <mwm:value>12345</mwm:value>
         <mwm:value>54321</mwm:value>

--- a/data/test_data/kml/generated_mixed_tracks.kml
+++ b/data/test_data/kml/generated_mixed_tracks.kml
@@ -285,8 +285,7 @@
         <mwm:lang code="default">Nice place to tan</mwm:lang>
       </mwm:description>
       <mwm:featureTypes>
-        <mwm:value>historic-castle</mwm:value>
-        <mwm:value>historic-memorial</mwm:value>
+        <mwm:value>leisure-beach_resort</mwm:value>
       </mwm:featureTypes>
       <mwm:customName>
         <mwm:lang code="en">Place I want to visit</mwm:lang>

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -815,6 +815,9 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
   auto const currentColor = track->GetColor(0);
   auto const newColor = [MWMBookmarksManager getColorFromUIColor:color];
 
+  if (newColor == currentColor && track->GetName()==title.UTF8String)
+    return;  // No changes in track parameters.
+
   if (newColor != currentColor)
     track->SetColor(newColor);
 
@@ -833,9 +836,11 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
   auto const currentColor = track->GetColor(0);
   auto const newColor = [MWMBookmarksManager getColorFromUIColor:color];
 
-  if (newColor != currentColor)
-    track->SetColor(newColor);
-  track->SetModifiedTimeStamp(kml::TimestampClock::now());
+  if (newColor == currentColor)
+      return;  // Nothing to update.
+
+  track->SetColor(newColor);
+  track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 - (void)moveTrack:(MWMTrackID)trackId toGroupId:(MWMMarkGroupID)groupId

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -754,7 +754,7 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
   bookmark->SetDescription(description.UTF8String);
   if (title.UTF8String != bookmark->GetPreferredName())
     bookmark->SetCustomName(title.UTF8String);
-  bookmark->SetModifiedTimeStamp(kml::TimestampClock::now());
+  bookmark->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 - (void)updateBookmark:(MWMMarkID)bookmarkId setColor:(UIColor *)color
@@ -770,7 +770,7 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
 
   self.bm.SetLastEditedBmColor(kml::MakeCustomBookmarkColorData(newColor));
   bookmark->SetColor(newColor);
-  bookmark->SetModifiedTimeStamp(kml::TimestampClock::now());
+  bookmark->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 - (void)setCategory:(MWMMarkGroupID)groupId bookmarksColor:(UIColor *)color
@@ -823,7 +823,7 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
 
   track->SetName(title.UTF8String);
   track->SetDescription(description.UTF8String);
-  track->SetModifiedTimeStamp(kml::TimestampClock::now());
+  track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 - (void)updateTrack:(MWMTrackID)trackId setColor:(UIColor *)color

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -754,7 +754,6 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
   bookmark->SetDescription(description.UTF8String);
   if (title.UTF8String != bookmark->GetPreferredName())
     bookmark->SetCustomName(title.UTF8String);
-  bookmark->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 - (void)updateBookmark:(MWMMarkID)bookmarkId setColor:(UIColor *)color
@@ -770,7 +769,6 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
 
   self.bm.SetLastEditedBmColor(kml::MakeCustomBookmarkColorData(newColor));
   bookmark->SetColor(newColor);
-  bookmark->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 - (void)setCategory:(MWMMarkGroupID)groupId bookmarksColor:(UIColor *)color
@@ -815,7 +813,8 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
   auto const currentColor = track->GetColor(0);
   auto const newColor = [MWMBookmarksManager getColorFromUIColor:color];
 
-  if (newColor == currentColor && track->GetName() == title.UTF8String)
+  if (newColor == currentColor && track->GetName() == title.UTF8String &&
+      track->GetDescription() == description.UTF8String)
     return;  // No changes in track parameters.
 
   if (newColor != currentColor)
@@ -823,7 +822,6 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
 
   track->SetName(title.UTF8String);
   track->SetDescription(description.UTF8String);
-  track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 - (void)updateTrack:(MWMTrackID)trackId setColor:(UIColor *)color
@@ -840,7 +838,6 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
     return;  // Nothing to update.
 
   track->SetColor(newColor);
-  track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 - (void)moveTrack:(MWMTrackID)trackId toGroupId:(MWMMarkGroupID)groupId

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -815,7 +815,7 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
   auto const currentColor = track->GetColor(0);
   auto const newColor = [MWMBookmarksManager getColorFromUIColor:color];
 
-  if (newColor == currentColor && track->GetName()==title.UTF8String)
+  if (newColor == currentColor && track->GetName() == title.UTF8String)
     return;  // No changes in track parameters.
 
   if (newColor != currentColor)
@@ -837,7 +837,7 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
   auto const newColor = [MWMBookmarksManager getColorFromUIColor:color];
 
   if (newColor == currentColor)
-      return;  // Nothing to update.
+    return;  // Nothing to update.
 
   track->SetColor(newColor);
   track->SetModifiedTimestamp(kml::TimestampClock::now());

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -749,6 +749,7 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
   bookmark->SetDescription(description.UTF8String);
   if (title.UTF8String != bookmark->GetPreferredName())
     bookmark->SetCustomName(title.UTF8String);
+  bookmark->SetModifiedTimeStamp(kml::TimestampClock::now());
 }
 
 - (void)updateBookmark:(MWMMarkID)bookmarkId setColor:(UIColor *)color
@@ -763,6 +764,7 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
     self.bm.SetLastEditedBmColor(kml::MakeCustomBookmarkColorData(newColor));
 
   bookmark->SetColor(newColor);
+  bookmark->SetModifiedTimeStamp(kml::TimestampClock::now());
 }
 
 - (void)setCategory:(MWMMarkGroupID)groupId bookmarksColor:(UIColor *)color
@@ -812,6 +814,7 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
 
   track->SetName(title.UTF8String);
   track->SetDescription(description.UTF8String);
+  track->SetModifiedTimeStamp(kml::TimestampClock::now());
 }
 
 - (void)updateTrack:(MWMTrackID)trackId setColor:(UIColor *)color
@@ -826,6 +829,7 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
 
   if (newColor != currentColor)
     track->SetColor(newColor);
+  track->SetModifiedTimeStamp(kml::TimestampClock::now());
 }
 
 - (void)moveTrack:(MWMTrackID)trackId toGroupId:(MWMMarkGroupID)groupId

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -745,7 +745,7 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
 
   if (bookmark->GetPreferredName() == title.UTF8String && bookmark->GetDescription() == description.UTF8String &&
       bookmark->GetColorForRendering() == newColor)
-    return; // No changes in bookmark parameters.
+    return;  // No changes in bookmark parameters.
 
   if (newColor != bookmark->GetColorForRendering())
     self.bm.SetLastEditedBmColor(kml::MakeCustomBookmarkColorData(newColor));
@@ -766,7 +766,7 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
 
   auto const newColor = [MWMBookmarksManager getColorFromUIColor:color];
   if (newColor == bookmark->GetColorForRendering())
-    return; // New color is the same as existing color. Nothing to update.
+    return;  // New color is the same as existing color. Nothing to update.
 
   self.bm.SetLastEditedBmColor(kml::MakeCustomBookmarkColorData(newColor));
   bookmark->SetColor(newColor);

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -742,6 +742,11 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
   ASSERT(bookmark, ("Invalid bookmark id:", bookmarkId));
 
   auto const newColor = [MWMBookmarksManager getColorFromUIColor:color];
+
+  if (bookmark->GetPreferredName() == title.UTF8String && bookmark->GetDescription() == description.UTF8String &&
+      bookmark->GetColorForRendering() == newColor)
+    return; // No changes in bookmark parameters.
+
   if (newColor != bookmark->GetColorForRendering())
     self.bm.SetLastEditedBmColor(kml::MakeCustomBookmarkColorData(newColor));
 
@@ -760,9 +765,10 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
   ASSERT(bookmark, ("Invalid bookmark id:", bookmarkId));
 
   auto const newColor = [MWMBookmarksManager getColorFromUIColor:color];
-  if (newColor != bookmark->GetColorForRendering())
-    self.bm.SetLastEditedBmColor(kml::MakeCustomBookmarkColorData(newColor));
+  if (newColor == bookmark->GetColorForRendering())
+    return; // New color is the same as existing color. Nothing to update.
 
+  self.bm.SetLastEditedBmColor(kml::MakeCustomBookmarkColorData(newColor));
   bookmark->SetColor(newColor);
   bookmark->SetModifiedTimeStamp(kml::TimestampClock::now());
 }

--- a/libs/kml/kml_tests/geojson_tests.cpp
+++ b/libs/kml/kml_tests/geojson_tests.cpp
@@ -784,7 +784,7 @@ kml::FileData GenerateKmlFileData()
   bookmarkData.m_customName[kEnLang] = "My favorite place";
   bookmarkData.m_color = {kml::PredefinedColor::Blue, 0};
   bookmarkData.m_icon = kml::BookmarkIcon::None;
-  bookmarkData.m_timestamp = kml::TimestampClock::from_time_t(800);
+  bookmarkData.m_createdTimestamp = kml::TimestampClock::from_time_t(800);
   bookmarkData.m_point = mercator::FromLatLon(52.48982, 13.39712);
   bookmarkData.m_visible = false;
   bookmarkData.m_minZoom = 10;
@@ -809,7 +809,7 @@ kml::FileData GenerateKmlFileDataWithTrack()
   trackData.m_description[kEsLang] = "Descripción de prueba de la pista.";
   trackData.m_layers = {{6.0, {kml::PredefinedColor::None, 0xff0000ff}},
                         {7.0, {kml::PredefinedColor::None, 0x00ff00ff}}};
-  trackData.m_timestamp = kml::TimestampClock::from_time_t(900);
+  trackData.m_createdTimestamp = kml::TimestampClock::from_time_t(900);
 
   trackData.m_geometry.AddLine({{mercator::FromLatLon(47, 45.25), 1},
                                 {mercator::FromLatLon(48, 45.5), 2},
@@ -822,7 +822,7 @@ kml::FileData GenerateKmlFileDataWithTrack()
   trackData2.m_localId = 1;
   trackData2.m_name[kDefaultLang] = "Another track";
   trackData2.m_layers = {{6.0, {kml::PredefinedColor::None, 0x93bf39ff}}};
-  trackData2.m_timestamp = kml::TimestampClock::from_time_t(960);
+  trackData2.m_createdTimestamp = kml::TimestampClock::from_time_t(960);
 
   trackData2.m_geometry.AddLine(
       {{mercator::FromLatLon(22, 30.1), 1}, {mercator::FromLatLon(23, 30.2), 2}, {mercator::FromLatLon(24, 30.3), 3}});
@@ -847,7 +847,7 @@ kml::FileData GenerateKmlFileDataWithMultiTrack()
   trackData.m_description[kEsLang] = "Descripción de prueba de la pista.";
   trackData.m_layers = {{6.0, {kml::PredefinedColor::None, 0x00ff00ff}},
                         {7.0, {kml::PredefinedColor::None, 0x0000ffff}}};
-  trackData.m_timestamp = kml::TimestampClock::from_time_t(900);
+  trackData.m_createdTimestamp = kml::TimestampClock::from_time_t(900);
 
   trackData.m_geometry.AddLine({{mercator::FromLatLon(47, 45.25), 1},
                                 {mercator::FromLatLon(48, 45.5), 2},

--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -121,7 +121,6 @@ kml::FileData GenerateKmlFileData()
   result.m_bookmarksData.emplace_back(std::move(bookmarkData2));
 
 
-/////////////////////
   kml::TrackData trackData;
   trackData.m_localId = 0;
   trackData.m_name[kDefaultLang] = "Test track";
@@ -387,7 +386,7 @@ UNIT_TEST(Kml_Serialization_Bin_File)
 {
   classificator::Load();
   auto const data = GenerateKmlFileData();
-  // KMB format doesn't have 'editTimestamp' field. Let's erase this field.
+  // KMB format doesn't have 'm_modifiedTimestamp' field. Let's erase this field.
   for (auto & bookmark : data.m_bookmarksData)
     bookmark.m_modifiedTimestamp = kml::Timestamp();
   for (auto & track : data.m_tracksData)

--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -102,7 +102,7 @@ kml::FileData GenerateKmlFileData()
   bookmarkData2.m_name[kRuLang] = "Маями";
   bookmarkData2.m_description[kDefaultLang] = "Nice place to tan";
   bookmarkData2.m_description[kRuLang] = "Отличное место для солнечных ванн";
-  bookmarkData2.m_featureTypes = {718, 715};
+  bookmarkData2.m_featureTypes = {cl.GetTypeByPath({"leisure", "beach_resort"})};
   bookmarkData2.m_customName[kDefaultLang] = "Хочу побывать";
   bookmarkData2.m_customName[kEnLang] = "Place I want to visit";
   bookmarkData2.m_color = {kml::PredefinedColor::Red, 0};

--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -97,7 +97,6 @@ kml::FileData GenerateKmlFileData()
   bookmarkData1.m_compilations = {1, 2, 3, 4, 5};
   result.m_bookmarksData.emplace_back(std::move(bookmarkData1));
 
-
   kml::BookmarkData bookmarkData2;
   bookmarkData2.m_name[kDefaultLang] = "Miami Beach";
   bookmarkData2.m_name[kRuLang] = "Маями";
@@ -119,7 +118,6 @@ kml::FileData GenerateKmlFileData()
   bookmarkData2.m_properties = {{"om_property1", "value1"}, {"om_property2", "value2"}, {"score", "A"}};
   bookmarkData2.m_compilations = {1, 3, 5};
   result.m_bookmarksData.emplace_back(std::move(bookmarkData2));
-
 
   kml::TrackData trackData;
   trackData.m_localId = 0;
@@ -391,7 +389,6 @@ UNIT_TEST(Kml_Serialization_Bin_File)
     bookmark.m_modifiedTimestamp = kml::Timestamp();
   for (auto & track : data.m_tracksData)
     track.m_modifiedTimestamp = kml::Timestamp();
-
 
   std::string const kmbFile = base::JoinPath(GetPlatform().TmpDir(), "tmp.kmb");
   SCOPE_GUARD(fileGuard, std::bind(&FileWriter::DeleteFileX, kmbFile));

--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -87,7 +87,7 @@ kml::FileData GenerateKmlFileData()
   bookmarkData1.m_color = {kml::PredefinedColor::Blue, 0};
   bookmarkData1.m_icon = kml::BookmarkIcon::None;
   bookmarkData1.m_viewportScale = 15;
-  bookmarkData1.m_timestamp = kml::TimestampClock::from_time_t(800);
+  bookmarkData1.m_createdTimestamp = kml::TimestampClock::from_time_t(800);
   bookmarkData1.m_point = m2::PointD(45.9242, 56.8679);
   bookmarkData1.m_boundTracks = {0};
   bookmarkData1.m_visible = false;
@@ -109,8 +109,8 @@ kml::FileData GenerateKmlFileData()
   bookmarkData2.m_color = {kml::PredefinedColor::Red, 0};
   bookmarkData2.m_icon = kml::BookmarkIcon::None;
   bookmarkData2.m_viewportScale = 15;
-  bookmarkData2.m_timestamp = kml::TimestampClock::from_time_t(1600);
-  bookmarkData2.m_editTimestamp = kml::TimestampClock::from_time_t(2400);
+  bookmarkData2.m_createdTimestamp = kml::TimestampClock::from_time_t(1600);
+  bookmarkData2.m_modifiedTimestamp = kml::TimestampClock::from_time_t(2400);
   bookmarkData2.m_point = m2::PointD(-80.12702, 26.709375);
   bookmarkData2.m_boundTracks = {0};
   bookmarkData2.m_visible = true;
@@ -130,8 +130,8 @@ kml::FileData GenerateKmlFileData()
   trackData.m_description[kRuLang] = "Тестовое описание трека";
   trackData.m_layers = {{6.0, {kml::PredefinedColor::None, 0xff0000ff}},
                         {7.0, {kml::PredefinedColor::None, 0x00ff00ff}}};
-  trackData.m_timestamp = kml::TimestampClock::from_time_t(900);
-  trackData.m_editTimestamp = kml::TimestampClock::from_time_t(1200);
+  trackData.m_createdTimestamp = kml::TimestampClock::from_time_t(900);
+  trackData.m_modifiedTimestamp = kml::TimestampClock::from_time_t(1200);
 
   trackData.m_geometry.AddLine({{{45.9242, 56.8679}, 1}, {{45.2244, 56.2786}, 2}, {{45.1964, 56.9832}, 3}});
 
@@ -389,9 +389,9 @@ UNIT_TEST(Kml_Serialization_Bin_File)
   auto const data = GenerateKmlFileData();
   // KMB format doesn't have 'editTimestamp' field. Let's erase this field.
   for (auto & bookmark : data.m_bookmarksData)
-    bookmark.m_editTimestamp = kml::Timestamp();
+    bookmark.m_modifiedTimestamp = kml::Timestamp();
   for (auto & track : data.m_tracksData)
-    track.m_editTimestamp = kml::Timestamp();
+    track.m_modifiedTimestamp = kml::Timestamp();
 
 
   std::string const kmbFile = base::JoinPath(GetPlatform().TmpDir(), "tmp.kmb");

--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -131,6 +131,7 @@ kml::FileData GenerateKmlFileData()
   trackData.m_layers = {{6.0, {kml::PredefinedColor::None, 0xff0000ff}},
                         {7.0, {kml::PredefinedColor::None, 0x00ff00ff}}};
   trackData.m_timestamp = kml::TimestampClock::from_time_t(900);
+  trackData.m_editTimestamp = kml::TimestampClock::from_time_t(1200);
 
   trackData.m_geometry.AddLine({{{45.9242, 56.8679}, 1}, {{45.2244, 56.2786}, 2}, {{45.1964, 56.9832}, 3}});
 
@@ -389,6 +390,8 @@ UNIT_TEST(Kml_Serialization_Bin_File)
   // KMB format doesn't have 'editTimestamp' field. Let's erase this field.
   for (auto & bookmark : data.m_bookmarksData)
     bookmark.m_editTimestamp = kml::Timestamp();
+  for (auto & track : data.m_tracksData)
+    track.m_editTimestamp = kml::Timestamp();
 
 
   std::string const kmbFile = base::JoinPath(GetPlatform().TmpDir(), "tmp.kmb");

--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -73,30 +73,55 @@ kml::FileData GenerateKmlFileData()
   result.m_categoryData.m_languageCodes = {1, 2, 8};
   result.m_categoryData.m_properties = {{"property1", "value1"}, {"property2", "value2"}};
 
-  kml::BookmarkData bookmarkData;
-  bookmarkData.m_name[kDefaultLang] = "Test bookmark";
-  bookmarkData.m_name[kRuLang] = "Тестовая метка";
-  bookmarkData.m_description[kDefaultLang] = "Test bookmark description";
-  bookmarkData.m_description[kRuLang] = "Тестовое описание метки";
+  kml::BookmarkData bookmarkData1;
+  bookmarkData1.m_name[kDefaultLang] = "Test bookmark";
+  bookmarkData1.m_name[kRuLang] = "Тестовая метка";
+  bookmarkData1.m_description[kDefaultLang] = "Test bookmark description";
+  bookmarkData1.m_description[kRuLang] = "Тестовое описание метки";
 
   auto const & cl = classif();
-  bookmarkData.m_featureTypes = {cl.GetTypeByPath({"historic", "castle"}), cl.GetTypeByPath({"historic", "memorial"})};
+  bookmarkData1.m_featureTypes = {cl.GetTypeByPath({"historic", "castle"}), cl.GetTypeByPath({"historic", "memorial"})};
 
-  bookmarkData.m_customName[kDefaultLang] = "Мое любимое место";
-  bookmarkData.m_customName[kEnLang] = "My favorite place";
-  bookmarkData.m_color = {kml::PredefinedColor::Blue, 0};
-  bookmarkData.m_icon = kml::BookmarkIcon::None;
-  bookmarkData.m_viewportScale = 15;
-  bookmarkData.m_timestamp = kml::TimestampClock::from_time_t(800);
-  bookmarkData.m_point = m2::PointD(45.9242, 56.8679);
-  bookmarkData.m_boundTracks = {0};
-  bookmarkData.m_visible = false;
-  bookmarkData.m_nearestToponym = "12345";
-  bookmarkData.m_minZoom = 10;
-  bookmarkData.m_properties = {{"bm_property1", "value1"}, {"bm_property2", "value2"}, {"score", "5"}};
-  bookmarkData.m_compilations = {1, 2, 3, 4, 5};
-  result.m_bookmarksData.emplace_back(std::move(bookmarkData));
+  bookmarkData1.m_customName[kDefaultLang] = "Мое любимое место";
+  bookmarkData1.m_customName[kEnLang] = "My favorite place";
+  bookmarkData1.m_color = {kml::PredefinedColor::Blue, 0};
+  bookmarkData1.m_icon = kml::BookmarkIcon::None;
+  bookmarkData1.m_viewportScale = 15;
+  bookmarkData1.m_timestamp = kml::TimestampClock::from_time_t(800);
+  bookmarkData1.m_point = m2::PointD(45.9242, 56.8679);
+  bookmarkData1.m_boundTracks = {0};
+  bookmarkData1.m_visible = false;
+  bookmarkData1.m_nearestToponym = "12345";
+  bookmarkData1.m_minZoom = 10;
+  bookmarkData1.m_properties = {{"bm_property1", "value1"}, {"bm_property2", "value2"}, {"score", "5"}};
+  bookmarkData1.m_compilations = {1, 2, 3, 4, 5};
+  result.m_bookmarksData.emplace_back(std::move(bookmarkData1));
 
+
+  kml::BookmarkData bookmarkData2;
+  bookmarkData2.m_name[kDefaultLang] = "Miami Beach";
+  bookmarkData2.m_name[kRuLang] = "Маями";
+  bookmarkData2.m_description[kDefaultLang] = "Nice place to tan";
+  bookmarkData2.m_description[kRuLang] = "Отличное место для солнечных ванн";
+  bookmarkData2.m_featureTypes = {718, 715};
+  bookmarkData2.m_customName[kDefaultLang] = "Хочу побывать";
+  bookmarkData2.m_customName[kEnLang] = "Place I want to visit";
+  bookmarkData2.m_color = {kml::PredefinedColor::Red, 0};
+  bookmarkData2.m_icon = kml::BookmarkIcon::None;
+  bookmarkData2.m_viewportScale = 15;
+  bookmarkData2.m_timestamp = kml::TimestampClock::from_time_t(1600);
+  bookmarkData2.m_editTimestamp = kml::TimestampClock::from_time_t(2400);
+  bookmarkData2.m_point = m2::PointD(-80.12702, 26.709375);
+  bookmarkData2.m_boundTracks = {0};
+  bookmarkData2.m_visible = true;
+  bookmarkData2.m_nearestToponym = "Miami";
+  bookmarkData2.m_minZoom = 10;
+  bookmarkData2.m_properties = {{"om_property1", "value1"}, {"om_property2", "value2"}, {"score", "A"}};
+  bookmarkData2.m_compilations = {1, 3, 5};
+  result.m_bookmarksData.emplace_back(std::move(bookmarkData2));
+
+
+/////////////////////
   kml::TrackData trackData;
   trackData.m_localId = 0;
   trackData.m_name[kDefaultLang] = "Test track";
@@ -361,6 +386,10 @@ UNIT_TEST(Kml_Serialization_Bin_File)
 {
   classificator::Load();
   auto const data = GenerateKmlFileData();
+  // KMB format doesn't have 'editTimestamp' field. Let's erase this field.
+  for (auto & bookmark : data.m_bookmarksData)
+    bookmark.m_editTimestamp = kml::Timestamp();
+
 
   std::string const kmbFile = base::JoinPath(GetPlatform().TmpDir(), "tmp.kmb");
   SCOPE_GUARD(fileGuard, std::bind(&FileWriter::DeleteFileX, kmbFile));

--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -385,7 +385,7 @@ UNIT_TEST(Kml_Deserialization_Bin_File)
 UNIT_TEST(Kml_Serialization_Bin_File)
 {
   classificator::Load();
-  auto const data = GenerateKmlFileData();
+  auto data = GenerateKmlFileData();
   // KMB format doesn't have 'm_modifiedTimestamp' field. Let's erase this field.
   for (auto & bookmark : data.m_bookmarksData)
     bookmark.m_modifiedTimestamp = kml::Timestamp();

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -40,7 +40,7 @@ bool IsCoord(std::string const & s)
   return s == "coord" || s == "gx:coord";
 }
 
-bool IsCreatedTimestamp(std::string const & s)
+bool IsWhenTag(std::string const & s)
 {
   return s == "when";
 }
@@ -1155,7 +1155,7 @@ void KmlParser::CharData(std::string & value)
       if (!IsTrack(prevTag))
         return false;
 
-      if (IsCreatedTimestamp(currTag))
+      if (IsWhenTag(currTag))
       {
         auto & timestamps = m_geometry.m_timestamps;
         ASSERT(!timestamps.empty(), ());
@@ -1441,7 +1441,7 @@ void KmlParser::CharData(std::string & value)
       }
       else if (prevTag == "TimeStamp")
       {
-        if (IsCreatedTimestamp(currTag))
+        if (IsWhenTag(currTag))
         {
           auto const ts = base::StringToTimestamp(value);
           if (ts != base::INVALID_TIME_STAMP)

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -45,11 +45,6 @@ bool IsCreatedTimestamp(std::string const & s)
   return s == "when";
 }
 
-bool IsModifiedTimestamp(std::string const & s)
-{
-  return s == "modified";
-}
-
 std::string_view constexpr kKmlHeader =
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
     "<kml xmlns=\"http://www.opengis.net/kml/2.2\" xmlns:gx=\"http://www.google.com/kml/ext/2.2\">\n"
@@ -406,6 +401,9 @@ void SaveBookmarkExtendedData(Writer & writer, BookmarkData const & bookmarkData
   }
 
   writer << kIndent6 << "<mwm:visibility>" << (bookmarkData.m_visible ? "1" : "0") << "</mwm:visibility>\n";
+  if (bookmarkData.m_modifiedTimestamp != Timestamp())
+    writer << "<mwm:modifiedTimestamp>" << TimestampToString(bookmarkData.m_modifiedTimestamp)
+           << "</mwm:modifiedTimestamp>";
 
   if (!bookmarkData.m_nearestToponym.empty())
   {
@@ -448,10 +446,8 @@ void SaveBookmarkData(Writer & writer, BookmarkData const & bookmarkData)
 
   if (bookmarkData.m_createdTimestamp != Timestamp())
   {
-    writer << kIndent4 << "<TimeStamp><when>" << TimestampToString(bookmarkData.m_createdTimestamp) << "</when>";
-    if (bookmarkData.m_modifiedTimestamp != Timestamp())
-      writer << "<modified>" << TimestampToString(bookmarkData.m_modifiedTimestamp) << "</modified>";
-    writer << "</TimeStamp>\n";
+    writer << kIndent4 << "<TimeStamp><when>" << TimestampToString(bookmarkData.m_createdTimestamp)
+           << "</when></TimeStamp>\n";
   }
 
   // Custom colors reference a shared #placemark-<rgbahex> style; presets keep #placemark-<name> so
@@ -596,6 +592,9 @@ void SaveTrackExtendedData(Writer & writer, TrackData const & trackData)
   writer << kIndent6 << "</mwm:additionalStyle>\n";
 
   writer << kIndent6 << "<mwm:visibility>" << (trackData.m_visible ? "1" : "0") << "</mwm:visibility>\n";
+  if (trackData.m_modifiedTimestamp != Timestamp())
+    writer << "<mwm:modifiedTimestamp>" << TimestampToString(trackData.m_modifiedTimestamp)
+           << "</mwm:modifiedTimestamp>";
 
   SaveStringsArray(writer, trackData.m_nearestToponyms, "nearestToponyms", kIndent6);
   SaveStringsMap(writer, trackData.m_properties, "properties", kIndent6);
@@ -630,10 +629,8 @@ void SaveTrackData(Writer & writer, TrackData const & trackData)
 
   if (trackData.m_createdTimestamp != Timestamp())
   {
-    writer << kIndent4 << "<TimeStamp><when>" << TimestampToString(trackData.m_createdTimestamp) << "</when>";
-    if (trackData.m_modifiedTimestamp != Timestamp())
-      writer << kIndent4 << "<modified>" << TimestampToString(trackData.m_modifiedTimestamp) << "</modified>";
-    writer << "</TimeStamp>\n";
+    writer << kIndent4 << "<TimeStamp><when>" << TimestampToString(trackData.m_createdTimestamp)
+           << "</when></TimeStamp>\n";
   }
 
   SaveTrackGeometry(writer, trackData.m_geometry);
@@ -723,8 +720,8 @@ void KmlParser::ResetPoint()
   m_org = {};
   m_predefinedColor = PredefinedColor::None;
   m_viewportScale = 0;
-  m_timestamp = {};
-  m_editTimestamp = {};
+  m_createdTimestamp = {};
+  m_modifiedTimestamp = {};
 
   m_color = 0;
   m_iconColor = 0;
@@ -1006,8 +1003,8 @@ void KmlParser::Pop(std::string_view tag)
         data.m_color = NormalizeBookmarkColorData({m_predefinedColor, m_iconColor});
         data.m_icon = m_icon;
         data.m_viewportScale = m_viewportScale;
-        data.m_createdTimestamp = m_timestamp;
-        data.m_modifiedTimestamp = m_editTimestamp;
+        data.m_createdTimestamp = m_createdTimestamp;
+        data.m_modifiedTimestamp = m_modifiedTimestamp;
         data.m_point = m_org;
         data.m_featureTypes = std::move(m_featureTypes);
         data.m_customName = std::move(m_customName);
@@ -1036,7 +1033,7 @@ void KmlParser::Pop(std::string_view tag)
           trackData.m_name = bookmarkData.m_name;
           trackData.m_description = bookmarkData.m_description;
           trackData.m_layers = std::move(m_trackLayers);
-          trackData.m_createdTimestamp = m_timestamp;
+          trackData.m_createdTimestamp = m_createdTimestamp;
           trackData.m_geometry = std::move(m_geometry);
           trackData.m_visible = m_visible;
           trackData.m_nearestToponyms = std::move(m_nearestToponyms);
@@ -1051,8 +1048,8 @@ void KmlParser::Pop(std::string_view tag)
         data.m_name = std::move(m_name);
         data.m_description = std::move(m_description);
         data.m_layers = std::move(m_trackLayers);
-        data.m_createdTimestamp = m_timestamp;
-        data.m_modifiedTimestamp = m_editTimestamp;
+        data.m_createdTimestamp = m_createdTimestamp;
+        data.m_modifiedTimestamp = m_modifiedTimestamp;
         data.m_geometry = std::move(m_geometry);
         data.m_visible = m_visible;
         data.m_nearestToponyms = std::move(m_nearestToponyms);
@@ -1420,6 +1417,12 @@ void KmlParser::CharData(std::string & value)
           else if (m_minZoom > 19)
             m_minZoom = 19;
         }
+        else if (currTag == "mwm:modifiedTimestamp")
+        {
+          auto const ts = base::StringToTimestamp(value);
+          if (ts != base::INVALID_TIME_STAMP)
+            m_modifiedTimestamp = TimestampClock::from_time_t(ts);
+        }
         else if (currTag == "mwm:compilations")
         {
           m_compilations.clear();
@@ -1441,13 +1444,7 @@ void KmlParser::CharData(std::string & value)
         {
           auto const ts = base::StringToTimestamp(value);
           if (ts != base::INVALID_TIME_STAMP)
-            m_timestamp = TimestampClock::from_time_t(ts);
-        }
-        else if (IsModifiedTimestamp(currTag))
-        {
-          auto const ts = base::StringToTimestamp(value);
-          if (ts != base::INVALID_TIME_STAMP)
-            m_editTimestamp = TimestampClock::from_time_t(ts);
+            m_createdTimestamp = TimestampClock::from_time_t(ts);
         }
       }
       else if (currTag == kStyleUrl)

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -40,9 +40,14 @@ bool IsCoord(std::string const & s)
   return s == "coord" || s == "gx:coord";
 }
 
-bool IsTimestamp(std::string const & s)
+bool IsCreatedTimestamp(std::string const & s)
 {
   return s == "when";
+}
+
+bool IsModifiedTimestamp(std::string const & s)
+{
+  return s == "modified";
 }
 
 std::string_view constexpr kKmlHeader =
@@ -442,7 +447,12 @@ void SaveBookmarkData(Writer & writer, BookmarkData const & bookmarkData)
   }
 
   if (bookmarkData.m_timestamp != Timestamp())
-    writer << kIndent4 << "<TimeStamp><when>" << TimestampToString(bookmarkData.m_timestamp) << "</when></TimeStamp>\n";
+  {
+    writer << kIndent4 << "<TimeStamp><when>" << TimestampToString(bookmarkData.m_timestamp) << "</when>";
+    if (bookmarkData.m_editTimestamp != Timestamp())
+      writer << "<modified>" << TimestampToString(bookmarkData.m_editTimestamp) << "</modified>";
+    writer << "</TimeStamp>\n";
+  }
 
   // Custom colors reference a shared #placemark-<rgbahex> style; presets keep #placemark-<name> so
   // old OM still matches by name. A bookmark that slipped through unnormalized as {None, 0} falls
@@ -991,6 +1001,7 @@ void KmlParser::Pop(std::string_view tag)
         data.m_icon = m_icon;
         data.m_viewportScale = m_viewportScale;
         data.m_timestamp = m_timestamp;
+        data.m_editTimestamp = m_editTimestamp;
         data.m_point = m_org;
         data.m_featureTypes = std::move(m_featureTypes);
         data.m_customName = std::move(m_customName);
@@ -1139,7 +1150,7 @@ void KmlParser::CharData(std::string & value)
       if (!IsTrack(prevTag))
         return false;
 
-      if (IsTimestamp(currTag))
+      if (IsCreatedTimestamp(currTag))
       {
         auto & timestamps = m_geometry.m_timestamps;
         ASSERT(!timestamps.empty(), ());
@@ -1419,11 +1430,17 @@ void KmlParser::CharData(std::string & value)
       }
       else if (prevTag == "TimeStamp")
       {
-        if (IsTimestamp(currTag))
+        if (IsCreatedTimestamp(currTag))
         {
           auto const ts = base::StringToTimestamp(value);
           if (ts != base::INVALID_TIME_STAMP)
             m_timestamp = TimestampClock::from_time_t(ts);
+        }
+        else if (IsModifiedTimestamp(currTag))
+        {
+          auto const ts = base::StringToTimestamp(value);
+          if (ts != base::INVALID_TIME_STAMP)
+            m_editTimestamp = TimestampClock::from_time_t(ts);
         }
       }
       else if (currTag == kStyleUrl)

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -403,7 +403,7 @@ void SaveBookmarkExtendedData(Writer & writer, BookmarkData const & bookmarkData
   writer << kIndent6 << "<mwm:visibility>" << (bookmarkData.m_visible ? "1" : "0") << "</mwm:visibility>\n";
   if (bookmarkData.m_modifiedTimestamp != Timestamp())
     writer << kIndent6 << "<mwm:modifiedTimestamp>" << TimestampToString(bookmarkData.m_modifiedTimestamp)
-           << "</mwm:modifiedTimestamp>";
+           << "</mwm:modifiedTimestamp>\n";
 
   if (!bookmarkData.m_nearestToponym.empty())
   {
@@ -594,7 +594,7 @@ void SaveTrackExtendedData(Writer & writer, TrackData const & trackData)
   writer << kIndent6 << "<mwm:visibility>" << (trackData.m_visible ? "1" : "0") << "</mwm:visibility>\n";
   if (trackData.m_modifiedTimestamp != Timestamp())
     writer << kIndent6 << "<mwm:modifiedTimestamp>" << TimestampToString(trackData.m_modifiedTimestamp)
-           << "</mwm:modifiedTimestamp>";
+           << "</mwm:modifiedTimestamp>\n";
 
   SaveStringsArray(writer, trackData.m_nearestToponyms, "nearestToponyms", kIndent6);
   SaveStringsMap(writer, trackData.m_properties, "properties", kIndent6);

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -402,7 +402,7 @@ void SaveBookmarkExtendedData(Writer & writer, BookmarkData const & bookmarkData
 
   writer << kIndent6 << "<mwm:visibility>" << (bookmarkData.m_visible ? "1" : "0") << "</mwm:visibility>\n";
   if (bookmarkData.m_modifiedTimestamp != Timestamp())
-    writer << "<mwm:modifiedTimestamp>" << TimestampToString(bookmarkData.m_modifiedTimestamp)
+    writer << kIndent6 << "<mwm:modifiedTimestamp>" << TimestampToString(bookmarkData.m_modifiedTimestamp)
            << "</mwm:modifiedTimestamp>";
 
   if (!bookmarkData.m_nearestToponym.empty())
@@ -593,7 +593,7 @@ void SaveTrackExtendedData(Writer & writer, TrackData const & trackData)
 
   writer << kIndent6 << "<mwm:visibility>" << (trackData.m_visible ? "1" : "0") << "</mwm:visibility>\n";
   if (trackData.m_modifiedTimestamp != Timestamp())
-    writer << "<mwm:modifiedTimestamp>" << TimestampToString(trackData.m_modifiedTimestamp)
+    writer << kIndent6 << "<mwm:modifiedTimestamp>" << TimestampToString(trackData.m_modifiedTimestamp)
            << "</mwm:modifiedTimestamp>";
 
   SaveStringsArray(writer, trackData.m_nearestToponyms, "nearestToponyms", kIndent6);

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -47,7 +47,8 @@ bool IsWhenTag(std::string const & s)
 
 std::string_view constexpr kKmlHeader =
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-    "<kml xmlns=\"http://www.opengis.net/kml/2.2\" xmlns:gx=\"http://www.google.com/kml/ext/2.2\">\n"
+    "<kml xmlns=\"http://www.opengis.net/kml/2.2\" xmlns:gx=\"http://www.google.com/kml/ext/2.2\" "
+    "xmlns:om=\"https://omaps.app\">\n"
     "<Document>\n";
 
 std::string_view constexpr kKmlFooter =
@@ -402,8 +403,7 @@ void SaveBookmarkExtendedData(Writer & writer, BookmarkData const & bookmarkData
 
   writer << kIndent6 << "<mwm:visibility>" << (bookmarkData.m_visible ? "1" : "0") << "</mwm:visibility>\n";
   if (bookmarkData.m_modifiedTimestamp != Timestamp())
-    writer << kIndent6 << "<mwm:modifiedTimestamp>" << TimestampToString(bookmarkData.m_modifiedTimestamp)
-           << "</mwm:modifiedTimestamp>\n";
+    writer << kIndent6 << "<om:modified>" << TimestampToString(bookmarkData.m_modifiedTimestamp) << "</om:modified>\n";
 
   if (!bookmarkData.m_nearestToponym.empty())
   {
@@ -593,8 +593,7 @@ void SaveTrackExtendedData(Writer & writer, TrackData const & trackData)
 
   writer << kIndent6 << "<mwm:visibility>" << (trackData.m_visible ? "1" : "0") << "</mwm:visibility>\n";
   if (trackData.m_modifiedTimestamp != Timestamp())
-    writer << kIndent6 << "<mwm:modifiedTimestamp>" << TimestampToString(trackData.m_modifiedTimestamp)
-           << "</mwm:modifiedTimestamp>\n";
+    writer << kIndent6 << "<om:modified>" << TimestampToString(trackData.m_modifiedTimestamp) << "</om:modified>\n";
 
   SaveStringsArray(writer, trackData.m_nearestToponyms, "nearestToponyms", kIndent6);
   SaveStringsMap(writer, trackData.m_properties, "properties", kIndent6);
@@ -1418,7 +1417,7 @@ void KmlParser::CharData(std::string & value)
           else if (m_minZoom > 19)
             m_minZoom = 19;
         }
-        else if (currTag == "mwm:modifiedTimestamp")
+        else if (currTag == "om:modified")
         {
           auto const ts = base::StringToTimestamp(value);
           if (ts != base::INVALID_TIME_STAMP)

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -1034,6 +1034,7 @@ void KmlParser::Pop(std::string_view tag)
           trackData.m_description = bookmarkData.m_description;
           trackData.m_layers = std::move(m_trackLayers);
           trackData.m_createdTimestamp = m_createdTimestamp;
+          trackData.m_modifiedTimestamp = m_modifiedTimestamp;
           trackData.m_geometry = std::move(m_geometry);
           trackData.m_visible = m_visible;
           trackData.m_nearestToponyms = std::move(m_nearestToponyms);

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -446,11 +446,11 @@ void SaveBookmarkData(Writer & writer, BookmarkData const & bookmarkData)
     writer << "</description>\n";
   }
 
-  if (bookmarkData.m_timestamp != Timestamp())
+  if (bookmarkData.m_createdTimestamp != Timestamp())
   {
-    writer << kIndent4 << "<TimeStamp><when>" << TimestampToString(bookmarkData.m_timestamp) << "</when>";
-    if (bookmarkData.m_editTimestamp != Timestamp())
-      writer << "<modified>" << TimestampToString(bookmarkData.m_editTimestamp) << "</modified>";
+    writer << kIndent4 << "<TimeStamp><when>" << TimestampToString(bookmarkData.m_createdTimestamp) << "</when>";
+    if (bookmarkData.m_modifiedTimestamp != Timestamp())
+      writer << "<modified>" << TimestampToString(bookmarkData.m_modifiedTimestamp) << "</modified>";
     writer << "</TimeStamp>\n";
   }
 
@@ -628,11 +628,11 @@ void SaveTrackData(Writer & writer, TrackData const & trackData)
   SaveTrackLayer(writer, layer, kIndent6);
   writer << kIndent4 << "</LineStyle></Style>\n";
 
-  if (trackData.m_timestamp != Timestamp())
+  if (trackData.m_createdTimestamp != Timestamp())
   {
-    writer << kIndent4 << "<TimeStamp><when>" << TimestampToString(trackData.m_timestamp) << "</when>";
-    if (trackData.m_editTimestamp != Timestamp())
-      writer << kIndent4 << "<modified>" << TimestampToString(trackData.m_editTimestamp) << "</modified>";
+    writer << kIndent4 << "<TimeStamp><when>" << TimestampToString(trackData.m_createdTimestamp) << "</when>";
+    if (trackData.m_modifiedTimestamp != Timestamp())
+      writer << kIndent4 << "<modified>" << TimestampToString(trackData.m_modifiedTimestamp) << "</modified>";
     writer << "</TimeStamp>\n";
   }
 
@@ -1006,8 +1006,8 @@ void KmlParser::Pop(std::string_view tag)
         data.m_color = NormalizeBookmarkColorData({m_predefinedColor, m_iconColor});
         data.m_icon = m_icon;
         data.m_viewportScale = m_viewportScale;
-        data.m_timestamp = m_timestamp;
-        data.m_editTimestamp = m_editTimestamp;
+        data.m_createdTimestamp = m_timestamp;
+        data.m_modifiedTimestamp = m_editTimestamp;
         data.m_point = m_org;
         data.m_featureTypes = std::move(m_featureTypes);
         data.m_customName = std::move(m_customName);
@@ -1036,7 +1036,7 @@ void KmlParser::Pop(std::string_view tag)
           trackData.m_name = bookmarkData.m_name;
           trackData.m_description = bookmarkData.m_description;
           trackData.m_layers = std::move(m_trackLayers);
-          trackData.m_timestamp = m_timestamp;
+          trackData.m_createdTimestamp = m_timestamp;
           trackData.m_geometry = std::move(m_geometry);
           trackData.m_visible = m_visible;
           trackData.m_nearestToponyms = std::move(m_nearestToponyms);
@@ -1051,8 +1051,8 @@ void KmlParser::Pop(std::string_view tag)
         data.m_name = std::move(m_name);
         data.m_description = std::move(m_description);
         data.m_layers = std::move(m_trackLayers);
-        data.m_timestamp = m_timestamp;
-        data.m_editTimestamp = m_editTimestamp;
+        data.m_createdTimestamp = m_timestamp;
+        data.m_modifiedTimestamp = m_editTimestamp;
         data.m_geometry = std::move(m_geometry);
         data.m_visible = m_visible;
         data.m_nearestToponyms = std::move(m_nearestToponyms);

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -629,7 +629,12 @@ void SaveTrackData(Writer & writer, TrackData const & trackData)
   writer << kIndent4 << "</LineStyle></Style>\n";
 
   if (trackData.m_timestamp != Timestamp())
-    writer << kIndent4 << "<TimeStamp><when>" << TimestampToString(trackData.m_timestamp) << "</when></TimeStamp>\n";
+  {
+    writer << kIndent4 << "<TimeStamp><when>" << TimestampToString(trackData.m_timestamp) << "</when>";
+    if (trackData.m_editTimestamp != Timestamp())
+      writer << kIndent4 << "<modified>" << TimestampToString(trackData.m_editTimestamp) << "</modified>";
+    writer << "</TimeStamp>\n";
+  }
 
   SaveTrackGeometry(writer, trackData.m_geometry);
   SaveTrackExtendedData(writer, trackData);
@@ -719,6 +724,7 @@ void KmlParser::ResetPoint()
   m_predefinedColor = PredefinedColor::None;
   m_viewportScale = 0;
   m_timestamp = {};
+  m_editTimestamp = {};
 
   m_color = 0;
   m_iconColor = 0;
@@ -1046,6 +1052,7 @@ void KmlParser::Pop(std::string_view tag)
         data.m_description = std::move(m_description);
         data.m_layers = std::move(m_trackLayers);
         data.m_timestamp = m_timestamp;
+        data.m_editTimestamp = m_editTimestamp;
         data.m_geometry = std::move(m_geometry);
         data.m_visible = m_visible;
         data.m_nearestToponyms = std::move(m_nearestToponyms);

--- a/libs/kml/serdes.hpp
+++ b/libs/kml/serdes.hpp
@@ -118,8 +118,8 @@ private:
   LocalizableString m_name;
   LocalizableString m_description;
   PredefinedColor m_predefinedColor;
-  Timestamp m_timestamp;
-  Timestamp m_editTimestamp;
+  Timestamp m_createdTimestamp;
+  Timestamp m_modifiedTimestamp;
   m2::PointD m_org;
   uint8_t m_viewportScale;
   ClassifierTypes m_featureTypes;

--- a/libs/kml/serdes.hpp
+++ b/libs/kml/serdes.hpp
@@ -119,6 +119,7 @@ private:
   LocalizableString m_description;
   PredefinedColor m_predefinedColor;
   Timestamp m_timestamp;
+  Timestamp m_editTimestamp;
   m2::PointD m_org;
   uint8_t m_viewportScale;
   ClassifierTypes m_featureTypes;

--- a/libs/kml/types.hpp
+++ b/libs/kml/types.hpp
@@ -402,9 +402,11 @@ struct BookmarkData
   BookmarkIcon m_icon = BookmarkIcon::None;
   // Viewport scale. 0 is a default value (no scale set).
   uint8_t m_viewportScale = 0;
-  // Creation timestamp.
+  // Creation timestamp in UTC.
   Timestamp m_createdTimestamp = {};
-  // Modification timestamp.
+  // Modification timestamp in UTC.
+  // TODO: This field is not serialized to/from KMB for backward compatibility.
+  //       Add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
   Timestamp m_modifiedTimestamp = {};
   // Coordinates in mercator.
   m2::PointD m_point;
@@ -514,9 +516,11 @@ struct TrackData
   LocalizableString m_description;
   // Layers.
   std::vector<TrackLayer> m_layers;
-  // Creation timestamp.
+  // Creation timestamp in UTC.
   Timestamp m_createdTimestamp = {};
-  // Last modification timestamp.
+  // Last modification timestamp in UTC.
+  // TODO: This field is not serialized to/from KMB for backward compatibility.
+  //       Add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
   Timestamp m_modifiedTimestamp = {};
   MultiGeometry m_geometry;
   // Visibility.

--- a/libs/kml/types.hpp
+++ b/libs/kml/types.hpp
@@ -362,7 +362,7 @@ struct BookmarkData
                                   visitor(m_description, "description"), visitor(m_featureTypes, "featureTypes"),
                                   visitor(m_customName, "customName"), visitor(m_color, "color"),
                                   visitor(m_icon, "icon"), visitor(m_viewportScale, "viewportScale"),
-                                  visitor(m_timestamp, "timestamp"), visitor(m_point, "point"),
+                                  visitor(m_createdTimestamp, "timestamp"), visitor(m_point, "point"),
                                   visitor(m_boundTracks, "boundTracks"), visitor(m_visible, "visible"),
                                   visitor(m_nearestToponym, "nearestToponym"), visitor(m_minZoom, "minZoom"),
                                   visitor(m_compilations, "compilations"), visitor(m_properties, "properties"),
@@ -374,7 +374,7 @@ struct BookmarkData
   {
     return m_id == data.m_id && m_name == data.m_name && m_description == data.m_description &&
            m_color == data.m_color && m_icon == data.m_icon && m_viewportScale == data.m_viewportScale &&
-           IsEqual(m_timestamp, data.m_timestamp) && IsEqual(m_editTimestamp, data.m_editTimestamp) &&
+           IsEqual(m_createdTimestamp, data.m_createdTimestamp) && IsEqual(m_modifiedTimestamp, data.m_modifiedTimestamp) &&
            m_point.EqualDxDy(data.m_point, kMwmPointAccuracy) && m_featureTypes == data.m_featureTypes &&
            m_customName == data.m_customName && m_boundTracks == data.m_boundTracks && m_visible == data.m_visible &&
            m_nearestToponym == data.m_nearestToponym && m_minZoom == data.m_minZoom &&
@@ -402,9 +402,9 @@ struct BookmarkData
   // Viewport scale. 0 is a default value (no scale set).
   uint8_t m_viewportScale = 0;
   // Creation timestamp.
-  Timestamp m_timestamp = {};
+  Timestamp m_createdTimestamp = {};
   // Modification timestamp.
-  Timestamp m_editTimestamp = {};
+  Timestamp m_modifiedTimestamp = {};
   // Coordinates in mercator.
   m2::PointD m_point;
   // Bound tracks (vector contains local track ids).
@@ -484,7 +484,7 @@ struct TrackData
 {
   DECLARE_VISITOR_AND_DEBUG_PRINT(TrackData, visitor(m_id, "id"), visitor(m_localId, "localId"),
                                   visitor(m_name, "name"), visitor(m_description, "description"),
-                                  visitor(m_layers, "layers"), visitor(m_timestamp, "timestamp"),
+                                  visitor(m_layers, "layers"), visitor(m_createdTimestamp, "timestamp"),
                                   visitor(m_geometry, "geometry"), visitor(m_visible, "visible"),
                                   visitor(m_nearestToponyms, "nearestToponyms"), visitor(m_properties, "properties"),
                                   VISITOR_COLLECTABLE)
@@ -494,8 +494,8 @@ struct TrackData
   bool operator==(TrackData const & data) const
   {
     return m_id == data.m_id && m_localId == data.m_localId && m_name == data.m_name &&
-           m_description == data.m_description && m_layers == data.m_layers && IsEqual(m_timestamp, data.m_timestamp) &&
-           IsEqual(m_editTimestamp, data.m_editTimestamp) && m_geometry == data.m_geometry &&
+           m_description == data.m_description && m_layers == data.m_layers && IsEqual(m_createdTimestamp, data.m_createdTimestamp) &&
+           IsEqual(m_modifiedTimestamp, data.m_modifiedTimestamp) && m_geometry == data.m_geometry &&
            m_visible == data.m_visible && m_nearestToponyms == data.m_nearestToponyms &&
            m_properties == data.m_properties;
   }
@@ -513,9 +513,9 @@ struct TrackData
   // Layers.
   std::vector<TrackLayer> m_layers;
   // Creation timestamp.
-  Timestamp m_timestamp = {};
+  Timestamp m_createdTimestamp = {};
   // Last modification timestamp.
-  Timestamp m_editTimestamp = {};
+  Timestamp m_modifiedTimestamp = {};
   MultiGeometry m_geometry;
   // Visibility.
   bool m_visible = true;

--- a/libs/kml/types.hpp
+++ b/libs/kml/types.hpp
@@ -404,7 +404,15 @@ struct BookmarkData
   uint8_t m_viewportScale = 0;
   // Creation timestamp in UTC.
   Timestamp m_createdTimestamp = {};
-  // Modification timestamp in UTC.
+  // Last content-modification timestamp in UTC. Empty until the first edit.
+  //
+  // Refreshed to "now" on every change to user-visible content: name, custom name, description,
+  // color, or a wholesale SetData() replacement (and, for tracks, geometry). It is deliberately
+  // NOT refreshed for:
+  //   - derived or non-content state: visibility, viewport scale, reverse-geocoded address;
+  //   - moving a bookmark/track to another list (only the involved lists' timestamps change);
+  //   - load/import, which must preserve the source value (the explicit Set*Timestamp setters).
+  // In the map layer this policy is enforced in one place: Bookmark/Track::SetDirty(updateModificationTime).
   // TODO: This field is not serialized to/from KMB for backward compatibility.
   //       Add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
   Timestamp m_modifiedTimestamp = {};
@@ -518,7 +526,8 @@ struct TrackData
   std::vector<TrackLayer> m_layers;
   // Creation timestamp in UTC.
   Timestamp m_createdTimestamp = {};
-  // Last modification timestamp in UTC.
+  // Last content-modification timestamp in UTC. See BookmarkData::m_modifiedTimestamp for the
+  // exact update policy.
   // TODO: This field is not serialized to/from KMB for backward compatibility.
   //       Add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
   Timestamp m_modifiedTimestamp = {};

--- a/libs/kml/types.hpp
+++ b/libs/kml/types.hpp
@@ -374,7 +374,8 @@ struct BookmarkData
   {
     return m_id == data.m_id && m_name == data.m_name && m_description == data.m_description &&
            m_color == data.m_color && m_icon == data.m_icon && m_viewportScale == data.m_viewportScale &&
-           IsEqual(m_createdTimestamp, data.m_createdTimestamp) && IsEqual(m_modifiedTimestamp, data.m_modifiedTimestamp) &&
+           IsEqual(m_createdTimestamp, data.m_createdTimestamp) &&
+           IsEqual(m_modifiedTimestamp, data.m_modifiedTimestamp) &&
            m_point.EqualDxDy(data.m_point, kMwmPointAccuracy) && m_featureTypes == data.m_featureTypes &&
            m_customName == data.m_customName && m_boundTracks == data.m_boundTracks && m_visible == data.m_visible &&
            m_nearestToponym == data.m_nearestToponym && m_minZoom == data.m_minZoom &&
@@ -494,7 +495,8 @@ struct TrackData
   bool operator==(TrackData const & data) const
   {
     return m_id == data.m_id && m_localId == data.m_localId && m_name == data.m_name &&
-           m_description == data.m_description && m_layers == data.m_layers && IsEqual(m_createdTimestamp, data.m_createdTimestamp) &&
+           m_description == data.m_description && m_layers == data.m_layers &&
+           IsEqual(m_createdTimestamp, data.m_createdTimestamp) &&
            IsEqual(m_modifiedTimestamp, data.m_modifiedTimestamp) && m_geometry == data.m_geometry &&
            m_visible == data.m_visible && m_nearestToponyms == data.m_nearestToponyms &&
            m_properties == data.m_properties;

--- a/libs/kml/types.hpp
+++ b/libs/kml/types.hpp
@@ -374,9 +374,9 @@ struct BookmarkData
   {
     return m_id == data.m_id && m_name == data.m_name && m_description == data.m_description &&
            m_color == data.m_color && m_icon == data.m_icon && m_viewportScale == data.m_viewportScale &&
-           IsEqual(m_timestamp, data.m_timestamp) && m_point.EqualDxDy(data.m_point, kMwmPointAccuracy) &&
-           m_featureTypes == data.m_featureTypes && m_customName == data.m_customName &&
-           m_boundTracks == data.m_boundTracks && m_visible == data.m_visible &&
+           IsEqual(m_timestamp, data.m_timestamp) && IsEqual(m_editTimestamp, data.m_editTimestamp) &&
+           m_point.EqualDxDy(data.m_point, kMwmPointAccuracy) && m_featureTypes == data.m_featureTypes &&
+           m_customName == data.m_customName && m_boundTracks == data.m_boundTracks && m_visible == data.m_visible &&
            m_nearestToponym == data.m_nearestToponym && m_minZoom == data.m_minZoom &&
            m_compilations == data.m_compilations && m_properties == data.m_properties;
   }
@@ -403,6 +403,8 @@ struct BookmarkData
   uint8_t m_viewportScale = 0;
   // Creation timestamp.
   Timestamp m_timestamp = {};
+  // Modification timestamp.
+  Timestamp m_editTimestamp = {};
   // Coordinates in mercator.
   m2::PointD m_point;
   // Bound tracks (vector contains local track ids).

--- a/libs/kml/types.hpp
+++ b/libs/kml/types.hpp
@@ -495,8 +495,9 @@ struct TrackData
   {
     return m_id == data.m_id && m_localId == data.m_localId && m_name == data.m_name &&
            m_description == data.m_description && m_layers == data.m_layers && IsEqual(m_timestamp, data.m_timestamp) &&
-           m_geometry == data.m_geometry && m_visible == data.m_visible &&
-           m_nearestToponyms == data.m_nearestToponyms && m_properties == data.m_properties;
+           IsEqual(m_editTimestamp, data.m_editTimestamp) && m_geometry == data.m_geometry &&
+           m_visible == data.m_visible && m_nearestToponyms == data.m_nearestToponyms &&
+           m_properties == data.m_properties;
   }
 
   bool operator!=(TrackData const & data) const { return !operator==(data); }
@@ -513,6 +514,8 @@ struct TrackData
   std::vector<TrackLayer> m_layers;
   // Creation timestamp.
   Timestamp m_timestamp = {};
+  // Last modification timestamp.
+  Timestamp m_editTimestamp = {};
   MultiGeometry m_geometry;
   // Visibility.
   bool m_visible = true;

--- a/libs/kml/types_v3.hpp
+++ b/libs/kml/types_v3.hpp
@@ -49,7 +49,7 @@ struct BookmarkDataV3
     data.m_color = m_color;
     data.m_icon = m_icon;
     data.m_viewportScale = m_viewportScale;
-    data.m_timestamp = m_timestamp;
+    data.m_createdTimestamp = m_timestamp;
     data.m_point = m_point;
     data.m_boundTracks = m_boundTracks;
     return data;
@@ -105,7 +105,7 @@ struct TrackDataV3
     data.m_name = m_name;
     data.m_description = m_description;
     data.m_layers = m_layers;
-    data.m_timestamp = m_timestamp;
+    data.m_createdTimestamp = m_timestamp;
     data.m_geometry.FromPoints(m_points);
     return data;
   }

--- a/libs/kml/types_v3.hpp
+++ b/libs/kml/types_v3.hpp
@@ -49,6 +49,8 @@ struct BookmarkDataV3
     data.m_color = m_color;
     data.m_icon = m_icon;
     data.m_viewportScale = m_viewportScale;
+    // TODO: Field `m_modifiedTimestamp` is not serialized to/from KMB for backward compatibility.
+    //       Add new field and add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
     data.m_createdTimestamp = m_timestamp;
     data.m_point = m_point;
     data.m_boundTracks = m_boundTracks;
@@ -105,6 +107,8 @@ struct TrackDataV3
     data.m_name = m_name;
     data.m_description = m_description;
     data.m_layers = m_layers;
+    // TODO: Field `m_modifiedTimestamp` is not serialized to/from KMB for backward compatibility.
+    //       Add new field and add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
     data.m_createdTimestamp = m_timestamp;
     data.m_geometry.FromPoints(m_points);
     return data;

--- a/libs/kml/types_v6.hpp
+++ b/libs/kml/types_v6.hpp
@@ -48,7 +48,7 @@ struct TrackDataV6
     data.m_name = m_name;
     data.m_description = m_description;
     data.m_layers = m_layers;
-    data.m_timestamp = m_timestamp;
+    data.m_createdTimestamp = m_timestamp;
     data.m_geometry.FromPoints(m_points);
     data.m_visible = m_visible;
     data.m_nearestToponyms = m_nearestToponyms;

--- a/libs/kml/types_v6.hpp
+++ b/libs/kml/types_v6.hpp
@@ -48,6 +48,8 @@ struct TrackDataV6
     data.m_name = m_name;
     data.m_description = m_description;
     data.m_layers = m_layers;
+    // TODO: Field `m_modifiedTimestamp` is not serialized to/from KMB for backward compatibility.
+    //       Add new field and add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
     data.m_createdTimestamp = m_timestamp;
     data.m_geometry.FromPoints(m_points);
     data.m_visible = m_visible;

--- a/libs/kml/types_v7.hpp
+++ b/libs/kml/types_v7.hpp
@@ -52,7 +52,7 @@ struct BookmarkDataV7
     data.m_color = m_color;
     data.m_icon = m_icon;
     data.m_viewportScale = m_viewportScale;
-    data.m_timestamp = m_timestamp;
+    data.m_createdTimestamp = m_timestamp;
     data.m_point = m_point;
     data.m_boundTracks = m_boundTracks;
     data.m_visible = m_visible;

--- a/libs/kml/types_v7.hpp
+++ b/libs/kml/types_v7.hpp
@@ -52,6 +52,8 @@ struct BookmarkDataV7
     data.m_color = m_color;
     data.m_icon = m_icon;
     data.m_viewportScale = m_viewportScale;
+    // TODO: Field `m_modifiedTimestamp` is not serialized to/from KMB for backward compatibility.
+    //       Add new field and add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
     data.m_createdTimestamp = m_timestamp;
     data.m_point = m_point;
     data.m_boundTracks = m_boundTracks;

--- a/libs/kml/types_v8.hpp
+++ b/libs/kml/types_v8.hpp
@@ -45,7 +45,7 @@ struct BookmarkDataV8
     m_color = src.m_color;
     m_icon = src.m_icon;
     m_viewportScale = src.m_viewportScale;
-    m_timestamp = src.m_timestamp;
+    m_timestamp = src.m_createdTimestamp;
     m_point = src.m_point;
     m_boundTracks = src.m_boundTracks;
     m_visible = src.m_visible;
@@ -66,7 +66,7 @@ struct BookmarkDataV8
     data.m_color = m_color;
     data.m_icon = m_icon;
     data.m_viewportScale = m_viewportScale;
-    data.m_timestamp = m_timestamp;
+    data.m_createdTimestamp = m_timestamp;
     data.m_point = m_point;
     data.m_boundTracks = m_boundTracks;
     data.m_visible = m_visible;

--- a/libs/kml/types_v8.hpp
+++ b/libs/kml/types_v8.hpp
@@ -45,6 +45,8 @@ struct BookmarkDataV8
     m_color = src.m_color;
     m_icon = src.m_icon;
     m_viewportScale = src.m_viewportScale;
+    // TODO: Field `m_modifiedTimestamp` is not serialized to/from KMB for backward compatibility.
+    //       Add new field and add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
     m_timestamp = src.m_createdTimestamp;
     m_point = src.m_point;
     m_boundTracks = src.m_boundTracks;
@@ -66,6 +68,8 @@ struct BookmarkDataV8
     data.m_color = m_color;
     data.m_icon = m_icon;
     data.m_viewportScale = m_viewportScale;
+    // TODO: Field `m_modifiedTimestamp` is not serialized to/from KMB for backward compatibility.
+    //       Add new field and add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
     data.m_createdTimestamp = m_timestamp;
     data.m_point = m_point;
     data.m_boundTracks = m_boundTracks;

--- a/libs/kml/types_v8mm.hpp
+++ b/libs/kml/types_v8mm.hpp
@@ -41,7 +41,7 @@ struct BookmarkDataV8MM
     data.m_color = m_color;
     data.m_icon = m_icon;
     data.m_viewportScale = m_viewportScale;
-    data.m_timestamp = m_timestamp;
+    data.m_createdTimestamp = m_timestamp;
     data.m_point = m_point;
     data.m_boundTracks = m_boundTracks;
     data.m_visible = m_visible;
@@ -113,7 +113,7 @@ struct TrackDataV8MM
     data.m_name = m_name;
     data.m_description = m_description;
     data.m_layers = m_layers;
-    data.m_timestamp = m_timestamp;
+    data.m_createdTimestamp = m_timestamp;
     data.m_geometry = m_geometry;
     data.m_visible = m_visible;
     data.m_nearestToponyms = m_nearestToponyms;

--- a/libs/kml/types_v8mm.hpp
+++ b/libs/kml/types_v8mm.hpp
@@ -41,6 +41,8 @@ struct BookmarkDataV8MM
     data.m_color = m_color;
     data.m_icon = m_icon;
     data.m_viewportScale = m_viewportScale;
+    // TODO: Field `m_modifiedTimestamp` is not serialized to/from KMB for backward compatibility.
+    //       Add new field and add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
     data.m_createdTimestamp = m_timestamp;
     data.m_point = m_point;
     data.m_boundTracks = m_boundTracks;
@@ -113,6 +115,8 @@ struct TrackDataV8MM
     data.m_name = m_name;
     data.m_description = m_description;
     data.m_layers = m_layers;
+    // TODO: Field `m_modifiedTimestamp` is not serialized to/from KMB for backward compatibility.
+    //       Add new field and add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
     data.m_createdTimestamp = m_timestamp;
     data.m_geometry = m_geometry;
     data.m_visible = m_visible;

--- a/libs/kml/types_v9mm.hpp
+++ b/libs/kml/types_v9mm.hpp
@@ -50,7 +50,7 @@ struct TrackDataV9MM : TrackDataV8MM
     data.m_name = m_name;
     data.m_description = m_description;
     data.m_layers = m_layers;
-    data.m_timestamp = m_timestamp;
+    data.m_createdTimestamp = m_timestamp;
     data.m_geometry = mergeGeometry(std::move(m_multiGeometry));
 
     // MultiGeometry's invariant (see MultiGeometry::IsValid) requires m_timestamps.size()

--- a/libs/kml/types_v9mm.hpp
+++ b/libs/kml/types_v9mm.hpp
@@ -50,6 +50,8 @@ struct TrackDataV9MM : TrackDataV8MM
     data.m_name = m_name;
     data.m_description = m_description;
     data.m_layers = m_layers;
+    // TODO: Field `m_modifiedTimestamp` is not serialized to/from KMB for backward compatibility.
+    //       Add new field and add it to `DECLARE_VISITOR_AND_DEBUG_PRINT` block to save/load in KMB format.
     data.m_createdTimestamp = m_timestamp;
     data.m_geometry = mergeGeometry(std::move(m_multiGeometry));
 

--- a/libs/map/bookmark.cpp
+++ b/libs/map/bookmark.cpp
@@ -74,11 +74,21 @@ Bookmark::Bookmark(kml::BookmarkData && data)
   m_data.m_color = kml::NormalizeBookmarkColorData(m_data.m_color);
 }
 
+// Marks the bookmark dirty and, when updateModificationTime is true (the default), refreshes
+// m_modifiedTimestamp. See kml::BookmarkData::m_modifiedTimestamp for the exact update policy
+// (which edits stamp it and when callers pass false).
+void Bookmark::SetDirty(bool updateModificationTime)
+{
+  Base::SetDirty(updateModificationTime);
+  if (updateModificationTime)
+    m_data.m_modifiedTimestamp = kml::TimestampClock::now();
+}
+
 void Bookmark::SetData(kml::BookmarkData const & data)
 {
-  SetDirty();
   m_data = data;
   m_data.m_color = kml::NormalizeBookmarkColorData(m_data.m_color);
+  SetDirty();  // Must run after the copy above, which would otherwise overwrite m_modifiedTimestamp.
 }
 
 kml::BookmarkData const & Bookmark::GetData() const
@@ -93,13 +103,13 @@ search::ReverseGeocoder::RegionAddress const & Bookmark::GetAddress() const
 
 void Bookmark::SetAddress(search::ReverseGeocoder::RegionAddress const & address)
 {
-  SetDirty();
+  SetDirty(false /* updateModificationTime */);
   m_address = address;
 }
 
 void Bookmark::SetIsVisible(bool isVisible)
 {
-  SetDirty();
+  SetDirty(false /* updateModificationTime */);
   m_isVisible = isVisible;
 }
 
@@ -295,7 +305,7 @@ kml::Timestamp Bookmark::GetCreatedTimestamp() const
 
 void Bookmark::SetCreatedTimestamp(kml::Timestamp timeStamp)
 {
-  SetDirty();
+  SetDirty(false /* updateModificationTime */);
   m_data.m_createdTimestamp = timeStamp;
 }
 
@@ -306,7 +316,7 @@ kml::Timestamp Bookmark::GetModifiedTimestamp() const
 
 void Bookmark::SetModifiedTimestamp(kml::Timestamp timeStamp)
 {
-  SetDirty();
+  SetDirty(false /* updateModificationTime */);
   m_data.m_modifiedTimestamp = timeStamp;
 }
 
@@ -317,7 +327,7 @@ uint8_t Bookmark::GetScale() const
 
 void Bookmark::SetScale(uint8_t scale)
 {
-  SetDirty();
+  SetDirty(false /* updateModificationTime */);
   m_data.m_viewportScale = scale;
 }
 

--- a/libs/map/bookmark.cpp
+++ b/libs/map/bookmark.cpp
@@ -288,23 +288,23 @@ void Bookmark::SetDescription(std::string const & description)
   kml::SetDefaultStr(m_data.m_description, description);
 }
 
-kml::Timestamp Bookmark::GetCreatedTimeStamp() const
+kml::Timestamp Bookmark::GetCreatedTimestamp() const
 {
   return m_data.m_createdTimestamp;
 }
 
-void Bookmark::SetCreatedTimeStamp(kml::Timestamp timeStamp)
+void Bookmark::SetCreatedTimestamp(kml::Timestamp timeStamp)
 {
   SetDirty();
   m_data.m_createdTimestamp = timeStamp;
 }
 
-kml::Timestamp Bookmark::GetModifiedTimeStamp() const
+kml::Timestamp Bookmark::GetModifiedTimestamp() const
 {
   return m_data.m_modifiedTimestamp;
 }
 
-void Bookmark::SetModifiedTimeStamp(kml::Timestamp timeStamp)
+void Bookmark::SetModifiedTimestamp(kml::Timestamp timeStamp)
 {
   SetDirty();
   m_data.m_modifiedTimestamp = timeStamp;

--- a/libs/map/bookmark.cpp
+++ b/libs/map/bookmark.cpp
@@ -299,6 +299,17 @@ void Bookmark::SetTimeStamp(kml::Timestamp timeStamp)
   m_data.m_timestamp = timeStamp;
 }
 
+kml::Timestamp Bookmark::GetEditTimeStamp() const
+{
+  return m_data.m_editTimestamp;
+}
+
+void Bookmark::SetEditTimeStamp(kml::Timestamp timeStamp)
+{
+  SetDirty();
+  m_data.m_editTimestamp = timeStamp;
+}
+
 uint8_t Bookmark::GetScale() const
 {
   return m_data.m_viewportScale;

--- a/libs/map/bookmark.cpp
+++ b/libs/map/bookmark.cpp
@@ -288,26 +288,26 @@ void Bookmark::SetDescription(std::string const & description)
   kml::SetDefaultStr(m_data.m_description, description);
 }
 
-kml::Timestamp Bookmark::GetTimeStamp() const
+kml::Timestamp Bookmark::GetCreatedTimeStamp() const
 {
-  return m_data.m_timestamp;
+  return m_data.m_createdTimestamp;
 }
 
-void Bookmark::SetTimeStamp(kml::Timestamp timeStamp)
+void Bookmark::SetCreatedTimeStamp(kml::Timestamp timeStamp)
 {
   SetDirty();
-  m_data.m_timestamp = timeStamp;
+  m_data.m_createdTimestamp = timeStamp;
 }
 
-kml::Timestamp Bookmark::GetEditTimeStamp() const
+kml::Timestamp Bookmark::GetModifiedTimeStamp() const
 {
-  return m_data.m_editTimestamp;
+  return m_data.m_modifiedTimestamp;
 }
 
-void Bookmark::SetEditTimeStamp(kml::Timestamp timeStamp)
+void Bookmark::SetModifiedTimeStamp(kml::Timestamp timeStamp)
 {
   SetDirty();
-  m_data.m_editTimestamp = timeStamp;
+  m_data.m_modifiedTimestamp = timeStamp;
 }
 
 uint8_t Bookmark::GetScale() const

--- a/libs/map/bookmark.hpp
+++ b/libs/map/bookmark.hpp
@@ -58,11 +58,11 @@ public:
   std::string GetDescription() const;
   void SetDescription(std::string const & description);
 
-  kml::Timestamp GetTimeStamp() const;
-  void SetTimeStamp(kml::Timestamp timeStamp);
+  kml::Timestamp GetCreatedTimeStamp() const;
+  void SetCreatedTimeStamp(kml::Timestamp timeStamp);
 
-  kml::Timestamp GetEditTimeStamp() const;
-  void SetEditTimeStamp(kml::Timestamp timeStamp);
+  kml::Timestamp GetModifiedTimeStamp() const;
+  void SetModifiedTimeStamp(kml::Timestamp timeStamp);
 
   uint8_t GetScale() const;
   void SetScale(uint8_t scale);

--- a/libs/map/bookmark.hpp
+++ b/libs/map/bookmark.hpp
@@ -61,6 +61,9 @@ public:
   kml::Timestamp GetTimeStamp() const;
   void SetTimeStamp(kml::Timestamp timeStamp);
 
+  kml::Timestamp GetEditTimeStamp() const;
+  void SetEditTimeStamp(kml::Timestamp timeStamp);
+
   uint8_t GetScale() const;
   void SetScale(uint8_t scale);
 

--- a/libs/map/bookmark.hpp
+++ b/libs/map/bookmark.hpp
@@ -88,6 +88,9 @@ public:
 
   kml::GroupIdCollection const & GetCompilations() const { return m_compilationIds; }
 
+protected:
+  void SetDirty(bool updateModificationTime = true) override;
+
 private:
   drape_ptr<df::UserPointMark::SymbolNameZoomInfo> GetCustomSymbolNames() const;
 

--- a/libs/map/bookmark.hpp
+++ b/libs/map/bookmark.hpp
@@ -58,11 +58,11 @@ public:
   std::string GetDescription() const;
   void SetDescription(std::string const & description);
 
-  kml::Timestamp GetCreatedTimeStamp() const;
-  void SetCreatedTimeStamp(kml::Timestamp timeStamp);
+  kml::Timestamp GetCreatedTimestamp() const;
+  void SetCreatedTimestamp(kml::Timestamp timeStamp);
 
-  kml::Timestamp GetModifiedTimeStamp() const;
-  void SetModifiedTimeStamp(kml::Timestamp timeStamp);
+  kml::Timestamp GetModifiedTimestamp() const;
+  void SetModifiedTimestamp(kml::Timestamp timeStamp);
 
   uint8_t GetScale() const;
   void SetScale(uint8_t scale);

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -2362,8 +2362,6 @@ void BookmarkManager::UpdateBookmark(kml::MarkId bmID, kml::BookmarkData const &
   auto const & newColor = bookmark->GetData().m_color;
   if (prevColor != newColor)
     SetLastEditedBmColor(newColor);
-
-  bookmark->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 void BookmarkManager::ChangeTrackColor(kml::TrackId trackId, dp::Color color)
@@ -2374,7 +2372,6 @@ void BookmarkManager::ChangeTrackColor(kml::TrackId trackId, dp::Color color)
     return;
 
   track->SetColor(color);
-  track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 void BookmarkManager::UpdateTrack(kml::TrackId trackId, kml::TrackData const & trackData)
@@ -2382,8 +2379,6 @@ void BookmarkManager::UpdateTrack(kml::TrackId trackId, kml::TrackData const & t
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto * track = GetTrackForEdit(trackId);
   track->SetData(trackData);
-
-  track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 kml::MarkGroupId BookmarkManager::LastEditedBMCategory()
@@ -3739,14 +3734,12 @@ void BookmarkManager::EditSession::SetCategoryCustomProperty(kml::MarkGroupId ca
 void BookmarkManager::EditSession::SetCategoryBookmarksColor(kml::MarkGroupId groupId, dp::Color color)
 {
   auto const & markIds = m_bmManager.GetUserMarkIds(groupId);
-  auto const now = kml::TimestampClock::now();
   for (auto const markId : markIds)
   {
     auto * bm = m_bmManager.GetBookmarkForEdit(markId);
     if (bm == nullptr || bm->GetColorForRendering() == color)
       continue;
     bm->SetColor(color);
-    bm->SetModifiedTimestamp(now);
   }
   m_bmManager.SetLastEditedBmColor(kml::MakeCustomBookmarkColorData(color));
 }

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -2363,16 +2363,17 @@ void BookmarkManager::UpdateBookmark(kml::MarkId bmID, kml::BookmarkData const &
   if (prevColor != newColor)
     SetLastEditedBmColor(newColor);
 
-  if (bm.m_modifiedTimestamp == kml::Timestamp())
-    bookmark->SetModifiedTimestamp(kml::TimestampClock::now());
+  bookmark->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 void BookmarkManager::ChangeTrackColor(kml::TrackId trackId, dp::Color color)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto * track = GetTrackForEdit(trackId);
-  track->SetColor(color);
+  if (track->GetColor(0) == color)
+    return;
 
+  track->SetColor(color);
   track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
@@ -2382,8 +2383,7 @@ void BookmarkManager::UpdateTrack(kml::TrackId trackId, kml::TrackData const & t
   auto * track = GetTrackForEdit(trackId);
   track->SetData(trackData);
 
-  if (trackData.m_modifiedTimestamp == kml::Timestamp())
-    track->SetModifiedTimestamp(kml::TimestampClock::now());
+  track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 kml::MarkGroupId BookmarkManager::LastEditedBMCategory()
@@ -3739,9 +3739,15 @@ void BookmarkManager::EditSession::SetCategoryCustomProperty(kml::MarkGroupId ca
 void BookmarkManager::EditSession::SetCategoryBookmarksColor(kml::MarkGroupId groupId, dp::Color color)
 {
   auto const & markIds = m_bmManager.GetUserMarkIds(groupId);
+  auto const now = kml::TimestampClock::now();
   for (auto const markId : markIds)
-    if (auto * bm = m_bmManager.GetBookmarkForEdit(markId))
-      bm->SetColor(color);
+  {
+    auto * bm = m_bmManager.GetBookmarkForEdit(markId);
+    if (bm == nullptr || bm->GetColorForRendering() == color)
+      continue;
+    bm->SetColor(color);
+    bm->SetModifiedTimestamp(now);
+  }
   m_bmManager.SetLastEditedBmColor(kml::MakeCustomBookmarkColorData(color));
 }
 

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -356,7 +356,7 @@ Bookmark * BookmarkManager::CreateBookmark(kml::BookmarkData && bmData, kml::Mar
   }
   else
   {
-    bmData.m_timestamp = kml::TimestampClock::now();
+    bmData.m_createdTimestamp = kml::TimestampClock::now();
     bmData.m_viewportScale = static_cast<uint8_t>(df::GetZoomLevel(m_viewport.GetScale()));
 
     bookmark = CreateBookmark(std::move(bmData));
@@ -742,7 +742,7 @@ std::vector<BookmarkManager::SortingType> BookmarkManager::GetAvailableSortingTy
     }
 
     if (!byTimeChecked)
-      byTimeChecked = !kml::IsEqual(bookmarkData.m_timestamp, kml::Timestamp{});
+      byTimeChecked = !kml::IsEqual(bookmarkData.m_createdTimestamp, kml::Timestamp{});
 
     if (byTypeChecked && byTimeChecked)
       break;
@@ -752,7 +752,7 @@ std::vector<BookmarkManager::SortingType> BookmarkManager::GetAvailableSortingTy
   {
     for (auto trackId : group->GetUserLines())
     {
-      if (!kml::IsEqual(GetTrack(trackId)->GetData().m_timestamp, kml::Timestamp{}))
+      if (!kml::IsEqual(GetTrack(trackId)->GetData().m_createdTimestamp, kml::Timestamp{}))
       {
         byTimeChecked = true;
         break;
@@ -1188,7 +1188,7 @@ kml::TrackId BookmarkManager::SaveTrackRecording(std::string trackName)
   std::vector<kml::TrackLayer> m_layers;
   m_layers.emplace_back(layer);
   trackData.m_layers = std::move(m_layers);
-  trackData.m_timestamp = kml::TimestampClock::now();
+  trackData.m_createdTimestamp = kml::TimestampClock::now();
 
   auto editSession = GetEditSession();
   auto const track = editSession.CreateTrack(std::move(trackData));
@@ -1240,7 +1240,7 @@ kml::TrackId BookmarkManager::SaveRoute(kml::TrackGeometry points, std::string c
   layers.emplace_back(layer);
   trackData.m_layers = std::move(layers);
 
-  trackData.m_timestamp = kml::TimestampClock::now();
+  trackData.m_createdTimestamp = kml::TimestampClock::now();
 
   auto editSession = GetEditSession();
   auto const track = editSession.CreateTrack(std::move(trackData));
@@ -1343,7 +1343,7 @@ void BookmarkManager::SortTracksByTime(std::vector<SortTrackData> & tracks)
   bool hasTimestamp = false;
   for (auto const & track : tracks)
   {
-    if (!kml::IsEqual(track.m_timestamp, kml::Timestamp{}))
+    if (!kml::IsEqual(track.m_createdTimestamp, kml::Timestamp{}))
     {
       hasTimestamp = true;
       break;
@@ -1354,7 +1354,7 @@ void BookmarkManager::SortTracksByTime(std::vector<SortTrackData> & tracks)
     return;
 
   std::sort(tracks.begin(), tracks.end(),
-            [](SortTrackData const & lbm, SortTrackData const & rbm) { return lbm.m_timestamp > rbm.m_timestamp; });
+            [](SortTrackData const & lbm, SortTrackData const & rbm) { return lbm.m_createdTimestamp > rbm.m_createdTimestamp; });
 }
 
 // static
@@ -1443,7 +1443,7 @@ void BookmarkManager::SortByTime(std::vector<SortBookmarkData> const & bookmarks
     sortedMarks.push_back(&mark);
 
   std::sort(sortedMarks.begin(), sortedMarks.end(), [](SortBookmarkData const * lbm, SortBookmarkData const * rbm)
-  { return lbm->m_timestamp > rbm->m_timestamp; });
+  { return lbm->m_createdTimestamp > rbm->m_createdTimestamp; });
 
   auto const currentTime = kml::TimestampClock::now();
 
@@ -1452,8 +1452,8 @@ void BookmarkManager::SortByTime(std::vector<SortBookmarkData> const & bookmarks
   for (auto mark : sortedMarks)
   {
     auto currentBlockType = SortedByTimeBlockType::Others;
-    if (mark->m_timestamp != kml::Timestamp{})
-      currentBlockType = GetSortedByTimeBlockType(currentTime - mark->m_timestamp);
+    if (mark->m_createdTimestamp != kml::Timestamp{})
+      currentBlockType = GetSortedByTimeBlockType(currentTime - mark->m_createdTimestamp);
 
     if (!lastBlockType)
     {
@@ -1486,7 +1486,7 @@ void BookmarkManager::SortByType(std::vector<SortBookmarkData> const & bookmarks
     sortedMarks.push_back(&mark);
 
   std::sort(sortedMarks.begin(), sortedMarks.end(), [](SortBookmarkData const * lbm, SortBookmarkData const * rbm)
-  { return lbm->m_timestamp > rbm->m_timestamp; });
+  { return lbm->m_createdTimestamp > rbm->m_createdTimestamp; });
 
   std::map<BookmarkBaseType, size_t> typesCount;
   size_t othersTypeMarksCount = 0;
@@ -2363,7 +2363,7 @@ void BookmarkManager::UpdateBookmark(kml::MarkId bmID, kml::BookmarkData const &
   if (prevColor != newColor)
     SetLastEditedBmColor(newColor);
 
-  bookmark->SetEditTimeStamp(kml::TimestampClock::now());
+  bookmark->SetModifiedTimeStamp(kml::TimestampClock::now());
 }
 
 void BookmarkManager::ChangeTrackColor(kml::TrackId trackId, dp::Color color)
@@ -2372,7 +2372,7 @@ void BookmarkManager::ChangeTrackColor(kml::TrackId trackId, dp::Color color)
   auto * track = GetTrackForEdit(trackId);
   track->SetColor(color);
 
-  track->SetEditTimestamp(kml::TimestampClock::now());
+  track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 void BookmarkManager::UpdateTrack(kml::TrackId trackId, kml::TrackData const & trackData)
@@ -2381,7 +2381,7 @@ void BookmarkManager::UpdateTrack(kml::TrackId trackId, kml::TrackData const & t
   auto * track = GetTrackForEdit(trackId);
   track->SetData(trackData);
 
-  track->SetEditTimestamp(kml::TimestampClock::now());
+  track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 kml::MarkGroupId BookmarkManager::LastEditedBMCategory()

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -2372,7 +2372,7 @@ void BookmarkManager::ChangeTrackColor(kml::TrackId trackId, dp::Color color)
   auto * track = GetTrackForEdit(trackId);
   track->SetColor(color);
 
-  track->SetModifiedTimestamp(kml::TimestampClock::now());
+  track->SetModifiedTimeStamp(kml::TimestampClock::now());
 }
 
 void BookmarkManager::UpdateTrack(kml::TrackId trackId, kml::TrackData const & trackData)
@@ -2381,7 +2381,7 @@ void BookmarkManager::UpdateTrack(kml::TrackId trackId, kml::TrackData const & t
   auto * track = GetTrackForEdit(trackId);
   track->SetData(trackData);
 
-  track->SetModifiedTimestamp(kml::TimestampClock::now());
+  track->SetModifiedTimeStamp(kml::TimestampClock::now());
 }
 
 kml::MarkGroupId BookmarkManager::LastEditedBMCategory()

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -2362,6 +2362,8 @@ void BookmarkManager::UpdateBookmark(kml::MarkId bmID, kml::BookmarkData const &
   auto const & newColor = bookmark->GetData().m_color;
   if (prevColor != newColor)
     SetLastEditedBmColor(newColor);
+
+  bookmark->SetEditTimeStamp(kml::TimestampClock::now());
 }
 
 void BookmarkManager::ChangeTrackColor(kml::TrackId trackId, dp::Color color)

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -2363,7 +2363,8 @@ void BookmarkManager::UpdateBookmark(kml::MarkId bmID, kml::BookmarkData const &
   if (prevColor != newColor)
     SetLastEditedBmColor(newColor);
 
-  bookmark->SetModifiedTimestamp(kml::TimestampClock::now());
+  if (bm.m_modifiedTimestamp == kml::Timestamp())
+    bookmark->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 void BookmarkManager::ChangeTrackColor(kml::TrackId trackId, dp::Color color)
@@ -2381,7 +2382,8 @@ void BookmarkManager::UpdateTrack(kml::TrackId trackId, kml::TrackData const & t
   auto * track = GetTrackForEdit(trackId);
   track->SetData(trackData);
 
-  track->SetModifiedTimestamp(kml::TimestampClock::now());
+  if (trackData.m_modifiedTimestamp == kml::Timestamp())
+    track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 kml::MarkGroupId BookmarkManager::LastEditedBMCategory()

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -2371,6 +2371,8 @@ void BookmarkManager::ChangeTrackColor(kml::TrackId trackId, dp::Color color)
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto * track = GetTrackForEdit(trackId);
   track->SetColor(color);
+
+  track->SetEditTimestamp(kml::TimestampClock::now());
 }
 
 void BookmarkManager::UpdateTrack(kml::TrackId trackId, kml::TrackData const & trackData)
@@ -2378,6 +2380,8 @@ void BookmarkManager::UpdateTrack(kml::TrackId trackId, kml::TrackData const & t
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto * track = GetTrackForEdit(trackId);
   track->SetData(trackData);
+
+  track->SetEditTimestamp(kml::TimestampClock::now());
 }
 
 kml::MarkGroupId BookmarkManager::LastEditedBMCategory()

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -1353,8 +1353,8 @@ void BookmarkManager::SortTracksByTime(std::vector<SortTrackData> & tracks)
   if (!hasTimestamp)
     return;
 
-  std::sort(tracks.begin(), tracks.end(),
-            [](SortTrackData const & lbm, SortTrackData const & rbm) { return lbm.m_createdTimestamp > rbm.m_createdTimestamp; });
+  std::sort(tracks.begin(), tracks.end(), [](SortTrackData const & lbm, SortTrackData const & rbm)
+  { return lbm.m_createdTimestamp > rbm.m_createdTimestamp; });
 }
 
 // static

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -2363,7 +2363,7 @@ void BookmarkManager::UpdateBookmark(kml::MarkId bmID, kml::BookmarkData const &
   if (prevColor != newColor)
     SetLastEditedBmColor(newColor);
 
-  bookmark->SetModifiedTimeStamp(kml::TimestampClock::now());
+  bookmark->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 void BookmarkManager::ChangeTrackColor(kml::TrackId trackId, dp::Color color)
@@ -2372,7 +2372,7 @@ void BookmarkManager::ChangeTrackColor(kml::TrackId trackId, dp::Color color)
   auto * track = GetTrackForEdit(trackId);
   track->SetColor(color);
 
-  track->SetModifiedTimeStamp(kml::TimestampClock::now());
+  track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 void BookmarkManager::UpdateTrack(kml::TrackId trackId, kml::TrackData const & trackData)
@@ -2381,7 +2381,7 @@ void BookmarkManager::UpdateTrack(kml::TrackId trackId, kml::TrackData const & t
   auto * track = GetTrackForEdit(trackId);
   track->SetData(trackData);
 
-  track->SetModifiedTimeStamp(kml::TimestampClock::now());
+  track->SetModifiedTimestamp(kml::TimestampClock::now());
 }
 
 kml::MarkGroupId BookmarkManager::LastEditedBMCategory()

--- a/libs/map/bookmark_manager.hpp
+++ b/libs/map/bookmark_manager.hpp
@@ -667,7 +667,7 @@ private:
       , m_name(GetPreferredBookmarkName(bmData))
       , m_point(bmData.m_point)
       , m_type(GetBookmarkMatchInfo(bmData.m_featureTypes).m_type)
-      , m_timestamp(bmData.m_timestamp)
+      , m_createdTimestamp(bmData.m_createdTimestamp)
       , m_address(address)
     {}
 
@@ -675,7 +675,7 @@ private:
     std::string m_name;
     m2::PointD m_point;
     BookmarkBaseType m_type;
-    kml::Timestamp m_timestamp;
+    kml::Timestamp m_createdTimestamp;
     search::ReverseGeocoder::RegionAddress m_address;
   };
 
@@ -684,12 +684,12 @@ private:
     explicit SortTrackData(kml::TrackData const & trackData)
       : m_id(trackData.m_id)
       , m_name(GetPreferredBookmarkStr(trackData.m_name))
-      , m_timestamp(trackData.m_timestamp)
+      , m_createdTimestamp(trackData.m_createdTimestamp)
     {}
 
     kml::TrackId m_id;
     std::string m_name;
-    kml::Timestamp m_timestamp;
+    kml::Timestamp m_createdTimestamp;
   };
 
   void GetSortedCategoryImpl(SortParams const & params, std::vector<SortBookmarkData> const & bookmarksForSort,

--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -193,13 +193,13 @@ void CheckBookmarks(BookmarkManager const & bmManager, kml::MarkGroupId groupId)
   TEST_EQUAL(kml::GetDefaultStr(bm->GetName()), "Nebraska", ());
   TEST_EQUAL(bm->GetColor(), kml::PredefinedColor::Red, ());
   TEST(bm->GetDescription().empty(), ());
-  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetCreatedTimeStamp()), 0, ());
+  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetCreatedTimestamp()), 0, ());
 
   bm = bmManager.GetBookmark(*it++);
   TEST_EQUAL(kml::GetDefaultStr(bm->GetName()), "Monongahela National Forest", ());
   TEST_EQUAL(bm->GetColor(), kml::PredefinedColor::Pink, ());
   TEST_EQUAL(bm->GetDescription(), "Huttonsville, WV 26273<br>", ());
-  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetCreatedTimeStamp()), 524214643, ());
+  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetCreatedTimestamp()), 524214643, ());
 
   bm = bmManager.GetBookmark(*it++);
   m2::PointD org = bm->GetPivot();
@@ -210,7 +210,7 @@ void CheckBookmarks(BookmarkManager const & bmManager, kml::MarkGroupId groupId)
   TEST_EQUAL(kml::GetDefaultStr(bm->GetName()), "From: Минск, Минская область, Беларусь", ());
   TEST_EQUAL(bm->GetColor(), kml::PredefinedColor::Blue, ());
   TEST(bm->GetDescription().empty(), ());
-  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetCreatedTimeStamp()), 888888888, ());
+  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetCreatedTimestamp()), 888888888, ());
 
   bm = bmManager.GetBookmark(*it++);
   org = bm->GetPivot();
@@ -218,7 +218,7 @@ void CheckBookmarks(BookmarkManager const & bmManager, kml::MarkGroupId groupId)
   TEST(AlmostEqualAbs(mercator::YToLat(org.y), 53.89306, kEps), ());
   TEST_EQUAL(kml::GetDefaultStr(bm->GetName()), "<MWM & Sons>", ());
   TEST_EQUAL(bm->GetDescription(), "Amps & <brackets>", ());
-  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetCreatedTimeStamp()), 0, ());
+  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetCreatedTimestamp()), 0, ());
 }
 
 FileType GetActiveFileType()
@@ -383,7 +383,7 @@ UNIT_TEST(Bookmarks_Timestamp)
   auto cat1 = bmManager.CreateBookmarkCategory(arrCat[0], false /* autoSave */);
 
   Bookmark const * pBm1 = bmManager.GetEditSession().CreateBookmark(std::move(b1), cat1);
-  TEST_NOT_EQUAL(kml::ToSecondsSinceEpoch(pBm1->GetCreatedTimeStamp()), 0, ());
+  TEST_NOT_EQUAL(kml::ToSecondsSinceEpoch(pBm1->GetCreatedTimestamp()), 0, ());
 
   kml::BookmarkData b2;
   kml::SetDefaultStr(b2.m_name, "newName");

--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -25,11 +25,13 @@
 #include <utf8.h>  // utf8::is_valid
 
 #include <array>
+#include <chrono>
 #include <cstring>  // strlen
 #include <map>
 #include <numeric>  // std::reduce
 #include <set>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace bookmarks_test
@@ -482,6 +484,184 @@ UNIT_TEST(Bookmarks_CustomColorAndLastEdited)
   auto const * bm2 = bmManager.GetEditSession().CreateBookmark(std::move(bmData2), cat);
   TEST_EQUAL(bm2->GetData().m_color.m_predefinedColor, kml::PredefinedColor::None, ());
   TEST_EQUAL(bm2->GetData().m_color.m_rgba, customB.GetRGBA(), ());
+}
+
+UNIT_TEST(Bookmarks_ModifiedTimestamp_AdvancesOnEachUpdate)
+{
+  ScopedBookmarksDir scopedDir;
+  Framework fm(kFrameworkParams);
+  BookmarkManager & bmManager = fm.GetBookmarkManager();
+  bmManager.EnableTestMode(true);
+
+  auto const catId = bmManager.CreateBookmarkCategory("cat", false /* autoSave */);
+
+  kml::BookmarkData bmData;
+  kml::SetDefaultStr(bmData.m_name, "bm");
+  bmData.m_point = m2::PointD(10, 10);
+  bmData.m_color.m_predefinedColor = kml::PredefinedColor::Blue;
+  auto const bmId = bmManager.GetEditSession().CreateBookmark(std::move(bmData), catId)->GetId();
+  TEST_EQUAL(bmManager.GetBookmark(bmId)->GetModifiedTimestamp(), kml::Timestamp{},
+             ("CreateBookmark does not stamp m_modifiedTimestamp"));
+
+  {
+    kml::BookmarkData copy = bmManager.GetBookmark(bmId)->GetData();
+    copy.m_color.m_predefinedColor = kml::PredefinedColor::Red;
+    bmManager.GetEditSession().UpdateBookmark(bmId, copy);
+  }
+  auto const bmTs1 = bmManager.GetBookmark(bmId)->GetModifiedTimestamp();
+  TEST_NOT_EQUAL(bmTs1, kml::Timestamp{}, ("First UpdateBookmark must set m_modifiedTimestamp"));
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  // Android-style second edit: clone the already-stamped data and forward it to UpdateBookmark.
+  {
+    kml::BookmarkData copy = bmManager.GetBookmark(bmId)->GetData();
+    TEST_NOT_EQUAL(copy.m_modifiedTimestamp, kml::Timestamp{}, ("copy carries the prior stamp"));
+    copy.m_color.m_predefinedColor = kml::PredefinedColor::Green;
+    bmManager.GetEditSession().UpdateBookmark(bmId, copy);
+  }
+  auto const bmTs2 = bmManager.GetBookmark(bmId)->GetModifiedTimestamp();
+  TEST_GREATER(bmTs2, bmTs1, ("Second UpdateBookmark must refresh m_modifiedTimestamp"));
+
+  kml::TrackData trackData;
+  kml::SetDefaultStr(trackData.m_name, "tr");
+  trackData.m_layers = {{5.0 /* lineWidth */, {kml::PredefinedColor::None, 0xff0000ff}}};
+  trackData.m_geometry.AddLine({{{0.0, 0.0}, 1}, {{1.0, 1.0}, 2}});
+  trackData.m_geometry.AddTimestamps({});
+  auto const trackId = bmManager.GetEditSession().CreateTrack(std::move(trackData))->GetId();
+  bmManager.GetEditSession().AttachTrack(trackId, catId);
+  TEST_EQUAL(bmManager.GetTrack(trackId)->GetModifiedTimestamp(), kml::Timestamp{},
+             ("CreateTrack does not stamp m_modifiedTimestamp"));
+
+  {
+    kml::TrackData copy = bmManager.GetTrack(trackId)->GetData();
+    kml::SetDefaultStr(copy.m_name, "renamed");
+    bmManager.GetEditSession().UpdateTrack(trackId, copy);
+  }
+  auto const trTs1 = bmManager.GetTrack(trackId)->GetModifiedTimestamp();
+  TEST_NOT_EQUAL(trTs1, kml::Timestamp{}, ("First UpdateTrack must set m_modifiedTimestamp"));
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  {
+    kml::TrackData copy = bmManager.GetTrack(trackId)->GetData();
+    TEST_NOT_EQUAL(copy.m_modifiedTimestamp, kml::Timestamp{}, ("copy carries the prior stamp"));
+    kml::SetDefaultStr(copy.m_name, "renamed again");
+    bmManager.GetEditSession().UpdateTrack(trackId, copy);
+  }
+  auto const trTs2 = bmManager.GetTrack(trackId)->GetModifiedTimestamp();
+  TEST_GREATER(trTs2, trTs1, ("Second UpdateTrack must refresh m_modifiedTimestamp"));
+}
+
+UNIT_TEST(Bookmarks_ModifiedTimestamp_FirstEditAfterImport)
+{
+  ScopedBookmarksDir scopedDir;
+  Framework fm(kFrameworkParams);
+  BookmarkManager & bmManager = fm.GetBookmarkManager();
+  bmManager.EnableTestMode(true);
+
+  auto const catId = bmManager.CreateBookmarkCategory("cat", false /* autoSave */);
+
+  // Simulate a bookmark imported from a KML that already has m_modifiedTimestamp set.
+  auto const importedStamp = kml::TimestampClock::from_time_t(2400);
+  kml::BookmarkData bmData;
+  kml::SetDefaultStr(bmData.m_name, "imported");
+  bmData.m_point = m2::PointD(10, 10);
+  bmData.m_color.m_predefinedColor = kml::PredefinedColor::Blue;
+  bmData.m_modifiedTimestamp = importedStamp;
+  auto const bmId = bmManager.GetEditSession().CreateBookmark(std::move(bmData), catId)->GetId();
+  TEST_EQUAL(bmManager.GetBookmark(bmId)->GetModifiedTimestamp(), importedStamp, ());
+
+  // Android first-edit pattern: clone existing data (carries importedStamp) and mutate.
+  {
+    kml::BookmarkData copy = bmManager.GetBookmark(bmId)->GetData();
+    copy.m_color.m_predefinedColor = kml::PredefinedColor::Red;
+    bmManager.GetEditSession().UpdateBookmark(bmId, copy);
+  }
+  TEST_GREATER(bmManager.GetBookmark(bmId)->GetModifiedTimestamp(), importedStamp,
+               ("First edit after import must refresh m_modifiedTimestamp"));
+
+  kml::TrackData trackData;
+  kml::SetDefaultStr(trackData.m_name, "imported track");
+  trackData.m_layers = {{5.0 /* lineWidth */, {kml::PredefinedColor::None, 0xff0000ff}}};
+  trackData.m_geometry.AddLine({{{0.0, 0.0}, 1}, {{1.0, 1.0}, 2}});
+  trackData.m_geometry.AddTimestamps({});
+  trackData.m_modifiedTimestamp = importedStamp;
+  auto const trackId = bmManager.GetEditSession().CreateTrack(std::move(trackData))->GetId();
+  bmManager.GetEditSession().AttachTrack(trackId, catId);
+  TEST_EQUAL(bmManager.GetTrack(trackId)->GetModifiedTimestamp(), importedStamp, ());
+
+  {
+    kml::TrackData copy = bmManager.GetTrack(trackId)->GetData();
+    kml::SetDefaultStr(copy.m_name, "renamed");
+    bmManager.GetEditSession().UpdateTrack(trackId, copy);
+  }
+  TEST_GREATER(bmManager.GetTrack(trackId)->GetModifiedTimestamp(), importedStamp,
+               ("First edit after import must refresh m_modifiedTimestamp"));
+}
+
+UNIT_TEST(Bookmarks_ModifiedTimestamp_BulkCategoryRecolor)
+{
+  ScopedBookmarksDir scopedDir;
+  Framework fm(kFrameworkParams);
+  BookmarkManager & bmManager = fm.GetBookmarkManager();
+  bmManager.EnableTestMode(true);
+
+  auto const catId = bmManager.CreateBookmarkCategory("cat", false /* autoSave */);
+
+  auto const makeBookmark = [&](kml::PredefinedColor color, std::string const & name)
+  {
+    kml::BookmarkData bmData;
+    kml::SetDefaultStr(bmData.m_name, name);
+    bmData.m_point = m2::PointD(1.0, 1.0);
+    bmData.m_color.m_predefinedColor = color;
+    return bmManager.GetEditSession().CreateBookmark(std::move(bmData), catId)->GetId();
+  };
+
+  auto const blueId = makeBookmark(kml::PredefinedColor::Blue, "blue");
+  auto const redId = makeBookmark(kml::PredefinedColor::Red, "red");
+  auto const greenId = makeBookmark(kml::PredefinedColor::Green, "green");
+
+  for (auto const id : {blueId, redId, greenId})
+    TEST_EQUAL(bmManager.GetBookmark(id)->GetModifiedTimestamp(), kml::Timestamp{}, ());
+
+  bmManager.GetEditSession().SetCategoryBookmarksColor(catId, kml::ColorFromPredefinedColor(kml::PredefinedColor::Red));
+
+  TEST_NOT_EQUAL(bmManager.GetBookmark(blueId)->GetModifiedTimestamp(), kml::Timestamp{},
+                 ("Blue->Red must bump m_modifiedTimestamp"));
+  TEST_EQUAL(bmManager.GetBookmark(redId)->GetModifiedTimestamp(), kml::Timestamp{},
+             ("Red->Red must NOT bump m_modifiedTimestamp"));
+  TEST_NOT_EQUAL(bmManager.GetBookmark(greenId)->GetModifiedTimestamp(), kml::Timestamp{},
+                 ("Green->Red must bump m_modifiedTimestamp"));
+
+  auto const makeTrack = [&](kml::PredefinedColor color, std::string const & name)
+  {
+    kml::TrackData trackData;
+    kml::SetDefaultStr(trackData.m_name, name);
+    trackData.m_layers = {
+        {5.0 /* lineWidth */, {kml::PredefinedColor::None, kml::ColorFromPredefinedColor(color).GetRGBA()}}};
+    trackData.m_geometry.AddLine({{{0.0, 0.0}, 1}, {{1.0, 1.0}, 2}});
+    trackData.m_geometry.AddTimestamps({});
+    auto const id = bmManager.GetEditSession().CreateTrack(std::move(trackData))->GetId();
+    bmManager.GetEditSession().AttachTrack(id, catId);
+    return id;
+  };
+
+  auto const blueTrId = makeTrack(kml::PredefinedColor::Blue, "blue track");
+  auto const redTrId = makeTrack(kml::PredefinedColor::Red, "red track");
+  auto const greenTrId = makeTrack(kml::PredefinedColor::Green, "green track");
+
+  for (auto const id : {blueTrId, redTrId, greenTrId})
+    TEST_EQUAL(bmManager.GetTrack(id)->GetModifiedTimestamp(), kml::Timestamp{}, ());
+
+  bmManager.GetEditSession().SetCategoryTracksColor(catId, kml::ColorFromPredefinedColor(kml::PredefinedColor::Red));
+
+  TEST_NOT_EQUAL(bmManager.GetTrack(blueTrId)->GetModifiedTimestamp(), kml::Timestamp{},
+                 ("Blue->Red track must bump m_modifiedTimestamp"));
+  TEST_EQUAL(bmManager.GetTrack(redTrId)->GetModifiedTimestamp(), kml::Timestamp{},
+             ("Red->Red track must NOT bump m_modifiedTimestamp"));
+  TEST_NOT_EQUAL(bmManager.GetTrack(greenTrId)->GetModifiedTimestamp(), kml::Timestamp{},
+                 ("Green->Red track must bump m_modifiedTimestamp"));
 }
 
 UNIT_TEST(Bookmarks_Getting)

--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -193,13 +193,13 @@ void CheckBookmarks(BookmarkManager const & bmManager, kml::MarkGroupId groupId)
   TEST_EQUAL(kml::GetDefaultStr(bm->GetName()), "Nebraska", ());
   TEST_EQUAL(bm->GetColor(), kml::PredefinedColor::Red, ());
   TEST(bm->GetDescription().empty(), ());
-  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetTimeStamp()), 0, ());
+  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetCreatedTimeStamp()), 0, ());
 
   bm = bmManager.GetBookmark(*it++);
   TEST_EQUAL(kml::GetDefaultStr(bm->GetName()), "Monongahela National Forest", ());
   TEST_EQUAL(bm->GetColor(), kml::PredefinedColor::Pink, ());
   TEST_EQUAL(bm->GetDescription(), "Huttonsville, WV 26273<br>", ());
-  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetTimeStamp()), 524214643, ());
+  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetCreatedTimeStamp()), 524214643, ());
 
   bm = bmManager.GetBookmark(*it++);
   m2::PointD org = bm->GetPivot();
@@ -210,7 +210,7 @@ void CheckBookmarks(BookmarkManager const & bmManager, kml::MarkGroupId groupId)
   TEST_EQUAL(kml::GetDefaultStr(bm->GetName()), "From: Минск, Минская область, Беларусь", ());
   TEST_EQUAL(bm->GetColor(), kml::PredefinedColor::Blue, ());
   TEST(bm->GetDescription().empty(), ());
-  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetTimeStamp()), 888888888, ());
+  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetCreatedTimeStamp()), 888888888, ());
 
   bm = bmManager.GetBookmark(*it++);
   org = bm->GetPivot();
@@ -218,7 +218,7 @@ void CheckBookmarks(BookmarkManager const & bmManager, kml::MarkGroupId groupId)
   TEST(AlmostEqualAbs(mercator::YToLat(org.y), 53.89306, kEps), ());
   TEST_EQUAL(kml::GetDefaultStr(bm->GetName()), "<MWM & Sons>", ());
   TEST_EQUAL(bm->GetDescription(), "Amps & <brackets>", ());
-  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetTimeStamp()), 0, ());
+  TEST_EQUAL(kml::ToSecondsSinceEpoch(bm->GetCreatedTimeStamp()), 0, ());
 }
 
 FileType GetActiveFileType()
@@ -383,7 +383,7 @@ UNIT_TEST(Bookmarks_Timestamp)
   auto cat1 = bmManager.CreateBookmarkCategory(arrCat[0], false /* autoSave */);
 
   Bookmark const * pBm1 = bmManager.GetEditSession().CreateBookmark(std::move(b1), cat1);
-  TEST_NOT_EQUAL(kml::ToSecondsSinceEpoch(pBm1->GetTimeStamp()), 0, ());
+  TEST_NOT_EQUAL(kml::ToSecondsSinceEpoch(pBm1->GetCreatedTimeStamp()), 0, ());
 
   kml::BookmarkData b2;
   kml::SetDefaultStr(b2.m_name, "newName");
@@ -1250,7 +1250,7 @@ UNIT_TEST(Bookmarks_Sorting)
                                               [](auto const & sum, auto const & type) { return sum + type + " "; })}};
       bmData.m_point = position;
       if (hours != kUnknownTime)
-        bmData.m_timestamp = currentTime - hours;
+        bmData.m_createdTimestamp = currentTime - hours;
       setFeatureTypes(types, bmData);
       auto const * bm = es.CreateBookmark(std::move(bmData));
       es.AttachBookmark(bm->GetId(), cat);
@@ -1263,7 +1263,7 @@ UNIT_TEST(Bookmarks_Sorting)
       trackData.m_geometry.AddLine({{{0.0, 0.0}, 1}, {{1.0, 0.0}, 2}});
       trackData.m_geometry.AddTimestamps({});
       if (hours != kUnknownTime)
-        trackData.m_timestamp = currentTime - hours;
+        trackData.m_createdTimestamp = currentTime - hours;
       auto const * track = es.CreateTrack(std::move(trackData));
       es.AttachTrack(track->GetId(), cat);
     }

--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -490,6 +490,7 @@ UNIT_TEST(Bookmarks_ModifiedTimestamp_AdvancesOnEachUpdate)
 {
   ScopedBookmarksDir scopedDir;
   Framework fm(kFrameworkParams);
+  df::VisualParams::Init(1.0, 1024);  // CreateBookmark needs it; keeps the test runnable in isolation.
   BookmarkManager & bmManager = fm.GetBookmarkManager();
   bmManager.EnableTestMode(true);
 
@@ -557,6 +558,7 @@ UNIT_TEST(Bookmarks_ModifiedTimestamp_FirstEditAfterImport)
 {
   ScopedBookmarksDir scopedDir;
   Framework fm(kFrameworkParams);
+  df::VisualParams::Init(1.0, 1024);  // CreateBookmark needs it; keeps the test runnable in isolation.
   BookmarkManager & bmManager = fm.GetBookmarkManager();
   bmManager.EnableTestMode(true);
 

--- a/libs/map/track.cpp
+++ b/libs/map/track.cpp
@@ -188,6 +188,17 @@ float Track::GetDepth(size_t layerIndex) const
   return layerIndex * 10;
 }
 
+kml::Timestamp Track::GetEditTimestamp() const
+{
+  return m_data.m_editTimestamp;
+}
+
+void Track::SetEditTimestamp(kml::Timestamp ts)
+{
+  m_isDirty = true;
+  m_data.m_editTimestamp = ts;
+}
+
 void Track::ForEachGeometry(GeometryFnT && fn) const
 {
   for (auto const & line : m_data.m_geometry.m_lines)

--- a/libs/map/track.cpp
+++ b/libs/map/track.cpp
@@ -78,7 +78,7 @@ std::string Track::GetName() const
 
 void Track::SetName(std::string const & name)
 {
-  m_isDirty = true;
+  SetDirty();
   kml::SetDefaultStr(m_data.m_name, name);
 }
 
@@ -89,7 +89,7 @@ std::string Track::GetDescription() const
 
 void Track::SetDescription(std::string const & description)
 {
-  m_isDirty = true;
+  SetDirty();
   kml::SetDefaultStr(m_data.m_description, description);
 }
 

--- a/libs/map/track.cpp
+++ b/libs/map/track.cpp
@@ -188,12 +188,12 @@ float Track::GetDepth(size_t layerIndex) const
   return layerIndex * 10;
 }
 
-kml::Timestamp Track::GetModifiedTimeStamp() const
+kml::Timestamp Track::GetModifiedTimestamp() const
 {
   return m_data.m_modifiedTimestamp;
 }
 
-void Track::SetModifiedTimeStamp(kml::Timestamp ts)
+void Track::SetModifiedTimestamp(kml::Timestamp ts)
 {
   SetDirty();
   m_data.m_modifiedTimestamp = ts;

--- a/libs/map/track.cpp
+++ b/libs/map/track.cpp
@@ -188,15 +188,15 @@ float Track::GetDepth(size_t layerIndex) const
   return layerIndex * 10;
 }
 
-kml::Timestamp Track::GetEditTimestamp() const
+kml::Timestamp Track::GetModifiedTimestamp() const
 {
-  return m_data.m_editTimestamp;
+  return m_data.m_modifiedTimestamp;
 }
 
-void Track::SetEditTimestamp(kml::Timestamp ts)
+void Track::SetModifiedTimestamp(kml::Timestamp ts)
 {
   m_isDirty = true;
-  m_data.m_editTimestamp = ts;
+  m_data.m_modifiedTimestamp = ts;
 }
 
 void Track::ForEachGeometry(GeometryFnT && fn) const

--- a/libs/map/track.cpp
+++ b/libs/map/track.cpp
@@ -95,7 +95,7 @@ void Track::SetDescription(std::string const & description)
 
 void Track::SetData(kml::TrackData const & data)
 {
-  m_isDirty = true;
+  SetDirty();
   m_data = data;
 
   m_elevationInfo.reset();
@@ -173,7 +173,7 @@ dp::Color Track::GetColor(size_t layerIndex) const
 
 void Track::SetColor(dp::Color color)
 {
-  m_isDirty = true;
+  SetDirty();
   m_data.m_layers[0].m_color.m_rgba = color.GetRGBA();
 }
 
@@ -195,7 +195,7 @@ kml::Timestamp Track::GetModifiedTimestamp() const
 
 void Track::SetModifiedTimestamp(kml::Timestamp ts)
 {
-  m_isDirty = true;
+  SetDirty();
   m_data.m_modifiedTimestamp = ts;
 }
 

--- a/libs/map/track.cpp
+++ b/libs/map/track.cpp
@@ -188,12 +188,12 @@ float Track::GetDepth(size_t layerIndex) const
   return layerIndex * 10;
 }
 
-kml::Timestamp Track::GetModifiedTimestamp() const
+kml::Timestamp Track::GetModifiedTimeStamp() const
 {
   return m_data.m_modifiedTimestamp;
 }
 
-void Track::SetModifiedTimestamp(kml::Timestamp ts)
+void Track::SetModifiedTimeStamp(kml::Timestamp ts)
 {
   SetDirty();
   m_data.m_modifiedTimestamp = ts;

--- a/libs/map/track.cpp
+++ b/libs/map/track.cpp
@@ -95,11 +95,11 @@ void Track::SetDescription(std::string const & description)
 
 void Track::SetData(kml::TrackData const & data)
 {
-  SetDirty();
   m_data = data;
 
   m_elevationInfo.reset();
   m_interactionData.reset();
+  SetDirty();  // Must run after the copy above, which would otherwise overwrite m_modifiedTimestamp.
 }
 
 m2::RectD Track::GetLimitRect() const
@@ -195,8 +195,16 @@ kml::Timestamp Track::GetModifiedTimestamp() const
 
 void Track::SetModifiedTimestamp(kml::Timestamp ts)
 {
-  SetDirty();
+  SetDirty(false /* updateModificationTime */);
   m_data.m_modifiedTimestamp = ts;
+}
+
+// See kml::BookmarkData::m_modifiedTimestamp for the m_modifiedTimestamp update policy.
+void Track::SetDirty(bool updateModificationTime)
+{
+  m_isDirty = true;
+  if (updateModificationTime)
+    m_data.m_modifiedTimestamp = kml::TimestampClock::now();
 }
 
 void Track::ForEachGeometry(GeometryFnT && fn) const

--- a/libs/map/track.hpp
+++ b/libs/map/track.hpp
@@ -91,8 +91,8 @@ public:
   float GetWidth(size_t layerIndex) const override;
   float GetDepth(size_t layerIndex) const override;
   void ForEachGeometry(GeometryFnT && fn) const override;
-  kml::Timestamp GetModifiedTimeStamp() const;
-  void SetModifiedTimeStamp(kml::Timestamp);
+  kml::Timestamp GetModifiedTimestamp() const;
+  void SetModifiedTimestamp(kml::Timestamp);
 
   void Attach(kml::MarkGroupId groupId);
   void Detach();

--- a/libs/map/track.hpp
+++ b/libs/map/track.hpp
@@ -91,8 +91,8 @@ public:
   float GetWidth(size_t layerIndex) const override;
   float GetDepth(size_t layerIndex) const override;
   void ForEachGeometry(GeometryFnT && fn) const override;
-  kml::Timestamp GetModifiedTimestamp() const;
-  void SetModifiedTimestamp(kml::Timestamp);
+  kml::Timestamp GetModifiedTimeStamp() const;
+  void SetModifiedTimeStamp(kml::Timestamp);
 
   void Attach(kml::MarkGroupId groupId);
   void Detach();

--- a/libs/map/track.hpp
+++ b/libs/map/track.hpp
@@ -91,6 +91,8 @@ public:
   float GetWidth(size_t layerIndex) const override;
   float GetDepth(size_t layerIndex) const override;
   void ForEachGeometry(GeometryFnT && fn) const override;
+  kml::Timestamp GetEditTimestamp() const;
+  void SetEditTimestamp(kml::Timestamp);
 
   void Attach(kml::MarkGroupId groupId);
   void Detach();

--- a/libs/map/track.hpp
+++ b/libs/map/track.hpp
@@ -91,8 +91,8 @@ public:
   float GetWidth(size_t layerIndex) const override;
   float GetDepth(size_t layerIndex) const override;
   void ForEachGeometry(GeometryFnT && fn) const override;
-  kml::Timestamp GetEditTimestamp() const;
-  void SetEditTimestamp(kml::Timestamp);
+  kml::Timestamp GetModifiedTimestamp() const;
+  void SetModifiedTimestamp(kml::Timestamp);
 
   void Attach(kml::MarkGroupId groupId);
   void Detach();

--- a/libs/map/track.hpp
+++ b/libs/map/track.hpp
@@ -102,6 +102,9 @@ public:
   kml::MultiGeometry::LineT GetGeometry() const;
   bool HasAltitudes() const;
 
+protected:
+  void SetDirty() { m_isDirty = true; }
+
 private:
   std::vector<Lengths> GetLengthsImpl() const;
   m2::RectD GetLimitRectImpl() const;

--- a/libs/map/track.hpp
+++ b/libs/map/track.hpp
@@ -103,7 +103,7 @@ public:
   bool HasAltitudes() const;
 
 protected:
-  void SetDirty() { m_isDirty = true; }
+  void SetDirty(bool updateModificationTime = true);
 
 private:
   std::vector<Lengths> GetLengthsImpl() const;

--- a/libs/map/user_mark.hpp
+++ b/libs/map/user_mark.hpp
@@ -97,7 +97,8 @@ public:
   virtual bool IsAvailableForSearch() const { return true; }
 
 protected:
-  void SetDirty() { m_isDirty = true; }
+  // updateModificationTime is honored by subclasses that store a modification timestamp (e.g. Bookmark).
+  virtual void SetDirty(bool updateModificationTime = true) { m_isDirty = true; }
 
   m2::PointD m_ptOrg;
 


### PR DESCRIPTION
Added `m_modifiedTimestamp` field to BookmarkData and TrackData structs.

Field is updated on every bookmark or track modification.

Added serialization to/from KML. Updated unit-tests.

Here's sample of KML file content:

```xml
<ExtendedData>
    <mwm:modifiedTimestamp>2026-02-24T02:24:55Z</mwm:modifiedTimestamp> <!-- New element -->
</ExtendedData>
```

TODO: serialize to/from GPX and GeoJson. Let's do a separate PR. It requires new fields for GPX and GeoJson formats.

**Q1:** Should we update `m_modifiedTimestamp` when bookmark is moved to another list?

**Q2:** Should we display creation date and modification date on UI? On bookmarks and tracks list or in edit dialog?