### PR TITLE
[android] Opening hours preview for places

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
@@ -24,12 +24,7 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
 
   public PlaceOpeningHoursAdapter() {}
 
-  public PlaceOpeningHoursAdapter(Timetable[] timetables, int firstDayOfWeek)
-  {
-    setTimetables(timetables, firstDayOfWeek);
-  }
-
-  public void setTimetables(Timetable[] timetables, int firstDayOfWeek)
+  public void setTimetables(Timetable[] timetables, int firstDayOfWeek, int currentDayOfWeek)
   {
     final List<Integer> weekDays = buildWeekByFirstDay(firstDayOfWeek);
     final List<WeekScheduleData> scheduleData = new ArrayList<>();
@@ -47,8 +42,6 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
           i++;
 
         i--;
-        final int endWeekDay = weekDays.get(i);
-        scheduleData.add(new WeekScheduleData(startWeekDay, endWeekDay, tt));
       }
       else
       {
@@ -59,9 +52,13 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
             break;
           i++;
         }
-
-        scheduleData.add(new WeekScheduleData(startWeekDay, weekDays.get(i), null));
       }
+
+      final int endWeekDay = weekDays.get(i);
+      final boolean isBold = (startWeekDay <= endWeekDay)
+                               ? (startWeekDay <= currentDayOfWeek && currentDayOfWeek <= endWeekDay)
+                               : (currentDayOfWeek >= startWeekDay || currentDayOfWeek <= endWeekDay);
+      scheduleData.add(new WeekScheduleData(startWeekDay, endWeekDay, tt, isBold));
     }
 
     mWeekSchedule = scheduleData;
@@ -105,6 +102,8 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
 
     final WeekScheduleData schedule = mWeekSchedule.get(position);
 
+    holder.setBoldStyle(schedule.isBold);
+
     if (schedule.isClosed)
     {
       holder.setWeekdays(formatWeekdaysRange(schedule.startWeekDay, schedule.endWeekDay));
@@ -145,13 +144,15 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
     public final int endWeekDay;
     public final boolean isClosed;
     public final Timetable timetable;
+    public final boolean isBold;
 
-    public WeekScheduleData(int startWeekDay, int endWeekDay, Timetable timetable)
+    public WeekScheduleData(int startWeekDay, int endWeekDay, Timetable timetable, boolean isBold)
     {
       this.startWeekDay = startWeekDay;
       this.endWeekDay = endWeekDay;
       this.isClosed = timetable == null;
       this.timetable = timetable;
+      this.isBold = isBold;
     }
   }
 
@@ -168,6 +169,13 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
       mOpenTime = itemView.findViewById(R.id.tv__opening_hours_time);
       mNonBusinessTime = itemView.findViewById(R.id.tv__opening_hours_nonbusiness_time);
       itemView.setVisibility(View.VISIBLE);
+    }
+
+    public void setBoldStyle(boolean isBold)
+    {
+      final int style = isBold ? R.style.MwmTextAppearance_PlacePage : R.style.MwmTextAppearance_Body3;
+      mWeekdays.setTextAppearance(itemView.getContext(), style);
+      mOpenTime.setTextAppearance(itemView.getContext(), style);
     }
 
     public void setWeekdays(String weekdays)

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageOpeningHoursFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageOpeningHoursFragment.java
@@ -1,17 +1,16 @@
 package app.organicmaps.widget.placepage.sections;
 
 import android.animation.ValueAnimator;
-import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
+import androidx.core.text.util.LocalePreferences;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
@@ -21,21 +20,26 @@ import app.organicmaps.editor.data.TimeFormatUtils;
 import app.organicmaps.sdk.bookmarks.data.MapObject;
 import app.organicmaps.sdk.bookmarks.data.Metadata;
 import app.organicmaps.sdk.editor.OpeningHours;
-import app.organicmaps.sdk.editor.data.Timespan;
+import app.organicmaps.sdk.editor.data.OpeningHoursInfo;
 import app.organicmaps.sdk.editor.data.Timetable;
-import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.UiUtils;
-import app.organicmaps.utils.Utils;
 import app.organicmaps.widget.placepage.PlacePageUtils;
 import app.organicmaps.widget.placepage.PlacePageViewModel;
+import java.text.DateFormat;
+import java.text.DateFormatSymbols;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
 
 public class PlacePageOpeningHoursFragment extends Fragment implements Observer<MapObject>
 {
   private View mFrame;
-  private TextView mTodayLabel;
-  private TextView mTodayOpenTime;
-  private TextView mTodayNonBusinessTime;
+  private View mSchedulePreviewContainer;
+  private View mDropdownContent;
+  private TextView mTvSchedulePreviewOpenIndicator;
+  private TextView mTvSchedulePreviewDescription;
+  private TextView mTvSingleLineOpeningHours;
   private RecyclerView mFullWeekOpeningHours;
   private PlaceOpeningHoursAdapter mOpeningHoursAdapter;
   private View dropDownIcon;
@@ -58,14 +62,16 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
   {
     super.onViewCreated(view, savedInstanceState);
     mFrame = view;
-    mTodayLabel = view.findViewById(R.id.oh_today_label);
-    mTodayOpenTime = view.findViewById(R.id.oh_today_open_time);
-    mTodayNonBusinessTime = view.findViewById(R.id.oh_nonbusiness_time);
     mFullWeekOpeningHours = view.findViewById(R.id.rw__full_opening_hours);
+    mSchedulePreviewContainer = view.findViewById(R.id.schedule_preview_container);
+    mTvSchedulePreviewOpenIndicator = view.findViewById(R.id.tv__schedule_preview_open_indicator);
+    mTvSchedulePreviewDescription = view.findViewById(R.id.tv__schedule_preview_description);
+    mTvSingleLineOpeningHours = view.findViewById(R.id.tv__single_line_opening_hours);
+    mDropdownContent = view.findViewById(R.id.dropdown_content);
     mOpeningHoursAdapter = new PlaceOpeningHoursAdapter();
     mFullWeekOpeningHours.setAdapter(mOpeningHoursAdapter);
     dropDownIcon = view.findViewById(R.id.dropdown_icon);
-    mFullWeekOpeningHours.getLayoutParams().height = 0;
+    mDropdownContent.getLayoutParams().height = 0;
     UiUtils.hide(dropDownIcon);
     isOhExpanded = false;
     mOhContainer = mFrame.findViewById(R.id.oh_container);
@@ -87,34 +93,6 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
     mFullWeekOpeningHours.addOnItemTouchListener(touchListener);
   }
 
-  private void refreshTodayNonBusinessTime(Timespan[] closedTimespans)
-  {
-    final String hoursClosedLabel = getResources().getString(R.string.editor_hours_closed);
-    if (closedTimespans == null || closedTimespans.length == 0)
-      UiUtils.clearTextAndHide(mTodayNonBusinessTime);
-    else
-      UiUtils.setTextAndShow(mTodayNonBusinessTime,
-                             TimeFormatUtils.formatNonBusinessTime(closedTimespans, hoursClosedLabel));
-  }
-
-  private void refreshTodayOpeningHours(String label, String openTime, @ColorInt int color)
-  {
-    UiUtils.setTextAndShow(mTodayLabel, label);
-    UiUtils.setTextAndShow(mTodayOpenTime, openTime);
-
-    mTodayLabel.setTextColor(color);
-    mTodayOpenTime.setTextColor(color);
-  }
-
-  private void refreshTodayOpeningHours(String label, @ColorInt int color)
-  {
-    UiUtils.setTextAndShow(mTodayLabel, label);
-    UiUtils.hide(mTodayOpenTime);
-
-    mTodayLabel.setTextColor(color);
-    mTodayOpenTime.setTextColor(color);
-  }
-
   private void refreshOpeningHours(MapObject mapObject)
   {
     final String ohStr = mapObject.getMetadata(Metadata.MetadataType.FMD_OPEN_HOURS);
@@ -124,91 +102,64 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
                                      TimeFormatUtils.formatTimetables(getResources(), ohStr, timetables));
       return true;
     });
-    final boolean isEmptyTT = (timetables == null || timetables.length == 0);
-    final int color = ThemeUtils.getColor(requireContext(), android.R.attr.textColorPrimary);
 
