### PR TITLE
[android] Removed unnecessary and dangerous catch block

### DIFF
--- a/android/app/src/main/java/app/organicmaps/util/Utils.java
+++ b/android/app/src/main/java/app/organicmaps/util/Utils.java
@@ -245,12 +245,6 @@ public class Utils
         Toast.makeText(context, context.getString(failMessage), Toast.LENGTH_LONG).show();
       Logger.e(TAG, "ActivityNotFoundException", e);
     }
-    catch (AndroidRuntimeException e)
-    {
-      Logger.e(TAG, "AndroidRuntimeException", e);
-      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      context.startActivity(intent);
-    }
   }
 
   private static boolean isHttpOrHttpsScheme(@NonNull String url)


### PR DESCRIPTION
The AndroidRuntimeException catch block is nonsensical, it does exactly the same what is done above.

It is not needed anymore after adding FLAG_ACTIVITY_NEW_TASK and was introduced by mistake.