### PR TITLE
feat: Add persistent altitude dashboard and expose route elevation data

### DIFF
--- a/android/app/src/main/java/app/organicmaps/maplayer/MapButtonsController.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/MapButtonsController.java
@@ -4,6 +4,7 @@ import android.animation.ArgbEvaluator;
 import android.animation.ObjectAnimator;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.location.Location;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.TypedValue;
@@ -11,6 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
+import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
@@ -21,10 +23,13 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import app.organicmaps.MwmActivity;
+import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
 import app.organicmaps.sdk.Framework;
 import app.organicmaps.sdk.downloader.MapManager;
 import app.organicmaps.sdk.downloader.UpdateInfo;
+import app.organicmaps.sdk.location.LocationHelper;
+import app.organicmaps.sdk.location.LocationListener;
 import app.organicmaps.sdk.location.TrackRecorder;
 import app.organicmaps.sdk.maplayer.isolines.IsolinesManager;
 import app.organicmaps.sdk.maplayer.subway.SubwayManager;
@@ -56,6 +61,8 @@ public class MapButtonsController extends Fragment
   private LayersButton mToggleMapLayerButton;
   @Nullable
   FloatingActionButton mTrackRecordingStatusButton;
+  @Nullable
+  private TextView mAltitudeView;
 
   @Nullable
   private MyPositionButton mNavMyPosition;
@@ -67,6 +74,26 @@ public class MapButtonsController extends Fragment
   private MapButtonClickListener mMapButtonClickListener;
   private PlacePageViewModel mPlacePageViewModel;
   private MapButtonsViewModel mMapButtonsViewModel;
+
+  private final LocationListener mLocationListener = new LocationListener()
+  {
+    @Override
+    public void onLocationUpdated(@NonNull Location location)
+    {
+      if (mAltitudeView == null) return;
+      mAltitudeView.setText(Framework.nativeFormatAltitude(location.getAltitude()));
+      UiUtils.show(mAltitudeView);
+    }
+
+    @Override
+    public void onLocationUpdateTimeout() {}
+
+    @Override
+    public void onLocationResolutionRequired(@android.app.PendingIntent pendingIntent) {}
+
+    @Override
+    public void onLocationDisabled() {}
+  };
 
   private final Observer<Integer> mPlacePageDistanceToTopObserver = this::move;
   private final Observer<Boolean> mButtonHiddenObserver = this::setButtonsHidden;
@@ -99,6 +126,7 @@ public class MapButtonsController extends Fragment
     mInnerLeftButtonsFrame = mFrame.findViewById(R.id.map_buttons_inner_left);
     mInnerRightButtonsFrame = mFrame.findViewById(R.id.map_buttons_inner_right);
     mBottomButtonsFrame = mFrame.findViewById(R.id.map_buttons_bottom);
+    mAltitudeView = mFrame.findViewById(R.id.dashboard_altitude);
 
     final FloatingActionButton helpButton = mFrame.findViewById(R.id.help_button);
     if (helpButton != null)
@@ -413,6 +441,7 @@ public class MapButtonsController extends Fragment
     mMapButtonsViewModel.getSearchOption().observe(activity, mSearchOptionObserver);
     mMapButtonsViewModel.getTrackRecorderState().observe(activity, mTrackRecorderObserver);
     mMapButtonsViewModel.getTopButtonsMarginTop().observe(activity, mTopButtonMarginObserver);
+    MwmApplication.from(activity).getLocationHelper().addListener(mLocationListener);
   }
 
   public void onResume()
@@ -448,6 +477,7 @@ public class MapButtonsController extends Fragment
     mMapButtonsViewModel.getButtonsHidden().removeObserver(mButtonHiddenObserver);
     mMapButtonsViewModel.getMyPositionMode().removeObserver(mMyPositionModeObserver);
     mMapButtonsViewModel.getSearchOption().removeObserver(mSearchOptionObserver);
+    MwmApplication.from(requireActivity()).getLocationHelper().removeListener(mLocationListener);
   }
 
   public void onSearchOptionChange(@Nullable SearchWheel.SearchOption searchOption)

--- a/android/app/src/main/res/layout/map_buttons_layout_regular.xml
+++ b/android/app/src/main/res/layout/map_buttons_layout_regular.xml
@@ -24,6 +24,13 @@
       android:layout_alignParentBottom="true"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
+    <include
+      layout="@layout/map_dashboard_altitude"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="@dimen/margin_base"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/layers_button" />
   </androidx.constraintlayout.widget.ConstraintLayout>
   <include
     layout="@layout/map_status_track_recording"

--- a/android/app/src/main/res/layout/map_dashboard_altitude.xml
+++ b/android/app/src/main/res/layout/map_dashboard_altitude.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/dashboard_altitude"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_shadow"
+    android:drawablePadding="4dp"
+    android:gravity="center_vertical"
+    android:paddingStart="12dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="12dp"
+    android:paddingBottom="8dp"
+    android:text="---"
+    android:textAppearance="@style/MwmTextAppearance.Body2"
+    android:textColor="@color/black_primary"
+    android:visibility="gone"
+    android:layout_marginBottom="@dimen/margin_base" />

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -1264,6 +1264,58 @@ JNIEXPORT jobjectArray Java_app_organicmaps_sdk_Framework_nativeGetRouteJunction
   return CreateJunctionInfoArray(env, result);
 }
 
