### PR TITLE
[android] Preserve "Saved" button state on screen rotation

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -176,8 +176,16 @@ final class RoutingBottomMenuController implements View.OnClickListener
     showRoutingDetails();
     UiUtils.show(mAltitudeChartFrame);
     Button saveButton = mAltitudeChartFrame.findViewById(R.id.btn__save);
-    saveButton.setText(R.string.save);
-    saveButton.setEnabled(true);
+    if (RoutingController.get().isRouteSaved())
+    {
+      saveButton.setText(R.string.saved);
+      saveButton.setEnabled(false);
+    }
+    else
+    {
+      saveButton.setText(R.string.save);
+      saveButton.setEnabled(true);
+    }
   }
 
   void hideAltitudeChartAndRoutingDetails()
@@ -471,6 +479,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
     else if (id == R.id.btn__save)
     {
       Framework.nativeSaveRoute();
+      RoutingController.get().setRouteSaved();
       Button saveButton = (Button) v;
       saveButton.setEnabled(false);
       saveButton.setText(R.string.saved);

--- a/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
@@ -80,6 +80,7 @@ public class RoutingController
   @Nullable
   private TransitRouteInfo mCachedTransitRouteInfo;
 
+  private boolean mRouteSaved;
   private int mInvalidRoutePointsTransactionId;
   private int mRemovingIntermediatePointsTransactionId;
 
@@ -275,6 +276,7 @@ public class RoutingController
 
     Logger.d(TAG, "build");
     mLastBuildProgress = 0;
+    mRouteSaved = false;
 
     setBuildState(BuildState.BUILDING);
     if (mContainer != null)
@@ -304,6 +306,16 @@ public class RoutingController
   public void deleteSavedRoute()
   {
     Framework.nativeDeleteSavedRoutePoints();
+  }
+
+  public boolean isRouteSaved()
+  {
+    return mRouteSaved;
+  }
+
+  public void setRouteSaved()
+  {
+    mRouteSaved = true;
   }
 
   public void rebuildLastRoute()


### PR DESCRIPTION
 The "Save" button in the routing panel reset to its initial state after screen rotation because `showAltitudeChartAndRoutingDetails()` is called from `RoutingController.restore()` after Bundle restore, 
overriding any Bundle-saved state.                                                                                                      
Store the flag in `RoutingController` singleton which survives configuration changes. Reset on `build()`.

<img width="274" height="382" alt="image" src="https://github.com/user-attachments/assets/9a2992f0-d55b-4d42-b688-70ce41c8a2b0" />
