### PR TITLE
[android] Start detailed opening hours list from current day

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageOpeningHoursFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageOpeningHoursFragment.java
@@ -29,7 +29,6 @@ import app.organicmaps.util.Utils;
 import app.organicmaps.widget.placepage.PlacePageUtils;
 import app.organicmaps.widget.placepage.PlacePageViewModel;
 import java.util.Calendar;
-import java.util.Locale;
 
 public class PlacePageOpeningHoursFragment extends Fragment implements Observer<MapObject>
 {


### PR DESCRIPTION
Fixes #12305

This change updates the ordering of the detailed opening hours list so that it starts from the current day instead of the locale’s first day of the week.

For example, if today is Thursday, the list will display:

Thu → Fri → Sat → Sun → Mon → Tue → Wed

This improves readability by showing today's schedule first.

@biodranik Please let me know if any adjustments are needed.
