### PR TITLE
[android] Do not use native framework until it fully initializes and loads maps (async)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -74,6 +74,7 @@ android {
     base.archivesName = rootProject.name.replaceAll('\\s', '') + '-' + defaultConfig.versionCode
 
     ndk.debugSymbolLevel = 'full'
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   flavorDimensions += 'default'
@@ -269,6 +270,8 @@ dependencies {
   testImplementation libs.androidx.junit
   testImplementation libs.mockito.core
   testImplementation libs.mockito.inline
+  androidTestImplementation libs.androidx.junit
+  androidTestImplementation libs.androidx.test.runner
 }
 
 def allowedPermissions = [

--- a/android/app/src/androidTest/java/app/organicmaps/test/OrganicMapsInitTest.java
+++ b/android/app/src/androidTest/java/app/organicmaps/test/OrganicMapsInitTest.java
@@ -1,0 +1,163 @@
+package app.organicmaps.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import app.organicmaps.MwmApplication;
+import app.organicmaps.sdk.OrganicMaps;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+/**
+ * Integration tests for the OrganicMaps initialization state machine.
+ *
+ * Tests are ordered because native framework init is a one-time operation
+ * per process — the first test performs cold-start init, subsequent tests
+ * exercise the post-READY API contract.
+ *
+ * Runs in the app module (not sdk) because nativeInitFramework needs
+ * the full app assets (translations, map data).
+ */
+@RunWith(AndroidJUnit4.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class OrganicMapsInitTest
+{
+  private static final int INIT_TIMEOUT_SEC = 30;
+
+  private static MwmApplication sApp;
+  private static OrganicMaps sOrganicMaps;
+
+  @BeforeClass
+  public static void setUp()
+  {
+    sApp = (MwmApplication) InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
+    sOrganicMaps = sApp.getOrganicMaps();
+  }
+
+  @Test
+  public void test1_coldStartInitTransitionsToReady() throws Exception
+  {
+    // Skip if already initialized (e.g., by the test app's Application.onCreate).
+    if (sOrganicMaps.arePlatformAndCoreInitialized())
+      return;
+
+    final CountDownLatch initLatch = new CountDownLatch(1);
+    final AtomicBoolean wasInitializing = new AtomicBoolean(false);
+    final AtomicBoolean wasNotReady = new AtomicBoolean(false);
+
+    InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+      try
+      {
+        boolean async = sApp.initOrganicMaps(initLatch::countDown);
+        assertTrue("First init should be async", async);
+        wasInitializing.set(sOrganicMaps.isCoreInitializing());
+        wasNotReady.set(!sOrganicMaps.arePlatformAndCoreInitialized());
+      }
+      catch (IOException e)
+      {
+        throw new RuntimeException(e);
+      }
+    });
+
+    assertTrue("State should be INITIALIZING right after init()", wasInitializing.get());
+    assertTrue("Should not be ready right after init()", wasNotReady.get());
+
+    assertTrue("Init should complete within " + INIT_TIMEOUT_SEC + "s",
+               initLatch.await(INIT_TIMEOUT_SEC, TimeUnit.SECONDS));
+
+    InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+      assertTrue("Should be ready after callback", sOrganicMaps.arePlatformAndCoreInitialized());
+      assertFalse("Should not be initializing after callback", sOrganicMaps.isCoreInitializing());
+    });
+  }
+
+  @Test
+  public void test2_warmLaunchReturnsFalseWithoutCallingCallback() throws Exception
+  {
+    // Ensure init has completed (may have been done by test1 or Application.onCreate).
+    ensureReady();
+
+    final AtomicBoolean callbackCalled = new AtomicBoolean(false);
+
+    InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+      try
+      {
+        boolean async = sApp.initOrganicMaps(() -> callbackCalled.set(true));
+        assertFalse("Warm launch should return false", async);
+      }
+      catch (IOException e)
+      {
+        throw new RuntimeException(e);
+      }
+    });
+
+    assertFalse("Warm launch should NOT call callback", callbackCalled.get());
+    assertTrue("Should still be ready", sOrganicMaps.arePlatformAndCoreInitialized());
+  }
+
+  @Test
+  public void test3_runWhenReadyExecutesImmediately() throws Exception
+  {
+    ensureReady();
+
+    final AtomicBoolean executed = new AtomicBoolean(false);
+
+    InstrumentationRegistry.getInstrumentation().runOnMainSync(
+        () -> sOrganicMaps.runWhenReady(() -> executed.set(true)));
+
+    assertTrue("runWhenReady should execute immediately when READY", executed.get());
+  }
+
+  @Test
+  public void test4_runWhenReadyFromCallbackDoesNotThrow() throws Exception
+  {
+    ensureReady();
+
+    // Verify that calling runWhenReady() inside a runWhenReady() callback
+    // does not throw (tests the drain-into-local-copy guard).
+    final AtomicBoolean innerExecuted = new AtomicBoolean(false);
+
+    InstrumentationRegistry.getInstrumentation().runOnMainSync(
+        () -> sOrganicMaps.runWhenReady(() -> sOrganicMaps.runWhenReady(() -> innerExecuted.set(true))));
+
+    assertTrue("Nested runWhenReady should execute without throwing", innerExecuted.get());
+  }
+
+  @Test
+  public void test5_isCoreInitializingFalseWhenReady() throws Exception
+  {
+    ensureReady();
+
+    assertFalse("isCoreInitializing should be false in READY state", sOrganicMaps.isCoreInitializing());
+  }
+
+  /// Wait for init to complete if it hasn't already.
+  private void ensureReady() throws Exception
+  {
+    if (sOrganicMaps.arePlatformAndCoreInitialized())
+      return;
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+      try
+      {
+        sApp.initOrganicMaps(latch::countDown);
+      }
+      catch (IOException e)
+      {
+        throw new RuntimeException(e);
+      }
+    });
+    assertTrue("Init should complete within " + INIT_TIMEOUT_SEC + "s",
+               latch.await(INIT_TIMEOUT_SEC, TimeUnit.SECONDS));
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/background/OsmUploadWork.java
+++ b/android/app/src/main/java/app/organicmaps/background/OsmUploadWork.java
@@ -10,6 +10,7 @@ import androidx.work.WorkManager;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 import app.organicmaps.MwmApplication;
+import app.organicmaps.sdk.OrganicMaps;
 import app.organicmaps.sdk.editor.Editor;
 import app.organicmaps.sdk.editor.OsmOAuth;
 import app.organicmaps.sdk.util.log.Logger;