-    if (isEmptyTT)
+    resetWeeklyViewState();
+
+    final boolean noOhString = ohStr.isEmpty();
+    final OpeningHoursInfo ohInfo = getOpeningHoursInfoFromString(ohStr);
+    final boolean isEmptyTT = timetables == null || timetables.length == 0;
+
+    refreshSchedulePreview(ohInfo);
+
+    if (noOhString)
     {
-      resetWeeklyViewState();
-      // 'opening_hours' tag wasn't parsed either because it's empty or wrong format.
-      if (!ohStr.isEmpty())
-      {
-        UiUtils.show(mFrame);
-        refreshTodayOpeningHours(ohStr, color);
-        UiUtils.hide(mTodayNonBusinessTime);
-      }
-      else
-        UiUtils.hide(mFrame);
+      // no 'opening_hours' tag
+      UiUtils.hide(mFrame);
+    }
+    else if (ohInfo == null)
+    {
+      // couldn't read anything from 'opening_hours' tag
+      UiUtils.show(mFrame);
+      UiUtils.show(mSchedulePreviewContainer);
+      UiUtils.hide(mTvSchedulePreviewOpenIndicator);
+      UiUtils.setTextAndShow(mTvSchedulePreviewDescription, ohStr);
+    }
+    else if (isEmptyTT)
+    {
+      // couldn't extract timetables from 'opening_hours' tag
+      UiUtils.show(mFrame);
+      UiUtils.setTextAndShow(mTvSingleLineOpeningHours, ohStr);
+      enableDropdownContent();
     }
     else
     {
       UiUtils.show(mFrame);
-      final Resources resources = getResources();
-      if (timetables[0].isFullWeek())
+
+      if (!ohInfo.isTwentyFourSeven) // Show whole week time table, except if it's open 24/7
       {
-        resetWeeklyViewState();
-        final Timetable tt = timetables[0];
-        if (tt.isFullday)
-        {
-          refreshTodayOpeningHours(resources.getString(R.string.twentyfour_seven), color);
-          UiUtils.clearTextAndHide(mTodayNonBusinessTime);
-        }
-        else
-        {
-          refreshTodayOpeningHours(resources.getString(R.string.daily), tt.workingTimespan.toWideString(), color);
-          refreshTodayNonBusinessTime(tt.closedTimespans);
-        }
-      }
-      else
-      {
-        // Show whole week time table.
-        int firstDayOfWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        mOpeningHoursAdapter.setTimetables(timetables, firstDayOfWeek);
-        if (isOhExpanded)
-        {
-          mFullWeekOpeningHours.measure(View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
-                                        View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
-          int newHeight = mFullWeekOpeningHours.getMeasuredHeight();
-          mFullWeekOpeningHours.getLayoutParams().height = newHeight;
-          mFullWeekOpeningHours.requestLayout();
-        }
-        UiUtils.show(dropDownIcon);
-        mOhContainer.setOnClickListener((v) -> expandOpeningHours());
-
-        // Show today's open time + non-business time.
-        boolean containsCurrentWeekday = false;
-        final int currentDay = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        for (Timetable tt : timetables)
-        {
-          if (tt.containsWeekday(currentDay))
-          {
-            containsCurrentWeekday = true;
-            String openTime;
-
-            if (tt.isFullday)
-            {
-              String allDay = resources.getString(R.string.editor_time_allday);
-              openTime = Utils.unCapitalize(allDay);
-            }
-            else
-              openTime = tt.workingTimespan.toWideString();
-
-            refreshTodayOpeningHours(resources.getString(R.string.today), openTime, color);
-            refreshTodayNonBusinessTime(tt.closedTimespans);
-
-            break;
-          }
-        }
-
-        // Show that place is closed today.
-        if (!containsCurrentWeekday)
-        {
-          refreshTodayOpeningHours(resources.getString(R.string.day_off_today),
-                                   ContextCompat.getColor(requireContext(), R.color.base_red));
-          UiUtils.hide(mTodayNonBusinessTime);
-        }
+        UiUtils.show(mFullWeekOpeningHours);
+        int currentDayOfWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
+        mOpeningHoursAdapter.setTimetables(timetables, getFirstDayOfWeek(), currentDayOfWeek);
+        enableDropdownContent();
       }
     }
+  }
+
+  private int getFirstDayOfWeek()
+  {
+    final List<String> stringDayList =
+        Arrays.asList(LocalePreferences.FirstDayOfWeek.SUNDAY, LocalePreferences.FirstDayOfWeek.MONDAY,
+                      LocalePreferences.FirstDayOfWeek.TUESDAY, LocalePreferences.FirstDayOfWeek.WEDNESDAY,
+                      LocalePreferences.FirstDayOfWeek.THURSDAY, LocalePreferences.FirstDayOfWeek.FRIDAY,
+                      LocalePreferences.FirstDayOfWeek.SATURDAY);
+
+    int dayIndex = stringDayList.indexOf(LocalePreferences.getFirstDayOfWeek());
+    if (dayIndex == -1)
+    {
+      return 1; // LocalePreferences.getFirstDayOfWeek() returned default
+    }
+
+    return dayIndex + 1;
   }
 
   private void expandOpeningHours()
@@ -216,27 +167,25 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
     int targetHeight, startHeight;
     if (!isOhExpanded)
     {
-      UiUtils.show(mFullWeekOpeningHours);
+      UiUtils.show(mDropdownContent);
       startHeight = 0;
-      mFullWeekOpeningHours.measure(View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
-                                    View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
-      targetHeight = mFullWeekOpeningHours.getMeasuredHeight();
+      targetHeight = getDropdownContentHeight();
       dropDownIcon.animate().rotation(-180f).setDuration(200).start();
       isOhExpanded = true;
     }
     else
     {
-      startHeight = mFullWeekOpeningHours.getMeasuredHeight();
+      startHeight = getDropdownContentHeight();
       targetHeight = 0;
       dropDownIcon.animate().rotation(0f).setDuration(200).start();
       isOhExpanded = false;
     }
-    mFullWeekOpeningHours.getLayoutParams().height = startHeight;
+    mDropdownContent.getLayoutParams().height = startHeight;
     final ValueAnimator va = ValueAnimator.ofInt(startHeight, targetHeight);
     va.setDuration(200);
     va.addUpdateListener(animation -> {
-      mFullWeekOpeningHours.getLayoutParams().height = (int) animation.getAnimatedValue();
-      mFullWeekOpeningHours.requestLayout();
+      mDropdownContent.getLayoutParams().height = (int) animation.getAnimatedValue();
+      mDropdownContent.requestLayout();
       if (mFrame.getParent() instanceof View)
         ((View) mFrame.getParent()).requestLayout();
     });
@@ -265,10 +214,155 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
   }
   private void resetWeeklyViewState()
   {
-    isOhExpanded = false;
-    UiUtils.hide(mFullWeekOpeningHours);
+    if (!isOhExpanded)
+    {
+      dropDownIcon.setRotation(0f);
+      mOhContainer.setOnClickListener(null);
+    }
+
     UiUtils.hide(dropDownIcon);
-    dropDownIcon.setRotation(0f);
-    mOhContainer.setOnClickListener(null);
+    UiUtils.hide(mDropdownContent);
+    UiUtils.hide(mTvSingleLineOpeningHours);
+    UiUtils.hide(mFullWeekOpeningHours);
+  }
+
+  private void enableDropdownContent()
+  {
+    UiUtils.show(mDropdownContent);
+    UiUtils.show(dropDownIcon);
+    mOhContainer.setOnClickListener((v) -> expandOpeningHours());
+
+    if (isOhExpanded)
+    {
+      mDropdownContent.getLayoutParams().height = getDropdownContentHeight();
+      mDropdownContent.requestLayout();
+    }
+  }
+
+  private int getDropdownContentHeight()
+  {
+    // request a layout with dropdown content at its full size to make sure mFrame.getWidth() returns the right result
+    mDropdownContent.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
+    mFrame.requestLayout();
+
+    mDropdownContent.measure(View.MeasureSpec.makeMeasureSpec(mFrame.getWidth(), View.MeasureSpec.EXACTLY),
+                             View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+    return mDropdownContent.getMeasuredHeight();
+  }
+
+  private OpeningHoursInfo getOpeningHoursInfoFromString(String ohStr)
+  {
+    final long currentTime = System.currentTimeMillis() / 1000L;
+    return OpeningHours.nativeGetOpeningHoursInfoFromString(ohStr, currentTime);
+  }
+
+  private void refreshSchedulePreview(OpeningHoursInfo ohInfo)
+  {
+    final long currentTime = System.currentTimeMillis() / 1000L;
+
+    if (ohInfo == null)
+    {
+      UiUtils.hide(mSchedulePreviewContainer);
+      return;
+    }
+
+    UiUtils.show(mSchedulePreviewContainer);
+
+    if (ohInfo.isTwentyFourSeven)
+    {
+      UiUtils.setTextAndShow(mTvSchedulePreviewOpenIndicator, getString(R.string.twentyfour_seven));
+      mTvSchedulePreviewOpenIndicator.setTextColor(ContextCompat.getColor(requireContext(), R.color.base_green));
+      UiUtils.hide(mTvSchedulePreviewDescription);
+    }
+    else if (ohInfo.state == OpeningHoursInfo.RuleState.Open)
+    {
+      String descriptionString;
+
+      if (ohInfo.nextTimeClosed == OpeningHoursInfo.TIME_NEVER) // Will stay open forever
+        descriptionString = "";
+      else
+      {
+        final long timeLeftMinutes = (ohInfo.nextTimeClosed - currentTime) / 60;
+
+        Date closeDate = new Date(ohInfo.nextTimeClosed * 1000L);
+        DateFormat dateFormat = android.text.format.DateFormat.getTimeFormat(requireContext());
+
+        if (timeLeftMinutes < 3 * 60) // Less than 3 hours
+          descriptionString = getString(R.string.closes_in, getTimeIntervalString(timeLeftMinutes)) + " • "
+                            + dateFormat.format(closeDate);
+        else if (timeLeftMinutes < 24 * 60) // Less than 24 hours
+          descriptionString = getString(R.string.closes_at, dateFormat.format(closeDate));
+        else
+          descriptionString = "";
+      }
+
+      UiUtils.setTextAndShow(mTvSchedulePreviewOpenIndicator, getString(R.string.editor_time_open));
+      mTvSchedulePreviewOpenIndicator.setTextColor(ContextCompat.getColor(requireContext(), R.color.base_green));
+
+      UiUtils.setTextAndHideIfEmpty(mTvSchedulePreviewDescription, descriptionString);
+    }
+    else // ohInfo.state == OpeningHoursInfo.RuleState.Closed
+    {
+      String descriptionString;
+
+      if (ohInfo.nextTimeOpen == OpeningHoursInfo.TIME_NEVER) // Will stay closed forever
+        descriptionString = "";
+      else
+      {
+        final long timeLeftMinutes = (ohInfo.nextTimeOpen - currentTime) / 60;
+
+        final Calendar nowCal = Calendar.getInstance();
+
+        Calendar openCal = Calendar.getInstance();
+        openCal.setTimeInMillis(ohInfo.nextTimeOpen * 1000L);
+
+        Date openDate = new Date(ohInfo.nextTimeOpen * 1000L);
+        DateFormat dateFormat = android.text.format.DateFormat.getTimeFormat(requireContext());
+
+        boolean willOpenToday = nowCal.get(Calendar.DAY_OF_YEAR) == openCal.get(Calendar.DAY_OF_YEAR)
+                             && nowCal.get(Calendar.YEAR) == openCal.get(Calendar.YEAR);
+
+        if (timeLeftMinutes < 3 * 60) // Less than 3 hours
+          descriptionString = getString(R.string.opens_in, getTimeIntervalString(timeLeftMinutes)) + " • "
+                            + dateFormat.format(openDate);
+        else if (willOpenToday) // Today
+          descriptionString = getString(R.string.opens_at, dateFormat.format(openDate));
+        else if (timeLeftMinutes < 24 * 60) // Less than 24 hours
+          descriptionString = getString(R.string.opens_tomorrow_at, dateFormat.format(openDate));
+        else if (timeLeftMinutes < 7 * 24 * 60) // Less than 1 week
+        {
+          final int openDay = openCal.get(Calendar.DAY_OF_WEEK);
+          final String openDayName = DateFormatSymbols.getInstance().getWeekdays()[openDay];
+          descriptionString = getString(R.string.opens_dayoftheweek_at, openDayName, dateFormat.format(openDate));
+        }
+        else
+          descriptionString = "";
+      }
+
+      UiUtils.setTextAndShow(mTvSchedulePreviewOpenIndicator, getString(R.string.closed_now));
+      mTvSchedulePreviewOpenIndicator.setTextColor(ContextCompat.getColor(requireContext(), R.color.base_red));
+
+      UiUtils.setTextAndHideIfEmpty(mTvSchedulePreviewDescription, descriptionString);
+    }
+  }
+
+  private String getTimeIntervalString(long minutes)
+  {
+    if (minutes >= 60)
+    {
+      if (minutes % 60 != 0)
+      {
+        return String.format("%d %s %d %s", minutes / 60, getString(R.string.hour), minutes % 60,
+                             getString(R.string.minute));
+      }
+      else
+      {
+        return String.format("%d %s", minutes / 60, getString(R.string.hour));
+      }
+    }
+    else
+    {
+      return String.format("%d %s", minutes % 60, getString(R.string.minute));
+    }
   }
 }

