### PR TITLE
[ios] Fix ruler position for the CarPlay

### DIFF
--- a/iphone/Maps/Classes/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Classes/CarPlay/CarPlayService.swift
@@ -33,6 +33,14 @@ final class CarPlayService: NSObject {
     interfaceController?.rootTemplate as? CPMapTemplate
   }
 
+  @objc var carplayLayoutMargins: UIEdgeInsets {
+    guard isCarplayActivated, let view = carplayVC?.view else {
+      return .zero
+    }
+    view.layoutIfNeeded()
+    return view.layoutMargins
+  }
+
   var preparedToPreviewTrips: [CPTrip] = []
   var isUserPanMap: Bool = false
   private var searchText = ""

--- a/iphone/Maps/Classes/Widgets/MWMMapWidgets.mm
+++ b/iphone/Maps/Classes/Widgets/MWMMapWidgets.mm
@@ -30,6 +30,14 @@
       gui::Position(m2::PointF(self.visualScale * 10, self.visualScale * 45), dp::LeftTop);
 }
 
+- (CGRect)carPlayLayout
+{
+  CGRect const bounds = [MapViewController sharedController].mapView.bounds;
+  UIEdgeInsets const insets = [MWMCarPlayService shared].carplayLayoutMargins;
+  CGRect const frame = UIEdgeInsetsInsetRect(bounds, insets);
+  return (CGRectIsNull(frame) || CGRectIsEmpty(frame)) ? bounds : frame;
+}
+
 - (void)resize:(CGSize)size
 {
   if (m_skin != nullptr)
@@ -37,8 +45,7 @@
   dispatch_async(dispatch_get_main_queue(), ^{
     if ([MWMCarPlayService shared].isCarplayActivated)
     {
-      CGRect bounds = [MapViewController sharedController].mapView.bounds;
-      [self updateLayout:bounds];
+      [self updateLayout:[self carPlayLayout]];
       return;
     }
     [self updateLayoutForAvailableArea];
@@ -47,11 +54,15 @@
 
 - (void)updateAvailableArea:(CGRect)frame
 {
+  if ([MWMCarPlayService shared].isCarplayActivated)
+  {
+    [self updateLayout:[self carPlayLayout]];
+    return;
+  }
+
   if (CGRectEqualToRect(self.availableArea, frame))
     return;
   self.availableArea = frame;
-  if ([MWMCarPlayService shared].isCarplayActivated)
-    return;
   [self updateLayout:frame];
 }
 


### PR DESCRIPTION
This PR fixes the ruler edges inset on the map when the CarPlay is enabled by appending carplay VC margins.
Here is how it looks on the different car screens:

<img width="760" height="694" alt="image" src="https://github.com/user-attachments/assets/9a666eab-e8da-4cc9-a538-57f0956bf1f6" />
<img width="760" height="1252" alt="image" src="https://github.com/user-attachments/assets/53aa1953-eb38-4132-81ef-e284a478afec" />
