### PR TITLE
[drape] Fix mixed-font shaping for Latin extended labels

### DIFF
--- a/libs/drape/drape_tests/glyph_mng_tests.cpp
+++ b/libs/drape/drape_tests/glyph_mng_tests.cpp
@@ -322,4 +322,32 @@ UNIT_TEST(GlyphLoadingTest)
   RunTestLoop("Polish", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
 }
 
+UNIT_TEST(ShapeText_MixedLatinExtendedFontRun)
+{
+  dp::GlyphManager::Params args;
+  args.m_uniBlocks = base::JoinPath("fonts", "unicode_blocks.txt");
+  args.m_whitelist = base::JoinPath("fonts", "whitelist.txt");
+  args.m_blacklist = base::JoinPath("fonts", "blacklist.txt");
+  GetPlatform().GetFontNames(args.m_fonts);
+
+  dp::GlyphManager mng(args);
+
+  auto const shapedText = mng.ShapeText("Uluṟu-Kata Tjuṯa", 27 /* fontPixelHeight */, "en");
+
+  TEST(!shapedText.m_glyphs.empty(), ());
+
+  int const firstFontIndex = shapedText.m_glyphs.front().m_key.m_fontIndex;
+  bool hasDifferentFontIndex = false;
+  for (auto const & glyph : shapedText.m_glyphs)
+  {
+    if (glyph.m_key.m_fontIndex != firstFontIndex)
+    {
+      hasDifferentFontIndex = true;
+      break;
+    }
+  }
+
+  TEST(hasDifferentFontIndex, ());
+}
+
 }  // namespace glyph_mng_tests

--- a/libs/drape/drape_tests/glyph_mng_tests.cpp
+++ b/libs/drape/drape_tests/glyph_mng_tests.cpp
@@ -336,18 +336,10 @@ UNIT_TEST(ShapeText_MixedLatinExtendedFontRun)
 
   TEST(!shapedText.m_glyphs.empty(), ());
 
-  int const firstFontIndex = shapedText.m_glyphs.front().m_key.m_fontIndex;
-  bool hasDifferentFontIndex = false;
   for (auto const & glyph : shapedText.m_glyphs)
   {
-    if (glyph.m_key.m_fontIndex != firstFontIndex)
-    {
-      hasDifferentFontIndex = true;
-      break;
-    }
+    TEST_NOT_EQUAL(glyph.m_key.m_glyphId, 0, ("notdef glyph found"));
   }
-
-  TEST(hasDifferentFontIndex, ());
 }
 
 }  // namespace glyph_mng_tests

--- a/libs/drape/glyph_manager.cpp
+++ b/libs/drape/glyph_manager.cpp
@@ -603,71 +603,72 @@ FreetypeError constexpr g_FT_Errors[] =
     // TODO(AB): Check if it's slower or faster.
     allGlyphs.m_glyphs.reserve(icu::UnicodeString{false, text.data(), static_cast<int32_t>(text.size())}.countChar32());
 
