### PR TITLE
[drape] Generalize bookmark titles on zoom without hiding bookmark glyphs

### DIFF
--- a/libs/drape_frontend/drape_engine.cpp
+++ b/libs/drape_frontend/drape_engine.cpp
@@ -868,6 +868,7 @@ drape_ptr<UserMarkRenderParams> DrapeEngine::GenerateMarkRenderInfo(UserPointMar
     renderInfo->m_customDepth = true;
   }
   renderInfo->m_depthLayer = mark->GetDepthLayerEx(m_bookmarksTextPlacement);
+  renderInfo->m_titleDepthLayer = mark->GetTitleDepthLayerEx(m_bookmarksTextPlacement);
   renderInfo->m_minZoom = mark->GetMinZoom();
   renderInfo->m_minTitleZoom = mark->GetMinTitleZoom();
   renderInfo->m_isVisible = mark->IsVisible();

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -43,6 +43,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <span>
 #include <thread>
 #include <utility>
 
@@ -58,6 +59,29 @@ double constexpr kVSyncInterval = 0.06;
 double constexpr kVSyncIntervalMetalVulkan = 0.03;
 
 std::string const kTransitBackgroundColor = "TransitBackground";
+
+std::array<OverlayCollisionDomain, 2> constexpr kOverlayCollisionDomains = {OverlayCollisionDomain::MainMap,
+                                                                            OverlayCollisionDomain::Bookmarks};
+
+std::span<DepthLayer const> GetCollisionDomainLayers(OverlayCollisionDomain domain)
+{
+  static constexpr std::array kMainMapLayers = {DepthLayer::OverlayLayer, DepthLayer::RoutingBottomMarkLayer,
+                                                DepthLayer::RoutingMarkLayer};
+  static constexpr std::array kBookmarksLayers = {DepthLayer::BookmarkTitleLayer};
+
+  switch (domain)
+  {
+  case OverlayCollisionDomain::MainMap: return kMainMapLayers;
+  case OverlayCollisionDomain::Bookmarks: return kBookmarksLayers;
+  }
+
+  UNREACHABLE();
+}
+
+bool ShouldTrackOverlays(OverlayCollisionDomain domain)
+{
+  return domain == OverlayCollisionDomain::MainMap;
+}
 
 template <typename ToDo>
 bool RemoveGroups(ToDo && filter, std::vector<drape_ptr<RenderGroup>> & groups, ref_ptr<dp::OverlayTree> tree)
@@ -150,7 +174,8 @@ FrontendRenderer::FrontendRenderer(Params && params)
   , m_trafficRenderer(new TrafficRenderer())
   , m_transitSchemeRenderer(new TransitSchemeRenderer())
   , m_drapeApiRenderer(new DrapeApiRenderer())
-  , m_overlayTree(new dp::OverlayTree(VisualParams::Instance().GetVisualScale()))
+  , m_mainOverlayTree(new dp::OverlayTree(VisualParams::Instance().GetVisualScale()))
+  , m_bookmarksOverlayTree(new dp::OverlayTree(VisualParams::Instance().GetVisualScale()))
   , m_enablePerspectiveInNavigation(false)
   , m_enable3dBuildings(params.m_allow3dBuildings)
   , m_isIsometry(false)
@@ -231,8 +256,11 @@ void FrontendRenderer::UpdateCanBeDeletedStatus()
   for (auto const & tileKey : m_notFinishedTiles)
     notFinishedTileRects.push_back(tileKey.GetGlobalRect());
 
-  for (RenderLayer & layer : m_layers)
+  for (size_t i = 0; i < m_layers.size(); ++i)
   {
+    auto const layerId = static_cast<DepthLayer>(i);
+    auto const tree = GetOverlayTree(layerId);
+    RenderLayer & layer = m_layers[i];
     for (auto & group : layer.m_renderGroups)
     {
       if (!group->IsPendingOnDelete())
@@ -245,7 +273,7 @@ void FrontendRenderer::UpdateCanBeDeletedStatus()
         if (tileRect.IsIntersect(screenRect))
           canBeDeleted = !HasIntersection(tileRect, notFinishedTileRects);
       }
-      layer.m_isDirty |= group->UpdateCanBeDeletedStatus(canBeDeleted, GetCurrentZoom(), make_ref(m_overlayTree));
+      layer.m_isDirty |= group->UpdateCanBeDeletedStatus(canBeDeleted, GetCurrentZoom(), tree);
     }
   }
 }
