### PR TITLE
[android] Fix missing space in opening hours on Place Page

### DIFF
--- a/android/app/src/main/res/layout/place_page_opening_hours_fragment.xml
+++ b/android/app/src/main/res/layout/place_page_opening_hours_fragment.xml
@@ -40,6 +40,7 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="6dp"
+      android:layout_marginEnd="32dp"
       android:layout_alignParentEnd="true"
       android:layout_toStartOf="@id/dropdown_icon"
       android:textAppearance="@style/MwmTextAppearance.PlacePage"


### PR DESCRIPTION
Fixes #12173

## Summary
Fixes the missing space between the day label (e.g., "Daily") and the opening time on the Place Page.

## Root cause
The day label (`oh_today_label`) and opening time (`oh_today_open_time`) are displayed in separate TextViews without spacing defined in the layout, resulting in text appearing as:

Daily08:00–22:00

## Solution
Added `layout_marginStart` to `oh_today_open_time` in `place_page_opening_hours_fragment.xml` to ensure proper visual separation between the label and time.

## Before vs After

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/41329ddb-cdde-4c2d-a4e6-9fdb824c5970) | ![after](https://github.com/user-attachments/assets/4a640df9-b395-4fd1-8f7c-76310ea1e997) |