### PR TITLE
[generator] Improve isolines quality for Chinese provinces

### DIFF
--- a/data/conf/isolines/countries-to-generate.json
+++ b/data/conf/isolines/countries-to-generate.json
@@ -1540,7 +1540,7 @@
         {
             "key": "China_Fujian",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1556,7 +1556,7 @@
         {
             "key": "China_Guangxi",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1564,7 +1564,7 @@
         {
             "key": "China_Guizhou",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1572,7 +1572,7 @@
         {
             "key": "China_Hebei",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1580,7 +1580,7 @@
         {
             "key": "China_Heilongjiang",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1596,7 +1596,7 @@
         {
             "key": "China_Hubei",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1604,7 +1604,7 @@
         {
             "key": "China_Hunan",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1612,7 +1612,7 @@
         {
             "key": "China_Inner Mongolia",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1628,7 +1628,7 @@
         {
             "key": "China_Jiangxi",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1660,7 +1660,7 @@
         {
             "key": "China_Qinghai",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1668,7 +1668,7 @@
         {
             "key": "China_Shaanxi",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1692,7 +1692,7 @@
         {
             "key": "China_Shanxi",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1708,7 +1708,7 @@
         {
             "key": "China_Xinjiang",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }
@@ -1716,7 +1716,7 @@
         {
             "key": "China_Yunnan",
             "value": {
-                "profileName": "poor",
+                "profileName": "small",
                 "tileCoordsSubset": [],
                 "tilesAreBanned": false
             }


### PR DESCRIPTION
## Summary

Upgrade the isolines profile for 14 Chinese provinces from `poor` (500m step) to `small` (50m step).

## Problem

Currently, most Chinese provinces use the `poor` isolines profile with a 500m contour interval. This provides almost no useful terrain information for hiking and outdoor activities:

- Popular hiking areas like Jiankou Great Wall (箭扣长城), Chongli ski resorts (崇礼), and many mountain regions show large blank areas with no contour lines
- At z14, users see empty green areas where 500-1000m mountains exist but no contours are rendered
- This is the #1 reason outdoor users in China switch to other mapping apps (as noted in #10012)

## Solution

Change 14 Chinese provinces from `poor` (500m) to `small` (50m) in `countries-to-generate.json`.

The `small` profile uses:
- `alitudesStep`: 50m (vs 500m)
- `simplificationZoom`: 14 (lower detail to save space)
- `maxIsolinesLength`: 500

## Testing

Regenerated `China_Hebei.mwm` with the new profile:

| Metric | Before (poor/500m) | After (small/50m) |
|--------|-------------------|-------------------|
| MWM size | 127 MB | 154 MB (+21%) |
| Contour visibility at z14 | Large blank areas | Full terrain detail |
| Min step visible | 500m only | 50m contours |

The 21% size increase is a reasonable tradeoff for vastly improved terrain readability.

### Before (500m contours, z14 at Jiankou Great Wall):
Large empty area with no contour lines between 500m and 1000m.

### After (50m contours, z14 at Jiankou Great Wall):
Contour lines at 500, 600, 700, 800, 900m clearly showing terrain.

## Changed regions

| Region | Old profile | New profile |
|--------|-----------|-------------|
| China_Fujian | poor (500m) | small (50m) |
| China_Guangxi | poor | small |
| China_Guizhou | poor | small |
| China_Hebei | poor | small |
| China_Heilongjiang | poor | small |
| China_Hubei | poor | small |
| China_Hunan | poor | small |
| China_Inner Mongolia | poor | small |
| China_Jiangxi | poor | small |
| China_Qinghai | poor | small |
| China_Shaanxi | poor | small |
| China_Shanxi | poor | small |
| China_Xinjiang | poor | small |
| China_Yunnan | poor | small |

Note: Provinces already using `extra_small` (100m) or better are not changed.

Related: #10012, #5567, #8672

LLM tools (Claude) were used to assist with testing and generating comparison screenshots.