### PR TITLE
[android] Fixes crash

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
@@ -385,6 +385,11 @@ public class PlacePageController
     mCustomPeekHeightAnimator = ValueAnimator.ofInt(initialHeight, peekHeight);
     mCustomPeekHeightAnimator.setInterpolator(new FastOutSlowInInterpolator());
     mCustomPeekHeightAnimator.addUpdateListener(valueAnimator -> {
+      if (!isAdded())
+      {
+        valueAnimator.cancel();
+        return;
+      }
       int value = (Integer) valueAnimator.getAnimatedValue();
       // Make sure the place page can reach the animated peek height to prevent jumps
       // maxHeight does not take the navbar height into account so we manually add it
@@ -745,6 +750,17 @@ public class PlacePageController
     super.onResume();
     if (mPlacePageBehavior.getState() != BottomSheetBehavior.STATE_HIDDEN && !Framework.nativeHasPlacePageInfo())
       mViewModel.setMapObject(null);
+  }
+
+  @Override
+  public void onDestroyView()
+  {
+    if (mCustomPeekHeightAnimator != null)
+    {
+      mCustomPeekHeightAnimator.cancel();
+      mCustomPeekHeightAnimator = null;
+    }
+    super.onDestroyView();
   }
 
   @Override


### PR DESCRIPTION
Fixes https://github.com/organicmaps/organicmaps/issues/12208
Follow-up to https://github.com/organicmaps/organicmaps/pull/12090

The `ValueAnimator` in `animatePeekHeight()` runs independent of the fragment lifecycle. If the fragment detaches while the 200ms animation is still running, the update listener fires and crashes because the fragment no longer has a context.

```
Exception java.lang.IllegalStateException:
  at androidx.fragment.app.Fragment.requireContext (Fragment.java:977)
  at androidx.fragment.app.Fragment.getResources (Fragment.java:1041)
  at app.organicmaps.widget.placepage.PlacePageController.calculatePeekHeight (PlacePageController.java:411)
  at app.organicmaps.widget.placepage.PlacePageController.setPlacePageHeightBounds (PlacePageController.java:321)
  at app.organicmaps.widget.placepage.PlacePageController.lambda$animatePeekHeight$4 (PlacePageController.java:399)
  at android.animation.ValueAnimator.animateValue (ValueAnimator.java:1735)
  at android.animation.ValueAnimator.animateBasedOnTime (ValueAnimator.java:1496)
  at android.animation.ValueAnimator.doAnimationFrame (ValueAnimator.java:1648)
  at android.animation.AnimationHandler.doAnimationFrame (AnimationHandler.java:307)
  at android.animation.AnimationHandler.-$$Nest$mdoAnimationFrame (Unknown Source)
  at android.animation.AnimationHandler$1.doFrame (AnimationHandler.java:86)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1317)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1327)
  at android.view.Choreographer.doCallbacks (Choreographer.java:985)
  at android.view.Choreographer.doFrame (Choreographer.java:911)
  at android.view.Choreographer$FrameDisplayEventReceiver.run (Choreographer.java:1302)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:241)
  at android.os.Looper.loop (Looper.java:358)
  at android.app.ActivityThread.main (ActivityThread.java:8120)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:548)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:942)
```