### PR TITLE
[android] Do not strip debug symbols in debug and beta

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -192,6 +192,12 @@ android {
 
       // Enable jni debug build
       jniDebuggable true
+
+      packagingOptions {
+        jniLibs {
+          keepDebugSymbols += ['**/liborganicmaps.so']
+        }
+      }
     }
 
     release {

--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -11,12 +11,6 @@ android {
     buildConfig = true
   }
 
-  packagingOptions {
-    jniLibs {
-      keepDebugSymbols += ['**/liborganicmaps.so']
-    }
-  }
-
   defaultConfig {
     externalNativeBuild {
       def pchFlag = 'OFF'


### PR DESCRIPTION
Before
<img width="433" height="534" alt="Screenshot 2026-03-03 at 20 41 08" src="https://github.com/user-attachments/assets/56ddd2ac-0731-4be7-b396-972400d28696" />
After
<img width="452" height="523" alt="Screenshot 2026-03-03 at 20 42 16" src="https://github.com/user-attachments/assets/85a7a8f2-e855-4cda-a1dc-038f4d815c83" />