@@ -44,8 +45,14 @@ public class OsmUploadWork extends Worker
   @Override
   public Result doWork()
   {
-    if (!MwmApplication.from(mContext).getOrganicMaps().arePlatformAndCoreInitialized())
+    final OrganicMaps om = MwmApplication.from(mContext).getOrganicMaps();
+    if (!om.arePlatformAndCoreInitialized())
     {
+      if (om.isCoreInitializing())
+      {
+        Logger.i(TAG, "Core still initializing, will retry: " + mWorkerParameters);
+        return Result.retry();
+      }
       Logger.w(TAG, "Application is not initialized, ignoring " + mWorkerParameters);
       return Result.failure();
     }

--- a/android/app/src/main/java/app/organicmaps/car/AndroidAutoSession.java
+++ b/android/app/src/main/java/app/organicmaps/car/AndroidAutoSession.java
@@ -3,6 +3,7 @@ package app.organicmaps.car;
 import androidx.annotation.NonNull;
 import androidx.car.app.Screen;
 import androidx.car.app.SessionInfo;
+import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
 import app.organicmaps.R;
 import app.organicmaps.car.screens.ErrorScreen;
@@ -59,12 +60,18 @@ public final class AndroidAutoSession extends CarAppSessionBase implements Displ
     final List<Screen> screensStack = new ArrayList<>();
     screensStack.add(new MapScreen(getCarContext(), mOrganicMapsContext, mSurfaceRenderer));
 
-    if (DownloaderHelpers.isWorldMapsDownloadNeeded(mOrganicMapsContext.getFlavor()))
-    {
-      mScreenManager.push(new DownloadMapsScreenBuilder(getCarContext(), mOrganicMapsContext)
-                              .setDownloaderType(DownloadMapsScreenBuilder.DownloaderType.FirstLaunch)
-                              .build());
-    }
+    // Defer world maps download check: DownloaderHelpers.isWorldMapsDownloadNeeded() calls
+    // CountryItem.fill() (native) on fdroid builds, so it can't run before core is ready.
+    mOrganicMapsContext.runWhenReady(() -> {
+      if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.CREATED))
+        return;
+      if (DownloaderHelpers.isWorldMapsDownloadNeeded(mOrganicMapsContext.getFlavor()))
+      {
+        mScreenManager.push(new DownloadMapsScreenBuilder(getCarContext(), mOrganicMapsContext)
+                                .setDownloaderType(DownloadMapsScreenBuilder.DownloaderType.FirstLaunch)
+                                .build());
+      }
+    });
 
     if (!LocationUtils.checkFineLocationPermission(getCarContext()))
       screensStack.add(

--- a/android/libs/car/src/main/java/app/organicmaps/car/CarAppSessionBase.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/CarAppSessionBase.java
@@ -9,6 +9,7 @@ import androidx.car.app.ScreenManager;
 import androidx.car.app.Session;
 import androidx.car.app.SessionInfo;
 import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
 import app.organicmaps.car.screens.NavigationScreen;
 import app.organicmaps.car.screens.PlaceScreen;
@@ -54,6 +55,8 @@ public abstract class CarAppSessionBase
   @SuppressWarnings("NotNullFieldNotInitialized")
   @NonNull
   protected CarSensorsManager mSensorsManager;
+  private boolean mNativeHooksAttached = false;
+  private boolean mDeferredHookCallbackPending = false;
 
   public CarAppSessionBase(@NonNull OrganicMaps organicMapsContext, @NonNull DisplayManager displayManager,
                            @NonNull SessionInfo sessionInfo, boolean isDebug)
@@ -106,6 +109,15 @@ public abstract class CarAppSessionBase
   public final void onNewIntent(@NonNull Intent intent)
   {
     Logger.d(TAG, intent.toString());
+    // IntentUtils.processIntent() calls Framework native methods. Defer until core is ready.
+    if (!mOrganicMapsContext.arePlatformAndCoreInitialized())
+    {
+      mOrganicMapsContext.runWhenReady(() -> {
+        if (getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.CREATED))
+          IntentUtils.processIntent(getCarContext(), mOrganicMapsContext, mSurfaceRenderer, mDisplayManager, intent);
+      });
+      return;
+    }
     IntentUtils.processIntent(getCarContext(), mOrganicMapsContext, mSurfaceRenderer, mDisplayManager, intent);
   }
 
