### PR TITLE
Fixed beta exception

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -67,7 +67,11 @@ project.ext.appName = 'Organic Maps'
 android {
   namespace = 'app.organicmaps'
 
-  enableKotlin = false
+  if (googleFirebaseServicesEnabled) {
+    enableKotlin = true
+  } else {
+    enableKotlin = false
+  }
 
   buildFeatures {
     dataBinding = true

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -28,3 +28,10 @@
 # R8 crypts the source line numbers in all log messages.
 # https://github.com/organicmaps/organicmaps/issues/6559#issuecomment-1812039926
 -dontoptimize
+
+# Room: keep no-arg constructors for generated _Impl classes (room-runtime:2.6.1 rule is insufficient for R8 full mode)
+# Used only when Firebase is enabled.
+-keep class * extends androidx.room.RoomDatabase { <init>(); }
+
+# Firebase: keep no-arg constructors for component registrars (fixed in firebase-components:19.0.0, needed for 18.0.0)
+-keep class * implements com.google.firebase.components.ComponentRegistrar { <init>(); }


### PR DESCRIPTION
Firebase requires kotlin and due to outdated libs (newer require minSdk 23), need some manual keep rules.


```
02-21 14:09:28.980 31851 31851 E AndroidRuntime: Caused by: java.lang.ClassNotFoundException: androidx.datastore.preferences.PreferenceDataStoreDelegateKt
```

```
02-21 14:26:02.824  1881  1881 E AndroidRuntime: Caused by: java.lang.NoSuchMethodException: androidx.work.impl.WorkDatabase_Impl.<init> []
```

```
02-21 14:26:02.809  1881  1881 W ComponentDiscovery: Caused by: java.lang.NoSuchMethodException: com.google.firebase.crashlytics.CrashlyticsRegistrar.<init> []
```