--- a/android/app/src/main/res/layout/place_page_opening_hours_fragment.xml
+++ b/android/app/src/main/res/layout/place_page_opening_hours_fragment.xml
@@ -5,7 +5,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:orientation="vertical"
-  android:layout_height="wrap_content">
+  android:layout_height="wrap_content" >
 
   <include layout="@layout/place_page_shadow_gap" />
 
@@ -19,77 +19,80 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginEnd="@dimen/margin_base"
-      android:layout_marginTop="@dimen/margin_quarter"
+      android:layout_alignTop="@+id/schedule_preview_container"
+      android:layout_alignBottom="@+id/schedule_preview_container"
       app:srcCompat="@drawable/ic_operating_hours"
       app:tint="?iconTint" />
 
-    <TextView
-      android:id="@+id/oh_today_label"
+    <LinearLayout
+      android:id="@+id/schedule_preview_container"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_marginTop="6dp"
-      android:layout_marginBottom="0dp"
+      android:minHeight="24dp"
+      android:layout_marginTop="@dimen/margin_quarter"
+      android:layout_marginEnd="@dimen/margin_half"
+      android:layout_marginBottom="@dimen/margin_half"
+      android:layout_toStartOf="@+id/dropdown_icon"
       android:layout_toEndOf="@id/icon"
-      android:textAppearance="@style/MwmTextAppearance.PlacePage"
-      tools:text="@string/today"
-      android:text="@string/today"
-      tools:visibility="visible" />
+      android:orientation="vertical">
 
-    <TextView
-      android:id="@+id/oh_today_open_time"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="6dp"
-      android:layout_marginEnd="32dp"
-      android:layout_alignParentEnd="true"
-      android:layout_toStartOf="@id/dropdown_icon"
-      android:textAppearance="@style/MwmTextAppearance.PlacePage"
-      tools:text="@string/twentyfour_seven"
-      android:text="@string/twentyfour_seven"
-      android:textAlignment="viewEnd"
-      tools:visibility="visible" />
+      <TextView
+        android:id="@+id/tv__schedule_preview_open_indicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textAppearance="@style/MwmTextAppearance.PlacePage"
+        tools:text="Open" />
+
+      <TextView
+        android:id="@+id/tv__schedule_preview_description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:textAppearance="@style/MwmTextAppearance.Body3"
+        tools:text="Imagine, just imagine that this text is very very long, like sooo much long" />
+    </LinearLayout>
 
     <ImageView
       android:id="@+id/dropdown_icon"
       android:layout_width="30dp"
       android:layout_height="30dp"
       android:layout_alignParentEnd="true"
-      android:layout_marginTop="1dp"
       android:layout_marginEnd="@dimen/neg_margin_quarter"
+      android:layout_alignTop="@+id/schedule_preview_container"
+      android:layout_alignBottom="@+id/schedule_preview_container"
       app:srcCompat="@drawable/ic_down"
       app:tint="?iconTint"
       tools:visibility="visible" />
 
-    <TextView
-      android:id="@+id/oh_nonbusiness_time"
+    <RelativeLayout
+      android:id="@+id/dropdown_content"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_width="wrap_content"
-      android:layout_below="@id/oh_today_label"
-      android:layout_alignStart="@id/oh_today_label"
-      android:layout_alignEnd="@id/oh_today_open_time"
-      android:layout_alignParentEnd="false"
-      android:textAlignment="viewEnd"
-      android:textAppearance="@style/MwmTextAppearance.Body4"
-      android:visibility="gone"
-      tools:visibility="visible" />
+      android:layout_below="@id/schedule_preview_container"
+      android:layout_alignStart="@id/icon">
 
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/rw__full_opening_hours"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentEnd="true"
-      android:layout_alignStart="@id/oh_nonbusiness_time"
-      android:layout_below="@id/oh_nonbusiness_time"
-      app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-      android:layout_marginTop="8dp"/>
+      <TextView
+        android:id="@+id/tv__single_line_opening_hours"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAlignment="viewStart"
+        android:textAppearance="@style/MwmTextAppearance.Body3"
+        tools:text="Very very ugly timetable format with very very very long text..." />
+
+      <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rw__full_opening_hours"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+    </RelativeLayout>
 
   </RelativeLayout>
-
-  <LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
-
-  </LinearLayout>
 
 </LinearLayout>

--- a/android/app/src/main/res/values-af/strings.xml
+++ b/android/app/src/main/res/values-af/strings.xml
@@ -705,6 +705,12 @@
     <string name="moreyear_ago_sorttype">Meer as ’n jaar gelede</string>
     <string name="near_me_sorttype">Naby my</string>
     <string name="others_sorttype">Ander</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Nou gesluit</string>
+    <string name="opens_tomorrow_at">Open môre om %s</string>
+    <string name="opens_dayoftheweek_at">Open %1$s om %2$s</string>
+    <string name="opens_at">Open om %s</string>
+    <string name="closes_at">Sluit om %s</string>
     <string name="editor_add_select_category_all_subtitle">Kategorieë</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -720,6 +720,12 @@
     <string name="moreyear_ago_sorttype">منذ أكثر من سنة</string>
     <string name="near_me_sorttype">قريب مني</string>
     <string name="others_sorttype">أخرى</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">مغلق الآن</string>
+    <string name="opens_tomorrow_at">يُفتتح غداً في %s</string>
+    <string name="opens_dayoftheweek_at">يفتح %1$s في %2$s</string>
+    <string name="opens_at">يفتح في %s</string>
+    <string name="closes_at">يغلق في %s</string>
     <string name="editor_add_select_category_all_subtitle">جميع الفئات</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -708,6 +708,12 @@
     <string name="moreyear_ago_sorttype">Bir ildən çox əvvəl</string>
     <string name="near_me_sorttype">Mənə yaxın</string>
     <string name="others_sorttype">Digərləri</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">İndi bağlıdır</string>
+    <string name="opens_tomorrow_at">Sabah açılır %s</string>
+    <string name="opens_dayoftheweek_at">%1$s %2$s açılır</string>
+    <string name="opens_at">Açılır %s</string>
+    <string name="closes_at">Bağlanır %s</string>
     <string name="editor_add_select_category_all_subtitle">Bütün kateqoriyalar</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -717,6 +717,12 @@
     <string name="moreyear_ago_sorttype">Больш за год таму</string>
     <string name="near_me_sorttype">Каля мяне</string>
     <string name="others_sorttype">Іншыя</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Зараз закрыта</string>
+    <string name="opens_tomorrow_at">Адкрыецца заўтра ў %s</string>
+    <string name="opens_dayoftheweek_at">Адкрываецца ў %1$s у %2$s</string>
+    <string name="opens_at">Адкрываецца ў %s</string>
+    <string name="closes_at">Закрываецца ў %s</string>
     <string name="editor_add_select_category_all_subtitle">Усе катэгорыі</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -707,6 +707,12 @@
     <string name="moreyear_ago_sorttype">Преди повече от година</string>
     <string name="near_me_sorttype">На близо</string>
     <string name="others_sorttype">Други</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Затворено сега</string>
+    <string name="opens_tomorrow_at">Открива се утре в %s</string>
+    <string name="opens_dayoftheweek_at">Отваря %1$s в %2$s</string>
+    <string name="opens_at">Отваря се в %s</string>
+    <string name="closes_at">Затваря се в %s</string>
     <string name="editor_add_select_category_all_subtitle">Всички категории</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -714,6 +714,12 @@
     <string name="moreyear_ago_sorttype">Fa més d’un any</string>
     <string name="near_me_sorttype">Prop meu</string>
     <string name="others_sorttype">Altres</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Ara és tancat</string>
+    <string name="opens_tomorrow_at">Obre demà a les %s</string>
+    <string name="opens_dayoftheweek_at">Obre el %1$s a les %2$s</string>
+    <string name="opens_at">Obre a les %s</string>
+    <string name="closes_at">Tanca a les %s</string>
     <string name="editor_add_select_category_all_subtitle">Totes les categories</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -714,6 +714,12 @@
     <string name="moreyear_ago_sorttype">Více než před rokem</string>
     <string name="near_me_sorttype">Blízko mě</string>
     <string name="others_sorttype">Ostatní</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Nyní je zavřeno</string>
