### PR TITLE
[ios] Fix MWMMapOverlayManager listeners retaining issue

### DIFF
--- a/iphone/CoreApi/CoreApi/Traffic/MWMMapOverlayManager.mm
+++ b/iphone/CoreApi/CoreApi/Traffic/MWMMapOverlayManager.mm
@@ -29,23 +29,26 @@ static NSString * didChangeMapOverlay = @"didChangeMapOverlay";
   if (self)
   {
     _observers = [NSHashTable weakObjectsHashTable];
-    GetFramework().GetTrafficManager().SetStateListener([self](TrafficManager::TrafficState state)
+    __weak __typeof(self) weakTrafficSelf = self;
+    GetFramework().GetTrafficManager().SetStateListener([weakTrafficSelf](TrafficManager::TrafficState state)
     {
-      for (id<MWMMapOverlayManagerObserver> observer in self.observers)
-        if ([observer respondsToSelector:@selector(onMapOverlayUpdated)])
-          [observer onMapOverlayUpdated];
+      __strong __typeof(weakTrafficSelf) self = weakTrafficSelf;
+      if (self)
+        [self notifyObservers];
     });
-    GetFramework().GetTransitManager().SetStateListener([self](TransitReadManager::TransitSchemeState state)
+    __weak __typeof(self) weakTransitSelf = self;
+    GetFramework().GetTransitManager().SetStateListener([weakTransitSelf](TransitReadManager::TransitSchemeState state)
     {
-      for (id<MWMMapOverlayManagerObserver> observer in self.observers)
-        if ([observer respondsToSelector:@selector(onMapOverlayUpdated)])
-          [observer onMapOverlayUpdated];
+      __strong __typeof(weakTransitSelf) self = weakTransitSelf;
+      if (self)
+        [self notifyObservers];
     });
-    GetFramework().GetIsolinesManager().SetStateListener([self](IsolinesManager::IsolinesState state)
+    __weak __typeof(self) weakIsolinesSelf = self;
+    GetFramework().GetIsolinesManager().SetStateListener([weakIsolinesSelf](IsolinesManager::IsolinesState state)
     {
-      for (id<MWMMapOverlayManagerObserver> observer in self.observers)
-        if ([observer respondsToSelector:@selector(onMapOverlayUpdated)])
-          [observer onMapOverlayUpdated];
+      __strong __typeof(weakIsolinesSelf) self = weakIsolinesSelf;
+      if (self)
+        [self notifyObservers];
     });
     [NSNotificationCenter.defaultCenter addObserverForName:didChangeMapOverlay
                                                     object:nil
@@ -57,6 +60,23 @@ static NSString * didChangeMapOverlay = @"didChangeMapOverlay";
                                                 }];
   }
   return self;
+}
+
+- (void)dealloc
+{
+  GetFramework().GetTrafficManager().SetStateListener({});
+  GetFramework().GetTransitManager().SetStateListener({});
+  GetFramework().GetIsolinesManager().SetStateListener({});
+}
+
+- (void)notifyObservers
+{
+  dispatch_async(dispatch_get_main_queue(), ^{
+    NSArray<id<MWMMapOverlayManagerObserver>> * observers = self.observers.allObjects;
+    for (id<MWMMapOverlayManagerObserver> observer in observers)
+      if ([observer respondsToSelector:@selector(onMapOverlayUpdated)])
+        [observer onMapOverlayUpdated];
+  });
 }
 
 #pragma mark - Add/Remove Observers


### PR DESCRIPTION
### Issue description
MWMMapOverlayManager.mm:32-56
```
GetFramework().GetTrafficManager().SetStateListener([self](TrafficManager::TrafficState state) {
  for (id<MWMMapOverlayManagerObserver> observer in self.observers)  // unsafe
    if ([observer respondsToSelector:@selector(onMapOverlayUpdated)])
      [observer onMapOverlayUpdated];
});
```
C++ framework callbacks fire on arbitrary threads and iterate self.observers (a weak NSHashTable) directly. If an observer is deallocated mid-iteration (the weak ref zeroes), the enumeration can throw NSGenericException. The same unsafe iteration appears in the NSNotificationCenter block at line 54 and in 3 other lambdas. A copy should be taken before iteration.

### Solution
Before notifying observers, they should be checked for existence. Added weakify/strongify for the cpp callbacks.