-    struct FontRun
+    auto const fontSupportsTextSegment = [this](int fontIndex, std::u16string_view text,
+                                                harfbuzz_shaping::TextSegment const & segment)
     {
-      int m_start = 0;
-      int m_length = 0;
-      int m_fontIndex = kInvalidFont;
-    };
-
-    auto const splitTextSegmentByFont = [this](std::u16string_view text,
-                                               harfbuzz_shaping::TextSegment const & segment)
-    {
-      buffer_vector<FontRun, 4> runs;
+      if (fontIndex < 0)
+        return false;
 
       auto it = text.begin() + segment.m_start;
       auto const end = it + segment.m_length;
-
       while (it != end)
       {
-        auto const runStart = static_cast<int>(it - text.begin());
-
-        auto tmp = it;
-        auto const u32Character = utf8::unchecked::next16(tmp);
-        int const fontIndex = GetFontIndex(u32Character);
-        it = tmp;
-
-        while (it != end)
-        {
-          auto probe = it;
-          auto const nextChar = utf8::unchecked::next16(probe);
-          if (GetFontIndex(nextChar) != fontIndex)
-            break;
-          it = probe;
-        }
-
-        runs.push_back({runStart, static_cast<int>(it - (text.begin() + runStart)), fontIndex});
+        auto const u32Character = utf8::unchecked::next16(it);
+        if (!m_impl->m_fonts[fontIndex]->HasGlyph(u32Character))
+          return false;
       }
 
-      return runs;
+      return true;
+    };
+
+    auto const findTextSegmentFont = [this, &fontSupportsTextSegment](std::u16string_view text,
+                                                                      harfbuzz_shaping::TextSegment const & segment)
+    {
+      int fontIndex = kInvalidFont;
+      auto it = text.begin() + segment.m_start;
+      auto const end = it + segment.m_length;
+      while (it != end)
+      {
+        auto const u32Character = utf8::unchecked::next16(it);
+        if (fontIndex == kInvalidFont)
+        {
+          fontIndex = GetFontIndex(u32Character);
+          if (fontIndex < 0)
+            LOG(LWARNING, ("No font was found for character", NumToHex(u32Character)));
+          continue;
+        }
+
+        if (m_impl->m_fonts[fontIndex]->HasGlyph(u32Character))
+          continue;
+
+        int const characterFontIndex = GetFontIndex(u32Character);
+        if (characterFontIndex < 0)
+        {
+          LOG(LWARNING, ("No font was found for character", NumToHex(u32Character)));
+          continue;
+        }
+
+        if (fontSupportsTextSegment(characterFontIndex, text, segment))
+          return characterFontIndex;
+      }
+
+      return fontIndex;
     };
 
     for (auto const & substring : segments)
     {
-      auto runs = splitTextSegmentByFont(text, substring);
-      if (substring.m_direction == HB_DIRECTION_RTL)
-        std::reverse(runs.begin(), runs.end());
-      for (auto const & run : runs)
-      {
-        if (run.m_fontIndex < 0)
-        {
-          auto u32CharacterIter{text.begin() + run.m_start};
-          auto const u32Character = utf8::unchecked::next16(u32CharacterIter);
-          LOG(LWARNING, ("No font was found for character", NumToHex(u32Character)));
-        }
-        else
-        {
-          hb_buffer_clear_contents(m_impl->m_harfbuzzBuffer);
-          hb_buffer_add_utf16(m_impl->m_harfbuzzBuffer, reinterpret_cast<uint16_t const *>(text.data()),
-                              static_cast<int>(text.size()), run.m_start, run.m_length);
-          hb_buffer_set_direction(m_impl->m_harfbuzzBuffer, substring.m_direction);
-          hb_buffer_set_script(m_impl->m_harfbuzzBuffer, substring.m_script);
-          hb_buffer_set_language(m_impl->m_harfbuzzBuffer, hbLanguage);
+      int const fontIndex = findTextSegmentFont(text, substring);
+      if (fontIndex < 0)
+        continue;
 
-          m_impl->m_fonts[run.m_fontIndex]->Shape(m_impl->m_harfbuzzBuffer, fontPixelHeight, run.m_fontIndex,
-                                                  allGlyphs);
-        }
-      }
+      hb_buffer_clear_contents(m_impl->m_harfbuzzBuffer);
+      hb_buffer_add_utf16(m_impl->m_harfbuzzBuffer, reinterpret_cast<uint16_t const *>(text.data()),
+                          static_cast<int>(text.size()), substring.m_start, substring.m_length);
+      hb_buffer_set_direction(m_impl->m_harfbuzzBuffer, substring.m_direction);
+      hb_buffer_set_script(m_impl->m_harfbuzzBuffer, substring.m_script);
+      hb_buffer_set_language(m_impl->m_harfbuzzBuffer, hbLanguage);
+
+      m_impl->m_fonts[fontIndex]->Shape(m_impl->m_harfbuzzBuffer, fontPixelHeight, fontIndex, allGlyphs);
     }
 
     // Uncomment utf8 printing for debugging if necessary. It crashes JNI with non-modified UTF-8 strings on Android 5

