### PR TITLE
[Android] Bookmark and BookmarkInfo native calls refactoring

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/Holders.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/Holders.java
@@ -344,7 +344,7 @@ public class Holders
     void bind(@NonNull SectionPosition position, @NonNull BookmarkListAdapter.SectionsDataSource sectionsDataSource)
     {
       final long bookmarkId = sectionsDataSource.getBookmarkId(position);
-      BookmarkInfo bookmark = new BookmarkInfo(sectionsDataSource.getCategory().getId(), bookmarkId);
+      BookmarkInfo bookmark = BookmarkManager.INSTANCE.getBookmarkInfo(bookmarkId);
       mName.setText(bookmark.getName());
       final Location loc = MwmApplication.from(mIcon.getContext()).getLocationHelper().getSavedLocation();
 

--- a/android/libs/car/src/main/java/app/organicmaps/car/screens/bookmarks/BookmarksLoader.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/screens/bookmarks/BookmarksLoader.java
@@ -134,7 +134,7 @@ class BookmarksLoader implements BookmarkManager.BookmarksSortingListener
     for (int i = 0; i < mBookmarksListSize && i < bookmarksIds.size(); ++i)
     {
       final long id = bookmarksIds.get(i);
-      bookmarks[i] = new BookmarkInfo(mBookmarkCategory.getId(), id);
+      bookmarks[i] = BookmarkManager.INSTANCE.getBookmarkInfo(id);
     }
 
     mBookmarkLoaderTask = ThreadPool.getWorker().submit(() -> {

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/Bookmark.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/Bookmark.cpp
@@ -53,13 +53,6 @@ Bookmark const * getBookmark(jlong bokmarkId)
 
 extern "C"
 {
-JNIEXPORT jint Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeGetColor(JNIEnv *, jclass, jlong bmk)
-{
-  auto const * mark = getBookmark(bmk);
-  return static_cast<jint>(
-      kml::kColorIndexMap[base::E2I(mark != nullptr ? mark->GetColor() : frm()->LastEditedBMColor())]);
-}
-
 JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeSetColor(JNIEnv *, jclass, jlong bmk, jint color)
 {
   auto const * mark = getBookmark(bmk);
@@ -69,43 +62,6 @@ JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeSetColor(J
   bmData.m_color.m_predefinedColor = kml::kOrderedPredefinedColors[color];
 
   g_framework->ReplaceBookmark(static_cast<kml::MarkId>(bmk), bmData);
-}
-
-JNIEXPORT jint Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeGetIcon(JNIEnv *, jclass, jlong bmk)
-{
-  auto const * mark = getBookmark(bmk);
-  return static_cast<jint>(mark != nullptr ? mark->GetData().m_icon : kml::BookmarkIcon::None);
-}
-
-JNIEXPORT jobject Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeGetXY(JNIEnv * env, jclass, jlong bmk)
-{
-  return jni::GetNewParcelablePointD(env, getBookmark(bmk)->GetPivot());
-}
-
-JNIEXPORT jstring Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeGetFeatureType(JNIEnv * env, jclass, jlong bmk)
-{
-  return jni::ToJavaString(env, kml::GetLocalizedFeatureType(getBookmark(bmk)->GetData().m_featureTypes));
-}
-
-JNIEXPORT jstring Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeGetName(JNIEnv * env, jclass, jlong bmk)
-{
-  return jni::ToJavaString(env, getBookmark(bmk)->GetPreferredName());
-}
-
-JNIEXPORT jstring Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeGetDescription(JNIEnv * env, jclass, jlong bmk)
-{
-  return jni::ToJavaString(env, getBookmark(bmk)->GetDescription());
-}
-
-JNIEXPORT jdouble Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeGetScale(JNIEnv *, jclass, jlong bmk)
-{
-  return getBookmark(bmk)->GetScale();
-}
-
-JNIEXPORT jstring Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeGetAddress(JNIEnv * env, jclass, jlong bmkId)
-{
-  auto const address = frm()->GetAddressAtPoint(getBookmark(bmkId)->GetPivot()).FormatAddress();
-  return jni::ToJavaString(env, address);
 }
 
 JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_Bookmark_nativeUpdateParams(JNIEnv * env, jclass, jlong bmk,

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/BookmarkManager.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/BookmarkManager.cpp
@@ -73,7 +73,19 @@ void PrepareClassRefs(JNIEnv * env)
                                                    "([Lapp/organicmaps/sdk/bookmarks/data/SortedBlock;J)V");
   g_onBookmarksSortingCancelled = jni::GetMethodID(env, bookmarkManagerInstance, "onBookmarksSortingCancelled", "(J)V");
   g_bookmarkInfoClass = jni::GetGlobalClassRef(env, "app/organicmaps/sdk/bookmarks/data/BookmarkInfo");
-  g_bookmarkInfoConstructor = jni::GetConstructorID(env, g_bookmarkInfoClass, "(JJ)V");
+  g_bookmarkInfoConstructor = jni::GetConstructorID(env, g_bookmarkInfoClass,
+                                                    "("
+                                                    "J"                   // categoryId
+                                                    "J"                   // bookmarkId
+                                                    "Ljava/lang/String;"  // title
+                                                    "Ljava/lang/String;"  // description
+                                                    "Ljava/lang/String;"  // featureType
+                                                    "I"                   // color
+                                                    "I"                   // iconType
+                                                    "Lapp/organicmaps/sdk/bookmarks/data/ParcelablePointD;"  // coords
+                                                    "D"                                                      // scale
+                                                    "Ljava/lang/String;"                                     // address
+                                                    ")V");
 
   g_onElevationCurrentPositionChangedMethod =
       jni::GetMethodID(env, bookmarkManagerInstance, "onElevationCurrentPositionChanged", "()V");
@@ -347,8 +359,19 @@ JNIEXPORT jobject Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_native
   auto const bookmark = frm()->GetBookmarkManager().GetBookmark(static_cast<kml::MarkId>(bmkId));
   if (!bookmark)
     return nullptr;
+
+  auto title = jni::ToJavaString(env, bookmark->GetPreferredName());
+  auto description = jni::ToJavaString(env, bookmark->GetDescription());
+  auto featureType = jni::ToJavaString(env, kml::GetLocalizedFeatureType(bookmark->GetData().m_featureTypes));
+  auto color = static_cast<jint>(kml::kColorIndexMap[base::E2I(bookmark->GetColor())]);
+  auto iconType = static_cast<jint>(bookmark->GetData().m_icon);
+  auto coords = jni::GetNewParcelablePointD(env, bookmark->GetPivot());
+  auto scale = static_cast<jdouble>(bookmark->GetScale());
+  auto address = jni::ToJavaString(env, frm()->GetAddressAtPoint(bookmark->GetPivot()).FormatAddress());
+
   return env->NewObject(g_bookmarkInfoClass, g_bookmarkInfoConstructor, static_cast<jlong>(bookmark->GetGroupId()),
-                        static_cast<jlong>(bmkId));
+                        static_cast<jlong>(bmkId), title, description, featureType, color, iconType, coords, scale,
+                        address);
 }
 
 static uint32_t shift(uint32_t v, uint8_t bitCount)

--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/Bookmark.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/Bookmark.java
@@ -17,11 +17,11 @@ import app.organicmaps.sdk.util.Constants;
 @SuppressLint("ParcelCreator")
 public class Bookmark extends MapObject
 {
-  private Icon mIcon;
+  private Icon mIcon; // Icon should not be 'final' because its color could be changed.
   private long mCategoryId;
   private final long mBookmarkId;
-  private final double mMerX;
-  private final double mMerY;
+  private final String mDescription;
+  private final double mScale;
 
   // Used by JNI.
   @Keep
@@ -36,30 +36,25 @@ public class Bookmark extends MapObject
 
     mCategoryId = categoryId;
     mBookmarkId = bookmarkId;
-    mIcon = getIconInternal();
+    BookmarkInfo bookmarkInfo = loadBookmarkInfo();
+    mDescription = bookmarkInfo.getDescription();
+    mIcon = bookmarkInfo.getIcon();
+    mScale = bookmarkInfo.getScale();
 
-    final ParcelablePointD ll = nativeGetXY(mBookmarkId);
-    mMerX = ll.x;
-    mMerY = ll.y;
-
-    initXY();
-  }
-
-  private void initXY()
-  {
-    setLat(Math.toDegrees(2.0 * Math.atan(Math.exp(Math.toRadians(mMerY))) - Math.PI / 2.0));
-    setLon(mMerX);
+    setLat(bookmarkInfo.getLat());
+    setLon(bookmarkInfo.getLon());
+    setTitle(bookmarkInfo.getName());
   }
 
   @Override
   public void writeToParcel(Parcel dest, int flags)
   {
-    super.writeToParcel(dest, flags);
+    super.writeToParcel(dest, flags); // Super class writes bookmark lat, lon and title
     dest.writeLong(mCategoryId);
     dest.writeLong(mBookmarkId);
+    dest.writeString(mDescription);
     dest.writeParcelable(mIcon, flags);
-    dest.writeDouble(mMerX);
-    dest.writeDouble(mMerY);
+    dest.writeDouble(mScale);
   }
 
   // Do not use Core while restoring from Parcel! In some cases this constructor is called before
@@ -67,13 +62,12 @@ public class Bookmark extends MapObject
   // TODO: Method restoreHasCurrentPermission causes this strange behaviour, needs to be investigated.
   protected Bookmark(@MapObjectType int type, Parcel source)
   {
-    super(type, source);
+    super(type, source); // Super class reads bookmark lat, lon and title
     mCategoryId = source.readLong();
     mBookmarkId = source.readLong();
+    mDescription = source.readString();
     mIcon = ParcelCompat.readParcelable(source, Icon.class.getClassLoader(), Icon.class);
-    mMerX = source.readDouble();
-    mMerY = source.readDouble();
-    initXY();
+    mScale = source.readDouble();
   }
 
   public long getBookmarkId()
@@ -84,31 +78,13 @@ public class Bookmark extends MapObject
   @Override
   public double getScale()
   {
-    return nativeGetScale(mBookmarkId);
-  }
-
-  @NonNull
-  public DistanceAndAzimut getDistanceAndAzimuth(double cLat, double cLon, double north)
-  {
-    return Framework.nativeGetDistanceAndAzimuth(mMerX, mMerY, cLat, cLon, north);
-  }
-
-  @NonNull
-  private Icon getIconInternal()
-  {
-    return new Icon(getColor(), nativeGetIcon(mBookmarkId));
+    return mScale;
   }
 
   @Nullable
   public Icon getIcon()
   {
     return mIcon;
-  }
-
-  @NonNull
-  public String getCategoryName()
-  {
-    return BookmarkManager.INSTANCE.getCategoryById(mCategoryId).getName();
   }
 
   public long getCategoryId()
@@ -126,74 +102,34 @@ public class Bookmark extends MapObject
 
   public void setIconColor(@ColorInt int color)
   {
-    mIcon = new Icon(PredefinedColors.getPredefinedColorIndex(color), nativeGetIcon(mBookmarkId));
-    nativeSetColor(mBookmarkId, mIcon.getColor());
-  }
-
-  @NonNull
-  public String getBookmarkFeatureType()
-  {
-    return nativeGetFeatureType(mBookmarkId);
+    final int colorIndex = PredefinedColors.getPredefinedColorIndex(color);
+    mIcon = new Icon(colorIndex, mIcon.getType());
+    nativeSetColor(mBookmarkId, colorIndex);
   }
 
   @PredefinedColors.Color
   public int getColor()
   {
-    return nativeGetColor(mBookmarkId);
-  }
-
-  @NonNull
-  public String getName()
-  {
-    return nativeGetName(mBookmarkId);
+    return mIcon.getColor();
   }
 
   @NonNull
   public String getDescription()
   {
-    return nativeGetDescription(mBookmarkId);
+    return mDescription;
   }
 
   @NonNull
-  public String getBookmarkAddress()
+  private BookmarkInfo loadBookmarkInfo()
   {
-    return nativeGetAddress(mBookmarkId);
+    BookmarkInfo info = BookmarkManager.INSTANCE.getBookmarkInfo(mBookmarkId);
+    if (info == null)
+      throw new IllegalStateException("BookmarkInfo for " + mBookmarkId + " not found.");
+
+    return info;
   }
 
-  @NonNull
-  public String getGe0Url(boolean addName)
-  {
-    return nativeEncode2Ge0Url(mBookmarkId, addName);
-  }
-
-  @NonNull
-  public String getHttpGe0Url(boolean addName)
-  {
-    return getGe0Url(addName).replaceFirst(Constants.Url.SHORT_SHARE_PREFIX, Constants.Url.HTTP_SHARE_PREFIX);
-  }
-
-  @NonNull
-  public BookmarkInfo getBookmarkInfo()
-  {
-    return new BookmarkInfo(mCategoryId, mBookmarkId);
-  }
-
-  @NonNull
-  static native String nativeGetFeatureType(long bookmarkId);
-  @NonNull
-  static native String nativeGetName(long bookmarkId);
-  @NonNull
-  static native String nativeGetDescription(long bookmarkId);
-  static native double nativeGetScale(long bookmarkId);
-  @NonNull
-  static native String nativeGetAddress(long bookmarkId);
-  @NonNull
-  static native ParcelablePointD nativeGetXY(long bookmarkId);
-
-  @PredefinedColors.Color
-  static native int nativeGetColor(long bookmarkId);
   static native int nativeSetColor(long bookmarkId, @PredefinedColors.Color int color);
-  static native int nativeGetIcon(long bookmarkId);
 
   static native void nativeUpdateParams(long bookmarkId, @NonNull String name, @PredefinedColors.Color int color,
                                         @NonNull String description);

--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/BookmarkInfo.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/BookmarkInfo.java
@@ -18,6 +18,8 @@ public class BookmarkInfo
   @NonNull
   private String mTitle;
   @NonNull
+  private final String mDescription;
+  @NonNull
   private final String mFeatureType;
   @NonNull
   private Icon mIcon;
@@ -29,18 +31,23 @@ public class BookmarkInfo
   @NonNull
   private final ParcelablePointD mLatLonPoint;
 
-  public BookmarkInfo(@IntRange(from = 0) long categoryId, @IntRange(from = 0) long bookmarkId)
+  // Called from JNI.
+  @Keep
+  @SuppressWarnings("unused")
+  private BookmarkInfo(@IntRange(from = 0) long categoryId, @IntRange(from = 0) long bookmarkId, @NonNull String title,
+                       @NonNull String description, @NonNull String featureType, @PredefinedColors.Color int color,
+                       int iconType, @NonNull ParcelablePointD coords, double scale, @NonNull String address)
   {
     mCategoryId = categoryId;
     mBookmarkId = bookmarkId;
-    mTitle = Bookmark.nativeGetName(mBookmarkId);
-    mFeatureType = Bookmark.nativeGetFeatureType(mBookmarkId);
-    mIcon = new Icon(Bookmark.nativeGetColor(mBookmarkId), Bookmark.nativeGetIcon(mBookmarkId));
-    final ParcelablePointD ll = Bookmark.nativeGetXY(mBookmarkId);
-    mMerX = ll.x;
-    mMerY = ll.y;
-    mScale = Bookmark.nativeGetScale(mBookmarkId);
-    mAddress = Bookmark.nativeGetAddress(mBookmarkId);
+    mTitle = title;
+    mDescription = description;
+    mFeatureType = featureType;
+    mIcon = new Icon(color, iconType);
+    mMerX = coords.x;
+    mMerY = coords.y;
+    mScale = scale;
+    mAddress = address;
     mLatLonPoint = GeoUtils.toLatLon(mMerX, mMerY);
   }
 
@@ -83,6 +90,16 @@ public class BookmarkInfo
     return getDistanceAndAzimuth(latitude, longitude, v).getDistance();
   }
 
+  public double getMerX()
+  {
+    return mMerX;
+  }
+
+  public double getMerY()
+  {
+    return mMerY;
+  }
+
   public double getLat()
   {
     return mLatLonPoint.x;
@@ -107,7 +124,7 @@ public class BookmarkInfo
   @NonNull
   public String getDescription()
   {
-    return Bookmark.nativeGetDescription(mBookmarkId);
+    return mDescription;
   }
 
   public void update(@NonNull String name, @Nullable Icon icon, @NonNull String description)


### PR DESCRIPTION
Reduced number of native calls. Currently `Bookmark` class has 7 native calls for a Bookmark properties:

* `String nativeGetFeatureType(long bookmarkId)`
* `String nativeGetName(long bookmarkId)`
* `String nativeGetDescription(long bookmarkId)`
* `double nativeGetScale(long bookmarkId)`
* `String nativeGetAddress(long bookmarkId)`
* `ParcelablePointD nativeGetXY(long bookmarkId)`
* `int nativeGetColor(long bookmarkId)`
* `int nativeGetIcon(long bookmarkId)`

And Java getters use expensive native calls.

To optimize JNI calls I removed separate calls and all `Bookmark` parameters are passed through `BookmarkInfo` constructor. 

Now `BookmarkManager.nativeGetBookmarkInfo(long id)` function is responsible to get ALL bookmark parameters with one JNI call.

Also `Bookmark` class was refactored to initialize a `BookmarkInfo` instance and take some fields needed for PP.

**Testing:** created bookmarks, modified, changed color from PlacePage and from bookmarks list.

### Benchmarking

OrganicMaps doesn't load all bookmarks in Android code. Single `BookmarkInfo` is created on tap on a bookmark or on edit. When Android shows a list of bookmarks only visible bookmarks are loaded.

I added extra code:

```
    Logger.i(TAG, "Bulk bookmark load start");
    long startTime = System.currentTimeMillis();

    long numBookmarks = 0;

    for (SortedBlock block : sortedResults)
    {
      for (long bookmarkId : block.getBookmarkIds())
        BookmarkManager.INSTANCE.getBookmarkInfo(bookmarkId);
      numBookmarks += block.getBookmarkIds().size();
    }

    long endTime = System.currentTimeMillis();
    Logger.i(TAG, "Finished loading " + numBookmarks + " bookmarks in " + (endTime - startTime) + " millis");
```

With 40 000 bookmarks batch:

* `master` version took 2264 millis
* `branch` version took 2062 millis.

I see 10% improvements. Not great, not terrible.
