### PR TITLE
[ios] Fix vertical panning for transport segmented cotrol on route building screen

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
@@ -219,6 +219,9 @@ final class NavigationDashboardViewController: UIViewController {
 
   private func setupTransportOptionsView() {
     transportOptionsView.interactor = interactor
+    transportOptionsView.onPanGesture = { [weak self] gesture in
+      self?.handlePan(gesture)
+    }
   }
 
   private func setupBottomMenuActions() {

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/TransportOptions/TransportOptionsView.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/TransportOptions/TransportOptionsView.swift
@@ -4,8 +4,10 @@ final class TransportOptionsView: UIView {
   private var segmentedControl = UISegmentedControl()
   private var routerTypes: [MWMRouterType] = []
   private var selectedRouterType: MWMRouterType = .vehicle
+  private let panelPanGestureRecognizer = UIPanGestureRecognizer()
 
   weak var interactor: NavigationDashboard.Interactor?
+  var onPanGesture: ((UIPanGestureRecognizer) -> Void)?
 
   init() {
     super.init(frame: .zero)
@@ -35,6 +37,13 @@ final class TransportOptionsView: UIView {
   private func setupSegmentedControlView() {
     segmentedControl.translatesAutoresizingMaskIntoConstraints = false
     segmentedControl.addTarget(self, action: #selector(didChangeSegment(_:)), for: .valueChanged)
+
+    panelPanGestureRecognizer.addTarget(self, action: #selector(handlePanGesture(_:)))
+    panelPanGestureRecognizer.delegate = self
+    panelPanGestureRecognizer.cancelsTouchesInView = false
+    panelPanGestureRecognizer.delaysTouchesBegan = true
+    addGestureRecognizer(panelPanGestureRecognizer)
+
     addSubview(segmentedControl)
     NSLayoutConstraint.activate([
       segmentedControl.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -72,5 +81,20 @@ final class TransportOptionsView: UIView {
     guard selectedRouterType != routerType else { return }
     selectedRouterType = routerType
     interactor?.process(.selectRouterType(routerType))
+  }
+
+  @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
+    onPanGesture?(gesture)
+  }
+}
+
+extension TransportOptionsView: UIGestureRecognizerDelegate {
+  private enum Constants {
+    static let velocityThreshold: CGFloat = 5
+  }
+
+  override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    let velocity = panelPanGestureRecognizer.velocity(in: self)
+    return abs(velocity.y) > abs(velocity.x) + Constants.velocityThreshold
   }
 }


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/12176

As I mentioned earlier, the native segmented control is very very limited for tweaking. For example, in the Apple Maps application, when you try to build a route and try to pan up or down, touching the segmented control, the screen will not scroll. It totally blocks the interaction. 

I have tried a bunch of approaches, but the most valid is a custom gesture pan recognizer that will handle vertical pan + delaying touches to the segmented control. 

This solution works as expected: 
- If the user swipes up and down, the gesture recognizer will be used to scroll the screen. 
- If the user starts dragging horizontally, the segmented control with a new liquid glass effect will start. But in this case, the vertical scroll will be cancelled. It is possible to recognize and handle both scrolls at the same time, vertical and horizontal, but in this case, when the user removes the finger, a new _undesired segment_ can be selected. It is quite an annoying behavior. So I limited the implementation to recognize only one scroll at the same time: either vertical or horizontal.