### PR TITLE
[ios] Allow to start a valid route when user is prompted to download more maps

### DIFF
--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -568,9 +568,16 @@ char const * kRenderAltitudeImagesQueueLabel = "mapsme.mwmrouter.renderAltitudeI
   {
   case routing::RouterResultCode::NoError: [self onRouteReady:NO]; break;
   case routing::RouterResultCode::HasWarnings: [self onRouteReady:YES]; break;
+  case routing::RouterResultCode::NeedMoreMaps:
+    self.routingOptions = [MWMRoutingOptions new];
+    [self presentDownloaderAlert:code countries:absentCountries];
+    // NeedMoreMaps can arrive after a valid route is already built. In that case
+    // the user may decline extra maps and still navigate along the current route.
+    if (![MWMRouter IsRouteValid])
+      [[MWMNavigationDashboardManager sharedManager] onRouteError:L(@"routing_planning_error")];
+    break;
   case routing::RouterResultCode::RouteFileNotExist:
   case routing::RouterResultCode::InconsistentMWMandRoute:
-  case routing::RouterResultCode::NeedMoreMaps:
   case routing::RouterResultCode::FileTooOld:
   case routing::RouterResultCode::RouteNotFound:
     self.routingOptions = [MWMRoutingOptions new];


### PR DESCRIPTION
### Before:
Navigation is blocked even if the route is valid.

<img width="334" height="729" alt="image" src="https://github.com/user-attachments/assets/f51133e8-262f-4173-a494-088f95a43120" />

### After
https://github.com/user-attachments/assets/cd5cf9a4-277e-4fd2-b40a-a59e2d3a7d9b

