### PR TITLE
[android][routing] Fix crash in SetRouter when called before Init.

### DIFF
--- a/libs/map/routing_manager.cpp
+++ b/libs/map/routing_manager.cpp
@@ -1307,6 +1307,16 @@ void RoutingManager::SetRouter(RouterType type)
   HidePreviewSegments();
 
   SetLastUsedRouter(type);
+
+  // m_numMwmIDs is initialized in Init(), which runs on the GUI thread after async map loading
+  // completes (Framework::InitRouting). SetRouter() can be called earlier (e.g. route restoration
+  // triggers onRoutePointsLoaded → RoutingController.prepare → Router.set before maps finish loading).
+  // Deferring is safe: Init() calls SetRouterImpl(GetLastUsedRouter()), picking up the type saved above.
+  /// @TODO(AB): The proper fix is to not set mFrameworkInitialized=true in Android's OrganicMaps.java
+  /// until the async native callback fires, so Java subsystems never see a half-initialized core.
+  if (!m_numMwmIDs)
+    return;
+
   SetRouterImpl(type);
 }
 


### PR DESCRIPTION
Commit 071210636b moved NumMwmIds from a local variable (created fresh in each SetRouterImpl call) to a member m_numMwmIDs initialized once in RoutingManager::Init(). Init() runs on the GUI thread after async map loading completes (Framework::InitRouting → LoadMapsAsync callback).

However, SetRouter() can be called earlier: when the Drape engine finishes initialization before maps are loaded, MwmActivity calls restoreRoute() → nativeLoadRoutePoints(). The async file-read callback fires on the GUI thread before the InitRouting task, triggering onRoutePointsLoaded → RoutingController.prepare → Router.set → JNI → SetRouter → SetRouterImpl → IndexRouter constructor, which dereferences the null m_numMwmIDs in CalcMaxSpeed() and crashes.

The fix: guard SetRouterImpl() behind a null check on m_numMwmIDs. SetLastUsedRouter(type) already persists the preference before the guard, and Init() calls SetRouterImpl(GetLastUsedRouter()), so the correct router type is applied once initialization completes.

The proper fix is to correct the Android readiness contract: OrganicMaps.java sets mFrameworkInitialized=true immediately after nativeInitFramework() returns, even though native routing is only initialized later in the async callback. Java subsystem initialization (RoutingController, SearchEngine, etc.) and the mFrameworkInitialized flag should be deferred until the async callback fires, making all arePlatformAndCoreInitialized() checks truthful. That is a broader change that also requires Android Auto work (AndroidAutoService passes null callback and CarAppSessionBase.onStart calls native methods assuming framework readiness).

https://play.google.com/console/u/0/developers/8084273541548442467/app/4972992444534608608/vitals/crashes/3e36cb1051d1ccbe4f7f33c458d88aa8/details?days=60&versionCode=26031112

