### PR TITLE
[android] Fix file sharing intent to use ACTION_SEND with proper ClipData

### DIFF
--- a/android/app/src/main/java/app/organicmaps/util/SharingUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/SharingUtils.java
@@ -24,15 +24,10 @@ import app.organicmaps.sdk.bookmarks.data.MapObject;
 import app.organicmaps.sdk.util.StorageUtils;
 import app.organicmaps.sdk.util.log.Logger;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 public class SharingUtils
 {
   private static final String TAG = SharingUtils.class.getSimpleName();
-  private static final String KML_MIME_TYPE = "application/vnd.google-earth.kml+xml";
-  private static final String KMZ_MIME_TYPE = "application/vnd.google-earth.kmz";
-  private static final String GPX_MIME_TYPE = "application/gpx+xml";
   private static final String TEXT_MIME_TYPE = "text/plain";
   public static class ShareInfo
   {
@@ -208,7 +203,7 @@ public class SharingUtils
 
   public static void shareFile(Context context, ActivityResultLauncher<SharingIntent> launcher, ShareInfo info)
   {
-    Intent intent = new Intent(Intent.ACTION_SEND_MULTIPLE);
+    Intent intent = new Intent(Intent.ACTION_SEND);
 
     if (!info.mSubject.isEmpty())
       intent.putExtra(Intent.EXTRA_SUBJECT, info.mSubject);
@@ -224,24 +219,20 @@ public class SharingUtils
     {
       final Uri fileUri = StorageUtils.getUriForFilePath(context, info.mFileName);
       Logger.i(TAG, "Sharing file " + info.mMimeType + " " + info.mFileName + " with URI " + fileUri);
-      intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, new ArrayList<>(List.of(fileUri)));
-      intent.setDataAndType(fileUri, info.mMimeType);
+      intent.putExtra(Intent.EXTRA_STREAM, fileUri);
+      intent.setType(info.mMimeType);
 
-      // Properly set permissions for intent, see
-      // https://developer.android.com/reference/androidx/core/content/FileProvider#include-the-permission-in-an-intent
+      // ClipData must be set explicitly: Intent.createChooser() does NOT
+      // copy EXTRA_STREAM into ClipData, so without this the chooser
+      // cannot grant URI read permission to the target app. This also
+      // ensures Google Drive reads the correct filename from FileProvider
+      // instead of falling back to EXTRA_SUBJECT.
+      final String fileName = fileUri.getPathSegments().get(fileUri.getPathSegments().size() - 1);
+      intent.setClipData(ClipData.newRawUri(fileName, fileUri));
       intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_ACTIVITY_NEW_TASK);
-
-      if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP_MR1)
-      {
-        intent.setClipData(ClipData.newRawUri("", fileUri));
-        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                        | Intent.FLAG_ACTIVITY_NEW_TASK);
-      }
 
       Intent saveIntent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
       saveIntent.setType(info.mMimeType);
-
-      final String fileName = fileUri.getPathSegments().get(fileUri.getPathSegments().size() - 1);
       saveIntent.putExtra(Intent.EXTRA_TITLE, fileName);
 
       Intent[] extraIntents = {saveIntent};
@@ -256,6 +247,10 @@ public class SharingUtils
       chooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, extraIntents);
 
       sharingIntent.SetSourceFile(fileUri);
+    }
+    else
+    {
+      intent.setType(info.mMimeType);
     }
 
     launcher.launch(sharingIntent);


### PR DESCRIPTION
PR #8817 changed ACTION_SEND to ACTION_SEND_MULTIPLE to fix Google Drive sharing (#8806), but SEND_MULTIPLE for a single file is non-standard and may prevent some apps from appearing in the chooser. The root cause was that ClipData was only set on API <= 22 (Lollipop), leaving API 23+ without proper URI permission propagation through Intent.createChooser().

- Use ACTION_SEND instead of ACTION_SEND_MULTIPLE (standard for single files, all file sharing in OM always produces a single file)
- Use putExtra(EXTRA_STREAM, uri) instead of putParcelableArrayListExtra
- Use setType() instead of setDataAndType(), which incorrectly sets the intent data field (SEND intents carry URIs via EXTRA_STREAM, not data)
- Set ClipData unconditionally on all API levels with the filename as label, so the chooser can grant URI read permission and Google Drive reads the correct filename from FileProvider instead of EXTRA_SUBJECT
- Remove Lollipop-only ClipData block (now redundant)
- Set MIME type for the no-file fallback path (bug report email-only)
- Remove unused MIME type constants and imports

Refs #8806, #8817

---

Fixes issue reported by a user (not all apps appear when gpx file is shared, e.g. zepp)