@@ -114,21 +126,23 @@ public abstract class CarAppSessionBase
   public void onStart(@NonNull LifecycleOwner owner)
   {
     Logger.d(TAG);
-    if (mDisplayManager.isCarDisplayUsed())
+
+    attachNativeHooksIfReady();
+
+    // If core isn't ready yet, defer hook attachment until initialization completes.
+    // Guard with a flag to avoid accumulating duplicate callbacks on start/stop cycles.
+    if (!mNativeHooksAttached && !mDeferredHookCallbackPending)
     {
-      LocationState.nativeSetListener(this);
-      Framework.nativePlacePageActivationListener(this);
-      mCurrentCountryChangedListener.onStart(getCarContext(), mOrganicMapsContext);
+      mDeferredHookCallbackPending = true;
+      mOrganicMapsContext.runWhenReady(() -> {
+        mDeferredHookCallbackPending = false;
+        if (getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED))
+          attachNativeHooksIfReady();
+      });
     }
 
     if (LocationUtils.checkFineLocationPermission(getCarContext()))
       mSensorsManager.onStart();
-
-    if (mDisplayManager.isCarDisplayUsed())
-    {
-      ThemeUtils.update(getCarContext(), mSurfaceRenderer.isRenderingActive());
-      onRestoreRoute();
-    }
   }
 
   @CallSuper
@@ -139,13 +153,28 @@ public abstract class CarAppSessionBase
 
     mSensorsManager.onStop();
 
