### PR TITLE
[ios] Fixed crash when sharing single track with diacritics

### DIFF
--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -637,11 +637,13 @@ static FileType convertFileTypeToCore(MWMFileType fileType)
   switch (sharingResult.m_code)
   {
   case BookmarkManager::SharingResult::Code::Success:
+  {
     urlToALocalFile = [NSURL fileURLWithPath:@(sharingResult.m_sharingPath.c_str()) isDirectory:NO];
     ASSERT(urlToALocalFile, ("Invalid share category URL"));
     self.shareCategoryURL = urlToALocalFile;
     status = MWMBookmarksShareStatusSuccess;
     break;
+  }
   case BookmarkManager::SharingResult::Code::EmptyCategory: status = MWMBookmarksShareStatusEmptyCategory; break;
   case BookmarkManager::SharingResult::Code::ArchiveError: status = MWMBookmarksShareStatusArchiveError; break;
   case BookmarkManager::SharingResult::Code::FileError: status = MWMBookmarksShareStatusFileError; break;

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInterfaces.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInterfaces.swift
@@ -63,7 +63,7 @@ protocol IBookmarksListView: AnyObject {
   func showMenu(_ items: [IBookmarksListMenuItem], from source: BookmarkToolbarButtonSource)
   func showColorPicker(with pickerType: ColorPickerType, _ completion: ((UIColor) -> Void)?)
   func enableEditing(_ enable: Bool)
-  func share(_ url: URL, completion: @escaping () -> Void)
+  func share(_ url: URL, displayName: String, completion: @escaping () -> Void)
   func showError(title: String, message: String)
 }
 

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListPresenter.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListPresenter.swift
@@ -161,7 +161,7 @@ final class BookmarksListPresenter {
           switch status {
           case .success:
             guard let url = url else { fatalError() }
-            self?.view?.share(url) {
+            self?.view?.share(url, displayName: self?.bookmarkGroup.title ?? "") {
               self?.interactor.finishExportFile()
             }
           case .emptyCategory:

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.swift
@@ -248,9 +248,10 @@ extension BookmarksListViewController: IBookmarksListView {
     navigationItem.rightBarButtonItem = enable ? editButtonItem : nil
   }
 
-  func share(_ url: URL, completion: @escaping () -> Void) {
+  func share(_ url: URL, displayName: String, completion: @escaping () -> Void) {
     let shareController = ActivityViewController.share(for: url,
-                                                       message: L("share_bookmarks_email_body")) { _, _, _, _ in
+                                                       message: L("share_bookmarks_email_body"),
+                                                       displayName: displayName) { _, _, _, _ in
       completion()
     }
     shareController.present(inParentViewController: self, anchorView: toolBar)

--- a/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
@@ -64,22 +64,24 @@ final class BMCViewController: MWMViewController {
   }
 
   private func shareCategoryFile(at index: Int, fileType: FileType, anchor: UIView) {
+    let categoryName = viewModel.category(at: index).title
     UIApplication.shared.showLoadingOverlay()
-    viewModel.shareCategoryFile(at: index, fileType: fileType, handler: sharingResultHandler(anchorView: anchor))
+    viewModel.shareCategoryFile(at: index, fileType: fileType, handler: sharingResultHandler(anchorView: anchor, displayName: categoryName))
   }
 
   private func shareAllCategories(anchor: UIView?) {
     UIApplication.shared.showLoadingOverlay()
-    viewModel.shareAllCategories(handler: sharingResultHandler(anchorView: anchor))
+    viewModel.shareAllCategories(handler: sharingResultHandler(anchorView: anchor, displayName: nil))
   }
 
-  private func sharingResultHandler(anchorView: UIView?) -> SharingResultCompletionHandler {
+  private func sharingResultHandler(anchorView: UIView?, displayName: String?) -> SharingResultCompletionHandler {
     { [weak self] status, url in
       UIApplication.shared.hideLoadingOverlay {
         guard let self else { return }
         switch status {
         case .success:
-          let shareController = ActivityViewController.share(for: url, message: L("share_bookmarks_email_body")) { [weak self] _, _, _, _ in
+          let shareController = ActivityViewController.share(for: url, message: L("share_bookmarks_email_body"),
+                                                             displayName: displayName) { [weak self] _, _, _, _ in
             self?.viewModel?.finishShareCategory()
           }
           shareController.present(inParentViewController: self, anchorView: anchorView)

--- a/iphone/Maps/Classes/Share/MWMActivityViewController.h
+++ b/iphone/Maps/Classes/Share/MWMActivityViewController.h
@@ -14,6 +14,7 @@ NS_SWIFT_NAME(ActivityViewController)
 
 + (instancetype)shareControllerForURL:(nullable NSURL *)url
                               message:(NSString *)message
+                          displayName:(nullable NSString *)displayName
                     completionHandler:(nullable UIActivityViewControllerCompletionWithItemsHandler)completionHandler;
 
 - (void)presentInParentViewController:(UIViewController *)parentVC anchorView:(nullable UIView *)anchorView;

--- a/iphone/Maps/Classes/Share/MWMActivityViewController.mm
+++ b/iphone/Maps/Classes/Share/MWMActivityViewController.mm
@@ -1,6 +1,71 @@
 #import "MWMActivityViewController.h"
+#import <LinkPresentation/LPLinkMetadata.h>
 #import "MWMEditorViralActivityItem.h"
 #import "MWMShareActivityItem.h"
+
+#pragma mark - File Share Activity Item
+
+@interface MWMFileShareActivityItem : NSObject <UIActivityItemSource>
+
+@property(nonatomic) NSURL * fileURL;
+@property(nonatomic, copy) NSString * displayName;
+
+@end
+
+@implementation MWMFileShareActivityItem
+
+- (instancetype)initWithFileURL:(NSURL *)url displayName:(NSString *)displayName
+{
+  self = [super init];
+  if (self)
+  {
+    _fileURL = url;
+    _displayName = [displayName copy];
+  }
+  return self;
+}
+
+- (id)activityViewControllerPlaceholderItem:(UIActivityViewController *)activityViewController
+{
+  return self.fileURL;
+}
+
+- (id)activityViewController:(UIActivityViewController *)activityViewController
+         itemForActivityType:(NSString *)activityType
+{
+  NSItemProvider * provider = [[NSItemProvider alloc] initWithContentsOfURL:self.fileURL];
+  if (provider)
+  {
+    NSString * ext = self.fileURL.pathExtension;
+    NSString * name = self.displayName;
+    // Avoid double extension (e.g. "Track.gpx.gpx").
+    if (ext.length > 0 && ![name.pathExtension isEqualToString:ext])
+      name = [NSString stringWithFormat:@"%@.%@", name, ext];
+    provider.suggestedName = name;
+    return provider;
+  }
+  return self.fileURL;
+}
+
+- (NSString *)activityViewController:(UIActivityViewController *)activityViewController
+              subjectForActivityType:(NSString *)activityType
+{
+  return self.displayName;
+}
+
+- (LPLinkMetadata *)activityViewControllerLinkMetadata:(UIActivityViewController *)activityViewController
+    API_AVAILABLE(ios(13.0))
+{
+  LPLinkMetadata * metadata = [[LPLinkMetadata alloc] init];
+  metadata.originalURL = self.fileURL;
+  metadata.title = self.displayName;
+  metadata.iconProvider = [[NSItemProvider alloc] initWithObject:[UIImage imageNamed:@"imgLogo"]];
+  return metadata;
+}
+
+@end
+
+#pragma mark - Activity View Controller
 
 @interface MWMActivityViewController ()
 
@@ -45,13 +110,24 @@
 
 + (instancetype)shareControllerForURL:(NSURL *)url
                               message:(NSString *)message
+                          displayName:(nullable NSString *)displayName
                     completionHandler:(UIActivityViewControllerCompletionWithItemsHandler)completionHandler
 {
-  NSMutableArray * items = [NSMutableArray arrayWithObject:message];
-  if (url)
-    [items addObject:url];
-
-  MWMActivityViewController * shareVC = [[self alloc] initWithActivityItems:items.copy];
+  MWMActivityViewController * shareVC;
+  if (url.isFileURL)
+  {
+    if (!displayName)
+      displayName = url.lastPathComponent.stringByDeletingPathExtension;
+    MWMFileShareActivityItem * item = [[MWMFileShareActivityItem alloc] initWithFileURL:url displayName:displayName];
+    shareVC = [[self alloc] initWithActivityItems:@[item, message]];
+  }
+  else
+  {
+    NSMutableArray * items = [NSMutableArray arrayWithObject:message];
+    if (url)
+      [items addObject:url];
+    shareVC = [[self alloc] initWithActivityItems:items.copy];
+  }
   shareVC.excludedActivityTypes = [shareVC.excludedActivityTypes arrayByAddingObject:UIActivityTypePostToFacebook];
   shareVC.completionWithItemsHandler = completionHandler;
   return shareVC;

--- a/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
@@ -381,8 +381,10 @@ extension PlacePageInteractor: PlacePageHeaderViewControllerDelegate {
       switch status {
       case .success:
         guard let url else { fatalError("Invalid sharing url") }
-        let shareViewController = ActivityViewController.share(for: url, message: self.placePageData.previewData.title!) { _, _, _, _ in
-          self.bookmarksManager.finishSharing()
+        let title = self.placePageData.previewData.title ?? "OrganicMaps"
+        let shareViewController = ActivityViewController.share(for: url, message: L("share_bookmarks_email_body"),
+                                                               displayName: title) { [weak self] _, _, _, _ in
+          self?.bookmarksManager.finishSharing()
         }
         self.presenter?.showActivity(shareViewController, from: sourceView)
       case .emptyCategory:

--- a/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
+++ b/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
@@ -258,6 +258,7 @@ static NSString * const kUDDidShowICloudSynchronizationEnablingAlert = @"kUDDidS
                     MWMActivityViewController * shareController = [MWMActivityViewController
                         shareControllerForURL:url
                                       message:L(@"share_bookmarks_email_body")
+                                  displayName:nil
                             completionHandler:^(UIActivityType _Nullable activityType, BOOL completed,
                                                 NSArray * _Nullable returnedItems, NSError * _Nullable activityError) {
                               [self setICloudSynchronizationEnablingAlertIsShown];


### PR DESCRIPTION
Also use recommended original file name in the sharing dialog.

Fixes user-reported and reproduced crash:
1. Create a track file with diacritics (e.g. save a track on a road with umlaut).
2. Share it to another app (reproduced with [Pado](https://apps.apple.com/us/app/pado/id781541632))

Needs testing and review @kirylkaveryn 