--- a/libs/drape/glyph_manager.cpp
+++ b/libs/drape/glyph_manager.cpp
@@ -603,15 +603,13 @@ FreetypeError constexpr g_FT_Errors[] =
     // TODO(AB): Check if it's slower or faster.
     allGlyphs.m_glyphs.reserve(icu::UnicodeString{false, text.data(), static_cast<int32_t>(text.size())}.countChar32());
 
-    auto const fontSupportsTextSegment = [this](int fontIndex, std::u16string_view text,
-                                                harfbuzz_shaping::TextSegment const & segment)
+    auto const fontSupportsText = [this](int fontIndex, std::u16string_view text)
     {
       if (fontIndex < 0)
         return false;
 
-      auto it = text.begin() + segment.m_start;
-      auto const end = it + segment.m_length;
-      while (it != end)
+      auto it = text.begin();
+      while (it != text.end())
       {
         auto const u32Character = utf8::unchecked::next16(it);
         if (!m_impl->m_fonts[fontIndex]->HasGlyph(u32Character))
@@ -621,8 +619,8 @@ FreetypeError constexpr g_FT_Errors[] =
       return true;
     };
 
-    auto const findTextSegmentFont = [this, &fontSupportsTextSegment](std::u16string_view text,
-                                                                      harfbuzz_shaping::TextSegment const & segment)
+    auto const findTextSegmentFonts = [this, &fontSupportsText](std::u16string_view text,
+                                                                harfbuzz_shaping::TextSegment const & segment)
     {
       int fontIndex = kInvalidFont;
       auto it = text.begin() + segment.m_start;
@@ -648,16 +646,30 @@ FreetypeError constexpr g_FT_Errors[] =
           continue;
         }
 
-        if (fontSupportsTextSegment(characterFontIndex, text, segment))
-          return characterFontIndex;
+        if (fontSupportsText(characterFontIndex, text))
+          return std::make_pair(fontIndex, characterFontIndex);
       }
 
-      return fontIndex;
+      return std::make_pair(fontIndex, kInvalidFont);
     };
 
