### PR TITLE
[android] Fixed ForegroundServiceDidNotStopInTimeException

### DIFF
--- a/android/app/src/main/java/app/organicmaps/downloader/BottomPanel.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/BottomPanel.java
@@ -39,11 +39,8 @@ class BottomPanel
     public void onClick(View v)
     {
       final String country = mFragment.getCurrentRoot();
-      MapManagerHelper.warnOn3gUpdate(mFragment.getContext(), country, () -> {
-        final Context context = mFragment.getContext();
-        DownloaderService.startForegroundService(context);
-        MapManagerHelper.startUpdate(context, country);
-      });
+      MapManagerHelper.warnOn3gUpdate(mFragment.getContext(), country,
+                                      () -> { MapManagerHelper.startUpdate(mFragment.getContext(), country); });
     }
   };
 

--- a/android/app/src/main/java/app/organicmaps/downloader/DownloaderService.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/DownloaderService.java
@@ -57,6 +57,12 @@ public class DownloaderService extends Service implements MapManager.StorageCall
     }
 
     Logger.i(TAG, "Downloading: " + MapManager.nativeIsDownloading());
+    if (!MapManager.nativeIsDownloading())
+    {
+      Logger.i(TAG, "No active downloads, stopping DownloaderService");
+      stopSelf(startId);
+      return START_NOT_STICKY;
+    }
 
     var notification = mNotifier.buildProgressNotification();
     Logger.i(TAG, "Starting Downloader Foreground Service");
@@ -79,8 +85,8 @@ public class DownloaderService extends Service implements MapManager.StorageCall
   @Override
   public void onStatusChanged(List<MapManager.StorageCallbackData> data)
   {
-    var isDownloading = MapManager.nativeIsDownloading();
-    var hasFailed = hasDownloadFailed(data);
+    final boolean isDownloading = MapManager.nativeIsDownloading();
+    final boolean hasFailed = hasDownloadFailed(data);
 
     Logger.i(TAG, "Downloading: " + isDownloading + " failure: " + hasFailed);
 
@@ -123,6 +129,25 @@ public class DownloaderService extends Service implements MapManager.StorageCall
     Logger.i(TAG, "onDestroy");
 
     MapManager.nativeUnsubscribe(mSubscriptionSlot);
+  }
+
+  @Override
+  public void onTimeout(int startId)
+  {
+    onTimeout(startId, 0);
+  }
+
+  @Override
+  public void onTimeout(int startId, int fgsType)
+  {
+    Logger.w(TAG, "Foreground service timed out, cancelling downloads and stopping the service"
+                      + " startId: " + startId + " fgsType: " + fgsType);
+    MapManager.nativeCancel(MapManager.nativeGetRoot());
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+      stopForeground(Service.STOP_FOREGROUND_REMOVE);
+    else
+      stopForeground(true);
+    stopSelf(startId);
   }
 
   /**

--- a/android/app/src/main/java/app/organicmaps/downloader/MapManagerHelper.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/MapManagerHelper.java
@@ -174,8 +174,9 @@ public class MapManagerHelper
    */
   public static void retryDownload(Context context, @NonNull String countryId)
   {
-    DownloaderService.startForegroundService(context);
+    final boolean wasDownloading = MapManager.nativeIsDownloading();
     MapManager.retryDownload(countryId);
+    startForegroundServiceIfNeeded(context, wasDownloading);
   }
 
   /**
@@ -183,8 +184,9 @@ public class MapManagerHelper
    */
   public static void startUpdate(Context context, @NonNull String root)
   {
-    DownloaderService.startForegroundService(context);
+    final boolean wasDownloading = MapManager.nativeIsDownloading();
     MapManager.startUpdate(root);
+    startForegroundServiceIfNeeded(context, wasDownloading);
   }
 
   /**
@@ -192,11 +194,10 @@ public class MapManagerHelper
    */
   public static void startDownload(Context context, String... countries)
   {
-    DownloaderService.startForegroundService(context);
+    final boolean wasDownloading = MapManager.nativeIsDownloading();
     for (var countryId : countries)
-    {
       MapManager.startDownload(countryId);
-    }
+    startForegroundServiceIfNeeded(context, wasDownloading);
   }
 
   /**
@@ -204,7 +205,17 @@ public class MapManagerHelper
    */
   public static void startDownload(Context context, @NonNull String countryId)
   {
-    DownloaderService.startForegroundService(context);
+    final boolean wasDownloading = MapManager.nativeIsDownloading();
     MapManager.startDownload(countryId);
+    startForegroundServiceIfNeeded(context, wasDownloading);
+  }
+
+  /**
+   * Only start foreground service when needed.
+   */
+  private static void startForegroundServiceIfNeeded(Context context, boolean wasDownloading)
+  {
+    if (!wasDownloading && MapManager.nativeIsDownloading())
+      DownloaderService.startForegroundService(context);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/organicmaps/organicmaps/issues/11360

1. Add missing Service.onTimeout(int startId, int fgsType) for Android 15+ to handle more than 6h dataSync task timeouts, see https://developer.android.com/develop/background-work/services/fgs/timeout

2. Removed the eager/duplicate service starts that make datasync timeouts easier to hit.

3. Start foreground service only when it is really necessary.