@@ -458,7 +486,8 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
   case Message::Type::SelectObject:
   {
     ref_ptr<SelectObjectMessage> msg = message;
-    m_overlayTree->SetSelectedFeature(msg->IsDismiss() ? FeatureID() : msg->GetFeatureID());
+    m_mainOverlayTree->SetSelectedFeature(msg->IsDismiss() ? FeatureID() : msg->GetFeatureID());
+    m_bookmarksOverlayTree->SetSelectedFeature(msg->IsDismiss() ? FeatureID() : msg->GetFeatureID());
     if (m_selectionShape == nullptr)
     {
       m_selectObjectMessage = make_unique_dp<SelectObjectMessage>(
@@ -525,7 +554,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
     ref_ptr<FlushTransitSchemeMessage> msg = message;
     auto renderData = msg->AcceptRenderData();
     CHECK(m_context != nullptr, ());
-    m_transitSchemeRenderer->AddRenderData(m_context, make_ref(m_gpuProgramManager), make_ref(m_overlayTree),
+    m_transitSchemeRenderer->AddRenderData(m_context, make_ref(m_gpuProgramManager), make_ref(m_mainOverlayTree),
                                            std::move(renderData));
     break;
   }
@@ -807,20 +836,20 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
     // Jagged lines on subway lines are only visible on low density screens
     // so we don't enable it here
     if (!msg->IsEnabled())
-      m_transitSchemeRenderer->ClearContextDependentResources(make_ref(m_overlayTree));
+      m_transitSchemeRenderer->ClearContextDependentResources(make_ref(m_mainOverlayTree));
     break;
   }
 
   case Message::Type::ClearTransitSchemeData:
   {
     ref_ptr<ClearTransitSchemeDataMessage> msg = message;
-    m_transitSchemeRenderer->Clear(msg->GetMwmId(), make_ref(m_overlayTree));
+    m_transitSchemeRenderer->Clear(msg->GetMwmId(), make_ref(m_mainOverlayTree));
     break;
   }
 
   case Message::Type::ClearAllTransitSchemeData:
   {
-    m_transitSchemeRenderer->ClearContextDependentResources(make_ref(m_overlayTree));
+    m_transitSchemeRenderer->ClearContextDependentResources(make_ref(m_mainOverlayTree));
     break;
   }
 
@@ -1123,9 +1152,11 @@ void FrontendRenderer::InvalidateRect(m2::RectD const & gRect)
     // Remove tiles to invalidate from screen.
     auto eraseFunction = [&tiles](drape_ptr<RenderGroup> const & group)
     { return tiles.find(group->GetTileKey()) != tiles.end(); };
-    for (RenderLayer & layer : m_layers)
+    for (size_t i = 0; i < m_layers.size(); ++i)
     {
-      RemoveGroups(eraseFunction, layer.m_renderGroups, make_ref(m_overlayTree));
+      auto const layerId = static_cast<DepthLayer>(i);
+      RenderLayer & layer = m_layers[i];
+      RemoveGroups(eraseFunction, layer.m_renderGroups, GetOverlayTree(layerId));
       layer.m_isDirty = true;
     }
 
@@ -1194,8 +1225,10 @@ void FrontendRenderer::AddToRenderGroup(dp::RenderState const & state, drape_ptr
 
 void FrontendRenderer::RemoveRenderGroupsLater(TRenderGroupRemovePredicate const & predicate)
 {
-  for (RenderLayer & layer : m_layers)
+  for (size_t i = 0; i < m_layers.size(); ++i)
   {
+    auto const layerId = static_cast<DepthLayer>(i);
+    RenderLayer & layer = m_layers[i];
     RemoveGroups([&predicate, &layer](drape_ptr<RenderGroup> const & group)
     {
       if (predicate(group))
@@ -1205,7 +1238,7 @@ void FrontendRenderer::RemoveRenderGroupsLater(TRenderGroupRemovePredicate const
         return group->CanBeDeleted();
       }
       return false;
-    }, layer.m_renderGroups, make_ref(m_overlayTree));
+    }, layer.m_renderGroups, GetOverlayTree(layerId));
   }
 }
 
@@ -1248,8 +1281,8 @@ std::pair<FeatureID, kml::MarkId> FrontendRenderer::GetVisiblePOI(m2::RectD cons
 {
   m2::PointD pt = pixelRect.Center();
   ScreenBase const & screen = m_userEventStream.GetCurrentScreen();
-  if (m_overlayTree->IsNeedUpdate())
-    BuildOverlayTree(screen);
+  if (m_mainOverlayTree->IsNeedUpdate() || m_bookmarksOverlayTree->IsNeedUpdate())
+    BuildOverlayTrees(screen);
 
   dp::TOverlayContainer selectResult;
 
@@ -1259,7 +1292,10 @@ std::pair<FeatureID, kml::MarkId> FrontendRenderer::GetVisiblePOI(m2::RectD cons
   SearchInNonDisplaceableUserMarksLayer(screen, DepthLayer::SearchMarkLayer, selectionRect, selectResult);
 
   if (selectResult.empty())
-    m_overlayTree->Select(pixelRect, selectResult);
+  {
+    m_mainOverlayTree->Select(pixelRect, selectResult);
+    m_bookmarksOverlayTree->Select(pixelRect, selectResult);
+  }
 
   if (selectResult.empty())
     return {FeatureID(), kml::kInvalidMarkId};
@@ -1321,9 +1357,10 @@ void FrontendRenderer::ProcessSelection(ref_ptr<SelectObjectMessage> msg)
     if (modelView.isPerspective() && msg->GetSelectedObject() != SelectionShape::ESelectedObject::OBJECT_TRACK)
     {
       dp::TOverlayContainer selectResult;
-      if (m_overlayTree->IsNeedUpdate())
-        BuildOverlayTree(modelView);
-      m_overlayTree->Select(msg->GetPosition(), selectResult);
+      if (m_mainOverlayTree->IsNeedUpdate() || m_bookmarksOverlayTree->IsNeedUpdate())
+        BuildOverlayTrees(modelView);
+      m_mainOverlayTree->Select(msg->GetPosition(), selectResult);
+      m_bookmarksOverlayTree->Select(msg->GetPosition(), selectResult);
       for (ref_ptr<dp::OverlayHandle> const & handle : selectResult)
         offsetZ = std::max(offsetZ, handle->GetPivotZ());
     }
@@ -1349,32 +1386,59 @@ void FrontendRenderer::ProcessSelection(ref_ptr<SelectObjectMessage> msg)
   }
 }
 
-void FrontendRenderer::BeginUpdateOverlayTree(ScreenBase const & modelView)
+OverlayCollisionDomain FrontendRenderer::GetOverlayCollisionDomain(DepthLayer layerId)
 {
-  if (m_overlayTree->Frame())
-    m_overlayTree->StartOverlayPlacing(modelView, GetCurrentZoom());
+  if (layerId == DepthLayer::BookmarkTitleLayer)
+    return OverlayCollisionDomain::Bookmarks;
+  return OverlayCollisionDomain::MainMap;
 }
 
-void FrontendRenderer::UpdateOverlayTree(ScreenBase const & modelView, drape_ptr<RenderGroup> & renderGroup)
+ref_ptr<dp::OverlayTree> FrontendRenderer::GetOverlayTree(OverlayCollisionDomain domain) const
 {
-  if (m_overlayTree->IsNeedUpdate())
-    renderGroup->CollectOverlay(make_ref(m_overlayTree));
+  switch (domain)
+  {
+  case OverlayCollisionDomain::MainMap: return make_ref(m_mainOverlayTree);
+  case OverlayCollisionDomain::Bookmarks: return make_ref(m_bookmarksOverlayTree);
+  }
+
+  UNREACHABLE();
+}
+
+ref_ptr<dp::OverlayTree> FrontendRenderer::GetOverlayTree(DepthLayer layerId) const
+{
+  return GetOverlayTree(GetOverlayCollisionDomain(layerId));
+}
+
+void FrontendRenderer::BeginUpdateOverlayTree(ref_ptr<dp::OverlayTree> tree, ScreenBase const & modelView)
+{
+  if (tree->Frame())
+    tree->StartOverlayPlacing(modelView, GetCurrentZoom());
+}
+
+void FrontendRenderer::UpdateOverlayTree(ref_ptr<dp::OverlayTree> tree, ScreenBase const & modelView,
+                                         drape_ptr<RenderGroup> & renderGroup)
+{
+  if (tree->IsNeedUpdate())
+    renderGroup->CollectOverlay(tree);
   else
     renderGroup->Update(modelView);
 }
 
-void FrontendRenderer::EndUpdateOverlayTree()
+void FrontendRenderer::EndUpdateOverlayTree(ref_ptr<dp::OverlayTree> tree, bool trackOverlays)
 {
-  if (m_overlayTree->IsNeedUpdate())
+  if (tree->IsNeedUpdate())
   {
-    m_overlayTree->EndOverlayPlacing();
+    tree->EndOverlayPlacing();
+
+    if (!trackOverlays)
+      return;
 
     // Track overlays.
     if (m_overlaysTracker->StartTracking(GetCurrentZoom(), m_myPositionController->IsModeHasPosition(),
                                          m_myPositionController->GetDrawablePosition(),
                                          m_myPositionController->GetHorizontalAccuracy()))
     {
-      for (auto const & handle : m_overlayTree->GetHandlesCache())
+      for (auto const & handle : tree->GetHandlesCache())
         if (handle->IsVisible())
           m_overlaysTracker->Track(handle->GetOverlayID().m_featureId);
       m_overlaysTracker->FinishTracking();
@@ -1472,6 +1536,7 @@ void FrontendRenderer::RenderScene(ScreenBase const & modelView, bool activeFram
       RenderUserMarksLayer(modelView, DepthLayer::UserMarkLayer);
       RenderUserMarksLayer(modelView, DepthLayer::RoutingBottomMarkLayer);
       RenderUserMarksLayer(modelView, DepthLayer::RoutingMarkLayer);
+      RenderUserMarksLayer(modelView, DepthLayer::BookmarkTitleLayer);
       RenderNonDisplaceableUserMarksLayer(modelView, DepthLayer::SearchMarkLayer);
     }
 
@@ -1480,8 +1545,9 @@ void FrontendRenderer::RenderScene(ScreenBase const & modelView, bool activeFram
 
     m_drapeApiRenderer->Render(m_context, make_ref(m_gpuProgramManager), modelView, m_frameValues);
 
-    for (auto const & arrow : m_overlayTree->GetDisplacementInfo())
-      m_debugRectRenderer->DrawArrow(m_context, modelView, arrow);
+    for (auto const domain : kOverlayCollisionDomains)
+      for (auto const & arrow : GetOverlayTree(domain)->GetDisplacementInfo())
+        m_debugRectRenderer->DrawArrow(m_context, modelView, arrow);
   }
 
   if (!m_postprocessRenderer->EndFrame(m_context, make_ref(m_gpuProgramManager), m_viewport))
@@ -1518,7 +1584,7 @@ void FrontendRenderer::Render2dLayer(ScreenBase const & modelView)
 {
   TRACE_SECTION("[drape] Render2dLayer");
   RenderLayer & layer2d = m_layers[static_cast<size_t>(DepthLayer::GeometryLayer)];
-  layer2d.Sort(make_ref(m_overlayTree));
+  layer2d.Sort(make_ref(m_mainOverlayTree));
 
   CHECK(m_context != nullptr, ());
   DEBUG_LABEL(m_context, "2D Layer");
@@ -1542,7 +1608,7 @@ void FrontendRenderer::PreRender3dLayer(ScreenBase const & modelView)
   m_context->ApplyFramebuffer("Buildings");
   m_viewport.Apply(m_context);
 
-  layer.Sort(make_ref(m_overlayTree));
+  layer.Sort(make_ref(m_mainOverlayTree));
   for (drape_ptr<RenderGroup> const & group : layer.m_renderGroups)
     RenderSingleGroup(m_context, modelView, make_ref(group));
 }
@@ -1567,7 +1633,7 @@ void FrontendRenderer::Render3dLayer(ScreenBase const & modelView)
     CHECK(m_context != nullptr, ());
     m_context->Clear(dp::ClearBits::DepthBit, dp::kClearBitsStoreAll);
 
-    layer.Sort(make_ref(m_overlayTree));
+    layer.Sort(make_ref(m_mainOverlayTree));
     for (drape_ptr<RenderGroup> const & group : layer.m_renderGroups)
       RenderSingleGroup(m_context, modelView, make_ref(group));
   }
@@ -1579,7 +1645,7 @@ void FrontendRenderer::RenderOverlayLayer(ScreenBase const & modelView)
   CHECK(m_context != nullptr, ());
   DEBUG_LABEL(m_context, "Overlay Layer");
   RenderLayer & overlay = m_layers[static_cast<size_t>(DepthLayer::OverlayLayer)];
-  BuildOverlayTree(modelView);
+  BuildOverlayTrees(modelView);
   for (drape_ptr<RenderGroup> & group : overlay.m_renderGroups)
     RenderSingleGroup(m_context, modelView, make_ref(group));
 }
@@ -1675,13 +1741,15 @@ void FrontendRenderer::RenderMwmBorderLayer(ScreenBase const & modelView)
 void FrontendRenderer::RenderUserMarksLayer(ScreenBase const & modelView, DepthLayer layerId)
 {
   TRACE_SECTION("[drape] RenderUserMarksLayer");
-  auto & renderGroups = m_layers[static_cast<size_t>(layerId)].m_renderGroups;
+  auto & layer = m_layers[static_cast<size_t>(layerId)];
+  auto & renderGroups = layer.m_renderGroups;
   if (renderGroups.empty())
     return;
 
   CHECK(m_context != nullptr, ());
   DEBUG_LABEL(m_context, "User Marks: " + DebugPrint(layerId));
   m_context->Clear(dp::ClearBits::DepthBit, dp::kClearBitsStoreAll);
+  layer.Sort(GetOverlayTree(layerId));
 
   for (drape_ptr<RenderGroup> & group : renderGroups)
     RenderSingleGroup(m_context, modelView, make_ref(group));
@@ -1800,7 +1868,8 @@ void FrontendRenderer::RenderFrame()
   if (!isActiveFrame)
   {
     if (m_frameData.m_inactiveFramesCounter == 0)
-      m_overlayTree->InvalidateOnNextFrame();
+      for (auto const domain : kOverlayCollisionDomains)
+        GetOverlayTree(domain)->InvalidateOnNextFrame();
     m_frameData.m_inactiveFramesCounter++;
   }
   else
@@ -1809,7 +1878,9 @@ void FrontendRenderer::RenderFrame()
   }
 
   bool const canSuspend = m_frameData.m_inactiveFramesCounter > FrameData::kMaxInactiveFrames;
-  m_frameData.m_forceFullRedrawNextFrame = m_overlayTree->IsNeedUpdate();
+  m_frameData.m_forceFullRedrawNextFrame = false;
+  for (auto const domain : kOverlayCollisionDomains)
+    m_frameData.m_forceFullRedrawNextFrame |= GetOverlayTree(domain)->IsNeedUpdate();
   if (canSuspend)
   {
 #if defined(OMIM_OS_DESKTOP)
@@ -1866,21 +1937,29 @@ void FrontendRenderer::RenderFrame()
 #endif
 }
 
-void FrontendRenderer::BuildOverlayTree(ScreenBase const & modelView)
+void FrontendRenderer::BuildOverlayTrees(ScreenBase const & modelView)
 {
-  TRACE_SECTION("[drape] BuildOverlayTree");
-  BeginUpdateOverlayTree(modelView);
-  for (auto const layerId :
-       {DepthLayer::OverlayLayer, DepthLayer::RoutingBottomMarkLayer, DepthLayer::RoutingMarkLayer})
+  TRACE_SECTION("[drape] BuildOverlayTrees");
+  auto const buildDomain = [this, &modelView](OverlayCollisionDomain domain)
   {
-    RenderLayer & overlay = m_layers[static_cast<size_t>(layerId)];
-    overlay.Sort(make_ref(m_overlayTree));
-    for (auto & group : overlay.m_renderGroups)
-      UpdateOverlayTree(modelView, group);
-  }
-  if (m_transitSchemeRenderer->IsSchemeVisible(GetCurrentZoom()) && !HasTransitRouteData())
-    m_transitSchemeRenderer->CollectOverlays(make_ref(m_overlayTree), modelView);
-  EndUpdateOverlayTree();
+    auto const tree = GetOverlayTree(domain);
+    auto const layers = GetCollisionDomainLayers(domain);
+    auto const trackOverlays = ShouldTrackOverlays(domain);
+    BeginUpdateOverlayTree(tree, modelView);
+    for (auto const layerId : layers)
+    {
+      RenderLayer & overlay = m_layers[static_cast<size_t>(layerId)];
+      overlay.Sort(tree);
+      for (auto & group : overlay.m_renderGroups)
+        UpdateOverlayTree(tree, modelView, group);
+    }
+    if (trackOverlays && m_transitSchemeRenderer->IsSchemeVisible(GetCurrentZoom()) && !HasTransitRouteData())
+      m_transitSchemeRenderer->CollectOverlays(tree, modelView);
+    EndUpdateOverlayTree(tree, trackOverlays);
+  };
+
+  for (auto const domain : kOverlayCollisionDomains)
+    buildDomain(domain);
 }
 
 void FrontendRenderer::PrepareBucket(dp::RenderState const & state, drape_ptr<dp::RenderBucket> & bucket)
@@ -1979,9 +2058,16 @@ bool FrontendRenderer::ResolveZoomLevel(ScreenBase const & screen)
 void FrontendRenderer::UpdateDisplacementEnabled()
 {
   if (m_choosePositionMode)
-    m_overlayTree->SetDisplacementEnabled(GetCurrentZoom() < scales::GetAddNewPlaceScale());
+  {
+    bool const enabled = GetCurrentZoom() < scales::GetAddNewPlaceScale();
+    for (auto const domain : kOverlayCollisionDomains)
+      GetOverlayTree(domain)->SetDisplacementEnabled(enabled);
+  }
   else
-    m_overlayTree->SetDisplacementEnabled(true);
+  {
+    for (auto const domain : kOverlayCollisionDomains)
+      GetOverlayTree(domain)->SetDisplacementEnabled(true);
+  }
 }
 
 void FrontendRenderer::OnTap(m2::PointD const & pt, bool isLongTap)
@@ -2169,12 +2255,12 @@ bool FrontendRenderer::OnNewVisibleViewport(m2::RectD const & oldViewport, m2::R
   }
   else
   {
-    if (m_overlayTree->IsNeedUpdate())
-      BuildOverlayTree(screen);
+    if (m_mainOverlayTree->IsNeedUpdate())
+      BuildOverlayTrees(screen);
 
     if (!(m_selectionShape->GetSelectedObject() == SelectionShape::OBJECT_POI &&
-          m_overlayTree->GetSelectedFeatureRect(screen, rect) &&
-          m_overlayTree->GetSelectedFeatureRect(targetScreen, targetRect)))
+          m_mainOverlayTree->GetSelectedFeatureRect(screen, rect) &&
+          m_mainOverlayTree->GetSelectedFeatureRect(targetScreen, targetRect)))
     {
       double const r = m_selectionShape->GetRadius();
       rect.Inflate(r, r);
@@ -2260,8 +2346,12 @@ TTilesCollection FrontendRenderer::ResolveTileKeys(ScreenBase const & screen)
            (key.m_x < result.m_minTileX || key.m_x >= result.m_maxTileX || key.m_y < result.m_minTileY ||
             key.m_y >= result.m_maxTileY || base::IsExist(tilesToDelete, key));
   };
-  for (RenderLayer & layer : m_layers)
-    layer.m_isDirty |= RemoveGroups(removePredicate, layer.m_renderGroups, make_ref(m_overlayTree));
+  for (size_t i = 0; i < m_layers.size(); ++i)
+  {
+    auto const layerId = static_cast<DepthLayer>(i);
+    RenderLayer & layer = m_layers[i];
+    layer.m_isDirty |= RemoveGroups(removePredicate, layer.m_renderGroups, GetOverlayTree(layerId));
+  }
 
   RemoveRenderGroupsLater([this](drape_ptr<RenderGroup> const & group)
   { return group->GetTileKey().m_zoomLevel != GetCurrentZoom(); });
@@ -2291,9 +2381,13 @@ void FrontendRenderer::OnContextDestroy()
   }
 
   m_selectObjectMessage.reset();