-    if (mDisplayManager.isCarDisplayUsed())
+    if (mNativeHooksAttached)
     {
       LocationState.nativeRemoveListener();
       Framework.nativeRemovePlacePageActivationListener(this);
+      mNativeHooksAttached = false;
     }
 
     mCurrentCountryChangedListener.onStop();
+  }
+
+  private void attachNativeHooksIfReady()
+  {
+    if (mNativeHooksAttached || !mDisplayManager.isCarDisplayUsed()
+        || !mOrganicMapsContext.arePlatformAndCoreInitialized())
+      return;
+
+    mNativeHooksAttached = true;
+    LocationState.nativeSetListener(this);
+    Framework.nativePlacePageActivationListener(this);
+    mCurrentCountryChangedListener.onStart(getCarContext(), mOrganicMapsContext);
+    ThemeUtils.update(getCarContext(), mSurfaceRenderer.isRenderingActive());
+    onRestoreRoute();
   }
 
   @NonNull

--- a/android/libs/car/src/main/java/app/organicmaps/car/screens/MapScreen.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/screens/MapScreen.java
@@ -22,6 +22,7 @@ import app.organicmaps.car.util.UiHelpers;
 import app.organicmaps.sdk.OrganicMaps;
 import app.organicmaps.sdk.car.renderer.Renderer;
 import app.organicmaps.sdk.car.screens.BaseMapScreen;
+import java.lang.ref.WeakReference;
 
 public class MapScreen extends BaseMapScreen
 {
@@ -29,6 +30,17 @@ public class MapScreen extends BaseMapScreen
                    @NonNull Renderer surfaceRenderer)
   {
     super(carContext, organicMapsContext, surfaceRenderer);
+    // Re-render with full button grid once native subsystems are initialized.
+    // Use WeakReference to avoid retaining a detached screen via the app-scoped callback queue.
+    if (!organicMapsContext.arePlatformAndCoreInitialized())
+    {
+      final WeakReference<MapScreen> weakThis = new WeakReference<>(this);
+      organicMapsContext.runWhenReady(() -> {
+        final MapScreen screen = weakThis.get();
+        if (screen != null)
+          screen.invalidate();
+      });
+    }
   }
 
   @NonNull
@@ -72,15 +84,26 @@ public class MapScreen extends BaseMapScreen
   private GridTemplate createGridTemplate()
   {
     final GridTemplate.Builder builder = new GridTemplate.Builder();
-
-    final ItemList.Builder itemsBuilder = new ItemList.Builder();
-    itemsBuilder.addItem(createSearchItem());
-    itemsBuilder.addItem(createCategoriesItem());
-    itemsBuilder.addItem(createBookmarksItem());
-    itemsBuilder.addItem(createSettingsItem());
-
     builder.setHeader(createHeader());
-    builder.setSingleList(itemsBuilder.build());
+
+    // Search, categories, bookmarks, and settings screens require native subsystems
+    // (SearchEngine, BookmarkManager, etc.) that are initialized asynchronously in
+    // onNativeFrameworkReady(). Show items only after core is ready; the constructor
+    // registers an invalidate() callback to re-render when initialization completes.
+    if (getOrganicMapsContext().arePlatformAndCoreInitialized())
+    {
+      final ItemList.Builder itemsBuilder = new ItemList.Builder();
+      itemsBuilder.addItem(createSearchItem());
+      itemsBuilder.addItem(createCategoriesItem());
+      itemsBuilder.addItem(createBookmarksItem());
+      itemsBuilder.addItem(createSettingsItem());
+      builder.setSingleList(itemsBuilder.build());
+    }
+    else
+    {
+      builder.setLoading(true);
+    }
+
     return builder.build();
   }
 