```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 19301 >>> app.organicmaps <<<

backtrace:
  #00  pc 0x0000000000623bd0  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/split_config.arm64_v8a.apk!liborganicmaps.so (routing::IndexRouter::IndexRouter(routing::VehicleType, bool, std::__ndk1::function<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)> const&, std::__ndk1::function<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> (m2::Point<double> const&)> const&, std::__ndk1::function<m2::Rect<double> (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)> const&, std::__ndk1::shared_ptr<routing::NumMwmIds>, std::__ndk1::shared_ptr<m4::Tree<unsigned short, m4::TraitsDef<unsigned short>>>, traffic::TrafficCache const&, DataSource&)+385) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #01  pc 0x00000000004e4f4c  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/split_config.arm64_v8a.apk!liborganicmaps.so (RoutingManager::SetRouterImpl(routing::RouterType)+767) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #02  pc 0x00000000004ea630  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/split_config.arm64_v8a.apk!liborganicmaps.so (RoutingManager::SetRouter(routing::RouterType)+1311) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #03  pc 0x0000000000dd838c  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (art_jni_trampoline+108)
  #04  pc 0x00000000006683e8  /apex/com.android.art/lib64/libart.so (nterp_helper+152)
  #05  pc 0x000000000024dfb0  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/base.apk (app.organicmaps.sdk.Router.set+4)
  #06  pc 0x0000000000668384  /apex/com.android.art/lib64/libart.so (nterp_helper+52)
  #07  pc 0x000000000025b3a8  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/base.apk (app.organicmaps.sdk.routing.RoutingController.prepare+20)
  #08  pc 0x00000000006692a4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #09  pc 0x000000000025b37a  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/base.apk (app.organicmaps.sdk.routing.RoutingController.prepare+46)
  #10  pc 0x00000000006692a4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #11  pc 0x000000000025b1dc  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/base.apk (app.organicmaps.sdk.routing.RoutingController.lambda$new$1+20)
  #12  pc 0x00000000006692a4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #13  pc 0x000000000025ad1c  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/base.apk (app.organicmaps.sdk.routing.RoutingController.$r8$lambda$gIjvc-WaY7aW_kM3UwbS5vvUETU)
  #14  pc 0x0000000000668384  /apex/com.android.art/lib64/libart.so (nterp_helper+52)
  #15  pc 0x000000000025a110  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/base.apk (app.organicmaps.sdk.routing.RoutingController$$ExternalSyntheticLambda1.onRoutePointsLoaded+4)
  #16  pc 0x00000000002aaf94  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+612)
  #17  pc 0x00000000002a8f14  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeVirtualOrInterfaceWithVarArgs<_jmethodID*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, std::__va_list)+904)
  #18  pc 0x0000000000614938  /apex/com.android.art/lib64/libart.so (art::JNI<false>::CallVoidMethodV(_JNIEnv*, _jobject*, _jmethodID*, std::__va_list)+328)
  #19  pc 0x00000000004361e4  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/split_config.arm64_v8a.apk!liborganicmaps.so (_JNIEnv::CallVoidMethod(_jobject*, _jmethodID*, ...)+631) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #20  pc 0x0000000000479988  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/split_config.arm64_v8a.apk!liborganicmaps.so (std::__ndk1::__function::__func<std::__ndk1::__bind<void (*)(std::__ndk1::shared_ptr<_jobject*>, bool), std::__ndk1::shared_ptr<_jobject*>, std::__ndk1::placeholders::__ph<1> const&>, std::__ndk1::allocator<std::__ndk1::__bind<void (*)(std::__ndk1::shared_ptr<_jobject*>, bool), std::__ndk1::shared_ptr<_jobject*>, std::__ndk1::placeholders::__ph<1> const&>>, void (bool)>::operator()(bool&&)+179) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #21  pc 0x00000000005868b8  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/split_config.arm64_v8a.apk!liborganicmaps.so (std::__ndk1::__function::__func<std::__ndk1::__bind<std::__ndk1::function<void (bool)> const&, bool>, std::__ndk1::allocator<std::__ndk1::__bind<std::__ndk1::function<void (bool)> const&, bool>>, void ()>::operator()()+436) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #22  pc 0x0000000000468de8  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/split_config.arm64_v8a.apk!liborganicmaps.so (android::GuiThread::ProcessTask(long)+436) (BuildId: cb3498734a28c99f51d3f1ef9211c5392d9f404e)
  #23  pc 0x0000000000dda40c  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (art_jni_trampoline+108)
  #24  pc 0x00000000001e7f70  /data/app/~~pNM2pUE-svIs4iPd6i0cYw==/app.organicmaps-h9zySke9PS21AHDc-s7w4g==/oat/arm64/base.odex (app.organicmaps.sdk.util.concurrency.UiThread$$ExternalSyntheticLambda0.run+64)
  #25  pc 0x0000000000923874  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.os.Handler.dispatchMessage+68)
  #26  pc 0x0000000000970380  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.os.Looper.loopOnce+1952)
  #27  pc 0x000000000096fb64  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.os.Looper.loop+244)
  #28  pc 0x00000000006677ec  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.app.ActivityThread.main+1644)
  #29  pc 0x00000000002ab260  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #30  pc 0x00000000002a12b4  /apex/com.android.art/lib64/libart.so (_jobject* art::InvokeMethod<(art::PointerSize)8>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jobject*, _jobject*, unsigned long)+552)
  #31  pc 0x00000000005ac130  /apex/com.android.art/lib64/libart.so (art::Method_invoke(_JNIEnv*, _jobject*, _jobject*, _jobjectArray*) (.__uniq.165753521025965369065708152063621506277)+32)
  #32  pc 0x0000000000dd8044  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (art_jni_trampoline+116)
  #33  pc 0x0000000000ccaeec  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run+108)
  #34  pc 0x0000000000cd386c  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (com.android.internal.os.ZygoteInit.main+3276)
  #35  pc 0x00000000002ab260  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #36  pc 0x00000000002a9e60  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeWithVarArgs<_jmethodID*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, std::__va_list)+876)
  #37  pc 0x000000000060b158  /apex/com.android.art/lib64/libart.so (art::JNI<true>::CallStaticVoidMethodV(_JNIEnv*, _jclass*, _jmethodID*, std::__va_list)+184)
  #38  pc 0x000000000010babc  /system/lib64/libandroid_runtime.so (_JNIEnv::CallStaticVoidMethod(_jclass*, _jmethodID*, ...)+108)
  #39  pc 0x0000000000136cc4  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::start(char const*, android::Vector<android::String8> const&, bool)+912)
  #40  pc 0x00000000000045c8  /system/bin/app_process64 (main+1288)
  #41  pc 0x00000000000a2660  /apex/com.android.runtime/lib64/bionic/libc.so (__libc_init+124)
```