+JNIEXPORT jobject Java_app_organicmaps_sdk_Framework_nativeGetRouteAltitudeData(JNIEnv * env, jclass)
+{
+  RoutingManager::DistanceAltitude altitudes;
+  if (!frm()->GetRoutingManager().GetRouteAltitudesAndDistancesM(altitudes))
+    return nullptr;
+
+  altitudes.Simplify();
+
+  static jclass const dataClass = jni::GetGlobalClassRef(env, "app/organicmaps/sdk/routing/RouteAltitudeData");
+  static jmethodID const constructor = jni::GetConstructorID(env, dataClass, "([D[I)V");
+
+  size_t const size = altitudes.m_distances.size();
+  jdoubleArray distances = env->NewDoubleArray(static_cast<jsize>(size));
+  env->SetDoubleArrayRegion(distances, 0, size, altitudes.m_distances.data());
+
+  jintArray elevs = env->NewIntArray(static_cast<jsize>(size));
+  // geometry::Altitude is int16_t, so we need to copy manually or cast if we want int array
+  // Assuming geometry::Altitudes is std::vector<geometry::Altitude>
+  // Let's iterate and fill
+  jint * elevElements = env->GetIntArrayElements(elevs, 0);
+  for (size_t i = 0; i < size; ++i)
+    elevElements[i] = static_cast<jint>(altitudes.m_altitudes[i]);
+  env->ReleaseIntArrayElements(elevs, elevElements, 0);
+
+  return env->NewObject(dataClass, constructor, distances, elevs);
+}
+
+JNIEXPORT jobject Java_app_organicmaps_sdk_Framework_nativeGetRouteAltitudeData(JNIEnv * env, jclass)
+{
+  RoutingManager::DistanceAltitude altitudes;
+  if (!frm()->GetRoutingManager().GetRouteAltitudesAndDistancesM(altitudes))
+    return nullptr;
+
+  altitudes.Simplify();
+
+  static jclass const dataClass = jni::GetGlobalClassRef(env, "app/organicmaps/sdk/routing/RouteAltitudeData");
+  static jmethodID const constructor = jni::GetConstructorID(env, dataClass, "([D[I)V");
+
+  size_t const size = altitudes.m_distances.size();
+  jdoubleArray distances = env->NewDoubleArray(static_cast<jsize>(size));
+  env->SetDoubleArrayRegion(distances, 0, size, altitudes.m_distances.data());
+
+  jintArray elevs = env->NewIntArray(static_cast<jsize>(size));
+  // geometry::Altitude is int16_t, so we need to copy manually or cast if we want int array
+  jint * elevElements = env->GetIntArrayElements(elevs, 0);
+  for (size_t i = 0; i < size; ++i)
+    elevElements[i] = static_cast<jint>(altitudes.m_altitudes[i]);
+  env->ReleaseIntArrayElements(elevs, elevElements, 0);
+
+  return env->NewObject(dataClass, constructor, distances, elevs);
+}
+
 JNIEXPORT jintArray Java_app_organicmaps_sdk_Framework_nativeGenerateRouteAltitudeChartBits(JNIEnv * env, jclass,
                                                                                             jint width, jint height,
                                                                                             jobject routeAltitudeLimits)
@@ -1823,6 +1875,8 @@ namespace
 JNINativeMethod const frameworkMethods[] = {
     {"nativeGetRouteFollowingInfo", "()Lapp/organicmaps/sdk/routing/RoutingInfo;",
      reinterpret_cast<void *>(&Java_app_organicmaps_sdk_Framework_nativeGetRouteFollowingInfo)},
+    {"nativeGetRouteAltitudeData", "()Lapp/organicmaps/sdk/routing/RouteAltitudeData;",
+     reinterpret_cast<void *>(&Java_app_organicmaps_sdk_Framework_nativeGetRouteAltitudeData)},
 };
 }
 

--- a/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
@@ -211,6 +211,9 @@ public class Framework
   public static native final int[] nativeGenerateRouteAltitudeChartBits(int width, int height,
                                                                         RouteAltitudeLimits routeAltitudeLimits);
 
+  @Nullable
+  public static native app.organicmaps.sdk.routing.RouteAltitudeData nativeGetRouteAltitudeData();
+
   // When an end user is going to a turn he gets sound turn instructions.
   // If C++ part wants the client to pronounce an instruction nativeGenerateTurnNotifications returns
   // an array of one of more strings. C++ part assumes that all these strings shall be pronounced by the client's TTS.

--- a/android/sdk/src/main/java/app/organicmaps/sdk/routing/RouteAltitudeData.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/routing/RouteAltitudeData.java
@@ -1,0 +1,17 @@
+package app.organicmaps.sdk.routing;
+
+import androidx.annotation.NonNull;
+
+public class RouteAltitudeData
+{
+  @NonNull
+  public final double[] distances; // meters from start
+  @NonNull
+  public final int[] altitudes;    // meters elevation
+
+  public RouteAltitudeData(@NonNull double[] distances, @NonNull int[] altitudes)
+  {
+    this.distances = distances;
+    this.altitudes = altitudes;
+  }
+}


### PR DESCRIPTION
This PR introduces a persistent altitude dashboard on the main map screen and exposes raw route elevation data via JNI for interactive route profiling.\n\nChanges:\n- Added dashboard layout.\n- Implemented JNI for route altitude data.\n- Updated MapButtonsController.