+    <string name="opens_tomorrow_at">Otevírá zítra v %s</string>
+    <string name="opens_dayoftheweek_at">Otevírá %1$s v %2$s</string>
+    <string name="opens_at">Otevírá v %s</string>
+    <string name="closes_at">Zavírá v %s</string>
     <string name="editor_add_select_category_all_subtitle">Všechny kategorie</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -708,6 +708,12 @@
     <string name="moreyear_ago_sorttype">Mere end et år siden</string>
     <string name="near_me_sorttype">I nærheden</string>
     <string name="others_sorttype">Andre</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Lukket nu</string>
+    <string name="opens_tomorrow_at">Åbner i morgen kl. %s</string>
+    <string name="opens_dayoftheweek_at">Åbner %1$s kl. %2$s</string>
+    <string name="opens_at">Åbner kl. %s</string>
+    <string name="closes_at">Lukker kl. %s</string>
     <string name="editor_add_select_category_all_subtitle">Alle kategorier</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -710,6 +710,12 @@
     <string name="moreyear_ago_sorttype">Vor über einem Jahr</string>
     <string name="near_me_sorttype">In meiner Nähe</string>
     <string name="others_sorttype">Sonstiges</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Jetzt geschlossen</string>
+    <string name="opens_tomorrow_at">Öffnet morgen um %s</string>
+    <string name="opens_dayoftheweek_at">Öffnet %1$s um %2$s</string>
+    <string name="opens_at">Öffnet um %s</string>
+    <string name="closes_at">Schließt um %s</string>
     <string name="editor_add_select_category_all_subtitle">Alle Kategorien</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -709,6 +709,12 @@
     <string name="moreyear_ago_sorttype">Περισσότερο από ένα χρόνο πριν</string>
     <string name="near_me_sorttype">Δίπλα μου</string>
     <string name="others_sorttype">Άλλα</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Κλειστό τώρα</string>
+    <string name="opens_tomorrow_at">Ανοίγει αύριο στις %s</string>
+    <string name="opens_dayoftheweek_at">Ανοίγει %1$s στις %2$s</string>
+    <string name="opens_at">Ανοίγει στις %s</string>
+    <string name="closes_at">Κλείνει στις %s</string>
     <string name="editor_add_select_category_all_subtitle">Όλες οι κατηγορίες</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-es-rMX/strings.xml
+++ b/android/app/src/main/res/values-es-rMX/strings.xml
@@ -377,6 +377,12 @@
     <!-- Android, title, max 20-22 symbols -->
     <string name="sort_bookmarks">Ordenar favoritos</string>
     <string name="near_me_sorttype">Cerca a mí</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Cerrado</string>
+    <string name="opens_tomorrow_at">Abre mañana en %s</string>
+    <string name="opens_dayoftheweek_at">Abre %1$s en %2$s</string>
+    <string name="opens_at">Abre en %s</string>
+    <string name="closes_at">Cierra en %s</string>
 
     <!-- SECTION: Bookmark types used for sorting -->
     <string name="food_places">Alimentación</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -714,6 +714,12 @@
     <string name="moreyear_ago_sorttype">Hace más de un año</string>
     <string name="near_me_sorttype">Cerca de mí</string>
     <string name="others_sorttype">Otros</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Cerrado ahora</string>
+    <string name="opens_tomorrow_at">Abre mañana a las %s</string>
+    <string name="opens_dayoftheweek_at">Abre el %1$s a las %2$s</string>
+    <string name="opens_at">Abre a las %s</string>
+    <string name="closes_at">Cierra a las %s</string>
     <string name="editor_add_select_category_all_subtitle">Todas las categorías</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -711,6 +711,12 @@
     <string name="moreyear_ago_sorttype">Üle aasta tagasi</string>
     <string name="near_me_sorttype">Minu lähedal</string>
     <string name="others_sorttype">Muud</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Praegu suletud</string>
+    <string name="opens_tomorrow_at">Avatakse homme kell %s</string>
+    <string name="opens_dayoftheweek_at">Avatakse %1$s kell %2$s</string>
+    <string name="opens_at">Avatakse kell %s</string>
+    <string name="closes_at">Suletakse kell %s</string>
     <string name="editor_add_select_category_all_subtitle">Kõik kategooriad</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -708,6 +708,12 @@
     <string name="moreyear_ago_sorttype">Duela urtebete baino gehiago</string>
     <string name="near_me_sorttype">Nigandik gertu</string>
     <string name="others_sorttype">Beste batzuk</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Orain itxita</string>
+    <string name="opens_tomorrow_at">Bihar %sean irekiko da</string>
+    <string name="opens_dayoftheweek_at">%1$sean %2$setan irekiko da</string>
+    <string name="opens_at">%setan irekiko da</string>
+    <string name="closes_at">%setan itxiko da</string>
     <string name="editor_add_select_category_all_subtitle">Kategoria guztiak</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -708,6 +708,12 @@
     <string name="moreyear_ago_sorttype">بیش از یک سال قبل</string>
     <string name="near_me_sorttype">نزدیک من</string>
     <string name="others_sorttype">دیگران</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">اکنون تعطیل است</string>
+    <string name="opens_tomorrow_at">فردا در %s باز می‌شود</string>
+    <string name="opens_dayoftheweek_at">باز می‌شود %1$s در %2$s</string>
+    <string name="opens_at">در %s باز می‌شود</string>
+    <string name="closes_at">در %s بسته می‌شود</string>
     <string name="editor_add_select_category_all_subtitle">همه دسته‌بندی‌ها</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -708,6 +708,12 @@
     <string name="moreyear_ago_sorttype">Yli vuosi sitten</string>
     <string name="near_me_sorttype">Lähelläni</string>
     <string name="others_sorttype">Muut</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Suljettu nyt</string>
+    <string name="opens_tomorrow_at">Aukeaa huomenna kello %s</string>
+    <string name="opens_dayoftheweek_at">Aukeaa %1$s kello %2$s</string>
+    <string name="opens_at">Aukeaa kello %s</string>
+    <string name="closes_at">Sulkeutuu kello %s</string>
     <string name="editor_add_select_category_all_subtitle">Kaikki kategoriat</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -712,6 +712,12 @@
     <string name="moreyear_ago_sorttype">Il y a plus d\'un an</string>
     <string name="near_me_sorttype">Près de moi</string>
     <string name="others_sorttype">Autres</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Fermé actuellement</string>
+    <string name="opens_tomorrow_at">Ouvre demain à %s</string>
+    <string name="opens_dayoftheweek_at">Ouvre le %1$s à %2$s</string>
+    <string name="opens_at">Ouvre à %s</string>
+    <string name="closes_at">Ferme à %s</string>
     <string name="editor_add_select_category_all_subtitle">Toutes les catégories</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-gl/strings.xml
+++ b/android/app/src/main/res/values-gl/strings.xml
@@ -711,6 +711,12 @@
     <string name="moreyear_ago_sorttype">Fai máis dun ano</string>
     <string name="near_me_sorttype">Preto de min</string>
     <string name="others_sorttype">Outros</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Pechado agora</string>
+    <string name="opens_tomorrow_at">Abre mañá a Ábreas %s</string>
+    <string name="opens_dayoftheweek_at">o %1$s ás %2$s</string>
+    <string name="opens_at">Abre a Ábreas %s</string>
+    <string name="closes_at">Pecha ás %s</string>
     <string name="editor_add_select_category_all_subtitle">Todas as categorías</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -705,6 +705,12 @@
     <string name="moreyear_ago_sorttype">एक साल से भी अधिक पहले</string>
     <string name="near_me_sorttype">मेरे पास</string>
     <string name="others_sorttype">अन्य</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">अब बंद</string>
+    <string name="opens_tomorrow_at">कल सुबह %s बजे खुलेगा</string>
+    <string name="opens_dayoftheweek_at">%1$s को %2$s पर खोलता है</string>
+    <string name="opens_at">%s बजे खुलता है</string>
+    <string name="closes_at">%s बजे बंद हो जाता है</string>
     <string name="editor_add_select_category_all_subtitle">सभी श्रेणियाँ</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-hr/strings.xml
+++ b/android/app/src/main/res/values-hr/strings.xml
@@ -712,6 +712,12 @@
     <string name="moreyear_ago_sorttype">Više od godinu dana</string>
     <string name="near_me_sorttype">U mojoj blizini</string>
     <string name="others_sorttype">Drugo</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Zatvoreno sada</string>
+    <string name="opens_tomorrow_at">Otvara se sutra u %s</string>
+    <string name="opens_dayoftheweek_at">Otvara %1$s u %2$s</string>
+    <string name="opens_at">Otvara se u %s</string>
+    <string name="closes_at">Zatvara se u %s</string>
     <string name="editor_add_select_category_all_subtitle">Sve kategorije</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -711,6 +711,12 @@
     <string name="moreyear_ago_sorttype">Több mint egy éve</string>
     <string name="near_me_sorttype">A közelben</string>
     <string name="others_sorttype">Egyebek</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Most zárva</string>
+    <string name="opens_tomorrow_at">Holnap ekkor nyit: %s</string>
+    <string name="opens_dayoftheweek_at">Nyitva ekkortól: %1$s eddig: %2$s</string>
+    <string name="opens_at">Kinyit ekkor: %s</string>
+    <string name="closes_at">Bezár ekkor: %s</string>
     <string name="editor_add_select_category_all_subtitle">Összes kategória</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-hy/strings.xml
+++ b/android/app/src/main/res/values-hy/strings.xml
@@ -708,6 +708,12 @@
     <string name="moreyear_ago_sorttype">Ավելի քան մեկ տարի առաջ</string>
     <string name="near_me_sorttype">Իմ մոտակայքում</string>
     <string name="others_sorttype">Այլ</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Փակ է</string>
+    <string name="opens_tomorrow_at">Բացվում է վաղը %s</string>
+    <string name="opens_dayoftheweek_at">Բացվում է %1$s՝ %2$s</string>
+    <string name="opens_at">Բացվում է %s</string>
+    <string name="closes_at">Փակվում է %s</string>
     <string name="editor_add_select_category_all_subtitle">Բոլոր կատեգորիաները</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -706,6 +706,12 @@
     <string name="moreyear_ago_sorttype">Lebih dari setahun yang lalu</string>
     <string name="near_me_sorttype">Dekat dengan saya</string>
     <string name="others_sorttype">Lainnya</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Sekarang Tutup</string>
