### PR TITLE
[ios][drape] Fix crosshair alignment when "Add Place" is pressed from search results

### DIFF
--- a/libs/drape_frontend/drape_frontend_tests/user_event_stream_tests.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/user_event_stream_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "base/thread.hpp"
 
+#include <cmath>
 #include <cstring>
 #include <functional>
 #include <list>
@@ -53,6 +54,21 @@ public:
                                                        false /* useVisibleViewport */,
                                                        nullptr /* parallelAnimCreator */));
   }
+
+  void AddResizeEvent(uint32_t w, uint32_t h) { m_stream.AddEvent(make_unique_dp<df::ResizeEvent>(w, h)); }
+
+  void AddSetVisibleViewport(m2::RectD const & rect)
+  {
+    m_stream.AddEvent(make_unique_dp<df::SetVisibleViewportEvent>(rect));
+  }
+
+  void AddSetCenter(m2::PointD const & center, int zoom, bool trackVisibleViewport)
+  {
+    m_stream.AddEvent(make_unique_dp<df::SetCenterEvent>(center, zoom, false /* isAnim */, trackVisibleViewport,
+                                                         nullptr /* parallelAnimCreator */));
+  }
+
+  ScreenBase const & GetScreen() const { return m_stream.GetCurrentScreen(); }
 
   void AddExpectation(char const * action) { m_expectation.push_back(action); }
 
@@ -193,6 +209,89 @@ UNIT_TEST(SimpleScale)
   }
   test.AddUserEvent(MakeTouchEvent(pointer1, pointer2, df::TouchEvent::TOUCH_UP));
   test.RunTest();