--- a/android/sdk/src/main/java/app/organicmaps/sdk/OrganicMaps.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/OrganicMaps.java
@@ -2,6 +2,8 @@ package app.organicmaps.sdk;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import androidx.annotation.IntDef;
+import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
@@ -26,10 +28,23 @@ import app.organicmaps.sdk.util.StorageUtils;
 import app.organicmaps.sdk.util.log.Logger;
 import app.organicmaps.sdk.util.log.LogsManager;
 import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class OrganicMaps implements DefaultLifecycleObserver
 {
   private static final String TAG = OrganicMaps.class.getSimpleName();
+
+  private static final int NOT_STARTED = 0;
+  private static final int INITIALIZING = 1;
+  private static final int READY = 2;
+
+  @Retention(RetentionPolicy.SOURCE)
+  @IntDef({NOT_STARTED, INITIALIZING, READY})
+  @interface CoreState
+  {}
 
   @NonNull
   private final String mFlavor;
@@ -52,8 +67,11 @@ public final class OrganicMaps implements DefaultLifecycleObserver
   @NonNull
   private final SensorHelper mSensorHelper;
 
-  private volatile boolean mFrameworkInitialized;
+  @CoreState
+  private volatile int mCoreState = NOT_STARTED;
   private volatile boolean mPlatformInitialized;
+  @NonNull
+  private final List<Runnable> mCoreReadyCallbacks = new ArrayList<>();
 
   @NonNull
   public LocationHelper getLocationHelper()
@@ -138,7 +156,22 @@ public final class OrganicMaps implements DefaultLifecycleObserver
 
   public boolean arePlatformAndCoreInitialized()
   {
-    return mFrameworkInitialized && mPlatformInitialized;
+    return mCoreState == READY && mPlatformInitialized;
+  }
+
+  public boolean isCoreInitializing()
+  {
+    return mCoreState == INITIALIZING;
+  }
+
+  /// Runs the action immediately if core is ready, or queues it for when core becomes ready.
+  @MainThread
+  public void runWhenReady(@NonNull Runnable action)
+  {
+    if (mCoreState == READY)
+      action.run();
+    else
+      mCoreReadyCallbacks.add(action);
   }
 
   @Override
@@ -190,12 +223,31 @@ public final class OrganicMaps implements DefaultLifecycleObserver
 
   private boolean initNativeFramework(@NonNull Runnable onComplete)
   {
-    if (mFrameworkInitialized)
+    if (mCoreState == READY)
       return false;
 
-    nativeInitFramework(onComplete);
+    // Queue the external callback (whether first or subsequent caller).
+    mCoreReadyCallbacks.add(onComplete);
 
+    if (mCoreState == INITIALIZING)
+      return true; // already in progress, callback queued
+
+    mCoreState = INITIALIZING;
+
+    // Pass a single internal callback to native. It will fire on the UI thread
+    // after LoadMapsAsync completes and InitRouting() has run.
+    nativeInitFramework(this::onNativeFrameworkReady);
+
+    // These two can run now — they only need g_framework (created synchronously above).
     initNativeStrings();
+    ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
+
+    return true;
+  }
+
+  /// Called from native on UI thread when LoadMapsAsync + InitRouting() completes.
+  private void onNativeFrameworkReady()
+  {
     SearchEngine.INSTANCE.initialize();
     BookmarkManager.loadBookmarks();
     TtsPlayer.INSTANCE.initialize(mContext);
@@ -203,11 +255,17 @@ public final class OrganicMaps implements DefaultLifecycleObserver
     TrafficManager.INSTANCE.initialize();
     mSubwayManager.initialize();
     mIsolinesManager.initialize();
-    ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
 
     Logger.i(TAG, "Framework initialized");
-    mFrameworkInitialized = true;
-    return true;
+
+    // Drain pending callbacks into a local copy before setting READY, so that callbacks
+    // which call runWhenReady() don't modify the list during iteration.
+    final List<Runnable> pending = new ArrayList<>(mCoreReadyCallbacks);
+    mCoreReadyCallbacks.clear();
+    mCoreState = READY;
+
+    for (Runnable cb : pending)
+      cb.run();
   }
 
   private void createPlatformDirectories(@NonNull String writablePath, @NonNull String privatePath,


### PR DESCRIPTION
A follow-up to https://github.com/organicmaps/organicmaps/pull/12420

May likely fix other strange issues when the not-yet-initialized native framework is called while loading maps from a slow SD-card.

Better check changes per-commit.