### PR TITLE
[github] Removed annoying ReviewDog clang-format comments

### DIFF
--- a/.github/workflows/code-style-check.yaml
+++ b/.github/workflows/code-style-check.yaml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Install clang-format
         run: |
@@ -46,12 +45,3 @@ jobs:
 
       - name: Run clang-format
         run: tools/unix/clang-format.sh
-
-      - name: Post clang-format comments
-        if: failure()
-        uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1.24.0
-        with:
-          fail_level: error
-          tool_name: clang-format
-        env:
-          GITHUB_TOKEN: ${{ secrets.REVIEWDOG_TOKEN }}


### PR DESCRIPTION
They can be checked in the failed action log