+}
+
+UNIT_TEST(SetCenter_TrackVisibleViewport_False_UsesGeometricScreenCenter)
+{
+  // Simulates "Add Place" triggered from a search result with an explicit coordinate.
+  UserEventStreamTest test(false);
+
+  uint32_t const kW = 1000, kH = 1000;
+  m2::RectD const kVisibleViewport(0.0, 0.0, static_cast<double>(kW), 700.0);
+
+  test.AddResizeEvent(kW, kH);
+  test.AddSetVisibleViewport(kVisibleViewport);
+  test.SetRect(m2::RectD(-100.0, -100.0, 100.0, 100.0));
+  test.RunTest();
+
+  m2::PointD const kTarget(0.0, 0.0);
+  test.AddSetCenter(kTarget, df::kDoNotChangeZoom, false /* trackVisibleViewport */);
+  test.RunTest();
+
+  ScreenBase const & screen = test.GetScreen();
+  m2::PointD const pixelPos = screen.GtoP(kTarget);
+
+  double const kEps = 1.0;  // 1 pixel tolerance
+  double const expectedX = kW * 0.5;
+  double const expectedY = kH * 0.5;
+  TEST(std::fabs(pixelPos.x - expectedX) < kEps, (pixelPos.x, "expected", expectedX));
+  TEST(std::fabs(pixelPos.y - expectedY) < kEps, (pixelPos.y, "expected", expectedY));
+}
+
+UNIT_TEST(SetCenter_TrackVisibleViewport_True_UsesVisibleViewportCenter)
+{
+  // Normal navigation (no explicit position): trackVisibleViewport=true
+  UserEventStreamTest test(false);
+
+  uint32_t const kW = 1000, kH = 1000;
+  m2::RectD const kVisibleViewport(0.0, 0.0, static_cast<double>(kW), 700.0);
+
+  test.AddResizeEvent(kW, kH);
+  test.AddSetVisibleViewport(kVisibleViewport);
+  test.SetRect(m2::RectD(-100.0, -100.0, 100.0, 100.0));
+  test.RunTest();
+
+  m2::PointD const kTarget(0.0, 0.0);
+  test.AddSetCenter(kTarget, df::kDoNotChangeZoom, true /* trackVisibleViewport */);
+  test.RunTest();
+
+  ScreenBase const & screen = test.GetScreen();
+  m2::PointD const pixelPos = screen.GtoP(kTarget);
+
+  double const kEps = 1.0;
+  m2::PointD const viewportCenter = kVisibleViewport.Center();
+  TEST(std::fabs(pixelPos.x - viewportCenter.x) < kEps, (pixelPos.x, "expected", viewportCenter.x));
+  TEST(std::fabs(pixelPos.y - viewportCenter.y) < kEps, (pixelPos.y, "expected", viewportCenter.y));
+}
+
+UNIT_TEST(SetCenter_TrackVisibleViewport_DifferentResults_WithAsymmetricViewport)
+{
+  // Regression guard: with an asymmetric visible viewport (UI panel present),
+  // trackVisibleViewport=false and trackVisibleViewport=true
+  uint32_t const kW = 1000, kH = 1000;
+  m2::RectD const kVisibleViewport(0.0, 0.0, static_cast<double>(kW), 700.0);
+  m2::PointD const kTarget(0.0, 0.0);
+
+  UserEventStreamTest testFalse(false);
+  testFalse.AddResizeEvent(kW, kH);
+  testFalse.AddSetVisibleViewport(kVisibleViewport);
+  testFalse.SetRect(m2::RectD(-100.0, -100.0, 100.0, 100.0));
+  testFalse.RunTest();
+  testFalse.AddSetCenter(kTarget, df::kDoNotChangeZoom, false);
+  testFalse.RunTest();
+  m2::PointD const pixelFalse = testFalse.GetScreen().GtoP(kTarget);
+
+  UserEventStreamTest testTrue(false);
+  testTrue.AddResizeEvent(kW, kH);
+  testTrue.AddSetVisibleViewport(kVisibleViewport);
+  testTrue.SetRect(m2::RectD(-100.0, -100.0, 100.0, 100.0));
+  testTrue.RunTest();
+  testTrue.AddSetCenter(kTarget, df::kDoNotChangeZoom, true);
+  testTrue.RunTest();
+  m2::PointD const pixelTrue = testTrue.GetScreen().GtoP(kTarget);
+
+  double const yDiff = std::fabs(pixelFalse.y - pixelTrue.y);
+  TEST(yDiff > 100.0, (yDiff, "Expected ~150px difference in Y due to 300px bottom panel"));
 }
 
 #endif

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -772,7 +772,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
           zoom = scales::GetAddNewPlaceScale();
         AddUserEvent(make_unique_dp<SetCenterEvent>(
             pt ? *pt : m_userEventStream.GetCurrentScreen().GlobalRect().Center(), zoom, true /* isAnim */,
-            true /* trackVisibleViewport */, nullptr /* parallelAnimCreator */));
+            !pt /* trackVisibleViewport */, nullptr /* parallelAnimCreator */));
       }
       else
       {

--- a/libs/drape_frontend/user_event_stream.cpp
+++ b/libs/drape_frontend/user_event_stream.cpp
@@ -414,7 +414,12 @@ bool UserEventStream::OnSetCenter(ref_ptr<SetCenterEvent> centerEvent)
   auto const zoom = centerEvent->GetZoom();
   auto const scaleFactor = centerEvent->GetScaleFactor();
 
-  if (centerEvent->TrackVisibleViewport())
+  bool const trackViewport = centerEvent->TrackVisibleViewport();
+
+  m2::PointD const pixelTarget =
+      trackViewport ? m_visibleViewport.Center() : GetCurrentScreen().PixelRectIn3d().Center();
+
+  if (trackViewport)
   {
     m_needTrackCenter = true;
     m_trackedCenter = center;
@@ -425,17 +430,17 @@ bool UserEventStream::OnSetCenter(ref_ptr<SetCenterEvent> centerEvent)
   if (zoom != kDoNotChangeZoom)
   {
     screen.SetFromParams(center, screen.GetAngle(), GetScreenScale(zoom));
-    screen.MatchGandP3d(center, m_visibleViewport.Center());
+    screen.MatchGandP3d(center, pixelTarget);
   }
   else if (scaleFactor > 0.0)
   {
     screen.SetOrg(center);
-    ApplyScale(m_visibleViewport.Center(), scaleFactor, screen);
+    ApplyScale(pixelTarget, scaleFactor, screen);
   }
   else
   {
     GetTargetScreen(screen);
-    screen.MatchGandP3d(center, m_visibleViewport.Center());
+    screen.MatchGandP3d(center, pixelTarget);
   }
 
   ShrinkAndScaleInto(screen, df::GetWorldRect());


### PR DESCRIPTION
### Description
This PR fixes an issue where the editor crosshair does not point to the correct selected place when "Add Place" is triggered from a search result. 

When a specific coordinate (`pt`) is provided via the search result, the map was incorrectly tracking the visible viewport center (which is offset by the bottom UI panel) instead of the geometric screen center where the `WIDGET_CHOOSE_POSITION_MARK` crosshair is drawn. 

**Changes made:**
* **`frontend_renderer.cpp`**: Updated the `SetCenterEvent` creation inside `AcceptMessage` (for `SetAddNewPlaceMode`). It now passes `!pt` instead of a hardcoded `true` for the `trackVisibleViewport` argument. This ensures that when an explicit coordinate is provided, it correctly toggles tracking off to ignore UI panel offsets.
* **`user_event_stream.cpp`**: Modified `OnSetCenter` so that screen matching (`MatchGandP3d`) and scaling (`ApplyScale`) no longer hardcode `m_visibleViewport.Center()`. Instead, it introduces a `pixelTarget` that respects the `trackViewport` flag using the visible viewport center when tracking is enabled, and dynamically calculating the geometric screen center when it is disabled.
* **`user_event_stream_tests.cpp`**: Added three new unit tests to verify the asymmetric viewport logic.

Fixes #12237

### Testing
* [x] **Unit Tests:** All `drape_frontend_tests` (specifically `UserEventStream*`) pass locally.
* [x] **Manual Testing:** Tested on the iOS Simulator. Verified that tapping "Add Place" from a specific search result accurately aligns the crosshair with the intended coordinate, even when the bottom UI panel is present. 

| Device | OS | Modes |
| :--- | :--- | :--- |
| iPhone 17 | iOS 26.2 | Portrait / Landscape |

### Screenshots / Video
Before; Showcasing both "Add place" situations:
https://github.com/user-attachments/assets/cfd076c4-8f57-4a5a-af80-470545e29754

After; Showcasing both "Add place" situations:
https://github.com/user-attachments/assets/f7541966-67a2-49f5-8802-ef0062f2c54e

---
*Note: AI tools (Google Gemini) were used to assist in debugging the drape tests*