### PR TITLE
[drape] Fixed (with todo) possible crash in OverlayTree.

### DIFF
--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -1868,8 +1868,11 @@ void FrontendRenderer::RenderFrame()
 void FrontendRenderer::BuildOverlayTree(ScreenBase const & modelView)
 {
   TRACE_SECTION("[drape] BuildOverlayTree");
+
+  /// @todo We can't skip overlay tree building call. Set valid 0 zoom here.
+  /// @see IsValidCurrentZoom, should realize how do we get here with invalid zoom.
   if (!IsValidCurrentZoom())
-    return;
+    m_currentZoomLevel = 0;
 
   BeginUpdateOverlayTree(modelView);
   for (auto const layerId :


### PR DESCRIPTION
More precise alternative to https://github.com/organicmaps/organicmaps/pull/12269
Fixes https://github.com/organicmaps/organicmaps/issues/8724
Still with todo.