### PR TITLE
Fixed GeoJSON FeatureCollection import for non-string properties

### DIFF
--- a/libs/kml/kml_tests/geojson_tests.cpp
+++ b/libs/kml/kml_tests/geojson_tests.cpp
@@ -672,6 +672,67 @@ UNIT_TEST(GeoJson_Writer_UMap_Invalid_Json)
   TEST_EQUAL(jsonString, expected_geojson, ());
 }
 
+UNIT_TEST(GeoJson_Parse_FeatureCollection_NonStringProperties)
+{
+  // FeatureCollection-level "properties" may contain non-string values
+  // (numbers, booleans, nested objects). This should parse without errors.
+  std::string_view constexpr input = R"({
+  "type": "FeatureCollection",
+  "properties": {
+    "name": "My Collection",
+    "count": 42,
+    "active": true,
+    "rating": 3.14,
+    "metadata": {
+      "source": "test",
+      "version": 2
+    }
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Test Point"
+      },
+      "geometry": {
+        "coordinates": [13.39712, 52.48982],
+        "type": "Point"
+      }
+    }
+  ]
+})";
+
+  kml::FileData const dataFromText = LoadGeojsonFromString(input);
+
+  TEST_EQUAL(dataFromText.m_bookmarksData.size(), 1, ());
+  TEST_EQUAL(kml::GetDefaultStr(dataFromText.m_bookmarksData.front().m_name), "Test Point", ());
+}
+
+UNIT_TEST(GeoJson_Parse_FeatureCollection_NoProperties)
+{
+  // FeatureCollection without "properties" field should also parse fine.
+  std::string_view constexpr input = R"({
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "No Collection Props"
+      },
+      "geometry": {
+        "coordinates": [2.3522, 48.8566],
+        "type": "Point"
+      }
+    }
+  ]
+})";
+
+  kml::FileData const dataFromText = LoadGeojsonFromString(input);
+
+  TEST_EQUAL(dataFromText.m_bookmarksData.size(), 1, ());
+  TEST_EQUAL(kml::GetDefaultStr(dataFromText.m_bookmarksData.front().m_name), "No Collection Props", ());
+}
+
 kml::FileData GenerateKmlFileData()
 {
   auto const kDefaultLang = StringUtf8Multilang::kDefaultCode;

--- a/libs/kml/serdes_geojson.hpp
+++ b/libs/kml/serdes_geojson.hpp
@@ -72,7 +72,7 @@ struct GeoJsonData
 {
   std::string type = "FeatureCollection";
   std::vector<GeoJsonFeature> features;
-  std::optional<std::map<std::string, std::string>> properties;
+  std::optional<GenericJsonMap> properties;
 };
 
 // Color convertion functions


### PR DESCRIPTION
Minimal example:

```
{
  "type": "FeatureCollection",
  "properties": {
    "numeric_failed_property": 35
  },
  "bbox": [
    1.105867113,
    2.492759383,
    3.174207034,
    4.522197734
  ],
  "features": [
    {
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [
          2.143268270,
          3.509529414
        ]
      },
      "properties": {
        "name": "Some custom name"
      }
    }
  ]
}
```