### PR TITLE
[drape] Fix Samsung Vulkan crash in DynamicTexture::UpdateState

### DIFF
--- a/libs/drape/support_manager.cpp
+++ b/libs/drape/support_manager.cpp
@@ -54,6 +54,13 @@ void SupportManager::Init(ref_ptr<GraphicsContext> context)
     m_maxLineWidth = std::max(props.limits.lineWidthRange[0], props.limits.lineWidthRange[1]);
     m_maxTextureSize = props.limits.maxImageDimension2D;
     m_maxTextureArrayLayers = props.limits.maxImageArrayLayers;
+
+    // Samsung Exynos Mali-G6xx/G7xx Vulkan drivers crash in vkCreateImage when
+    // creating texture 2d arrays with arrayLayers=64 for tile background rendering.
+    // Affected SoCs: s5e9955 (Mali-G720), s5e8845 (Mali-G615), Android 13-16.
+    // Disable texture arrays to force SimpleTexturePool fallback.
+    if (m_rendererName.starts_with("Mali-G6") || m_rendererName.starts_with("Mali-G7"))
+      m_maxTextureArrayLayers = 1;
   }
   LOG(LINFO, ("Max line width =", m_maxLineWidth, "| Max texture size =", m_maxTextureSize,
               "| Max texture array layers =", m_maxTextureArrayLayers));


### PR DESCRIPTION
Samsung Exynos Mali-G6xx/G7xx Vulkan drivers crash in vkCreateImage when creating a texture 2d array with arrayLayers=64 for tile background rendering (TextureArrayPool introduced in 9caed31e30).

The crash manifests as CHECK_VK_CALL(vkCreateImage) -> abort() in VulkanObjectManager::CreateImage. The crash trace shows it in the DynamicTexture::UpdateState path on the frontend renderer thread, triggered by the 64-layer tile background texture array exhausting internal Mali driver resources on the backend renderer thread.

Affected devices:
- Samsung s5e9955 (Exynos 2500, Mali-G720): r11s, r0s, b0s, g0s, b7s
- Samsung s5e8845 (Exynos 1480, Mali-G615): a55x
- Android 13, 14, 15, 16

Fix: Disable texture 2d arrays on Mali-G6xx/G7xx by overriding maxTextureArrayLayers=1 in SupportManager::Init. This forces TextureManager::GetTexturePool to use SimpleTexturePool (individual textures per tile) instead of TextureArrayPool (single 64-layer texture array). SimpleTexturePool is the pre-existing fallback path that was always used before the texture 2d array optimization.

https://play.google.com/console/u/0/developers/8084273541548442467/app/4972992444534608608/vitals/crashes/92aa41541626107ca79e253d4af8efd1/details?days=60&versionCode=26031112
```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 20095 >>> app.organicmaps <<<

backtrace:
  #00  pc 0x00000000000938b8  /apex/com.android.runtime/lib64/bionic/libc.so (abort+164)
  #01  pc 0x0000000000a8a63c  /data/app/~~H0h2fdpQlRzY5HSzJbCc5Q==/app.organicmaps-U-1pUceVYjdvsCEi9LW8qg==/split_config.arm64_v8a.apk!liborganicmaps.so (dp::vulkan::VulkanObjectManager::CreateImage(unsigned int, VkFormat, VkImageTiling, unsigned int, unsigned int, unsigned int, unsigned int)+177) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #02  pc 0x0000000000a9375c  /data/app/~~H0h2fdpQlRzY5HSzJbCc5Q==/app.organicmaps-U-1pUceVYjdvsCEi9LW8qg==/split_config.arm64_v8a.apk!liborganicmaps.so (dp::vulkan::VulkanTexture::Create(ref_ptr<dp::GraphicsContext>, dp::HWTexture::Params const&, ref_ptr<void>)+145) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #03  pc 0x0000000000aeec10  /data/app/~~H0h2fdpQlRzY5HSzJbCc5Q==/app.organicmaps-U-1pUceVYjdvsCEi9LW8qg==/split_config.arm64_v8a.apk!liborganicmaps.so (dp::DynamicTexture<dp::StipplePenIndex, dp::StipplePenKey, (dp::Texture::ResourceType)2>::Create(ref_ptr<dp::GraphicsContext>, dp::HWTexture::Params const&, ref_ptr<void>)+23) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #04  pc 0x0000000000aee938  /data/app/~~H0h2fdpQlRzY5HSzJbCc5Q==/app.organicmaps-U-1pUceVYjdvsCEi9LW8qg==/split_config.arm64_v8a.apk!liborganicmaps.so (dp::DynamicTexture<dp::StipplePenIndex, dp::StipplePenKey, (dp::Texture::ResourceType)2>::UpdateState(ref_ptr<dp::GraphicsContext>)+44) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #05  pc 0x0000000000abc110  /data/app/~~H0h2fdpQlRzY5HSzJbCc5Q==/app.organicmaps-U-1pUceVYjdvsCEi9LW8qg==/split_config.arm64_v8a.apk!liborganicmaps.so (dp::TextureManager::UpdateDynamicTextures(ref_ptr<dp::GraphicsContext>)+367) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #06  pc 0x00000000008ddd14  /data/app/~~H0h2fdpQlRzY5HSzJbCc5Q==/app.organicmaps-U-1pUceVYjdvsCEi9LW8qg==/split_config.arm64_v8a.apk!liborganicmaps.so (df::FrontendRenderer::RenderFrame()+1757) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #07  pc 0x00000000008e15a0  /data/app/~~H0h2fdpQlRzY5HSzJbCc5Q==/app.organicmaps-U-1pUceVYjdvsCEi9LW8qg==/split_config.arm64_v8a.apk!liborganicmaps.so (df::FrontendRenderer::Routine::Do()+62) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #08  pc 0x0000000000bd5fe8  /data/app/~~H0h2fdpQlRzY5HSzJbCc5Q==/app.organicmaps-U-1pUceVYjdvsCEi9LW8qg==/split_config.arm64_v8a.apk!liborganicmaps.so (threads::(anonymous namespace)::RunRoutine(std::__ndk1::shared_ptr<threads::IRoutine>)+26) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #09  pc 0x0000000000be285c  /data/app/~~H0h2fdpQlRzY5HSzJbCc5Q==/app.organicmaps-U-1pUceVYjdvsCEi9LW8qg==/split_config.arm64_v8a.apk!liborganicmaps.so (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::shared_ptr<threads::IRoutine>), std::__ndk1::shared_ptr<threads::IRoutine>>>(void*)+179) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #10  pc 0x00000000000f85d8  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208)
  #11  pc 0x00000000000950f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)
```