+    <string name="opens_tomorrow_at">Dibuka besok pada pukul %s</string>
+    <string name="opens_dayoftheweek_at">Membuka %1$s di %2$s</string>
+    <string name="opens_at">Dibuka di %s</string>
+    <string name="closes_at">Ditutup pada %s</string>
     <string name="editor_add_select_category_all_subtitle">Semua kategori</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-is/strings.xml
+++ b/android/app/src/main/res/values-is/strings.xml
@@ -711,6 +711,12 @@
     <string name="moreyear_ago_sorttype">Fyrir meira en ári síðan</string>
     <string name="near_me_sorttype">Nálægt mér</string>
     <string name="others_sorttype">Annað</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Lokað núna</string>
+    <string name="opens_tomorrow_at">Opnar á morgun kl. %s</string>
+    <string name="opens_dayoftheweek_at">Opnar %1$s kl. %2$s</string>
+    <string name="opens_at">Opnar %s</string>
+    <string name="closes_at">Lokar %s</string>
     <string name="editor_add_select_category_all_subtitle">Allir flokkar</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -713,6 +713,12 @@
     <string name="moreyear_ago_sorttype">Più di un anno fa</string>
     <string name="near_me_sorttype">Vicino a me</string>
     <string name="others_sorttype">Altri</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Ora chiuso</string>
+    <string name="opens_tomorrow_at">Apre domani alle %s</string>
+    <string name="opens_dayoftheweek_at">Apre %1$s alle %2$s</string>
+    <string name="opens_at">Apre alle %s</string>
+    <string name="closes_at">Chiude alle %s</string>
     <string name="editor_add_select_category_all_subtitle">Tutte le categorie</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -708,6 +708,12 @@
     <string name="moreyear_ago_sorttype">לפני יותר משנה</string>
     <string name="near_me_sorttype">קרוב אלי</string>
     <string name="others_sorttype">אחרים</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">סגור כעת</string>
+    <string name="opens_tomorrow_at">נפתח מחר ב-%s</string>
+    <string name="opens_dayoftheweek_at">נפתח ביום %1$s ב-%2$s</string>
+    <string name="opens_at">נפתח מחר ב-%s</string>
+    <string name="closes_at">נסגר ב-%s</string>
     <string name="editor_add_select_category_all_subtitle">כל הקטגוריות</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -707,6 +707,12 @@
     <string name="moreyear_ago_sorttype">1年以上前</string>
     <string name="near_me_sorttype">近隣</string>
     <string name="others_sorttype">その他</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">現在閉店</string>
+    <string name="opens_tomorrow_at">明日の %s から営業</string>
+    <string name="opens_dayoftheweek_at">%1$s の %2$s から営業</string>
+    <string name="opens_at">%s から営業</string>
+    <string name="closes_at">%s に閉店</string>
     <string name="editor_add_select_category_all_subtitle">全てのカテゴリ</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -706,6 +706,12 @@
     <string name="moreyear_ago_sorttype">1년 그 이상 전</string>
     <string name="near_me_sorttype">나와 가까운 곳</string>
     <string name="others_sorttype">기타</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">지금 닫힘</string>
+    <string name="opens_tomorrow_at">내일 %s에 오픈</string>
+    <string name="opens_dayoftheweek_at">%2$s에서 %1$s을(를) 엽니다.</string>
+    <string name="opens_at">%s에 열림</string>
+    <string name="closes_at">%s에서 닫힘</string>
     <string name="editor_add_select_category_all_subtitle">모든 카테고리</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-lo/strings.xml
+++ b/android/app/src/main/res/values-lo/strings.xml
@@ -662,6 +662,12 @@
     <string name="moreyear_ago_sorttype">ຫຼາຍກວ່າໜຶ່ງປີຜ່ານມາ</string>
     <string name="near_me_sorttype">ໃກ້ຂ້ອຍ</string>
     <string name="others_sorttype">ອື່ນໆ</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">ປິດຢູ່ໃນຂະນະນີ້</string>
+    <string name="opens_tomorrow_at">ຈະເປີດມື້ອື່ນເວລາ %s</string>
+    <string name="opens_dayoftheweek_at">ຈະເປີດວັນ%1$s ເວລາ %2$s</string>
+    <string name="opens_at">ຈະເປີດເວລາ %s</string>
+    <string name="closes_at">ຈະປິດເວລາ %s</string>
     <string name="editor_add_select_category_all_subtitle">ໝວດໝູ່ທັງໝົດ</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-lt/strings.xml
+++ b/android/app/src/main/res/values-lt/strings.xml
@@ -711,6 +711,12 @@
     <string name="moreyear_ago_sorttype">Virš metų senumo</string>
     <string name="near_me_sorttype">Netoliese</string>
     <string name="others_sorttype">Kitkas</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Dabar uždaryta</string>
+    <string name="opens_tomorrow_at">Atsidaro rytoj %s</string>
+    <string name="opens_dayoftheweek_at">Atsidaro %1$s %2$s</string>
+    <string name="opens_at">Atsidaro %s</string>
+    <string name="closes_at">Užsidaro %s</string>
     <string name="editor_add_select_category_all_subtitle">Visos kategorijos</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-lv/strings.xml
+++ b/android/app/src/main/res/values-lv/strings.xml
@@ -711,6 +711,12 @@
     <string name="moreyear_ago_sorttype">Vairāk nekā pirms gada</string>
     <string name="near_me_sorttype">Man tuvumā</string>
     <string name="others_sorttype">Cits</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Šobrīd slēgts</string>
+    <string name="opens_tomorrow_at">Atveras rīt %s</string>
+    <string name="opens_dayoftheweek_at">Atveras %1$s plkst. %2$s</string>
+    <string name="opens_at">Atveras plkst. %s</string>
+    <string name="closes_at">Slēgts no plkst. %s</string>
     <string name="editor_add_select_category_all_subtitle">Visas kategorijas</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -708,6 +708,12 @@
     <string name="moreyear_ago_sorttype">एक वर्षांपूर्वी</string>
     <string name="near_me_sorttype">माझ्या जवळ</string>
     <string name="others_sorttype">इतर</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">आता बंद</string>
+    <string name="opens_tomorrow_at">उद्या %s ला उघडेल</string>
+    <string name="opens_dayoftheweek_at">%1$s ला %2$s वाजता उघडेल</string>
+    <string name="opens_at">%s ला उघडेल</string>
+    <string name="closes_at">%s ला बंद होईल</string>
     <string name="editor_add_select_category_all_subtitle">सर्व प्रवर्ग</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-mt/strings.xml
+++ b/android/app/src/main/res/values-mt/strings.xml
@@ -717,6 +717,12 @@
     <string name="moreyear_ago_sorttype">Aktar minn sena ilu</string>
     <string name="near_me_sorttype">Ħdejja</string>
     <string name="others_sorttype">Oħrajn</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Magħluq issa</string>
+    <string name="opens_tomorrow_at">Jiftaħ għada fil-%s</string>
+    <string name="opens_dayoftheweek_at">Jiftaħ %1$s fl-%2$s</string>
+    <string name="opens_at">Jiftaħ f \' %s</string>
+    <string name="closes_at">Jagħlaq f ’ %s</string>
     <string name="editor_add_select_category_all_subtitle">Kategoriji kollha</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -708,6 +708,12 @@
     <string name="moreyear_ago_sorttype">Mer enn ett år siden</string>
     <string name="near_me_sorttype">Nær meg</string>
     <string name="others_sorttype">Andre</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Lukket nå</string>
+    <string name="opens_tomorrow_at">Åpner i morgen klokka %s</string>
+    <string name="opens_dayoftheweek_at">Åpner %1$s klokka %2$s</string>
+    <string name="opens_at">Åpner klokka %s</string>
+    <string name="closes_at">Stenger %s</string>
     <string name="editor_add_select_category_all_subtitle">Alle kategorier</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -711,6 +711,12 @@
     <string name="moreyear_ago_sorttype">Meer dan een jaar geleden</string>
     <string name="near_me_sorttype">Dicht bij mij</string>
     <string name="others_sorttype">Andere</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Nu gesloten</string>
+    <string name="opens_tomorrow_at">Opent morgen om %s</string>
+    <string name="opens_dayoftheweek_at">Opent %1$s om %2$s</string>
+    <string name="opens_at">Opent om %s</string>
+    <string name="closes_at">Sluit om %s</string>
     <string name="editor_add_select_category_all_subtitle">Alle categorieën</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -714,6 +714,12 @@
     <string name="moreyear_ago_sorttype">Ponad rok temu</string>
     <string name="near_me_sorttype">W pobliżu</string>
     <string name="others_sorttype">Inne</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Nieczynne</string>
+    <string name="opens_tomorrow_at">Otwarcie jutro o %s</string>
+    <string name="opens_dayoftheweek_at">Otwarcie %1$s o %2$s</string>
+    <string name="opens_at">Otwarcie o %s</string>
+    <string name="closes_at">Zamknięcie o %s</string>
     <string name="editor_add_select_category_all_subtitle">Wszystkie kategorie</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -493,6 +493,10 @@
     <string name="moremonth_ago_sorttype">Há mais de um mês</string>
     <string name="moreyear_ago_sorttype">Há mais de um ano</string>
     <string name="near_me_sorttype">Próximo de mim</string>
+    <string name="opens_tomorrow_at">Abre amanhã em %s</string>
+    <string name="opens_dayoftheweek_at">Abre %1$s em %2$s</string>
+    <string name="opens_at">Abre em %s</string>
+    <string name="closes_at">Encerra às %s</string>
 
     <!-- SECTION: Bookmark types used for sorting -->
     <string name="food_places">Alimentos</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -712,6 +712,12 @@
     <string name="moreyear_ago_sorttype">Mais de um ano atrás</string>
     <string name="near_me_sorttype">Perto de mim</string>
     <string name="others_sorttype">Outros</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Fechado agora</string>
