### PR TITLE
[android] Crash fix

### DIFF
--- a/android/sdk/car/src/main/java/app/organicmaps/sdk/car/renderer/SurfaceCallback.java
+++ b/android/sdk/car/src/main/java/app/organicmaps/sdk/car/renderer/SurfaceCallback.java
@@ -97,9 +97,15 @@ final class SurfaceCallback extends SurfaceCallbackBase
   {
     Logger.d(TAG, "Surface destroyed");
     if (mPresentation != null)
+    {
       mPresentation.dismiss();
+      mPresentation = null;
+    }
     if (mVirtualDisplay != null)
+    {
       mVirtualDisplay.release();
+      mVirtualDisplay = null;
+    }
   }
 
   @NonNull


### PR DESCRIPTION
Fixes https://github.com/organicmaps/organicmaps/issues/11937

Without the fix, startPresenting (after onDisplayChangedToCar) calls mPresentation.show() on the already released display.