-  m_overlayTree->SetSelectedFeature(FeatureID());
-  m_overlayTree->SetDebugRectRenderer(nullptr);
-  m_overlayTree->Clear();
+  for (auto const domain : kOverlayCollisionDomains)
+  {
+    auto const tree = GetOverlayTree(domain);
+    tree->SetSelectedFeature(FeatureID());
+    tree->SetDebugRectRenderer(nullptr);
+    tree->Clear();
+  }
 
   m_guiRenderer.reset();
   m_selectionShape.reset();
@@ -2354,8 +2448,12 @@ void FrontendRenderer::OnContextCreate()
       m_context, m_gpuProgramManager->GetProgram(gpu::Program::DebugRect), m_gpuProgramManager->GetParamsSetter());
   m_debugRectRenderer->SetEnabled(m_isDebugRectRenderingEnabled);
 
-  m_overlayTree->SetDebugRectRenderer(make_ref(m_debugRectRenderer));
-  m_overlayTree->SetVisualScale(VisualParams::Instance().GetVisualScale());
+  for (auto const domain : kOverlayCollisionDomains)
+  {
+    auto const tree = GetOverlayTree(domain);
+    tree->SetDebugRectRenderer(make_ref(m_debugRectRenderer));
+    tree->SetVisualScale(VisualParams::Instance().GetVisualScale());
+  }
 
   // Resources recovering.
   m_screenQuadRenderer = make_unique_dp<ScreenQuadRenderer>(m_context);
