### PR TITLE
Drop X11 dependencies

### DIFF
--- a/3party/CMakeLists.txt
+++ b/3party/CMakeLists.txt
@@ -66,6 +66,7 @@ if (PLATFORM_DESKTOP)
   set(GLFW_INSTALL OFF CACHE BOOL "")
   set(GLFW_VULKAN_STATIC OFF CACHE BOOL "")
   set(GLFW_BUILD_WAYLAND OFF CACHE BOOL "")
+  set(GLFW_BUILD_X11 OFF CACHE BOOL "")
   # Disable ARC for glfw and re-enable after it because it's globally set in the root CMakeLists.txt
   set(CMAKE_OBJC_FLAGS "")
   add_subdirectory(glfw)

--- a/cmake/OmimOptions.cmake
+++ b/cmake/OmimOptions.cmake
@@ -8,7 +8,6 @@ if (DEFINED ENV{CMAKE_UNITY_BUILD})
 endif ()
 
 set(CMAKE_UNITY_BUILD_BATCH_SIZE "50" CACHE STRING "Batch size for unity build")
-set(CACHE{GLFW_BUILD_X11} VALUE OFF)
 option(USE_CCACHE "Use ccache" ON)
 option(WITH_SYSTEM_PROVIDED_3PARTY "Enable compilation with system provided dependencies" OFF)
 option(BUILD_DESIGNER "Build application as design tool" OFF)

--- a/cmake/OmimOptions.cmake
+++ b/cmake/OmimOptions.cmake
@@ -8,6 +8,7 @@ if (DEFINED ENV{CMAKE_UNITY_BUILD})
 endif ()
 
 set(CMAKE_UNITY_BUILD_BATCH_SIZE "50" CACHE STRING "Batch size for unity build")
+set(CACHE{GLFW_BUILD_X11} VALUE OFF)
 option(USE_CCACHE "Use ccache" ON)
 option(WITH_SYSTEM_PROVIDED_3PARTY "Enable compilation with system provided dependencies" OFF)
 option(BUILD_DESIGNER "Build application as design tool" OFF)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -112,10 +112,6 @@ sudo apt update && sudo apt install -y \
     libicu-dev \
     libqt6svg6-dev \
     libsqlite3-dev \
-    libxrandr-dev \
-    libxinerama-dev \
-    libxcursor-dev \
-    libxi-dev \
     zlib1g-dev
 ```
 


### PR DESCRIPTION
From [GLFW doc](https://www.glfw.org/docs/latest/compile_guide.html#compile_generate_cli):
> By default, GLFW will use Wayland and X11 on Linux and other Unix-like systems other than macOS. To disable support for one or both of these, set the [GLFW_BUILD_WAYLAND](https://www.glfw.org/docs/latest/compile_guide.html#GLFW_BUILD_WAYLAND) and/or [GLFW_BUILD_X11](https://www.glfw.org/docs/latest/compile_guide.html#GLFW_BUILD_X11) CMake option.
`cmake -S path/to/glfw -B path/to/build -D GLFW_BUILD_X11=0`

~~TODO: adjust the dependencies in the Readme and CI, if needed.~~
Done.

Fix #12504 