### PR TITLE
[ios] Fix interpolated point selection in elevation chart

### DIFF
--- a/iphone/Chart/Chart/ChartData/ChartData.swift
+++ b/iphone/Chart/Chart/ChartData/ChartData.swift
@@ -40,11 +40,47 @@ public struct ChartValue {
   }
 }
 
+public extension Array {
+  func firstIndexAtOrAfter<Value: Comparable>(_ value: Value, by keyPath: KeyPath<Element, Value>) -> Int? {
+    guard !isEmpty else { return nil }
+
+    var lower = 0
+    var upper = count
+    while lower < upper {
+      let mid = lower + (upper - lower) / 2
+      if self[mid][keyPath: keyPath] < value {
+        lower = mid + 1
+      } else {
+        upper = mid
+      }
+    }
+
+    return lower < count ? lower : nil
+  }
+}
+
 extension Array where Element == ChartValue {
   var maxDistance: CGFloat { map(\.x).max() ?? 0 }
 
-  func altitude(at relativeDistance: CGFloat) -> CGFloat {
-    guard let distance = last?.x else { return 0 }
-    return first { $0.x >= distance * relativeDistance }?.y ?? 0
+  func interpolatedAltitude(at distance: CGFloat) -> CGFloat {
+    guard let first, let last else { return 0 }
+    if distance <= first.x {
+      return first.y
+    }
+    if distance >= last.x {
+      return last.y
+    }
+
+    guard let upperIndex = firstIndexAtOrAfter(distance, by: \.x) else {
+      return last.y
+    }
+    let upper = self[upperIndex]
+    if upper.x == distance || upperIndex == 0 {
+      return upper.y
+    }
+
+    let lower = self[upperIndex - 1]
+    let progress = (distance - lower.x) / (upper.x - lower.x)
+    return lower.y + progress * (upper.y - lower.y)
   }
 }

--- a/iphone/Chart/Chart/ChartData/ChartPathBuilder.swift
+++ b/iphone/Chart/Chart/ChartData/ChartPathBuilder.swift
@@ -10,7 +10,7 @@ extension ChartPathBuilder {
   func makeLinePreviewPath(line: ChartPresentationLine) -> UIBezierPath {
     let path = UIBezierPath()
     let values = line.values
-    let xScale = CGFloat(values.count) / values.maxDistance
+    let xScale = values.maxDistance > 0 ? CGFloat(max(values.count - 1, 1)) / values.maxDistance : 0
     for i in 0 ..< values.count {
       let x = values[i].x * xScale
       let y = values[i].y - line.minY
@@ -26,7 +26,7 @@ extension ChartPathBuilder {
   func makeLinePath(line: ChartPresentationLine) -> UIBezierPath {
     let path = UIBezierPath()
     let values = line.values
-    let xScale = CGFloat(values.count) / values.maxDistance
+    let xScale = values.maxDistance > 0 ? CGFloat(max(values.count - 1, 1)) / values.maxDistance : 0
     for i in 0 ..< values.count {
       let x = values[i].x * xScale
       let y = values[i].y - line.minY
@@ -43,13 +43,14 @@ extension ChartPathBuilder {
     let path = UIBezierPath()
     path.move(to: CGPoint(x: 0, y: 0))
     let aggregatedValues = line.aggregatedValues
-    let xScale = CGFloat(aggregatedValues.count) / aggregatedValues.maxDistance
+    let xScale = aggregatedValues.maxDistance > 0 ? CGFloat(max(aggregatedValues.count - 1, 1)) / aggregatedValues.maxDistance : 0
+    let maxX = CGFloat(max(aggregatedValues.count - 1, 1))
     for i in 0 ..< aggregatedValues.count {
       let x = aggregatedValues[i].x * xScale
       let y = aggregatedValues[i].y - CGFloat(line.minY)
       path.addLine(to: CGPoint(x: x, y: y))
     }
-    path.addLine(to: CGPoint(x: aggregatedValues.maxDistance, y: 0))
+    path.addLine(to: CGPoint(x: maxX, y: 0))
     path.close()
     return path
   }
@@ -58,13 +59,14 @@ extension ChartPathBuilder {
     let path = UIBezierPath()
     path.move(to: CGPoint(x: 0, y: 0))
     let aggregatedValues = line.aggregatedValues
-    let xScale = CGFloat(aggregatedValues.count) / aggregatedValues.maxDistance
+    let xScale = aggregatedValues.maxDistance > 0 ? CGFloat(max(aggregatedValues.count - 1, 1)) / aggregatedValues.maxDistance : 0
+    let maxX = CGFloat(max(aggregatedValues.count - 1, 1))
     for i in 0 ..< aggregatedValues.count {
       let x = aggregatedValues[i].x * xScale
       let y = aggregatedValues[i].y - CGFloat(line.minY)
       path.addLine(to: CGPoint(x: x, y: y))
     }
-    path.addLine(to: CGPoint(x: aggregatedValues.maxDistance, y: 0))
+    path.addLine(to: CGPoint(x: maxX, y: 0))
     path.close()
     return path
   }

--- a/iphone/Chart/Chart/ChartData/ChartPresentationData.swift
+++ b/iphone/Chart/Chart/ChartData/ChartPresentationData.swift
@@ -27,12 +27,19 @@ public class ChartPresentationData {
   }
 
   func xAxisValueAt(_ point: CGFloat) -> Double {
-    let distance = chartData.xAxisValues.last!
-    let p1 = floor(point)
-    let p2 = ceil(point)
-    let v1 = p1 / CGFloat(pointsCount) * distance
-    let v2 = p2 / CGFloat(pointsCount) * distance
-    return v1 + (v2 - v1) * Double(point.truncatingRemainder(dividingBy: 1))
+    distance(forChartX: point)
+  }
+
+  func chartX(forDistance distance: Double) -> CGFloat {
+    guard pointsCount > 1, let maxDistance = chartData.xAxisValues.last, maxDistance > 0 else { return 0 }
+    return CGFloat(distance / maxDistance) * CGFloat(pointsCount - 1)
+  }
+
+  func distance(forChartX point: CGFloat) -> Double {
+    guard pointsCount > 1, let maxDistance = chartData.xAxisValues.last else {
+      return chartData.xAxisValues.last ?? 0
+    }
+    return Double(point) / Double(pointsCount - 1) * maxDistance
   }
 
   func lineAt(_ index: Int) -> ChartPresentationLine {

--- a/iphone/Chart/Chart/Views/ChartView.swift
+++ b/iphone/Chart/Chart/Views/ChartView.swift
@@ -129,7 +129,7 @@ public class ChartView: UIView {
     }
   }
 
-  public typealias OnSelectedPointChangedClosure = (_ px: CGFloat) -> Void
+  public typealias OnSelectedPointChangedClosure = (_ distance: Double) -> Void
   public var onSelectedPointChanged: OnSelectedPointChangedClosure?
 
   override init(frame: CGRect) {
@@ -173,33 +173,42 @@ public class ChartView: UIView {
   public func setSelectedPoint(_ x: Double) {
     guard selectedPointDistance != x else { return }
     selectedPointDistance = x
-    let routeLength = chartData.xAxisValueAt(CGFloat(chartData.pointsCount - 1))
+    let routeLength = chartData.distance(forChartX: CGFloat(chartData.pointsCount - 1))
     let upper = chartData.xAxisValueAt(CGFloat(chartPreviewView.maxX))
     var lower = chartData.xAxisValueAt(CGFloat(chartPreviewView.minX))
     let rangeLength = upper - lower
-    if x < lower || x > upper {
+    if x < lower || x > upper, routeLength > 0 {
       let current = Double(chartInfoView.infoX) * rangeLength + lower
-      let dx = x - current
-      let dIdx = Int(dx / routeLength * Double(chartData.pointsCount))
+      let currentChartX = chartData.chartX(forDistance: current)
+      let targetChartX = chartData.chartX(forDistance: x)
+      let dIdx = Int(round(targetChartX - currentChartX))
       var lowerIdx = chartPreviewView.minX + dIdx
       var upperIdx = chartPreviewView.maxX + dIdx
       if lowerIdx < 0 {
         upperIdx -= lowerIdx
         lowerIdx = 0
       } else if upperIdx >= chartData.pointsCount {
-        lowerIdx -= upperIdx - chartData.pointsCount - 1
+        lowerIdx -= upperIdx - chartData.pointsCount + 1
         upperIdx = chartData.pointsCount - 1
       }
       chartPreviewView.setX(min: lowerIdx, max: upperIdx)
       lower = chartData.xAxisValueAt(CGFloat(chartPreviewView.minX))
+      let updatedUpper = chartData.xAxisValueAt(CGFloat(chartPreviewView.maxX))
+      let currentRangeLength = updatedUpper - lower
+      guard currentRangeLength > 0 else { return }
+      chartInfoView.infoX = max(0, min(1, CGFloat((x - lower) / currentRangeLength)))
+      return
     }
-    chartInfoView.infoX = CGFloat((x - lower) / rangeLength)
+    let currentRangeLength = upper - lower
+    guard currentRangeLength > 0 else { return }
+    chartInfoView.infoX = max(0, min(1, CGFloat((x - lower) / currentRangeLength)))
   }
 
   fileprivate func setMyPosition(_ x: Double) {
     let upper = chartData.xAxisValueAt(CGFloat(chartPreviewView.maxX))
     let lower = chartData.xAxisValueAt(CGFloat(chartPreviewView.minX))
     let rangeLength = upper - lower
+    guard rangeLength > 0 else { return }
     chartInfoView.myPositionX = CGFloat((x - lower) / rangeLength)
   }
 
@@ -327,16 +336,16 @@ extension ChartView: ChartPreviewViewDelegate {
     updateCharts(animationStyle: .none)
     chartInfoView.update()
     setMyPosition(myPosition)
-    let x = chartInfoView.infoX * CGFloat(xAxisView.upperBound - xAxisView.lowerBound) + CGFloat(xAxisView.lowerBound)
-    onSelectedPointChanged?(x)
+    let chartX = chartInfoView.infoX * CGFloat(xAxisView.upperBound - xAxisView.lowerBound) + CGFloat(xAxisView.lowerBound)
+    onSelectedPointChanged?(chartData.distance(forChartX: chartX))
   }
 }
 
 extension ChartView: ChartInfoViewDelegate {
   func chartInfoView(_ view: ChartInfoView, didMoveToPoint pointX: CGFloat) {
     let p = convert(CGPoint(x: pointX, y: 0), from: view)
-    let x = (p.x / bounds.width) * CGFloat(xAxisView.upperBound - xAxisView.lowerBound) + CGFloat(xAxisView.lowerBound)
-    onSelectedPointChanged?(x)
+    let chartX = (p.x / bounds.width) * CGFloat(xAxisView.upperBound - xAxisView.lowerBound) + CGFloat(xAxisView.lowerBound)
+    onSelectedPointChanged?(chartData.distance(forChartX: chartX))
   }
 
   func chartInfoView(_: ChartInfoView, didCaptureInfoView captured: Bool) {
@@ -345,28 +354,21 @@ extension ChartView: ChartInfoViewDelegate {
 
   func chartInfoView(_ view: ChartInfoView, infoAtPointX pointX: CGFloat) -> (String, [ChartLineInfo])? {
     let p = convert(CGPoint(x: pointX, y: .zero), from: view)
-    let x = (p.x / bounds.width) * CGFloat(xAxisView.upperBound - xAxisView.lowerBound) + CGFloat(xAxisView.lowerBound)
-    let x1 = floor(x)
-    let x2 = ceil(x)
-    guard !pointX.isZero, Int(x1) < chartData.labels.count, x >= 0 else { return nil }
-    let label = chartData.labelAt(x)
+    let chartX = (p.x / bounds.width) * CGFloat(xAxisView.upperBound - xAxisView.lowerBound) + CGFloat(xAxisView.lowerBound)
+    guard !pointX.isZero, chartX >= 0, chartX <= CGFloat(chartData.pointsCount - 1) else { return nil }
+    let distance = CGFloat(chartData.distance(forChartX: chartX))
+    let label = chartData.labelAt(chartX)
 
     var result: [ChartLineInfo] = []
     for i in 0 ..< chartData.linesCount {
       let line = chartData.lineAt(i)
       guard line.type != .lineArea else { continue }
-      let y1 = line.values.altitude(at: x1 / CGFloat(chartData.pointsCount))
-      let y2 = line.values.altitude(at: x2 / CGFloat(chartData.pointsCount))
-
-      let dx = x - x1
-      let y = dx * (y2 - y1) + y1
+      let y = line.values.interpolatedAltitude(at: distance)
       let py = round(chartsContainerView.bounds.height * CGFloat(y - yAxisView.lowerBound) /
         CGFloat(yAxisView.upperBound - yAxisView.lowerBound))
-
-      let v = round(dx * CGFloat(y2 - y1)) + CGFloat(y1)
       result.append(ChartLineInfo(color: line.color,
                                   point: chartsContainerView.convert(CGPoint(x: p.x, y: py), to: view),
-                                  formattedValue: chartData.formatter.yAxisString(from: Double(v))))
+                                  formattedValue: chartData.formatter.yAxisString(from: Double(y))))
     }
 
     return (label, result)

--- a/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfilePresenter.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfilePresenter.swift
@@ -10,7 +10,7 @@ protocol ElevationProfilePresenterProtocol: UICollectionViewDataSource, UICollec
   func configure()
   func update(with trackData: PlacePageTrackData)
   func onDifficultyButtonPressed()
-  func onSelectedPointChanged(_ point: CGFloat)
+  func onSelectedPointChanged(_ distance: Double)
 }
 
 protocol ElevationProfileViewControllerDelegate: AnyObject {
@@ -111,11 +111,10 @@ extension ElevationProfilePresenter: ElevationProfilePresenterProtocol {
     delegate?.openDifficultyPopup()
   }
 
-  func onSelectedPointChanged(_ point: CGFloat) {
+  func onSelectedPointChanged(_ distance: Double) {
     guard let chartData else { return }
-    let distance: Double = floor(point) / CGFloat(chartData.points.count) * chartData.maxDistance
-    let point = chartData.points.first { $0.distance >= distance } ?? chartData.points[0]
-    delegate?.updateMapPoint(point.coordinates, distance: point.distance)
+    let point = chartData.interpolatedCoordinates(at: distance)
+    delegate?.updateMapPoint(point, distance: distance)
   }
 }
 
@@ -175,12 +174,29 @@ private struct ElevationProfileChartData {
     chartLines = [l1, l2]
   }
 
-  private static func altBetweenPoints(_ p1: ElevationHeightPoint,
-                                       _ p2: ElevationHeightPoint,
-                                       at distance: Double) -> Double {
-    assert(distance > p1.distance && distance < p2.distance, "distance must be between points")
-    let d = (distance - p1.distance) / (p2.distance - p1.distance)
-    return p1.altitude + round(Double(p2.altitude - p1.altitude) * d)
+  fileprivate func interpolatedCoordinates(at distance: Double) -> CLLocationCoordinate2D {
+    guard let first = points.first, let last = points.last else {
+      return .init()
+    }
+    if distance <= first.distance {
+      return first.coordinates
+    }
+    if distance >= last.distance {
+      return last.coordinates
+    }
+
+    guard let upperIndex = points.firstIndexAtOrAfter(distance, by: \.distance) else {
+      return last.coordinates
+    }
+    let upper = points[upperIndex]
+    if upper.distance == distance || upperIndex == 0 {
+      return upper.coordinates
+    }
+
+    let lower = points[upperIndex - 1]
+    let progress = (distance - lower.distance) / (upper.distance - lower.distance)
+    return CLLocationCoordinate2D(latitude: lower.coordinates.latitude + (upper.coordinates.latitude - lower.coordinates.latitude) * progress,
+                                  longitude: lower.coordinates.longitude + (upper.coordinates.longitude - lower.coordinates.longitude) * progress)
   }
 }
 


### PR DESCRIPTION
## Summary
- interpolate elevation chart selection by actual track distance instead of snapping to the nearest sample
- unify distance <-> chartX conversion and fix X scaling so the marker aligns with the rendered line
- propagate interpolated distance and coordinates from the elevation profile presenter to avoid snapping back after drag

## Results
### Before: no interpolation -> bad snapping both on the map and the chart

https://github.com/user-attachments/assets/fec172a7-192b-4fe6-9c3f-5d7fdddd7fdc

### After: smooth interpolation 

https://github.com/user-attachments/assets/0d1fa993-118f-43da-92c6-d9b6066af7bf


