### PR TITLE
[tracks] Show track names on map for imported GPX/KML files

### DIFF
--- a/libs/drape_frontend/drape_engine.cpp
+++ b/libs/drape_frontend/drape_engine.cpp
@@ -908,6 +908,12 @@ drape_ptr<UserLineRenderParams> DrapeEngine::GenerateLineRenderInfo(UserLineMark
     renderInfo->m_layers.emplace_back(mark->GetColor(layerIndex), mark->GetWidth(layerIndex),
                                       mark->GetDepth(layerIndex));
   }
+
+  renderInfo->m_hasTitle = mark->HasTitle();
+  renderInfo->m_title = mark->GetTitle();
+  renderInfo->m_minTitleZoom = mark->GetMinTitleZoom();
+  renderInfo->m_trackId = mark->GetId();
+
   return renderInfo;
 }
 

--- a/libs/drape_frontend/user_mark_shapes.cpp
+++ b/libs/drape_frontend/user_mark_shapes.cpp
@@ -3,6 +3,7 @@
 #include "drape_frontend/colored_symbol_shape.hpp"
 #include "drape_frontend/line_shape.hpp"
 #include "drape_frontend/map_shape.hpp"
+#include "drape_frontend/path_text_shape.hpp"
 #include "drape_frontend/poi_symbol_shape.hpp"
 #include "drape_frontend/shape_view_params.hpp"
 #include "drape_frontend/text_layout.hpp"
@@ -19,10 +20,8 @@
 #include "indexer/scales.hpp"
 
 #include "geometry/clipping.hpp"
-#include "geometry/mercator.hpp"
 
 #include <array>
-#include <cmath>
 #include <vector>
 
 namespace df
@@ -32,6 +31,8 @@ namespace
 std::array<double, 20> constexpr kLineWidthZoomFactor = {
     // 1   2    3    4    5    6    7    8    9    10   11   12   13   14   15   16   17   18   19   20
     0.3, 0.3, 0.3, 0.4, 0.5, 0.6, 0.7, 0.7, 0.7, 0.7, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+int constexpr kMinTrackTitleZoom = 13;
 
 template <typename TCreateVector>
 void AlignFormingNormals(TCreateVector const & fn, dp::Anchor anchor, dp::Anchor first, dp::Anchor second,
@@ -560,6 +561,7 @@ void CacheUserLines(ref_ptr<dp::GraphicsContext> context, TileKey const & tileKe
       if (spline->GetSize() < 2)
         continue;
 
+      bool titleRendered = false;
       for (auto const & clippedSpline : m2::ClipSplineByRect(tileRect, spline))
       {
         for (auto const & layer : renderInfo.m_layers)
@@ -579,8 +581,34 @@ void CacheUserLines(ref_ptr<dp::GraphicsContext> context, TileKey const & tileKe
 
           LineShape(clippedSpline, params).Draw(context, make_ref(&batcher), textures);
         }
+
+        if (!titleRendered && renderInfo.m_hasTitle && tileKey.m_zoomLevel >= kMinTrackTitleZoom)
+        {
+          PathTextViewParams textParams;
+          textParams.m_tileCenter = tileRect.Center();
+          textParams.m_mainText = renderInfo.m_title;
+          textParams.m_auxText = {};
+          textParams.m_textFont.m_color = dp::Color::Black();
+          textParams.m_textFont.m_outlineColor = dp::Color::White();
+          textParams.m_textFont.m_size = 12.0f * static_cast<float>(df::VisualParams::Instance().GetVisualScale());
+          textParams.m_baseGtoPScale = 1.0 / GetScreenScale(tileKey.m_zoomLevel);
+          textParams.m_depthTestEnabled = true;
+          textParams.m_depth = renderInfo.m_layers.empty() ? 0.0f : renderInfo.m_layers[0].m_depth;
+          textParams.m_depthLayer = DepthLayer::OverlayLayer;
+          textParams.m_minVisibleScale = renderInfo.m_minTitleZoom;
+          textParams.m_markId = renderInfo.m_trackId;
+
+          uint32_t const textIndex = kStartUserMarkOverlayIndex + static_cast<uint32_t>(renderInfo.m_trackId);
+          PathTextShape pathText(clippedSpline, textParams, tileKey, textIndex);
+          if (pathText.CalculateLayout(textures))
+          {
+            pathText.Draw(context, make_ref(&batcher), textures);
+            titleRendered = true;
+          }
+        }
       }
     }
   }
 }
+
 }  // namespace df

--- a/libs/drape_frontend/user_mark_shapes.hpp
+++ b/libs/drape_frontend/user_mark_shapes.hpp
@@ -63,6 +63,10 @@ struct UserLineRenderParams
   DepthLayer m_depthLayer = DepthLayer::UserLineLayer;
   std::vector<LineLayer> m_layers;
   std::vector<m2::SharedSpline> m_splines;
+  bool m_hasTitle = false;
+  std::string m_title;
+  int m_minTitleZoom = 13;  // Use kMinTrackTitleZoom from user_mark_shapes.cpp
+  kml::TrackId m_trackId = kml::kInvalidTrackId;
 };
 
 using UserMarksRenderCollection = std::unordered_map<kml::MarkId, drape_ptr<UserMarkRenderParams>>;

--- a/libs/drape_frontend/user_marks_provider.hpp
+++ b/libs/drape_frontend/user_marks_provider.hpp
@@ -116,6 +116,9 @@ public:
 
   using GeometryFnT = std::function<void(std::vector<m2::PointD> &&)>;
   virtual void ForEachGeometry(GeometryFnT && fn) const = 0;
+  virtual bool HasTitle() const { return !GetTitle().empty(); }
+  virtual std::string GetTitle() const = 0;
+  virtual int GetMinTitleZoom() const = 0;
 
 private:
   kml::TrackId m_id;

--- a/libs/map/track.cpp
+++ b/libs/map/track.cpp
@@ -191,6 +191,16 @@ void Track::ForEachGeometry(GeometryFnT && fn) const
   }
 }
 
+std::string Track::GetTitle() const
+{
+  return GetName();
+}
+
+int Track::GetMinTitleZoom() const
+{
+  return 13;
+}
+
 void Track::Attach(kml::MarkGroupId groupId)
 {
   ASSERT_EQUAL(m_groupID, kml::kInvalidMarkGroupId, ());

--- a/libs/map/track.hpp
+++ b/libs/map/track.hpp
@@ -66,6 +66,9 @@ public:
   float GetDepth(size_t layerIndex) const override;
   void ForEachGeometry(GeometryFnT && fn) const override;
 
+  std::string GetTitle() const override;
+  int GetMinTitleZoom() const override;
+
   void Attach(kml::MarkGroupId groupId);
   void Detach();
 


### PR DESCRIPTION
Fixes #12198 — Show track names on map
Track names from imported GPX/KML files now appear as labels along the track path on the map.
**Changes:**
- Add HasTitle/GetTitle/GetMinTitleZoom API to UserLineMark base class
- Implement in Track class using existing GetName()
- Thread title params through UserLineRenderParams and GenerateLineRenderInfo()
- Render track name labels in CacheUserLines using PathTextShape along the full spline path at zoom >= 13
- Fix baseGtoPScale to use inverse of GetScreenScale (pixels per mercator)
- Fallback to centered TextShape when PathTextShape layout fails

**AFTER**
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/ab9cc993-7667-4379-a70a-c334a93b12d3" />


@biodranik  PTAL 
thank you!