+    <string name="opens_tomorrow_at">Abre amanhã às %s</string>
+    <string name="opens_dayoftheweek_at">Abre %1$s às %2$s</string>
+    <string name="opens_at">Abre às %s</string>
+    <string name="closes_at">Fecha às %s</string>
     <string name="editor_add_select_category_all_subtitle">Todas as categorias</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -708,6 +708,12 @@
     <string name="moreyear_ago_sorttype">Cu mai mult de un an în urmă</string>
     <string name="near_me_sorttype">Lângă mine</string>
     <string name="others_sorttype">Altele</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Închis acum</string>
+    <string name="opens_tomorrow_at">Deschide mâine la %s</string>
+    <string name="opens_dayoftheweek_at">Deschide %1$s la %2$s</string>
+    <string name="opens_at">Deschide la %s</string>
+    <string name="closes_at">Închide la %s</string>
     <string name="editor_add_select_category_all_subtitle">Toate categoriile</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -715,6 +715,12 @@
     <string name="moreyear_ago_sorttype">Больше года назад</string>
     <string name="near_me_sorttype">Рядом со мной</string>
     <string name="others_sorttype">Другие</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Сейчас закрыто</string>
+    <string name="opens_tomorrow_at">Откроется завтра в %s</string>
+    <string name="opens_dayoftheweek_at">Открывается в %1$s в %2$s</string>
+    <string name="opens_at">Открывается в %s</string>
+    <string name="closes_at">Закрывается в %s</string>
     <string name="editor_add_select_category_all_subtitle">Все категории</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -709,6 +709,12 @@
     <string name="moreyear_ago_sorttype">Pred viac ako rokom</string>
     <string name="near_me_sorttype">Blízko mňa</string>
     <string name="others_sorttype">Iné</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Teraz zatvorené</string>
+    <string name="opens_tomorrow_at">Otvoria zajtra o %s</string>
+    <string name="opens_dayoftheweek_at">Otvoria v %1$s o %2$s</string>
+    <string name="opens_at">Otvárajú o %s</string>
+    <string name="closes_at">Zatvárajú o %s</string>
     <string name="editor_add_select_category_all_subtitle">Všetky kategórie</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-sl/strings.xml
+++ b/android/app/src/main/res/values-sl/strings.xml
@@ -714,6 +714,12 @@
     <string name="moreyear_ago_sorttype">Pred več kot letom dni</string>
     <string name="near_me_sorttype">V bližini</string>
     <string name="others_sorttype">Drugo</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Trenutno zaprto</string>
+    <string name="opens_tomorrow_at">Odpira se jutri ob %s</string>
+    <string name="opens_dayoftheweek_at">Odpira se %1$s ob %2$s</string>
+    <string name="opens_at">Odpira se ob %s</string>
+    <string name="closes_at">Zapira se ob %s</string>
     <string name="editor_add_select_category_all_subtitle">Vse kategorije</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-sq/strings.xml
+++ b/android/app/src/main/res/values-sq/strings.xml
@@ -696,6 +696,12 @@
     <string name="moreyear_ago_sorttype">Më shumë se një vit më parë</string>
     <string name="near_me_sorttype">Pranë meje</string>
     <string name="others_sorttype">Të tjera</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Mbyllur tani</string>
+    <string name="opens_tomorrow_at">Hapet nesër në %s</string>
+    <string name="opens_dayoftheweek_at">Hapet %1$s në %2$s</string>
+    <string name="opens_at">Hapet në %s</string>
+    <string name="closes_at">Mbyllet në %s</string>
     <string name="editor_add_select_category_all_subtitle">Të Gjitha Kategoritë</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-sr/strings.xml
+++ b/android/app/src/main/res/values-sr/strings.xml
@@ -711,6 +711,12 @@
     <string name="moreyear_ago_sorttype">Пре више од годину дана</string>
     <string name="near_me_sorttype">Близу мене</string>
     <string name="others_sorttype">Остали</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Затворено сада</string>
+    <string name="opens_tomorrow_at">Отвара се сутра у %s</string>
+    <string name="opens_dayoftheweek_at">Отвара се %1$s у %2$s</string>
+    <string name="opens_at">Отвара се у %s</string>
+    <string name="closes_at">Затвара се у %s</string>
     <string name="editor_add_select_category_all_subtitle">Све категорије</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -708,6 +708,12 @@
     <string name="moreyear_ago_sorttype">Över ett år sedan</string>
     <string name="near_me_sorttype">Nära mig</string>
     <string name="others_sorttype">Andra</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Stängt just nu</string>
+    <string name="opens_tomorrow_at">Öppnar i morgon på %s</string>
+    <string name="opens_dayoftheweek_at">Öppnar %1$s vid %2$s</string>
+    <string name="opens_at">Öppnas vid %s</string>
+    <string name="closes_at">Stänger vid %s</string>
     <string name="editor_add_select_category_all_subtitle">Alla kategorier</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-sw/strings.xml
+++ b/android/app/src/main/res/values-sw/strings.xml
@@ -705,6 +705,12 @@
     <string name="moreyear_ago_sorttype">Zaidi ya mwaka mmoja uliopita</string>
     <string name="near_me_sorttype">Karibu yangu</string>
     <string name="others_sorttype">Nyingine</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Imefungwa sasa</string>
+    <string name="opens_tomorrow_at">Inafunguliwa kesho saa %s</string>
+    <string name="opens_dayoftheweek_at">Hufungua %1$s katika %2$s</string>
+    <string name="opens_at">Hufunguka saa %s</string>
+    <string name="closes_at">Inafungwa saa %s</string>
     <string name="editor_add_select_category_all_subtitle">Kategoria Zote</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -707,6 +707,12 @@
     <string name="moreyear_ago_sorttype">มากกว่าหนึ่งปีที่ผ่านมา</string>
     <string name="near_me_sorttype">ใกล้ฉัน</string>
     <string name="others_sorttype">อื่นๆ</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">ปิดตอนนี้</string>
+    <string name="opens_tomorrow_at">เปิดพรุ่งนี้ที่ %s</string>
+    <string name="opens_dayoftheweek_at">เปิด %1$s ที่ %2$s</string>
+    <string name="opens_at">เปิดที่ %s</string>
+    <string name="closes_at">ปิดที่ %s</string>
     <string name="editor_add_select_category_all_subtitle">หมวดหมูทั้งหมด</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -710,6 +710,12 @@
     <string name="moreyear_ago_sorttype">Bir yıldan daha önce</string>
     <string name="near_me_sorttype">Bana yakınlarda</string>
     <string name="others_sorttype">Diğerleri</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Şu anda kapalı</string>
+    <string name="opens_tomorrow_at">Açılış yarın %s</string>
+    <string name="opens_dayoftheweek_at">Açılış %1$s %2$s</string>
+    <string name="opens_at">Açılış %s</string>
+    <string name="closes_at">Kapanış %s</string>
     <string name="editor_add_select_category_all_subtitle">Tüm kategoriler</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -715,6 +715,12 @@
     <string name="moreyear_ago_sorttype">Понад рік тому</string>
     <string name="near_me_sorttype">Поруч зі мною</string>
     <string name="others_sorttype">Інші</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Зараз закрито</string>
+    <string name="opens_tomorrow_at">Відкриття завтра о %s</string>
+    <string name="opens_dayoftheweek_at">Відчиняється в %1$s о %2$s</string>
+    <string name="opens_at">Відкриття о %s</string>
+    <string name="closes_at">Закривається о %s</string>
     <string name="editor_add_select_category_all_subtitle">Усі категорії</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -706,6 +706,12 @@
     <string name="moreyear_ago_sorttype">Hơn một năm trước</string>
     <string name="near_me_sorttype">Ở gần tôi</string>
     <string name="others_sorttype">Khác</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Hiện đã đóng</string>
+    <string name="opens_tomorrow_at">Mở cửa vào ngày mai tại %s</string>
+    <string name="opens_dayoftheweek_at">Mở %1$s tại %2$s</string>
+    <string name="opens_at">Mở tại %s</string>
+    <string name="closes_at">Đóng cửa lúc %s</string>
     <string name="editor_add_select_category_all_subtitle">Mọi thể loại</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -709,6 +709,12 @@
     <string name="moreyear_ago_sorttype">一年多以前</string>
     <string name="near_me_sorttype">在我附近</string>
     <string name="others_sorttype">其他</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">現已關門</string>
+    <string name="opens_tomorrow_at">明天 %s 營業</string>
+    <string name="opens_dayoftheweek_at">%1$s %2$s 營業</string>
+    <string name="opens_at">%s 營業</string>
+    <string name="closes_at">%s 關門</string>
     <string name="editor_add_select_category_all_subtitle">所有類別</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -709,6 +709,12 @@
     <string name="moreyear_ago_sorttype">一年多以前</string>
     <string name="near_me_sorttype">在我附近</string>
     <string name="others_sorttype">其他</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">现已关门</string>
+    <string name="opens_tomorrow_at">明天 %s 营业</string>
+    <string name="opens_dayoftheweek_at">%1$s %2$s 营业</string>
+    <string name="opens_at">%s 营业</string>
+    <string name="closes_at">%s 不营业</string>
     <string name="editor_add_select_category_all_subtitle">所有类别</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -708,6 +708,12 @@
     <string name="moreyear_ago_sorttype">More than a year ago</string>
     <string name="near_me_sorttype">Near me</string>
     <string name="others_sorttype">Others</string>
+    <!-- Place Page opening hours text -->
+    <string name="closed_now">Closed now</string>
+    <string name="opens_tomorrow_at">Opens tomorrow at %s</string>
+    <string name="opens_dayoftheweek_at">Opens %1$s at %2$s</string>
+    <string name="opens_at">Opens at %s</string>
+    <string name="closes_at">Closes at %s</string>
     <string name="editor_add_select_category_all_subtitle">All Categories</string>
 
     <!-- SECTION: Bookmark types used for sorting -->