@@ -2388,7 +2486,8 @@ void FrontendRenderer::OnContextCreate()
 
 void FrontendRenderer::OnRenderingEnabled()
 {
-  m_overlayTree->InvalidateOnNextFrame();
+  for (auto const domain : kOverlayCollisionDomains)
+    GetOverlayTree(domain)->InvalidateOnNextFrame();
 
 #ifndef DRAPE_MEASURER_BENCHMARK
   DrapeMeasurer::Instance().Start();
@@ -2570,8 +2669,12 @@ void FrontendRenderer::UpdateScene(ScreenBase const & modelView)
            (m_maxGeneration - key.m_generation > kMaxGenerationRange) ||
            (group->IsUserMark() && (m_maxUserMarksGeneration - key.m_userMarksGeneration > kMaxGenerationRange));
   };
-  for (RenderLayer & layer : m_layers)
-    layer.m_isDirty |= RemoveGroups(removePredicate, layer.m_renderGroups, make_ref(m_overlayTree));
+  for (size_t i = 0; i < m_layers.size(); ++i)
+  {
+    auto const layerId = static_cast<DepthLayer>(i);
+    RenderLayer & layer = m_layers[i];
+    layer.m_isDirty |= RemoveGroups(removePredicate, layer.m_renderGroups, GetOverlayTree(layerId));
+  }
 
   if (m_forceUpdateScene || m_forceUpdateUserMarks || m_lastReadedModelView != modelView)
   {

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -486,8 +486,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
   case Message::Type::SelectObject:
   {
     ref_ptr<SelectObjectMessage> msg = message;
-    m_mainOverlayTree->SetSelectedFeature(msg->IsDismiss() ? FeatureID() : msg->GetFeatureID());
-    m_bookmarksOverlayTree->SetSelectedFeature(msg->IsDismiss() ? FeatureID() : msg->GetFeatureID());
+    SetSelectedFeatureForAllTrees(msg->IsDismiss() ? FeatureID() : msg->GetFeatureID());
     if (m_selectionShape == nullptr)
     {
       m_selectObjectMessage = make_unique_dp<SelectObjectMessage>(
@@ -1281,8 +1280,7 @@ std::pair<FeatureID, kml::MarkId> FrontendRenderer::GetVisiblePOI(m2::RectD cons
 {
   m2::PointD pt = pixelRect.Center();
   ScreenBase const & screen = m_userEventStream.GetCurrentScreen();
-  if (m_mainOverlayTree->IsNeedUpdate() || m_bookmarksOverlayTree->IsNeedUpdate())
-    BuildOverlayTrees(screen);
+  EnsureOverlayTreesBuilt(screen);
 
   dp::TOverlayContainer selectResult;
 
@@ -1292,10 +1290,7 @@ std::pair<FeatureID, kml::MarkId> FrontendRenderer::GetVisiblePOI(m2::RectD cons
   SearchInNonDisplaceableUserMarksLayer(screen, DepthLayer::SearchMarkLayer, selectionRect, selectResult);
 
   if (selectResult.empty())
-  {
-    m_mainOverlayTree->Select(pixelRect, selectResult);
-    m_bookmarksOverlayTree->Select(pixelRect, selectResult);
-  }
+    SelectFromOverlayTrees(pixelRect, selectResult);
 
   if (selectResult.empty())
     return {FeatureID(), kml::kInvalidMarkId};
@@ -1357,10 +1352,8 @@ void FrontendRenderer::ProcessSelection(ref_ptr<SelectObjectMessage> msg)
     if (modelView.isPerspective() && msg->GetSelectedObject() != SelectionShape::ESelectedObject::OBJECT_TRACK)
     {
       dp::TOverlayContainer selectResult;
-      if (m_mainOverlayTree->IsNeedUpdate() || m_bookmarksOverlayTree->IsNeedUpdate())
-        BuildOverlayTrees(modelView);
-      m_mainOverlayTree->Select(msg->GetPosition(), selectResult);
-      m_bookmarksOverlayTree->Select(msg->GetPosition(), selectResult);
+      EnsureOverlayTreesBuilt(modelView);
+      SelectFromOverlayTrees(msg->GetPosition(), selectResult);
       for (ref_ptr<dp::OverlayHandle> const & handle : selectResult)
         offsetZ = std::max(offsetZ, handle->GetPivotZ());
     }
@@ -1407,6 +1400,73 @@ ref_ptr<dp::OverlayTree> FrontendRenderer::GetOverlayTree(OverlayCollisionDomain
 ref_ptr<dp::OverlayTree> FrontendRenderer::GetOverlayTree(DepthLayer layerId) const
 {
   return GetOverlayTree(GetOverlayCollisionDomain(layerId));
+}
+
+bool FrontendRenderer::AnyOverlayTreeNeedsUpdate() const
+{
+  for (auto const domain : kOverlayCollisionDomains)
+    if (GetOverlayTree(domain)->IsNeedUpdate())
+      return true;
+  return false;
+}
+
+void FrontendRenderer::EnsureOverlayTreesBuilt(ScreenBase const & screen)
+{
+  if (AnyOverlayTreeNeedsUpdate())
+    BuildOverlayTrees(screen);
+}
+
+void FrontendRenderer::InvalidateOverlayTrees()
+{
+  for (auto const domain : kOverlayCollisionDomains)
+    GetOverlayTree(domain)->InvalidateOnNextFrame();
+}
+
+void FrontendRenderer::SetSelectedFeatureForAllTrees(FeatureID const & featureId)
+{
+  for (auto const domain : kOverlayCollisionDomains)
+    GetOverlayTree(domain)->SetSelectedFeature(featureId);
+}
+
+void FrontendRenderer::ConfigureOverlayTrees(ref_ptr<DebugRectRenderer> debugRectRenderer, float visualScale)
+{
+  for (auto const domain : kOverlayCollisionDomains)
+  {
+    auto const tree = GetOverlayTree(domain);
+    tree->SetDebugRectRenderer(debugRectRenderer);
+    tree->SetVisualScale(visualScale);
+  }
+}
+
+void FrontendRenderer::ClearOverlayTrees()
+{
+  for (auto const domain : kOverlayCollisionDomains)
+  {
+    auto const tree = GetOverlayTree(domain);
+    tree->SetSelectedFeature(FeatureID());
+    tree->SetDebugRectRenderer(nullptr);
+    tree->Clear();
+  }
+}
+
+void FrontendRenderer::SelectFromOverlayTrees(m2::RectD const & pixelRect, dp::TOverlayContainer & result) const
+{
+  for (auto const domain : kOverlayCollisionDomains)
+    GetOverlayTree(domain)->Select(pixelRect, result);
+}
+
+void FrontendRenderer::SelectFromOverlayTrees(m2::PointD const & position, dp::TOverlayContainer & result) const
+{
+  for (auto const domain : kOverlayCollisionDomains)
+    GetOverlayTree(domain)->Select(position, result);
+}
+
+bool FrontendRenderer::TryGetSelectedFeatureRect(OverlayCollisionDomain domain, ScreenBase const & screen,
+                                                 ScreenBase const & targetScreen, m2::RectD & rect,
+                                                 m2::RectD & targetRect) const
+{
+  auto const tree = GetOverlayTree(domain);
+  return tree->GetSelectedFeatureRect(screen, rect) && tree->GetSelectedFeatureRect(targetScreen, targetRect);
 }
 
 void FrontendRenderer::BeginUpdateOverlayTree(ref_ptr<dp::OverlayTree> tree, ScreenBase const & modelView)
@@ -1868,8 +1928,7 @@ void FrontendRenderer::RenderFrame()
   if (!isActiveFrame)
   {
     if (m_frameData.m_inactiveFramesCounter == 0)
-      for (auto const domain : kOverlayCollisionDomains)
-        GetOverlayTree(domain)->InvalidateOnNextFrame();
+      InvalidateOverlayTrees();
     m_frameData.m_inactiveFramesCounter++;
   }
   else
@@ -1878,9 +1937,7 @@ void FrontendRenderer::RenderFrame()
   }
 
   bool const canSuspend = m_frameData.m_inactiveFramesCounter > FrameData::kMaxInactiveFrames;
-  m_frameData.m_forceFullRedrawNextFrame = false;
-  for (auto const domain : kOverlayCollisionDomains)
-    m_frameData.m_forceFullRedrawNextFrame |= GetOverlayTree(domain)->IsNeedUpdate();
+  m_frameData.m_forceFullRedrawNextFrame = AnyOverlayTreeNeedsUpdate();
   if (canSuspend)
   {
 #if defined(OMIM_OS_DESKTOP)
@@ -2255,12 +2312,10 @@ bool FrontendRenderer::OnNewVisibleViewport(m2::RectD const & oldViewport, m2::R
   }
   else
   {
-    if (m_mainOverlayTree->IsNeedUpdate())
-      BuildOverlayTrees(screen);
+    EnsureOverlayTreesBuilt(screen);
 
     if (!(m_selectionShape->GetSelectedObject() == SelectionShape::OBJECT_POI &&
-          m_mainOverlayTree->GetSelectedFeatureRect(screen, rect) &&
-          m_mainOverlayTree->GetSelectedFeatureRect(targetScreen, targetRect)))
+          TryGetSelectedFeatureRect(OverlayCollisionDomain::MainMap, screen, targetScreen, rect, targetRect)))
     {
       double const r = m_selectionShape->GetRadius();
       rect.Inflate(r, r);
@@ -2381,13 +2436,7 @@ void FrontendRenderer::OnContextDestroy()
   }
 
   m_selectObjectMessage.reset();
-  for (auto const domain : kOverlayCollisionDomains)
-  {
-    auto const tree = GetOverlayTree(domain);
-    tree->SetSelectedFeature(FeatureID());
-    tree->SetDebugRectRenderer(nullptr);
-    tree->Clear();
-  }
+  ClearOverlayTrees();
 
   m_guiRenderer.reset();
   m_selectionShape.reset();
@@ -2448,12 +2497,7 @@ void FrontendRenderer::OnContextCreate()
       m_context, m_gpuProgramManager->GetProgram(gpu::Program::DebugRect), m_gpuProgramManager->GetParamsSetter());
   m_debugRectRenderer->SetEnabled(m_isDebugRectRenderingEnabled);
 
-  for (auto const domain : kOverlayCollisionDomains)
-  {
-    auto const tree = GetOverlayTree(domain);
-    tree->SetDebugRectRenderer(make_ref(m_debugRectRenderer));
-    tree->SetVisualScale(VisualParams::Instance().GetVisualScale());
-  }
+  ConfigureOverlayTrees(make_ref(m_debugRectRenderer), VisualParams::Instance().GetVisualScale());
 
   // Resources recovering.
   m_screenQuadRenderer = make_unique_dp<ScreenQuadRenderer>(m_context);
@@ -2486,8 +2530,7 @@ void FrontendRenderer::OnContextCreate()
 
 void FrontendRenderer::OnRenderingEnabled()
 {
-  for (auto const domain : kOverlayCollisionDomains)
-    GetOverlayTree(domain)->InvalidateOnNextFrame();
+  InvalidateOverlayTrees();
 
 #ifndef DRAPE_MEASURER_BENCHMARK
   DrapeMeasurer::Instance().Start();

--- a/libs/drape_frontend/frontend_renderer.hpp
+++ b/libs/drape_frontend/frontend_renderer.hpp
@@ -221,6 +221,16 @@ private:
   static OverlayCollisionDomain GetOverlayCollisionDomain(DepthLayer layerId);
   ref_ptr<dp::OverlayTree> GetOverlayTree(OverlayCollisionDomain domain) const;
   ref_ptr<dp::OverlayTree> GetOverlayTree(DepthLayer layerId) const;
+  bool AnyOverlayTreeNeedsUpdate() const;
+  void EnsureOverlayTreesBuilt(ScreenBase const & screen);
+  void InvalidateOverlayTrees();
+  void SetSelectedFeatureForAllTrees(FeatureID const & featureId);
+  void ConfigureOverlayTrees(ref_ptr<DebugRectRenderer> debugRectRenderer, float visualScale);
+  void ClearOverlayTrees();
+  void SelectFromOverlayTrees(m2::RectD const & pixelRect, dp::TOverlayContainer & result) const;
+  void SelectFromOverlayTrees(m2::PointD const & position, dp::TOverlayContainer & result) const;
+  bool TryGetSelectedFeatureRect(OverlayCollisionDomain domain, ScreenBase const & screen,
+                                 ScreenBase const & targetScreen, m2::RectD & rect, m2::RectD & targetRect) const;
 
   void EmitModelViewChanged(ScreenBase const & modelView) const;
 

--- a/libs/drape_frontend/frontend_renderer.hpp
+++ b/libs/drape_frontend/frontend_renderer.hpp
@@ -48,6 +48,12 @@ class RenderBucket;
 
 namespace df
 {
+enum class OverlayCollisionDomain : uint8_t
+{
+  MainMap,
+  Bookmarks
+};
+
 class DebugRectRenderer;
 class DrapeNotifier;
 class ScenarioManager;
@@ -211,7 +217,10 @@ private:
   ScreenBase const & ProcessEvents(bool & modelViewChanged, bool & viewportChanged, bool & needActiveFrame);
   void PrepareScene(ScreenBase const & modelView);
   void UpdateScene(ScreenBase const & modelView);
-  void BuildOverlayTree(ScreenBase const & modelView);
+  void BuildOverlayTrees(ScreenBase const & modelView);
+  static OverlayCollisionDomain GetOverlayCollisionDomain(DepthLayer layerId);
+  ref_ptr<dp::OverlayTree> GetOverlayTree(OverlayCollisionDomain domain) const;
+  ref_ptr<dp::OverlayTree> GetOverlayTree(DepthLayer layerId) const;
 
   void EmitModelViewChanged(ScreenBase const & modelView) const;
 
@@ -263,9 +272,10 @@ private:
   template <class MessageT>
   void UpdateAll();
 
-  void BeginUpdateOverlayTree(ScreenBase const & modelView);
-  void UpdateOverlayTree(ScreenBase const & modelView, drape_ptr<RenderGroup> & renderGroup);
-  void EndUpdateOverlayTree();
+  void BeginUpdateOverlayTree(ref_ptr<dp::OverlayTree> tree, ScreenBase const & modelView);
+  void UpdateOverlayTree(ref_ptr<dp::OverlayTree> tree, ScreenBase const & modelView,
+                         drape_ptr<RenderGroup> & renderGroup);
+  void EndUpdateOverlayTree(ref_ptr<dp::OverlayTree> tree, bool trackOverlays);
 
   template <typename TRenderGroup>
   void AddToRenderGroup(dp::RenderState const & state, drape_ptr<dp::RenderBucket> && renderBucket,
@@ -336,7 +346,8 @@ private:
   drape_ptr<GpsTrackRenderer> m_gpsTrackRenderer;
   drape_ptr<DrapeApiRenderer> m_drapeApiRenderer;
 
-  drape_ptr<dp::OverlayTree> m_overlayTree;
+  drape_ptr<dp::OverlayTree> m_mainOverlayTree;
+  drape_ptr<dp::OverlayTree> m_bookmarksOverlayTree;
 
   FrameValues m_frameValues;
 

--- a/libs/drape_frontend/render_group.cpp
+++ b/libs/drape_frontend/render_group.cpp
@@ -124,7 +124,7 @@ bool RenderGroup::IsUserMark() const
   auto const depthLayer = GetDepthLayer(m_state);
   return depthLayer == DepthLayer::UserLineLayer || depthLayer == DepthLayer::UserMarkLayer ||
          depthLayer == DepthLayer::RoutingBottomMarkLayer || depthLayer == DepthLayer::RoutingMarkLayer ||
-         depthLayer == DepthLayer::SearchMarkLayer;
+         depthLayer == DepthLayer::BookmarkTitleLayer || depthLayer == DepthLayer::SearchMarkLayer;
 }
 
 bool RenderGroup::UpdateCanBeDeletedStatus(bool canBeDeleted, int currentZoom, ref_ptr<dp::OverlayTree> tree)

--- a/libs/drape_frontend/render_state_extension.cpp
+++ b/libs/drape_frontend/render_state_extension.cpp
@@ -11,8 +11,8 @@ std::array<RenderStateExtension, static_cast<size_t>(DepthLayer::LayersCount)> k
     RenderStateExtension(DepthLayer::UserLineLayer),    RenderStateExtension(DepthLayer::MwmBorderLayer),
     RenderStateExtension(DepthLayer::OverlayLayer),     RenderStateExtension(DepthLayer::TransitSchemeLayer),
     RenderStateExtension(DepthLayer::UserMarkLayer),    RenderStateExtension(DepthLayer::RoutingBottomMarkLayer),
-    RenderStateExtension(DepthLayer::RoutingMarkLayer), RenderStateExtension(DepthLayer::SearchMarkLayer),
-    RenderStateExtension(DepthLayer::GuiLayer)};
+    RenderStateExtension(DepthLayer::RoutingMarkLayer), RenderStateExtension(DepthLayer::BookmarkTitleLayer),
+    RenderStateExtension(DepthLayer::SearchMarkLayer),  RenderStateExtension(DepthLayer::GuiLayer)};
 
 struct RenderStateExtensionFactory
 {

--- a/libs/drape_frontend/render_state_extension.hpp
+++ b/libs/drape_frontend/render_state_extension.hpp
@@ -21,6 +21,7 @@ enum class DepthLayer : uint8_t
   UserMarkLayer,
   RoutingBottomMarkLayer,
   RoutingMarkLayer,
+  BookmarkTitleLayer,
   SearchMarkLayer,
   GuiLayer,
   LayersCount
@@ -57,6 +58,7 @@ inline std::string DebugPrint(DepthLayer layer)
   case DepthLayer::UserMarkLayer: return "UserMarkLayer";
   case DepthLayer::RoutingBottomMarkLayer: return "RoutingBottomMarkLayer";
   case DepthLayer::RoutingMarkLayer: return "RoutingMarkLayer";
+  case DepthLayer::BookmarkTitleLayer: return "BookmarkTitleLayer";
   case DepthLayer::SearchMarkLayer: return "SearchMarkLayer";
   case DepthLayer::GuiLayer: return "GuiLayer";
   case DepthLayer::LayersCount: CHECK(false, ("Try to output LayersCount"));

--- a/libs/drape_frontend/user_mark_shapes.cpp
+++ b/libs/drape_frontend/user_mark_shapes.cpp
@@ -266,8 +266,8 @@ void GenerateTextShapes(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::Textur
 
     params.m_depthTestEnabled = renderInfo.m_depthTestEnabled;
     params.m_depth = renderInfo.m_depth;
-    params.m_depthLayer = renderInfo.m_depthLayer;
-    params.m_minVisibleScale = renderInfo.m_minZoom;
+    params.m_depthLayer = renderInfo.m_titleDepthLayer;
+    params.m_minVisibleScale = renderInfo.m_minTitleZoom;
 
     uint32_t const overlayIndex = kStartUserMarkOverlayIndex + renderInfo.m_index;
     if (renderInfo.m_hasTitlePriority)

--- a/libs/drape_frontend/user_mark_shapes.hpp
+++ b/libs/drape_frontend/user_mark_shapes.hpp
@@ -37,6 +37,7 @@ struct UserMarkRenderParams
   float m_depth = 0.0;
   bool m_customDepth = false;
   DepthLayer m_depthLayer = DepthLayer::UserMarkLayer;
+  DepthLayer m_titleDepthLayer = DepthLayer::UserMarkLayer;
   bool m_hasCreationAnimation = false;
   mutable bool m_justCreated = false;  ///< will be reset after first caching
   bool m_isVisible = true;

--- a/libs/drape_frontend/user_marks_provider.hpp
+++ b/libs/drape_frontend/user_marks_provider.hpp
@@ -70,6 +70,7 @@ public:
   virtual DepthLayer GetDepthLayer() const = 0;
   virtual drape_ptr<TitlesInfo> GetTitleDecl() const = 0;
   virtual DepthLayer GetDepthLayerEx(settings::Placement) const { return GetDepthLayer(); }
+  virtual DepthLayer GetTitleDepthLayerEx(settings::Placement p) const { return GetDepthLayerEx(p); }
   virtual drape_ptr<TitlesInfo> GetTitleDeclEx(settings::Placement, dp::Color) const { return GetTitleDecl(); }
 
   virtual drape_ptr<SymbolNameZoomInfo> GetSymbolNames() const = 0;

--- a/libs/map/bookmark.cpp
+++ b/libs/map/bookmark.cpp
@@ -128,14 +128,16 @@ drape_ptr<df::UserPointMark::TitlesInfo> Bookmark::GetTitleDeclEx(settings::Plac
 
 df::DepthLayer Bookmark::GetDepthLayerEx(settings::Placement p) const
 {
+  UNUSED_VALUE(p);
+  return df::DepthLayer::UserMarkLayer;
+}
+
+df::DepthLayer Bookmark::GetTitleDepthLayerEx(settings::Placement p) const
+{
   if (p == settings::Placement::None)
     return df::DepthLayer::UserMarkLayer;
 
-  // Texts:
-  // - UserMarkLayer, aren't visible at all
-  // - RoutingMarkLayer, displaced by Feature's texts
-  // - SearchMarkLayer, overlapped with each other :)
-  return df::DepthLayer::SearchMarkLayer;
+  return df::DepthLayer::BookmarkTitleLayer;
 }
 
 dp::Anchor Bookmark::GetAnchor() const

--- a/libs/map/bookmark.hpp
+++ b/libs/map/bookmark.hpp
@@ -56,6 +56,8 @@ public:
 
   drape_ptr<TitlesInfo> GetTitleDeclEx(settings::Placement p, dp::Color outlineColor) const override;
   df::DepthLayer GetDepthLayerEx(settings::Placement p) const override;
+  df::DepthLayer GetTitleDepthLayerEx(settings::Placement p) const override;
+  bool HasTitlePriority() const override { return true; }
 
   dp::Anchor GetAnchor() const override;
   drape_ptr<SymbolNameZoomInfo> GetSymbolNames() const override;

--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -1,5 +1,6 @@
 #include "testing/testing.hpp"
 
+#include "map/bookmark.hpp"
 #include "map/bookmark_helpers.hpp"
 #include "map/framework.hpp"
 
@@ -1623,6 +1624,36 @@ UNIT_CLASS_TEST(Runner, Bookmarks_TestSaveRoute)
   std::vector const expectedLine = {{geometry::PointWithAltitude(m2::PointD(0.0, 0.0), 0.0),
                                      geometry::PointWithAltitude(m2::PointD(0.001, 0.001), 0)}};
   TEST_EQUAL(line, expectedLine, ());
+}
+
+UNIT_TEST(Bookmark_TitleDepthLayers)
+{
+  Bookmark bookmark({0.0, 0.0});
+  bookmark.SetName("Bookmark title", kml::kDefaultLangCode);
+
+  TEST_EQUAL(bookmark.GetDepthLayerEx(settings::Placement::None), df::DepthLayer::UserMarkLayer, ());
+  TEST_EQUAL(bookmark.GetDepthLayerEx(settings::Placement::Right), df::DepthLayer::UserMarkLayer, ());
+  TEST_EQUAL(bookmark.GetDepthLayerEx(settings::Placement::Bottom), df::DepthLayer::UserMarkLayer, ());
+  TEST(bookmark.HasTitlePriority(), ());
+
+  TEST_EQUAL(bookmark.GetTitleDepthLayerEx(settings::Placement::None), df::DepthLayer::UserMarkLayer, ());
+  TEST_EQUAL(bookmark.GetTitleDepthLayerEx(settings::Placement::Right), df::DepthLayer::BookmarkTitleLayer, ());
+  TEST_EQUAL(bookmark.GetTitleDepthLayerEx(settings::Placement::Bottom), df::DepthLayer::BookmarkTitleLayer, ());
+
+  auto const noTitle = bookmark.GetTitleDeclEx(settings::Placement::None, dp::Color::Black());
+  TEST(!noTitle, ());
+
+  auto const rightTitle = bookmark.GetTitleDeclEx(settings::Placement::Right, dp::Color::Black());
+  TEST(rightTitle != nullptr, ());
+  TEST_EQUAL(rightTitle->size(), 1, ());
+  TEST_EQUAL(rightTitle->front().m_anchor, dp::Left, ());
+  TEST_EQUAL(rightTitle->front().m_primaryText, "Bookmark title", ());
+
+  auto const bottomTitle = bookmark.GetTitleDeclEx(settings::Placement::Bottom, dp::Color::Black());
+  TEST(bottomTitle != nullptr, ());
+  TEST_EQUAL(bottomTitle->size(), 1, ());
+  TEST_EQUAL(bottomTitle->front().m_anchor, dp::Top, ());
+  TEST_EQUAL(bottomTitle->front().m_primaryText, "Bookmark title", ());
 }
 
 }  // namespace bookmarks_test


### PR DESCRIPTION
## Summary

Generalize bookmark titles on zoom without generalizing bookmark glyphs.

This changes bookmark rendering so bookmark titles participate in runtime collision resolution, while bookmark glyphs keep their current behavior and remain always visible on the map.

The titles will be drawn in the separate `overlay tree`, because they should not be in the conflict with the POI glyphs and other map objects - they should be just overlayed (discussable, but the long name may take too much space, and it's better to see at least smth under the title rather than nothing).

## What changed

- split user-mark render params into separate symbol and title depth layers
- added a dedicated `BookmarkTitleLayer`
- kept bookmark glyphs on `UserMarkLayer`
- routed bookmark titles to `BookmarkTitleLayer` when bookmark text placement is enabled
- separated bookmark-title collisions from the main map overlay domain
- refactored the renderer to use generic overlay collision domains instead of
  hardcoded title-specific tree plumbing
- preserved existing behavior for routing marks, search marks, and other user marks
- kept bookmark title hit-testing working after the collision-domain split

## Result

- bookmark glyphs remain always visible
- bookmark titles become runtime-displaceable
- bookmark titles stop drawing on top of each other
- bookmark titles no longer compete with nearby map icons and map captions from
  the main overlay domain
- draw order and collision policy are now separated concepts in the renderer
- search marks remain non-displaceable

## Todo:
- [ ] Maybe disable titles on some zoom
- [ ] Always show the title when the bookmark is selected
- [ ] The map can still be cluttered with the titles overlapping the bookmarks icons itself

## Before / After
<img width="300" height="2556" alt="image" src="https://github.com/user-attachments/assets/b882a27b-b5a0-48f7-b0a8-eba37856738c" /> <img width="300" height="2556" alt="image" src="https://github.com/user-attachments/assets/e738fe8c-38c1-423f-b8bb-099386bdc1c1" />


https://github.com/user-attachments/assets/8622c5ba-9741-4063-a177-54db28e686d7

