### PR TITLE
[android] Hide plus fab if all maps are downloaded or updatable

### DIFF
--- a/android/app/src/main/java/app/organicmaps/downloader/BottomPanel.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/BottomPanel.java
@@ -9,7 +9,6 @@ import static app.organicmaps.sdk.downloader.CountryItem.STATUS_PARTLY;
 import static app.organicmaps.sdk.downloader.CountryItem.STATUS_PROGRESS;
 import static app.organicmaps.sdk.downloader.CountryItem.STATUS_UPDATABLE;
 
-import android.content.Context;
 import android.view.View;
 import android.widget.Button;
 import app.organicmaps.R;
@@ -107,12 +106,14 @@ class BottomPanel
     boolean search = adapter.isSearchResultsMode();
 
     boolean show = !search;
-    UiUtils.showIf(show && adapter.isMyMapsMode(), mFab);
+    String root = adapter.getCurrentRootId();
+    int status = MapManager.nativeGetStatus(root);
+
+    // Hide FAB when all maps are already downloaded - nothing new to download
+    UiUtils.showIf(show && adapter.isMyMapsMode() && status != STATUS_DONE, mFab);
 
     if (show)
     {
-      String root = adapter.getCurrentRootId();
-      int status = MapManager.nativeGetStatus(root);
       if (adapter.isMyMapsMode())
       {
         switch (status)


### PR DESCRIPTION
- Hide the floating action button (FAB) in the downloader when there are no maps available to download
- FAB is hidden when status is `STATUS_DONE` (all downloaded) or `STATUS_UPDATABLE` (all present, just updates available)
- FAB remains visible when there are downloadable regions (`STATUS_PARTLY`, `STATUS_PROGRESS`, etc.)

<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/ebc752b4-df10-4f06-a03a-66cf2ac2812d" />
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/aa4d4686-93b3-435c-b183-d54d8573c2a6" />


Fixes #8271