--- a/android/app/src/test/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapterTest.java
+++ b/android/app/src/test/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapterTest.java
@@ -80,7 +80,7 @@ public class PlaceOpeningHoursAdapterTest
     timetables[1] = new Timetable(new Timespan(new HoursMinutes(12, 0, true), new HoursMinutes(14, 0, true)),
                                   new Timespan[0], false, new int[] {7});
 
-    adapter.setTimetables(timetables, Calendar.SUNDAY);
+    adapter.setTimetables(timetables, Calendar.SUNDAY, Calendar.MONDAY);
 
     /* Expected parsed schedule:
      *  0 - Su, closed
@@ -96,6 +96,9 @@ public class PlaceOpeningHoursAdapterTest
     assertEquals(schedule.get(0).endWeekDay, 1);
     assertFalse(schedule.get(1).isClosed);
     assertFalse(schedule.get(2).isClosed);
+    assertFalse(schedule.get(0).isBold);
+    assertTrue(schedule.get(1).isBold);
+    assertFalse(schedule.get(2).isBold);
   }
 
   @Test
@@ -109,7 +112,7 @@ public class PlaceOpeningHoursAdapterTest
     timetables[1] = new Timetable(new Timespan(new HoursMinutes(12, 0, true), new HoursMinutes(14, 0, true)),
                                   new Timespan[0], false, new int[] {7});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY);
+    adapter.setTimetables(timetables, Calendar.MONDAY, Calendar.MONDAY);
 
     /* Expected parsed schedule:
      *  0 - Mo-Fr, open
@@ -125,6 +128,9 @@ public class PlaceOpeningHoursAdapterTest
     assertTrue(schedule.get(2).isClosed); // Su    - closed
     assertEquals(schedule.get(2).startWeekDay, 1);
     assertEquals(schedule.get(2).endWeekDay, 1);
+    assertTrue(schedule.get(0).isBold);
+    assertFalse(schedule.get(1).isBold);
+    assertFalse(schedule.get(2).isBold);
   }
 
   @Test
@@ -141,7 +147,7 @@ public class PlaceOpeningHoursAdapterTest
     timetables[2] = new Timetable(new Timespan(new HoursMinutes(11, 0, true), new HoursMinutes(18, 0, true)),
                                   new Timespan[0], false, new int[] {6});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY);
+    adapter.setTimetables(timetables, Calendar.MONDAY, Calendar.THURSDAY);
 
     /* Expected parsed schedule:
      *  0 - Mo, open
@@ -163,6 +169,12 @@ public class PlaceOpeningHoursAdapterTest
     assertTrue(schedule.get(5).isClosed); // Sa, Su - closed
     assertEquals(schedule.get(5).startWeekDay, 7);
     assertEquals(schedule.get(5).endWeekDay, 1);
+    assertFalse(schedule.get(0).isBold);
+    assertFalse(schedule.get(1).isBold);
+    assertFalse(schedule.get(2).isBold);
+    assertTrue(schedule.get(3).isBold);
+    assertFalse(schedule.get(4).isBold);
+    assertFalse(schedule.get(5).isBold);
   }
 
   @Test
@@ -179,7 +191,7 @@ public class PlaceOpeningHoursAdapterTest
     timetables[2] = new Timetable(new Timespan(new HoursMinutes(11, 0, true), new HoursMinutes(18, 0, true)),
                                   new Timespan[0], false, new int[] {6});
 
-    adapter.setTimetables(timetables, Calendar.SUNDAY);
+    adapter.setTimetables(timetables, Calendar.SUNDAY, Calendar.MONDAY);
 
     /* Expected parsed schedule:
      *  0 - Su, closed
@@ -203,6 +215,13 @@ public class PlaceOpeningHoursAdapterTest
     assertTrue(schedule.get(6).isClosed); // Sa - closed
     assertEquals(schedule.get(6).startWeekDay, 7);
     assertEquals(schedule.get(6).endWeekDay, 7);
+    assertFalse(schedule.get(0).isBold);
+    assertTrue(schedule.get(1).isBold);
+    assertFalse(schedule.get(2).isBold);
+    assertFalse(schedule.get(3).isBold);
+    assertFalse(schedule.get(4).isBold);
+    assertFalse(schedule.get(5).isBold);
+    assertFalse(schedule.get(6).isBold);
   }
 
   @Test
@@ -213,7 +232,7 @@ public class PlaceOpeningHoursAdapterTest
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(18, 0, true)),
                                   new Timespan[0], false, new int[] {2, 4, 6});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY);
+    adapter.setTimetables(timetables, Calendar.MONDAY, Calendar.MONDAY);
 
     /* Expected parsed schedule:
      *  0 - Mo, open
@@ -235,6 +254,12 @@ public class PlaceOpeningHoursAdapterTest
     assertTrue(schedule.get(5).isClosed); // Sa, Su - closed
     assertEquals(schedule.get(5).startWeekDay, 7);
     assertEquals(schedule.get(5).endWeekDay, 1);
+    assertTrue(schedule.get(0).isBold);
+    assertFalse(schedule.get(1).isBold);
+    assertFalse(schedule.get(2).isBold);
+    assertFalse(schedule.get(3).isBold);
+    assertFalse(schedule.get(4).isBold);
+    assertFalse(schedule.get(5).isBold);
   }
 
   @Test
@@ -245,7 +270,7 @@ public class PlaceOpeningHoursAdapterTest
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(18, 0, true)),
                                   new Timespan[0], false, new int[] {2, 4, 6});
 
-    adapter.setTimetables(timetables, Calendar.SUNDAY);
+    adapter.setTimetables(timetables, Calendar.SUNDAY, Calendar.SUNDAY);
 
     /* Expected parsed schedule:
      *  0 - Su, closed
@@ -269,17 +294,24 @@ public class PlaceOpeningHoursAdapterTest
     assertTrue(schedule.get(6).isClosed); // Sa - closed
     assertEquals(schedule.get(6).startWeekDay, 7);
     assertEquals(schedule.get(6).endWeekDay, 7);
+    assertTrue(schedule.get(0).isBold);
+    assertFalse(schedule.get(1).isBold);
+    assertFalse(schedule.get(2).isBold);
+    assertFalse(schedule.get(3).isBold);
+    assertFalse(schedule.get(4).isBold);
+    assertFalse(schedule.get(5).isBold);
+    assertFalse(schedule.get(5).isBold);
   }
 
   @Test
   public void test_open_weekend_sunday() throws IllegalAccessException
   {
-    // opening_hours = "Sa-Su 11:00-24:00"
+    // opening_hours = "Sa-Su 9:00-24:00"
     Timetable[] timetables = new Timetable[1];
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
                                   new Timespan[0], false, new int[] {1, 7});
 
-    adapter.setTimetables(timetables, Calendar.SUNDAY);
+    adapter.setTimetables(timetables, Calendar.SUNDAY, Calendar.MONDAY);
 
     /* Expected parsed schedule:
      *  0 - Su, open
@@ -299,17 +331,20 @@ public class PlaceOpeningHoursAdapterTest
     assertEquals(schedule.get(1).endWeekDay, 6);
     assertEquals(schedule.get(2).startWeekDay, 7);
     assertEquals(schedule.get(2).endWeekDay, 7);
+    assertFalse(schedule.get(0).isBold);
+    assertTrue(schedule.get(1).isBold);
+    assertFalse(schedule.get(2).isBold);
   }
 
   @Test
   public void test_open_weekend_monday() throws IllegalAccessException
   {
-    // opening_hours = "Sa-Su 11:00-24:00"
+    // opening_hours = "Sa-Su 9:00-24:00"
     Timetable[] timetables = new Timetable[1];
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
                                   new Timespan[0], false, new int[] {1, 7});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY);
+    adapter.setTimetables(timetables, Calendar.MONDAY, Calendar.SUNDAY);
 
     /* Expected parsed schedule:
      *  0 - Mo-Fr, closed
@@ -323,5 +358,56 @@ public class PlaceOpeningHoursAdapterTest
     assertFalse(schedule.get(1).isClosed); // Sa-Su - open
     assertEquals(schedule.get(1).startWeekDay, 7);
     assertEquals(schedule.get(1).endWeekDay, 1);
+    assertFalse(schedule.get(0).isBold);
+    assertTrue(schedule.get(1).isBold);
+  }
+
+  @Test
+  public void test_bold_weekend_monday() throws IllegalAccessException
+  {
+    // opening_hours = "Sa-Su 9:00-24:00"
+    Timetable[] timetables = new Timetable[1];
+    timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
+                                  new Timespan[0], false, new int[] {1, 7});
+
+    adapter.setTimetables(timetables, Calendar.MONDAY, Calendar.SATURDAY);
+
+    /* Expected parsed schedule:
+     *  0 - Mo-Fr, closed
+     *  1 - Sa-Su, open
+     * */
+
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    assertNotNull(schedule);
+    assertEquals(2, schedule.size());
+    assertTrue(schedule.get(0).isClosed); // Mo-Fr - closed
+    assertFalse(schedule.get(1).isClosed); // Sa-Su - open
+    assertEquals(schedule.get(1).startWeekDay, 7);
+    assertEquals(schedule.get(1).endWeekDay, 1);
+    assertFalse(schedule.get(0).isBold);
+    assertTrue(schedule.get(1).isBold);
+  }
+
+  @Test
+  public void test_whole_week() throws IllegalAccessException
+  {
+    // opening_hours = "Mo-Su 9:00-24:00"
+    Timetable[] timetables = new Timetable[1];
+    timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
+                                  new Timespan[0], false, new int[] {1, 2, 3, 4, 5, 6, 7});
+
+    adapter.setTimetables(timetables, Calendar.MONDAY, Calendar.FRIDAY);
+
+    /* Expected parsed schedule:
+     *  0 - Mo-Su, open
+     * */
+
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    assertNotNull(schedule);
+    assertEquals(1, schedule.size());
+    assertFalse(schedule.get(0).isClosed); // Mo-Su - open
+    assertEquals(schedule.get(0).startWeekDay, 2);
+    assertEquals(schedule.get(0).endWeekDay, 1);
+    assertTrue(schedule.get(0).isBold);
   }
 }

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/editor/OpeningHours.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/editor/OpeningHours.cpp
@@ -39,6 +39,9 @@ jfieldID g_fidWorkingTimespan;
 jfieldID g_fidClosedTimespans;
 jfieldID g_fidIsFullday;
 jfieldID g_fidWeekdays;