+    int fallbackFontIndex = kInvalidFont;
+    buffer_vector<int, 4> segmentFontIndexes;
+    segmentFontIndexes.reserve(segments.size());
     for (auto const & substring : segments)
     {
-      int const fontIndex = findTextSegmentFont(text, substring);
+      auto const [fontIndex, segmentFallbackFontIndex] = findTextSegmentFonts(text, substring);
+      segmentFontIndexes.push_back(fontIndex);
+      fallbackFontIndex = segmentFallbackFontIndex;
+      if (fallbackFontIndex >= 0)
+        break;
+    }
+
+    for (size_t i = 0; i < segments.size(); ++i)
+    {
+      auto const & substring = segments[i];
+      int const fontIndex =
+          fallbackFontIndex >= 0 ? fallbackFontIndex : segmentFontIndexes[i];
       if (fontIndex < 0)
         continue;
 

--- a/libs/drape/glyph_manager.cpp
+++ b/libs/drape/glyph_manager.cpp
@@ -602,34 +602,69 @@ FreetypeError constexpr g_FT_Errors[] =
     // TODO(AB): Check if it's slower or faster.
     allGlyphs.m_glyphs.reserve(icu::UnicodeString{false, text.data(), static_cast<int32_t>(text.size())}.countChar32());
 
+    struct FontRun
+    {
+      int m_start = 0;
+      int m_length = 0;
+      int m_fontIndex = kInvalidFont;
+    };
+
+    auto const splitTextSegmentByFont = [this](std::u16string_view text,
+                                               harfbuzz_shaping::TextSegment const & segment)
+    {
+      std::vector<FontRun> runs;
+
+      auto it = text.begin() + segment.m_start;
+      auto const end = it + segment.m_length;
+
+      while (it != end)
+      {
+        auto const runStart = static_cast<int>(it - text.begin());
+
+        auto tmp = it;
+        auto const u32Character = utf8::unchecked::next16(tmp);
+        int const fontIndex = GetFontIndexImmutable(u32Character);
+        it = tmp;
+
+        while (it != end)
+        {
+          auto probe = it;
+          auto const nextChar = utf8::unchecked::next16(probe);
+          if (GetFontIndexImmutable(nextChar) != fontIndex)
+            break;
+          it = probe;
+        }
+
+        runs.push_back({runStart, static_cast<int>(it - (text.begin() + runStart)), fontIndex});
+      }
+
+      return runs;
+    };
+
     for (auto const & substring : segments)
     {
-      hb_buffer_clear_contents(m_impl->m_harfbuzzBuffer);
-
-      // TODO(AB): Some substrings use different fonts.
-      hb_buffer_add_utf16(m_impl->m_harfbuzzBuffer, reinterpret_cast<uint16_t const *>(text.data()),
-                          static_cast<int>(text.size()), substring.m_start, substring.m_length);
-      hb_buffer_set_direction(m_impl->m_harfbuzzBuffer, substring.m_direction);
-      hb_buffer_set_script(m_impl->m_harfbuzzBuffer, substring.m_script);
-      hb_buffer_set_language(m_impl->m_harfbuzzBuffer, hbLanguage);
-
-      auto u32CharacterIter{text.begin() + substring.m_start};
-      auto const end{u32CharacterIter + substring.m_length};
-      do
+      for (auto const & run : splitTextSegmentByFont(text, substring))
       {
-        auto const u32Character = utf8::unchecked::next16(u32CharacterIter);
-        // TODO(AB): Mapping characters to fonts can be optimized.
-        int const fontIndex = GetFontIndex(u32Character);
-        if (fontIndex < 0)
+        hb_buffer_clear_contents(m_impl->m_harfbuzzBuffer);
+
+        hb_buffer_add_utf16(m_impl->m_harfbuzzBuffer, reinterpret_cast<uint16_t const *>(text.data()),
+                            static_cast<int>(text.size()), run.m_start, run.m_length);
+        hb_buffer_set_direction(m_impl->m_harfbuzzBuffer, substring.m_direction);
+        hb_buffer_set_script(m_impl->m_harfbuzzBuffer, substring.m_script);
+        hb_buffer_set_language(m_impl->m_harfbuzzBuffer, hbLanguage);
+
+        if (run.m_fontIndex < 0)
+        {
+          auto u32CharacterIter{text.begin() + run.m_start};
+          auto const u32Character = utf8::unchecked::next16(u32CharacterIter);
           LOG(LWARNING, ("No font was found for character", NumToHex(u32Character)));
+        }
         else
         {
-          // TODO(AB): Mapping font only by the first character in a string may fail in theory in some cases.
-          m_impl->m_fonts[fontIndex]->Shape(m_impl->m_harfbuzzBuffer, fontPixelHeight, fontIndex, allGlyphs);
-          break;
+          m_impl->m_fonts[run.m_fontIndex]->Shape(m_impl->m_harfbuzzBuffer, fontPixelHeight, run.m_fontIndex,
+                                                  allGlyphs);
         }
       }
-      while (u32CharacterIter != end);
     }
 
     // Uncomment utf8 printing for debugging if necessary. It crashes JNI with non-modified UTF-8 strings on Android 5

--- a/libs/drape/glyph_manager.cpp
+++ b/libs/drape/glyph_manager.cpp
@@ -10,6 +10,7 @@
 #include "coding/reader.hpp"
 #include "coding/string_utf8_multilang.hpp"
 
+#include "base/buffer_vector.hpp"
 #include "base/internal/message.hpp"
 #include "base/logging.hpp"
 #include "base/macros.hpp"
@@ -612,7 +613,7 @@ FreetypeError constexpr g_FT_Errors[] =
     auto const splitTextSegmentByFont = [this](std::u16string_view text,
                                                harfbuzz_shaping::TextSegment const & segment)
     {
-      std::vector<FontRun> runs;
+      buffer_vector<FontRun, 4> runs;
 
       auto it = text.begin() + segment.m_start;
       auto const end = it + segment.m_length;
@@ -623,14 +624,14 @@ FreetypeError constexpr g_FT_Errors[] =
 
         auto tmp = it;
         auto const u32Character = utf8::unchecked::next16(tmp);
-        int const fontIndex = GetFontIndexImmutable(u32Character);
+        int const fontIndex = GetFontIndex(u32Character);
         it = tmp;
 
         while (it != end)
         {
           auto probe = it;
           auto const nextChar = utf8::unchecked::next16(probe);
-          if (GetFontIndexImmutable(nextChar) != fontIndex)
+          if (GetFontIndex(nextChar) != fontIndex)
             break;
           it = probe;
         }
@@ -643,16 +644,11 @@ FreetypeError constexpr g_FT_Errors[] =
 
     for (auto const & substring : segments)
     {
-      for (auto const & run : splitTextSegmentByFont(text, substring))
+      auto runs = splitTextSegmentByFont(text, substring);
+      if (substring.m_direction == HB_DIRECTION_RTL)
+        std::reverse(runs.begin(), runs.end());
+      for (auto const & run : runs)
       {
-        hb_buffer_clear_contents(m_impl->m_harfbuzzBuffer);
-
-        hb_buffer_add_utf16(m_impl->m_harfbuzzBuffer, reinterpret_cast<uint16_t const *>(text.data()),
-                            static_cast<int>(text.size()), run.m_start, run.m_length);
-        hb_buffer_set_direction(m_impl->m_harfbuzzBuffer, substring.m_direction);
-        hb_buffer_set_script(m_impl->m_harfbuzzBuffer, substring.m_script);
-        hb_buffer_set_language(m_impl->m_harfbuzzBuffer, hbLanguage);
-
         if (run.m_fontIndex < 0)
         {
           auto u32CharacterIter{text.begin() + run.m_start};
@@ -661,6 +657,13 @@ FreetypeError constexpr g_FT_Errors[] =
         }
         else
         {
+          hb_buffer_clear_contents(m_impl->m_harfbuzzBuffer);
+          hb_buffer_add_utf16(m_impl->m_harfbuzzBuffer, reinterpret_cast<uint16_t const *>(text.data()),
+                              static_cast<int>(text.size()), run.m_start, run.m_length);
+          hb_buffer_set_direction(m_impl->m_harfbuzzBuffer, substring.m_direction);
+          hb_buffer_set_script(m_impl->m_harfbuzzBuffer, substring.m_script);
+          hb_buffer_set_language(m_impl->m_harfbuzzBuffer, hbLanguage);
+
           m_impl->m_fonts[run.m_fontIndex]->Shape(m_impl->m_harfbuzzBuffer, fontPixelHeight, run.m_fontIndex,
                                                   allGlyphs);
         }


### PR DESCRIPTION
### Description
This PR fixes a rendering issue affecting mixed-font Latin labels such as “Uluṟu-Kata Tjuṯa”.

The issue was caused by shaping a whole HarfBuzz segment with a single font selected from the first supported character in that segment. In some cases, this produced incorrect rendering for less common Latin extended characters like ṟ and ṯ.

Changes made:
- Updated glyph_manager.cpp so HarfBuzz segments are split into consecutive font runs and each run is shaped with the appropriate font.
- Added a regression test for “Uluṟu-Kata Tjuṯa” in glyph_mng_tests.cpp.

Fixes #12185

Testing
* [x] **Unit Tests:** drape_tests pass locally
* [x] **Manual Testing:** Verified the corrected rendering manually
* [x] **New Tests:** Added regression test for the reported case

### Screenshots: Before/After

![Before](https://github.com/user-attachments/assets/8571f940-b92b-4273-a866-feceb6c734ba)

<img width="914" height="621" alt="After" src="https://github.com/user-attachments/assets/1f34e506-1d1c-4380-8c42-5305a03a3ae8" />