+// ID-s for OpeningHoursInfo class
+jclass g_clazzOpeningHoursInfo;
+jmethodID g_ctorOpeningHoursInfo;
 
 jobject JavaHoursMinutes(JNIEnv * env, jlong hours, jlong minutes)
 {
@@ -103,6 +106,26 @@ jobjectArray JavaTimetables(JNIEnv * env, TimeTableSet & tts)
   }
 
   return result;
+}
+
+jobject JavaOpeningHoursInfo(JNIEnv * env, RuleState state, bool isTwentyFourSeven, time_t nextTimeOpen,
+                             time_t nextTimeClosed)
+{
+  ASSERT(state != RuleState::Unknown, ("Shouldn't instantiate java OpeningHours with unknown state"));
+
+  jlong javaTimeNeverConstant = static_cast<jlong>(-1);
+  jlong jlongNextTimeOpen = static_cast<jlong>(nextTimeOpen);
+  jlong jlongNextTimeClosed = static_cast<jlong>(nextTimeClosed);
+
+  if (nextTimeOpen == std::numeric_limits<time_t>::max())
+    jlongNextTimeOpen = javaTimeNeverConstant;
+  if (nextTimeClosed == std::numeric_limits<time_t>::max())
+    jlongNextTimeClosed = javaTimeNeverConstant;
+
+  jobject const info = env->NewObject(g_clazzOpeningHoursInfo, g_ctorOpeningHoursInfo, static_cast<jint>(state),
+                                      isTwentyFourSeven, jlongNextTimeOpen, jlongNextTimeClosed);
+  ASSERT(info, (jni::DescribeException()));
+  return info;
 }
 
 HourMinutes NativeHoursMinutes(JNIEnv * env, jobject jHourMinutes)
@@ -201,6 +224,11 @@ JNIEXPORT void Java_app_organicmaps_sdk_editor_OpeningHours_nativeInit(JNIEnv * 
   ASSERT(g_fidIsFullday, (jni::DescribeException()));
   g_fidWeekdays = env->GetFieldID(g_clazzTimetable, "weekdays", "[I");
   ASSERT(g_fidWeekdays, (jni::DescribeException()));
+
+  g_clazzOpeningHoursInfo = jni::GetGlobalClassRef(env, "app/organicmaps/sdk/editor/data/OpeningHoursInfo");
+  // Java signature : OpeningHoursInfo(int state, boolean isTwentyFourHours, long nextTimeOpen, long nextTimeClosed)
+  g_ctorOpeningHoursInfo = env->GetMethodID(g_clazzOpeningHoursInfo, "<init>", "(IZJJ)V");
+  ASSERT(g_ctorOpeningHoursInfo, (jni::DescribeException()));
 }
 
 JNIEXPORT jobjectArray Java_app_organicmaps_sdk_editor_OpeningHours_nativeGetDefaultTimetables(JNIEnv * env,
@@ -307,4 +335,24 @@ JNIEXPORT jboolean Java_app_organicmaps_sdk_editor_OpeningHours_nativeIsTimetabl
 {
   return OpeningHours(jni::ToNativeString(env, jSource)).IsValid();
 }
+
+JNIEXPORT jobject Java_app_organicmaps_sdk_editor_OpeningHours_nativeGetOpeningHoursInfoFromString(JNIEnv * env,
+                                                                                                   jclass clazz,
+                                                                                                   jstring jSource,
+                                                                                                   jlong jCurrentTime)
+{
+  std::string const source = jni::ToNativeString(env, jSource);
+  OpeningHours const oh = OpeningHours(source);
+
+  if (!source.empty() && oh.IsValid())
+  {
+    OpeningHours::InfoT info = oh.GetInfo(static_cast<time_t>(jCurrentTime));
+    if (info.state == osmoh::RuleState::Unknown)
+      return nullptr;
+    return JavaOpeningHoursInfo(env, info.state, oh.IsTwentyFourHours(), info.nextTimeOpen, info.nextTimeClosed);
+  }
+
+  return nullptr;
+}
+
 }  // extern "C"

--- a/android/sdk/src/main/java/app/organicmaps/sdk/editor/OpeningHours.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/editor/OpeningHours.java
@@ -3,6 +3,7 @@ package app.organicmaps.sdk.editor;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import app.organicmaps.sdk.editor.data.OpeningHoursInfo;
 import app.organicmaps.sdk.editor.data.Timespan;
 import app.organicmaps.sdk.editor.data.Timetable;
 
@@ -55,4 +56,7 @@ public final class OpeningHours
    * @return true if timetable string is valid OSM timetable.
    */
   public static native boolean nativeIsTimetableStringValid(String source);
+
+  @Nullable
+  public static native OpeningHoursInfo nativeGetOpeningHoursInfoFromString(String source, long currentTime);
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/editor/data/OpeningHoursInfo.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/editor/data/OpeningHoursInfo.java
@@ -1,0 +1,39 @@
+package app.organicmaps.sdk.editor.data;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.Keep;
+
+// Called from JNI.
+@Keep
+@SuppressWarnings("unused")
+public class OpeningHoursInfo
+{
+  // Used for nextTimeOpen and nextTimeClosed when the place will stay open (or closed) forever
+  public static final long TIME_NEVER = -1;
+
+  public enum RuleState
+  {
+    Open,
+    Closed,
+  }
+
+  public OpeningHoursInfo(@IntRange(from = 0, to = 2) int state, boolean isTwentyFourSeven, long nextTimeOpen,
+                          long nextTimeClosed)
+  {
+    switch (state)
+    {
+    case 0: this.state = RuleState.Open; break;
+    case 1: this.state = RuleState.Closed; break;
+    default: this.state = RuleState.Closed; assert false;
+    }
+
+    this.nextTimeOpen = nextTimeOpen;
+    this.nextTimeClosed = nextTimeClosed;
+    this.isTwentyFourSeven = isTwentyFourSeven;
+  }
+
+  public final RuleState state;
+  public final long nextTimeOpen; // Is TIME_NEVER if currently closed but never opens
+  public final long nextTimeClosed; // Is TIME_NEVER if currently open but never closes
+  public final boolean isTwentyFourSeven;
+}

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -29003,7 +29003,7 @@ zh-Hant = 與朋友分享
 
 [closed_now]
 comment = Place Page opening hours text
-tags = apple-maps
+tags = android-app,apple-maps
 en = Closed now
 af = Nou gesluit
 ar = مغلق الآن
@@ -29058,7 +29058,7 @@ zh-Hans = 现已关门
 zh-Hant = 現已關門
 
 [opens_tomorrow_at]
-tags = apple-maps
+tags = android-app,apple-maps
 en = Opens tomorrow at %@
 af = Open môre om %@
 ar = يُفتتح غداً في %@
@@ -29114,7 +29114,7 @@ zh-Hans = 明天 %@ 营业
 zh-Hant = 明天 %@ 營業
 
 [opens_dayoftheweek_at]
-tags = apple-maps
+tags = android-app,apple-maps
 en = Opens %1$@ at %2$@
 af = Open %1$@ om %2$@
 ar = يفتح %1$@ في %2$@
@@ -29170,7 +29170,7 @@ zh-Hans = %1$@ %2$@ 营业
 zh-Hant = %1$@ %2$@ 營業
 
 [opens_at]
-tags = apple-maps
+tags = android-app,apple-maps
 en = Opens at %@
 af = Open om %@
 ar = يفتح في %@
@@ -29226,7 +29226,7 @@ zh-Hans = %@ 营业
 zh-Hant = %@ 營業
 
 [closes_at]
-tags = apple-maps
+tags = apple-maps,android-app
 en = Closes at %@
 af = Sluit om %@
 ar = يغلق في %@


### PR DESCRIPTION
Add a preview of the schedule of a place at the top of the page, indicating if it's closed or open, with the time remaining before it closes or opens. The behavior should be exactly the same as the current implementation on iOS, as I tried to follow as much as possible the implementation that was proposed in #3045.

- Closes #1852
- Closes #1688

Changes:
- Added JNI bindings for the `OpeningHours::InfoT` struct (translated as `OpeningHoursInfo` in java) 
- Created `OpeningHours.nativeGetOpeningHoursInfoFromString` in java to get the result of `OpeningHours::GetInfo`
- Marked some ios translations to also be on android

Tests made:
- android with api level 36 and 28
- tested many places on many dates
- tested with places that are open 24/7

There are two issues with the current implementation:
- If you look at the time remaining before a place open *before* a time change, but the place opens *after* the time change, the result is wrong by one hour (fortunately I had a lot of luck and tested it on the right day). I'm not sure how to handle this edge case, nor if it's even possible to do so in a clean way, since it looks like even `java.util.Calendar` is confused about it. I can't test myself if the bug also exists with the iOS implementation.
- For places with weird schedule format that isn't parsed properly by the app, it sometimes display "open" or "closed". But it is likely a problem inside the native function `OpeningHours::GetInfo` and should be handled in a separate PR.

Screenshots:
<img height="500" alt="Screenshot From 2026-03-28 23-47-18" src="https://github.com/user-attachments/assets/98a3c849-ca78-4da7-97ed-e7cf7a537f42" /><img height="500" alt="Screenshot From 2026-03-28 23-45-49" src="https://github.com/user-attachments/assets/0434a20f-6428-497e-a94c-436961fef588" /><img height="500"   alt="image" src="https://github.com/user-attachments/assets/a50d78e6-5580-4750-a9e3-6c7908e4b46b" />





