### PR TITLE
[platform] Stream chunk downloads to disk instead of buffering in RAM

### DIFF
--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/util/HttpClient.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/util/HttpClient.cpp
@@ -83,6 +83,12 @@ void SetInt(ScopedEnv & env, jobject params, jfieldID const fieldId, int const v
   RethrowOnJniException(env);
 }
 
+void SetLong(ScopedEnv & env, jobject params, jfieldID const fieldId, int64_t const value)
+{
+  env->SetLongField(params, fieldId, static_cast<jlong>(value));
+  RethrowOnJniException(env);
+}
+
 void GetString(ScopedEnv & env, jobject const params, jfieldID const fieldId, std::string & result)
 {
   jni::ScopedLocalRef<jstring> const wrappedValue(env.get(),
@@ -141,7 +147,11 @@ public:
                   {"followRedirects", GetHttpParamsFieldId(env, "followRedirects", "Z")},
                   {"loadHeaders", GetHttpParamsFieldId(env, "loadHeaders", "Z")},
                   {"httpResponseCode", GetHttpParamsFieldId(env, "httpResponseCode", "I")},
-                  {"timeoutMillisec", GetHttpParamsFieldId(env, "timeoutMillisec", "I")}};
+                  {"timeoutMillisec", GetHttpParamsFieldId(env, "timeoutMillisec", "I")},
+                  {"outputFileIsSegment", GetHttpParamsFieldId(env, "outputFileIsSegment", "Z")},
+                  {"outputFileOffset", GetHttpParamsFieldId(env, "outputFileOffset", "J")},
+                  {"outputFileSegmentBytes", GetHttpParamsFieldId(env, "outputFileSegmentBytes", "J")},
+                  {"outputFileTotalBytes", GetHttpParamsFieldId(env, "outputFileTotalBytes", "J")}};
   }
 
   jfieldID GetId(std::string const & fieldName) const
@@ -167,6 +177,11 @@ struct AsyncContext
   // Global ref to the Params object so we can read results on the callback thread.
   jobject m_paramsGlobalRef = nullptr;
   std::atomic<bool> m_dataAborted{false};
+  // Mirrors HttpClient::m_receivedFileSegment.has_value() at request-send time.
+  // Segment-mode completions require errorCode == 206 for m_success; any other HTTP
+  // code (404, 416, 500, etc.) or negative error code must map to m_success=false,
+  // matching Qt/Apple semantics.
+  bool m_isSegmentMode = false;
 };
 
 // Extract Result from a Java Params object.
@@ -208,11 +223,11 @@ platform::HttpClient::Result ExtractResult(JNIEnv * env, jobject params)
 }  // namespace
 
 // JNI streaming callbacks — called from Java during response body reading.
-
-extern "C" JNIEXPORT jboolean Java_app_organicmaps_sdk_util_HttpClient_nativeOnData(JNIEnv * env, jclass /*clazz*/,
-                                                                                    jlong nativeCtxPtr,
-                                                                                    jbyteArray dataBuffer,
-                                                                                    jint dataSize)
+extern "C"
+{
+JNIEXPORT jboolean Java_app_organicmaps_sdk_util_HttpClient_nativeOnData(JNIEnv * env, jclass /*clazz*/,
+                                                                         jlong nativeCtxPtr, jbyteArray dataBuffer,
+                                                                         jint dataSize)
 {
   auto * ctx = reinterpret_cast<AsyncContext *>(nativeCtxPtr);
   ASSERT(ctx && ctx->m_dataHandler, ());
@@ -233,36 +248,49 @@ extern "C" JNIEXPORT jboolean Java_app_organicmaps_sdk_util_HttpClient_nativeOnD
   return shouldContinue ? JNI_TRUE : JNI_FALSE;
 }
 
-extern "C" JNIEXPORT void Java_app_organicmaps_sdk_util_HttpClient_nativeOnProgress(JNIEnv * /*env*/, jclass /*clazz*/,
-                                                                                    jlong nativeCtxPtr,
-                                                                                    jlong bytesTransferred,
-                                                                                    jlong totalBytes)
+JNIEXPORT void Java_app_organicmaps_sdk_util_HttpClient_nativeOnProgress(JNIEnv * /*env*/, jclass /*clazz*/,
+                                                                         jlong nativeCtxPtr, jlong bytesTransferred,
+                                                                         jlong totalBytes)
 {
   auto * ctx = reinterpret_cast<AsyncContext *>(nativeCtxPtr);
   ASSERT(ctx && ctx->m_progressHandler, ());
   ctx->m_progressHandler(bytesTransferred, totalBytes);
 }
 
-extern "C" JNIEXPORT jboolean Java_app_organicmaps_sdk_util_HttpClient_hasNativeDataHandler(JNIEnv * /*env*/,
-                                                                                            jclass /*clazz*/,
-                                                                                            jlong nativeCtxPtr)
+JNIEXPORT jint Java_app_organicmaps_sdk_util_HttpClient_nativeValidateSegmentResponse(
+    JNIEnv * env, jclass /*clazz*/, jint httpResponseCode, jstring contentRange, jlong outputFileOffset,
+    jlong outputFileSegmentBytes, jlong outputFileTotalBytes)
+{
+  std::string contentRangeValue;
+  if (contentRange)
+    contentRangeValue = jni::ToNativeString(env, contentRange);
+
+  platform::HttpClient::ReceivedFileSegment segment;
+  segment.m_offset = static_cast<int64_t>(outputFileOffset);
+  segment.m_expectedBytes = static_cast<int64_t>(outputFileSegmentBytes);
+  segment.m_expectedTotalBytes = static_cast<int64_t>(outputFileTotalBytes);
+  auto const validation = platform::HttpClient::ValidateReceivedFileSegmentResponse(static_cast<int>(httpResponseCode),
+                                                                                    contentRangeValue, segment);
+  return static_cast<jint>(validation.m_errorCode);
+}
+
+JNIEXPORT jboolean Java_app_organicmaps_sdk_util_HttpClient_hasNativeDataHandler(JNIEnv * /*env*/, jclass /*clazz*/,
+                                                                                 jlong nativeCtxPtr)
 {
   auto * ctx = reinterpret_cast<AsyncContext *>(nativeCtxPtr);
   return (ctx && ctx->m_dataHandler) ? JNI_TRUE : JNI_FALSE;
 }
 
-extern "C" JNIEXPORT jboolean Java_app_organicmaps_sdk_util_HttpClient_hasNativeProgressHandler(JNIEnv * /*env*/,
-                                                                                                jclass /*clazz*/,
-                                                                                                jlong nativeCtxPtr)
+JNIEXPORT jboolean Java_app_organicmaps_sdk_util_HttpClient_hasNativeProgressHandler(JNIEnv * /*env*/, jclass /*clazz*/,
+                                                                                     jlong nativeCtxPtr)
 {
   auto * ctx = reinterpret_cast<AsyncContext *>(nativeCtxPtr);
   return (ctx && ctx->m_progressHandler) ? JNI_TRUE : JNI_FALSE;
 }
 
 // JNI callback from OkHttp's thread — called by HttpClient.java after enqueue() completes.
-extern "C" JNIEXPORT void Java_app_organicmaps_sdk_util_HttpClient_nativeOnComplete(JNIEnv * env, jclass /*clazz*/,
-                                                                                    jlong nativeCtxPtr,
-                                                                                    jboolean success)
+JNIEXPORT void Java_app_organicmaps_sdk_util_HttpClient_nativeOnComplete(JNIEnv * env, jclass /*clazz*/,
+                                                                         jlong nativeCtxPtr, jboolean success)
 {
   std::unique_ptr<AsyncContext> ctx(reinterpret_cast<AsyncContext *>(nativeCtxPtr));
 
@@ -276,7 +304,13 @@ extern "C" JNIEXPORT void Java_app_organicmaps_sdk_util_HttpClient_nativeOnCompl
   else if (success && ctx->m_paramsGlobalRef)
   {
     result = ExtractResult(env, ctx->m_paramsGlobalRef);
-    result.m_success = true;
+    // Negative error codes (kInconsistentFileSize, kWriteException) signal an
+    // application-level failure even though the HTTP transfer completed without
+    // throwing. Segment mode is stricter: only 206 means the requested chunk was
+    // accepted and written successfully — any other HTTP code (404, 416, 500, ...)
+    // leaves no bytes on disk, so must not be reported as success. Matches Qt/Apple
+    // m_success semantics.
+    result.m_success = result.m_errorCode >= 0 && (!ctx->m_isSegmentMode || result.m_errorCode == 206);
   }
   else if (ctx->m_paramsGlobalRef)
   {
@@ -301,6 +335,7 @@ extern "C" JNIEXPORT void Java_app_organicmaps_sdk_util_HttpClient_nativeOnCompl
   if (ctx->m_handler)
     ctx->m_handler(std::move(result));
 }
+}  // extern "C"
 
 //***********************************************************************
 // Exported functions implementation
@@ -369,6 +404,19 @@ HttpClient::RequestHandle HttpClient::RunHttpRequestAsync(CompletionHandler hand
     SetBoolean(env, httpParamsObject.get(), ids.GetId("loadHeaders"), m_loadHeaders);
     SetInt(env, httpParamsObject.get(), ids.GetId("timeoutMillisec"), static_cast<int>(m_timeoutSec * 1000));
 
+    // Segment mode: stream the response body into an existing file at the given offset
+    // with pre-write validation of 206 + Content-Range. Takes precedence over
+    // outputFilePath-only mode on the Java side.
+    if (m_receivedFileSegment)
+    {
+      SetString(env, httpParamsObject.get(), ids.GetId("outputFilePath"), m_receivedFileSegment->m_path);
+      SetBoolean(env, httpParamsObject.get(), ids.GetId("outputFileIsSegment"), true);
+      SetLong(env, httpParamsObject.get(), ids.GetId("outputFileOffset"), m_receivedFileSegment->m_offset);
+      SetLong(env, httpParamsObject.get(), ids.GetId("outputFileSegmentBytes"), m_receivedFileSegment->m_expectedBytes);
+      SetLong(env, httpParamsObject.get(), ids.GetId("outputFileTotalBytes"),
+              m_receivedFileSegment->m_expectedTotalBytes);
+    }
+
     ::SetHeaders(env, httpParamsObject.get(), m_headers);
   }
   catch (JniException const &)
@@ -384,6 +432,7 @@ HttpClient::RequestHandle HttpClient::RunHttpRequestAsync(CompletionHandler hand
   ctx->m_dataHandler = m_dataHandler;
   ctx->m_cancelChecker = handle.MakeCancelChecker();
   ctx->m_paramsGlobalRef = env->NewGlobalRef(httpParamsObject.get());
+  ctx->m_isSegmentMode = m_receivedFileSegment.has_value();
 
   // Call Java HttpClient.runAsync(Params, long nativeCtxPtr) — returns a Call object.
   static jmethodID const runAsyncMethod = env->GetStaticMethodID(

--- a/android/sdk/src/main/java/app/organicmaps/sdk/util/HttpClient.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/util/HttpClient.java
@@ -33,6 +33,7 @@ import app.organicmaps.sdk.util.log.Logger;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -58,6 +59,7 @@ public final class HttpClient
   // These constants must match the C++ HttpClient error codes in http_client.hpp.
   private static final int kNoError = -1;
   private static final int kWriteException = -2;
+  private static final int kInconsistentFileSize = -3;
   private static final int kCancelled = -6;
 
   private static volatile OkHttpClient sBaseClient;
@@ -241,6 +243,16 @@ public final class HttpClient
     final boolean hasProgressHandler = hasNativeProgressHandler(nativeCtxPtr);
     final boolean useStreaming = hasDataHandler || hasProgressHandler;
 
+    if (p.outputFileIsSegment)
+    {
+      // Segment mode: validate 206 + Content-Range against the expected segment BEFORE
+      // writing any byte. Stream directly to the target file at the configured offset
+      // with random-access I/O so multiple chunks of the same file can run concurrently
+      // without sharing a BufferedSink or tracking a seek position.
+      processSegmentResponse(p, response, responseBody, nativeCtxPtr, hasProgressHandler);
+      return;
+    }
+
     if (!TextUtils.isEmpty(p.outputFilePath))
     {
       try (BufferedSink sink = Okio.buffer(Okio.sink(new File(p.outputFilePath))))
@@ -266,6 +278,73 @@ public final class HttpClient
     else
     {
       p.responseData = responseBody.bytes();
+    }
+  }
+
+  // Stream a ranged response body directly into an existing file at the configured
+  // segment offset, with pre-write validation of 206 + Content-Range. Never populates
+  // p.responseData. On validation failure or I/O error, sets p.httpResponseCode to the
+  // final transport error code and returns without writing to the file.
+  private static void processSegmentResponse(@NonNull Params p, @NonNull Response response,
+                                             @NonNull ResponseBody responseBody, long nativeCtxPtr,
+                                             boolean hasProgressHandler) throws IOException
+  {
+    // Keep the status + Content-Range policy in shared C++ so all backends make the
+    // same accept/reject decision. Java still owns segment file I/O and body streaming.
+    p.httpResponseCode =
+        nativeValidateSegmentResponse(p.httpResponseCode, response.header("Content-Range"), p.outputFileOffset,
+                                      p.outputFileSegmentBytes, p.outputFileTotalBytes);
+    if (p.httpResponseCode != 206)
+      return;
+
+    // Open the existing file for random-access writing. RandomAccessFile with mode "rw"
+    // creates the file if missing, so we require the caller (downloader) to have
+    // created it already; an empty existing file would pass through here. The missing-
+    // file case is guarded in native code by checking that the .downloading file exists
+    // before issuing chunk requests.
+    File targetFile = new File(p.outputFilePath);
+    if (!targetFile.exists())
+    {
+      Logger.w(TAG, "Segment target file does not exist: " + p.outputFilePath);
+      p.httpResponseCode = kWriteException;
+      return;
+    }
+
+    long bytesWritten = 0;
+    try (RandomAccessFile raf = new RandomAccessFile(targetFile, "rw");
+         okio.BufferedSource source = responseBody.source())
+    {
+      raf.seek(p.outputFileOffset);
+      // 64 KB buffer: RandomAccessFile.write is unbuffered, so each iteration is a
+      // syscall + JNI crossing. Matches typical 512 KB segment chunks at ~8 iterations.
+      byte[] buffer = new byte[65536];
+      int bytesRead;
+      while ((bytesRead = source.read(buffer)) != -1)
+      {
+        long remaining = p.outputFileSegmentBytes - bytesWritten;
+        if (bytesRead > remaining)
+        {
+          Logger.w(TAG, "Segment overflow: " + bytesRead + " bytes received, only " + remaining + " expected");
+          p.httpResponseCode = kInconsistentFileSize;
+          return;
+        }
+        raf.write(buffer, 0, bytesRead);
+        bytesWritten += bytesRead;
+        if (hasProgressHandler)
+          nativeOnProgress(nativeCtxPtr, bytesWritten, p.outputFileSegmentBytes);
+      }
+    }
+    catch (IOException e)
+    {
+      Logger.e(TAG, "Segment file write error for " + p.outputFilePath, e);
+      p.httpResponseCode = kWriteException;
+      throw e;
+    }
+
+    if (bytesWritten != p.outputFileSegmentBytes)
+    {
+      Logger.w(TAG, "Segment underflow: " + bytesWritten + " bytes written, expected " + p.outputFileSegmentBytes);
+      p.httpResponseCode = kInconsistentFileSize;
     }
   }
 
@@ -324,6 +403,9 @@ public final class HttpClient
 
   // Called from OkHttp's callback thread to deliver results to C++.
   private static native void nativeOnComplete(long nativeCtxPtr, boolean success);
+  private static native int nativeValidateSegmentResponse(int httpResponseCode, @Nullable String contentRange,
+                                                          long outputFileOffset, long outputFileSegmentBytes,
+                                                          long outputFileTotalBytes);
   // Streaming callbacks — called during response body reading.
   private static native boolean nativeOnData(long nativeCtxPtr, byte[] buffer, int size);
   private static native void nativeOnProgress(long nativeCtxPtr, long bytesTransferred, long totalBytes);
@@ -358,6 +440,15 @@ public final class HttpClient
     boolean followRedirects = true;
     boolean loadHeaders;
     int timeoutMillisec = Constants.READ_TIMEOUT_MS;
+    // Segment mode: when true, outputFilePath points to an existing file and the
+    // response body is streamed into it at outputFileOffset. Transport validates
+    // 206 + Content-Range against outputFileSegmentBytes / outputFileTotalBytes
+    // before writing any bytes. When outputFileIsSegment is true, responseData
+    // is NOT populated.
+    boolean outputFileIsSegment;
+    long outputFileOffset;
+    long outputFileSegmentBytes;
+    long outputFileTotalBytes; // -1 = do not validate the total file size.
 
     public Params(String url)
     {

--- a/libs/platform/http_client.cpp
+++ b/libs/platform/http_client.cpp
@@ -2,9 +2,13 @@
 
 #include "coding/base64.hpp"
 
+#include "base/assert.hpp"
+#include "base/logging.hpp"
 #include "base/string_utils.hpp"
 
+#include <cctype>
 #include <condition_variable>
+#include <ranges>
 #include <sstream>
 
 namespace platform
@@ -115,6 +119,13 @@ HttpClient & HttpClient::SetReceivedFile(string const & received_file)
   return *this;
 }
 
+HttpClient & HttpClient::SetReceivedFileSegment(ReceivedFileSegment segment)
+{
+  CHECK(!m_dataHandler, ("SetReceivedFileSegment is mutually exclusive with SetDataHandler"));
+  m_receivedFileSegment = std::move(segment);
+  return *this;
+}
+
 HttpClient & HttpClient::SetUserAndPassword(string const & user, string const & password)
 {
   m_headers.emplace("Authorization", "Basic " + base64::Encode(user + ":" + password));
@@ -159,6 +170,7 @@ HttpClient & HttpClient::SetProgressHandler(ProgressHandler handler)
 
 HttpClient & HttpClient::SetDataHandler(DataHandler handler)
 {
+  CHECK(!m_receivedFileSegment, ("SetDataHandler is mutually exclusive with SetReceivedFileSegment"));
   m_dataHandler = std::move(handler);
   return *this;
 }
@@ -240,6 +252,82 @@ void HttpClient::LoadHeaders(bool loadHeaders)
 HttpClient::Headers const & HttpClient::GetHeaders() const
 {
   return m_headers;
+}
+
+// static
+bool HttpClient::ParseContentRange(std::string_view header, int64_t & start, int64_t & end, int64_t & total)
+{
+  strings::Trim(header);
+  // Strip the "bytes " prefix (case-insensitive per RFC 7233).
+  if (header.size() >= 6 &&
+      std::ranges::equal(header | std::views::take(6), std::string_view{"bytes "},
+                         [](char a, char b) { return std::tolower(static_cast<unsigned char>(a)) == b; }))
+  {
+    header.remove_prefix(6);
+    strings::Trim(header);
+  }
+  auto const dash = header.find('-');
+  auto const slash = header.find('/');
+  if (dash == std::string_view::npos || slash == std::string_view::npos || dash >= slash)
+    return false;
+  if (!strings::to_int(header.substr(0, dash), start))
+    return false;
+  if (!strings::to_int(header.substr(dash + 1, slash - dash - 1), end))
+    return false;
+  auto const totalStr = header.substr(slash + 1);
+  if (totalStr == "*")
+    total = -1;
+  else if (!strings::to_int(totalStr, total))
+    return false;
+  return true;
+}
+
+// static
+HttpClient::ReceivedFileSegmentValidation HttpClient::ValidateReceivedFileSegmentResponse(
+    int httpCode, std::string_view contentRange, ReceivedFileSegment const & segment)
+{
+  if (httpCode != 206)
+  {
+    // 2xx-without-206 means the server ignored the Range header. Preserve 4xx/5xx so
+    // higher layers can still distinguish real HTTP failures such as 404.
+    if (httpCode >= 200 && httpCode < 300)
+    {
+      LOG(LWARNING, ("Segment response protocol violation: expected HTTP 206, got", httpCode));
+      return {false, kInconsistentFileSize};
+    }
+    return {false, httpCode};
+  }
+
+  int64_t start = 0;
+  int64_t end = 0;
+  int64_t total = -1;
+  if (contentRange.empty() || !ParseContentRange(contentRange, start, end, total))
+  {
+    LOG(LWARNING, ("Invalid or missing Content-Range for segment response:", std::string(contentRange)));
+    return {false, kInconsistentFileSize};
+  }
+
+  int64_t const expectedEnd = segment.m_offset + segment.m_expectedBytes - 1;
+  if (start != segment.m_offset || end != expectedEnd)
+  {
+    LOG(LWARNING, ("Content-Range mismatch: got", start, "-", end, "expected", segment.m_offset, "-", expectedEnd));
+    return {false, kInconsistentFileSize};
+  }
+
+  // If the caller supplied an expected total file size, the server must echo it back.
+  // A "*" would let a mirror serve a chunk from another file version at the same offset.
+  if (segment.m_expectedTotalBytes >= 0 && total < 0)
+  {
+    LOG(LWARNING, ("Server sent Content-Range with unknown total, expected", segment.m_expectedTotalBytes));
+    return {false, kInconsistentFileSize};
+  }
+  if (segment.m_expectedTotalBytes >= 0 && total != segment.m_expectedTotalBytes)
+  {
+    LOG(LWARNING, ("Content-Range total mismatch: got", total, "expected", segment.m_expectedTotalBytes));
+    return {false, kInconsistentFileSize};
+  }
+
+  return {true, 206};
 }
 
 // static

--- a/libs/platform/http_client.hpp
+++ b/libs/platform/http_client.hpp
@@ -28,7 +28,9 @@ SOFTWARE.
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 
@@ -39,6 +41,7 @@ class HttpClient
 public:
   static auto constexpr kNoError = -1;
   static auto constexpr kWriteException = -2;
+  static auto constexpr kInconsistentFileSize = -3;
   static auto constexpr kCancelled = -6;
 
   using Headers = std::unordered_map<std::string, std::string>;
@@ -51,6 +54,24 @@ public:
     std::string m_urlReceived;
     std::string m_serverResponse;
     Headers m_headers;
+  };
+
+  // Sink config for streaming a ranged response into an existing file at a specific offset.
+  // Used by the chunked downloader to write each chunk directly to disk without accumulating
+  // the body in memory. Transport validates 206 Partial Content and Content-Range before
+  // writing any bytes; mismatch yields kInconsistentFileSize.
+  struct ReceivedFileSegment
+  {
+    std::string m_path;
+    int64_t m_offset = 0;
+    int64_t m_expectedBytes = 0;
+    int64_t m_expectedTotalBytes = -1;  // -1 means do not validate the total file size.
+  };
+
+  struct ReceivedFileSegmentValidation
+  {
+    bool m_ok = false;
+    int m_errorCode = kNoError;
   };
 
   using CompletionHandler = std::function<void(Result)>;
@@ -113,6 +134,12 @@ public:
                            std::string const & http_method = "POST", std::string const & content_encoding = "");
   // If set, stores server reply in file specified.
   HttpClient & SetReceivedFile(std::string const & received_file);
+  // If set, streams a ranged response body directly into the specified file at the given
+  // offset. The transport validates 206 + Content-Range before the first byte is written.
+  // Mutually exclusive with SetReceivedFile(): if both are configured, segment mode wins.
+  // Mutually exclusive with SetDataHandler() (CHECK-enforced).
+  // In segment mode, Result::m_serverResponse remains empty.
+  HttpClient & SetReceivedFileSegment(ReceivedFileSegment segment);
   // This method is mutually exclusive with SetBodyFile().
   template <typename StringT>
   HttpClient & SetBodyData(StringT && body_data, std::string const & content_type,
@@ -162,6 +189,18 @@ public:
   // Internal helper, used by platform implementations.
   static std::string NormalizeServerCookies(std::string && cookies);
 
+  // Parses a Content-Range header value ("bytes <start>-<end>/<total|*>" per RFC 7233 §4.2).
+  // On success returns true and fills start/end/total; total is set to -1 if the server sent "*".
+  // Used by native HTTP backends to validate ranged responses in segment mode.
+  static bool ParseContentRange(std::string_view header, int64_t & start, int64_t & end, int64_t & total);
+
+  // Validates HTTP status + Content-Range for a ranged response targeting |segment|.
+  // On success returns {true, 206}. On failure returns {false, finalErrorCode}, where
+  // finalErrorCode is either kInconsistentFileSize for protocol violations or the original
+  // HTTP status for genuine HTTP errors such as 404.
+  static ReceivedFileSegmentValidation ValidateReceivedFileSegmentResponse(int httpCode, std::string_view contentRange,
+                                                                           ReceivedFileSegment const & segment);
+
 private:
   std::string m_urlRequested;
   // Contains final content's url taking redirects (if any) into an account.
@@ -170,6 +209,9 @@ private:
   std::string m_inputFile;
   // Used instead of m_serverResponse if set.
   std::string m_outputFile;
+  // If set, the response body is streamed into an existing file at a validated segment.
+  // Takes precedence over m_outputFile.
+  std::optional<ReceivedFileSegment> m_receivedFileSegment;
   // Data we received from the server if m_outputFile wasn't initialized.
   std::string m_serverResponse;
   std::string m_bodyData;

--- a/libs/platform/http_client_apple.mm
+++ b/libs/platform/http_client_apple.mm
@@ -33,6 +33,8 @@ SOFTWARE.
 
 #include "base/logging.hpp"
 
+#include <optional>
+
 using CancelChecker = platform::HttpClient::CancelChecker;
 
 // Per-request delegate that bridges NSURLSession callbacks to C++ HttpClient handlers.
@@ -56,6 +58,12 @@ using CancelChecker = platform::HttpClient::CancelChecker;
   BOOL m_dataAborted;
   std::string m_urlRequested;
   std::string m_outputFile;
+
+  // Segment-mode state. When set, m_outputFile is unused and bytes are streamed into
+  // m_segment->m_path at m_segment->m_offset after 206 + Content-Range validation.
+  std::optional<platform::HttpClient::ReceivedFileSegment> m_segment;
+  int64_t m_segmentBytesWritten;
+  int m_segmentErrorCode;  // kNoError unless a segment-specific failure overrides HTTP code.
 }
 
 - (instancetype)initWithHandler:(platform::HttpClient::CompletionHandler)handler
@@ -65,7 +73,8 @@ using CancelChecker = platform::HttpClient::CancelChecker;
                 followRedirects:(BOOL)followRedirects
                     loadHeaders:(BOOL)loadHeaders
                    urlRequested:(std::string)urlRequested
-                     outputFile:(std::string)outputFile;
+                     outputFile:(std::string)outputFile
+                        segment:(std::optional<platform::HttpClient::ReceivedFileSegment>)segment;
 
 @end
 
@@ -79,6 +88,7 @@ using CancelChecker = platform::HttpClient::CancelChecker;
                     loadHeaders:(BOOL)loadHeaders
                    urlRequested:(std::string)urlRequested
                      outputFile:(std::string)outputFile
+                        segment:(std::optional<platform::HttpClient::ReceivedFileSegment>)segment
 {
   if (self = [super init])
   {
@@ -90,11 +100,18 @@ using CancelChecker = platform::HttpClient::CancelChecker;
     m_loadHeaders = loadHeaders;
     m_urlRequested = std::move(urlRequested);
     m_outputFile = std::move(outputFile);
-    m_accumulatedData = [[NSMutableData alloc] init];
+    m_segment = std::move(segment);
+    m_segmentBytesWritten = 0;
+    m_segmentErrorCode = platform::HttpClient::kNoError;
+    // Accumulator is only used when not streaming to a file or user handler.
+    bool const needAccumulator = !m_dataHandler && m_outputFile.empty() && !m_segment;
+    m_accumulatedData = needAccumulator ? [[NSMutableData alloc] init] : nil;
     m_outputFileHandle = nil;
     m_writeError = NO;
     m_dataAborted = NO;
-    if (!m_outputFile.empty())
+    // Segment mode takes precedence over plain output file and defers file open
+    // until 206 + Content-Range are validated in didReceiveResponse.
+    if (!m_segment && !m_outputFile.empty())
     {
       // Create/truncate the file and open a handle for streaming writes.
       if (![[NSFileManager defaultManager] createFileAtPath:@(m_outputFile.c_str()) contents:nil attributes:nil])
@@ -188,7 +205,52 @@ using CancelChecker = platform::HttpClient::CancelChecker;
       m_result.m_headers.emplace("set-cookie", platform::HttpClient::NormalizeServerCookies(setCookies.UTF8String));
   }
 
+  // Segment mode: validate 206 Partial Content and Content-Range against the expected
+  // segment BEFORE allowing any body bytes. A 200 (range ignored) or mismatched range
+  // would corrupt adjacent chunks at different offsets.
+  if (m_segment && ![self validateSegmentResponse:httpResponse])
+  {
+    m_writeError = YES;
+    [dataTask cancel];
+    completionHandler(NSURLSessionResponseCancel);
+    return;
+  }
+
   completionHandler(NSURLSessionResponseAllow);
+}
+
+- (BOOL)validateSegmentResponse:(NSHTTPURLResponse *)httpResponse
+{
+  int const httpCode = static_cast<int>(httpResponse.statusCode);
+  NSString * crValue = [httpResponse.allHeaderFields objectForKey:@"Content-Range"];
+  auto const validation = platform::HttpClient::ValidateReceivedFileSegmentResponse(
+      httpCode, crValue ? std::string_view(crValue.UTF8String) : std::string_view(), *m_segment);
+  if (!validation.m_ok)
+  {
+    m_segmentErrorCode = validation.m_errorCode;
+    return NO;
+  }
+
+  // Open the existing target file without truncating and seek to the segment offset.
+  NSString * path = @(m_segment->m_path.c_str());
+  m_outputFileHandle = [NSFileHandle fileHandleForUpdatingAtPath:path];
+  if (!m_outputFileHandle)
+  {
+    LOG(LWARNING, ("Can't open segment file for updating:", m_segment->m_path));
+    m_segmentErrorCode = platform::HttpClient::kWriteException;
+    return NO;
+  }
+  NSError * seekError = nil;
+  if (![m_outputFileHandle seekToOffset:static_cast<unsigned long long>(m_segment->m_offset) error:&seekError])
+  {
+    LOG(LWARNING, ("Can't seek segment file", m_segment->m_path, "to offset", m_segment->m_offset, ":",
+                   seekError.localizedDescription.UTF8String));
+    [m_outputFileHandle closeFile];
+    m_outputFileHandle = nil;
+    m_segmentErrorCode = platform::HttpClient::kWriteException;
+    return NO;
+  }
+  return YES;
 }
 
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
@@ -216,14 +278,32 @@ using CancelChecker = platform::HttpClient::CancelChecker;
   }
   else if (m_outputFileHandle)
   {
+    // Segment mode: refuse to write past the expected segment length — the server is
+    // sending more than advertised in Content-Range.
+    if (m_segment)
+    {
+      int64_t const remaining = m_segment->m_expectedBytes - m_segmentBytesWritten;
+      if (length > remaining)
+      {
+        LOG(LWARNING, ("Segment overflow:", length, "bytes received, only", remaining, "expected"));
+        m_writeError = YES;
+        m_segmentErrorCode = platform::HttpClient::kInconsistentFileSize;
+        [dataTask cancel];
+        return;
+      }
+    }
     NSError * writeError = nil;
     if (![m_outputFileHandle writeData:data error:&writeError])
     {
       LOG(LERROR, ("File write error:", writeError.localizedDescription.UTF8String));
       m_writeError = YES;
+      if (m_segment)
+        m_segmentErrorCode = platform::HttpClient::kWriteException;
       [dataTask cancel];
       return;
     }
+    if (m_segment)
+      m_segmentBytesWritten += length;
   }
   else
   {
@@ -257,7 +337,11 @@ using CancelChecker = platform::HttpClient::CancelChecker;
           m_handler(std::move(m_result));
         return;
       }
-      m_result.m_errorCode = platform::HttpClient::kCancelled;
+      // Self-inflicted cancels (m_writeError / m_dataAborted) must NOT be mapped to
+      // kCancelled — the real error is set later, and preserving the HTTP status here
+      // lets segment mode return 404 etc.
+      if (!m_writeError && !m_dataAborted)
+        m_result.m_errorCode = platform::HttpClient::kCancelled;
     }
     else if (error.code == NSURLErrorUserCancelledAuthentication)
     {
@@ -279,19 +363,35 @@ using CancelChecker = platform::HttpClient::CancelChecker;
     m_outputFileHandle = nil;
   }
 
+  // Segment-mode: verify the server delivered exactly the number of bytes advertised
+  // by Content-Range. A short body means the transfer ended before the segment was
+  // fully received, which must NOT be treated as a successful chunk.
+  if (m_segment && !m_writeError && !error && m_segmentBytesWritten != m_segment->m_expectedBytes &&
+      m_segmentErrorCode == platform::HttpClient::kNoError)
+  {
+    LOG(LWARNING, ("Segment underflow:", m_segmentBytesWritten, "bytes written, expected", m_segment->m_expectedBytes));
+    m_writeError = YES;
+    m_segmentErrorCode = platform::HttpClient::kInconsistentFileSize;
+  }
+
   // Report file write/open failure.
   if (m_writeError)
   {
     m_result.m_success = false;
-    m_result.m_errorCode = platform::HttpClient::kWriteException;
+    if (m_segmentErrorCode != platform::HttpClient::kNoError)
+      m_result.m_errorCode = m_segmentErrorCode;
+    else if (!m_segment)
+      m_result.m_errorCode = platform::HttpClient::kWriteException;
+    // Segment mode with m_segmentErrorCode == kNoError: preserve the HTTP code (e.g. 404),
+    // so the downloader's 404 → FileNotFound mapping still works.
   }
 
   // DataHandler requested abort — override the HTTP success set in didReceiveResponse.
   if (m_dataAborted)
     m_result.m_success = false;
 
-  // Store accumulated data in result (only when not streaming to DataHandler or file).
-  if (!m_dataHandler && m_outputFile.empty() && m_accumulatedData.length > 0)
+  // Store accumulated data in result (only when not streaming to DataHandler, file, or segment).
+  if (!m_dataHandler && m_outputFile.empty() && !m_segment && m_accumulatedData.length > 0)
     m_result.m_serverResponse.assign(reinterpret_cast<char const *>(m_accumulatedData.bytes), m_accumulatedData.length);
 
   if (m_handler)
@@ -313,6 +413,7 @@ HttpClient::RequestHandle HttpClient::RunHttpRequestAsync(CompletionHandler hand
   std::string const bodyData = m_bodyData;
   std::string const inputFile = m_inputFile;
   std::string const outputFile = m_outputFile;
+  auto const segment = m_receivedFileSegment;
   std::string const cookies = m_cookies;
   Headers const headers = m_headers;
   bool const followRedirects = m_followRedirects;
@@ -358,10 +459,10 @@ HttpClient::RequestHandle HttpClient::RunHttpRequestAsync(CompletionHandler hand
     LOG(LDEBUG, ("Uploading file", inputFile, file_size, "bytes"));
   }
 
-  // Use delegate-based task when streaming is needed: DataHandler, ProgressHandler, or file output.
-  // The delegate's didReceiveData: writes chunks to disk incrementally, avoiding buffering the
-  // entire response body in memory.
-  bool const useDelegate = m_progressHandler || m_dataHandler || !outputFile.empty();
+  // Use delegate-based task when streaming is needed: DataHandler, ProgressHandler, file
+  // output, or segment output. The delegate's didReceiveData: writes chunks to disk
+  // incrementally, avoiding buffering the entire response body in memory.
+  bool const useDelegate = m_progressHandler || m_dataHandler || !outputFile.empty() || segment.has_value();
 
   NSURLSessionDataTask * task = nil;
 
@@ -376,7 +477,8 @@ HttpClient::RequestHandle HttpClient::RunHttpRequestAsync(CompletionHandler hand
                                                                 followRedirects:followRedirects ? YES : NO
                                                                     loadHeaders:loadHeaders ? YES : NO
                                                                    urlRequested:urlRequested
-                                                                     outputFile:outputFile];
+                                                                     outputFile:outputFile
+                                                                        segment:segment];
 
     task = [[HttpSessionManager sharedManager] dataTaskWithRequest:request delegate:delegate completionHandler:nil];
   }
@@ -395,7 +497,8 @@ HttpClient::RequestHandle HttpClient::RunHttpRequestAsync(CompletionHandler hand
                                                         followRedirects:followRedirects ? YES : NO
                                                             loadHeaders:NO
                                                            urlRequested:urlRequested
-                                                             outputFile:std::string()]
+                                                             outputFile:std::string()
+                                                                segment:std::nullopt]
           completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
             Result result;
 

--- a/libs/platform/http_client_qt.cpp
+++ b/libs/platform/http_client_qt.cpp
@@ -66,7 +66,8 @@ namespace platform
 HttpClientReply::HttpClientReply(QNetworkReply * reply, HttpClient::CompletionHandler handler,
                                  HttpClient::ProgressHandler progressHandler, HttpClient::DataHandler dataHandler,
                                  CancelChecker cancelChecker, bool loadHeaders, bool followRedirects,
-                                 std::string urlRequested, std::string cookies, std::string outputFile)
+                                 std::string urlRequested, std::string cookies, std::string outputFile,
+                                 std::optional<HttpClient::ReceivedFileSegment> segment)
   : m_reply(reply)
   , m_handler(std::move(handler))
   , m_progressHandler(std::move(progressHandler))
@@ -77,8 +78,11 @@ HttpClientReply::HttpClientReply(QNetworkReply * reply, HttpClient::CompletionHa
   , m_urlRequested(std::move(urlRequested))
   , m_cookies(std::move(cookies))
   , m_outputFile(std::move(outputFile))
+  , m_segment(std::move(segment))
 {
-  if (!m_outputFile.empty())
+  // Segment mode takes precedence over plain output file and defers file open
+  // until 206 + Content-Range are validated in ValidateSegmentIfNeeded().
+  if (!m_segment && !m_outputFile.empty())
   {
     m_outputFileStream = new QFile(QString::fromStdString(m_outputFile), this);
     if (!m_outputFileStream->open(QIODevice::WriteOnly | QIODevice::Truncate))
@@ -102,10 +106,65 @@ HttpClientReply::HttpClientReply(QNetworkReply * reply, HttpClient::CompletionHa
     m_reply->abort();
 }
 
+bool HttpClientReply::ValidateSegmentIfNeeded()
+{
+  if (!m_segment)
+    return !m_writeError;
+  if (m_segmentValidated)
+    return !m_writeError;
+  // Only run once, even on failure.
+  m_segmentValidated = true;
+
+  int const httpCode = m_reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+  QByteArray const crBytes = m_reply->rawHeader("Content-Range");
+  std::string_view const contentRange = crBytes.isEmpty()
+                                          ? std::string_view()
+                                          : std::string_view(crBytes.constData(), static_cast<size_t>(crBytes.size()));
+  auto const validation = HttpClient::ValidateReceivedFileSegmentResponse(httpCode, contentRange, *m_segment);
+  if (!validation.m_ok)
+  {
+    m_writeError = true;
+    m_segmentErrorCode = validation.m_errorCode;
+    return false;
+  }
+
+  // Open the existing target file without truncating and seek to the segment offset.
+  m_outputFileStream = new QFile(QString::fromStdString(m_segment->m_path), this);
+  if (!m_outputFileStream->open(QIODevice::ReadWrite | QIODevice::ExistingOnly))
+  {
+    LOG(LWARNING, ("Can't open segment file for writing:", m_segment->m_path));
+    delete m_outputFileStream;
+    m_outputFileStream = nullptr;
+    m_writeError = true;
+    m_segmentErrorCode = HttpClient::kWriteException;
+    return false;
+  }
+  if (!m_outputFileStream->seek(static_cast<qint64>(m_segment->m_offset)))
+  {
+    LOG(LWARNING, ("Can't seek segment file", m_segment->m_path, "to offset", m_segment->m_offset));
+    m_outputFileStream->close();
+    m_writeError = true;
+    m_segmentErrorCode = HttpClient::kWriteException;
+    return false;
+  }
+  return true;
+}
+
 void HttpClientReply::OnReadyRead()
 {
   if (m_writeError)
     return;
+
+  // Segment mode requires header validation BEFORE any byte is written to disk. If the
+  // response is not a valid 206 Partial Content for the requested range, fail fast —
+  // otherwise we'd overwrite adjacent chunks' data at the wrong offset.
+  if (m_segment && !ValidateSegmentIfNeeded())
+  {
+    // Drain and discard; abort the transfer.
+    m_reply->readAll();
+    m_reply->abort();
+    return;
+  }
 
   QByteArray const data = m_reply->readAll();
   if (data.isEmpty())
@@ -122,13 +181,31 @@ void HttpClientReply::OnReadyRead()
   }
   else if (m_outputFileStream)
   {
+    // Segment mode: refuse to write past the expected segment length — the server is
+    // sending more than advertised in Content-Range.
+    if (m_segment)
+    {
+      int64_t const remaining = m_segment->m_expectedBytes - m_segmentBytesWritten;
+      if (data.size() > remaining)
+      {
+        LOG(LWARNING, ("Segment overflow:", data.size(), "bytes received, only", remaining, "expected"));
+        m_writeError = true;
+        m_segmentErrorCode = HttpClient::kInconsistentFileSize;
+        m_reply->abort();
+        return;
+      }
+    }
     if (m_outputFileStream->write(data) != data.size())
     {
-      LOG(LWARNING, ("File write error for:", m_outputFile));
+      LOG(LWARNING, ("File write error for:", m_segment ? m_segment->m_path : m_outputFile));
       m_writeError = true;
+      if (m_segment)
+        m_segmentErrorCode = HttpClient::kWriteException;
       m_reply->abort();
       return;
     }
+    if (m_segment)
+      m_segmentBytesWritten += data.size();
   }
   else
   {
@@ -205,13 +282,38 @@ void HttpClientReply::OnFinished()
 
     if (!m_dataHandler)
     {
+      // Segment mode: validate headers here too, in case the body arrived with no
+      // readyRead firing (e.g. empty 206 body, or status != 206).
+      if (m_segment)
+        ValidateSegmentIfNeeded();
+
       if (m_outputFileStream)
       {
         QByteArray const remaining = m_reply->readAll();
         if (!remaining.isEmpty())
         {
-          if (m_outputFileStream->write(remaining) != remaining.size())
+          // Segment overflow check: any bytes past expectedBytes are a protocol violation.
+          if (m_segment)
+          {
+            int64_t const available = m_segment->m_expectedBytes - m_segmentBytesWritten;
+            if (remaining.size() > available)
+            {
+              LOG(LWARNING,
+                  ("Segment overflow at finish:", remaining.size(), "bytes trailing, only", available, "expected"));
+              m_writeError = true;
+              m_segmentErrorCode = HttpClient::kInconsistentFileSize;
+            }
+          }
+          if (!m_writeError && m_outputFileStream->write(remaining) != remaining.size())
+          {
             m_writeError = true;
+            if (m_segment)
+              m_segmentErrorCode = HttpClient::kWriteException;
+          }
+          else if (!m_writeError && m_segment)
+          {
+            m_segmentBytesWritten += remaining.size();
+          }
         }
         m_outputFileStream->close();
       }
@@ -230,6 +332,16 @@ void HttpClientReply::OnFinished()
     LOG(LDEBUG, ("Network error:", m_reply->errorString().toStdString(), "while connecting to", m_urlRequested));
   }
 
+  // Segment-mode: verify the server delivered exactly the number of bytes advertised
+  // by Content-Range. A short body means the transfer ended before the segment was
+  // fully received, which must NOT be treated as a successful chunk.
+  if (m_segment && !m_writeError && m_segmentValidated && m_segmentBytesWritten != m_segment->m_expectedBytes)
+  {
+    LOG(LWARNING, ("Segment underflow:", m_segmentBytesWritten, "bytes written, expected", m_segment->m_expectedBytes));
+    m_writeError = true;
+    m_segmentErrorCode = HttpClient::kInconsistentFileSize;
+  }
+
   // File open or write error — report failure regardless of HTTP result.
   // Must be outside the if/else above because abort() on file-open failure
   // yields noError=false and httpCode=0, skipping the if branch entirely.
@@ -238,7 +350,12 @@ void HttpClientReply::OnFinished()
     if (m_outputFileStream)
       m_outputFileStream->close();
     result.m_success = false;
-    result.m_errorCode = HttpClient::kWriteException;
+    if (m_segmentErrorCode != HttpClient::kNoError)
+      result.m_errorCode = m_segmentErrorCode;
+    else if (!m_segment)
+      result.m_errorCode = HttpClient::kWriteException;
+    // Segment mode with m_segmentErrorCode == kNoError: preserve the HTTP code (e.g. 404),
+    // so the downloader's 404 → FileNotFound mapping still works.
   }
 
   // DataHandler requested abort — override the HTTP success.
@@ -311,6 +428,7 @@ HttpClient::RequestHandle HttpClient::RunHttpRequestAsync(CompletionHandler hand
   auto const urlRequested = m_urlRequested;
   auto const cookies = m_cookies;
   auto const outputFile = m_outputFile;
+  auto const segment = m_receivedFileSegment;
   auto impl = handle.m_impl;
   auto cancelChecker = handle.MakeCancelChecker();
 
@@ -350,7 +468,7 @@ HttpClient::RequestHandle HttpClient::RunHttpRequestAsync(CompletionHandler hand
       reply = manager.sendCustomRequest(request, QByteArray::fromStdString(httpMethod), bodyBytes);
 
     new HttpClientReply(reply, std::move(handler), progressHandler, dataHandler, std::move(cancelChecker), loadHeaders,
-                        followRedirects, urlRequested, cookies, outputFile);
+                        followRedirects, urlRequested, cookies, outputFile, segment);
 
     // Install platform cancel hook. reply->abort() must be called on the
     // reply's thread; use QMetaObject::invokeMethod with QueuedConnection.

--- a/libs/platform/http_client_qt.hpp
+++ b/libs/platform/http_client_qt.hpp
@@ -7,6 +7,9 @@
 #include <QNetworkReply>
 #include <QObject>
 
+#include <cstdint>
+#include <optional>
+
 namespace platform
 {
 using CancelChecker = HttpClient::CancelChecker;
@@ -21,7 +24,7 @@ public:
   HttpClientReply(QNetworkReply * reply, HttpClient::CompletionHandler handler,
                   HttpClient::ProgressHandler progressHandler, HttpClient::DataHandler dataHandler,
                   CancelChecker cancelChecker, bool loadHeaders, bool followRedirects, std::string urlRequested,
-                  std::string cookies, std::string outputFile);
+                  std::string cookies, std::string outputFile, std::optional<HttpClient::ReceivedFileSegment> segment);
 
 private slots:
   void OnReadyRead();
@@ -29,6 +32,12 @@ private slots:
   void OnFinished();
 
 private:
+  // Validates 206 + Content-Range for segment mode and opens the output file at the target
+  // offset on the first call. Idempotent; sets m_writeError + m_segmentErrorCode on failure.
+  // Must be called before any write to the output file. Returns true if the segment is ready
+  // to receive data, false if validation failed.
+  bool ValidateSegmentIfNeeded();
+
   QNetworkReply * m_reply;
   HttpClient::CompletionHandler m_handler;
   HttpClient::ProgressHandler m_progressHandler;
@@ -43,6 +52,13 @@ private:
   bool m_writeError = false;
   bool m_dataAborted = false;
   std::string m_accumulatedData;
+
+  // Segment-mode state. When m_segment is set, m_outputFile is unused and the body is
+  // streamed into m_segment->m_path at m_segment->m_offset after header validation.
+  std::optional<HttpClient::ReceivedFileSegment> m_segment;
+  bool m_segmentValidated = false;
+  int64_t m_segmentBytesWritten = 0;
+  int m_segmentErrorCode = HttpClient::kNoError;  // Overrides result error code when set.
 };
 
 // QObject worker living on a dedicated QThread. Owns the QNetworkAccessManager

--- a/libs/platform/http_request.cpp
+++ b/libs/platform/http_request.cpp
@@ -9,7 +9,6 @@
 #include "coding/internal/file_data.hpp"
 
 #include "base/logging.hpp"
-#include "base/string_utils.hpp"
 #include "base/thread.hpp"
 
 #include <atomic>
@@ -43,6 +42,9 @@ using AliveFlag = std::shared_ptr<std::atomic<bool>>;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 /// Downloads file using chunked strategy, backed by HttpClient async API.
+/// Each chunk is streamed directly to disk via SetReceivedFileSegment — the chunk body
+/// is never materialized in RAM on the transport side, so Android's Large Object Space
+/// is not churned by per-chunk 512 KB byte[] allocations.
 class FileHttpRequest : public HttpRequest
 {
   ChunksDownloadStrategy m_strategy;
@@ -56,7 +58,7 @@ class FileHttpRequest : public HttpRequest
 
   AliveFlag m_alive;
   string m_filePath;
-  std::unique_ptr<FileWriter> m_writer;
+  string m_downloadingPath;  // m_filePath + DOWNLOADING_FILE_EXTENSION, cached.
   size_t m_goodChunksCount;
   bool m_doCleanProgressFiles;
 
@@ -74,32 +76,35 @@ class FileHttpRequest : public HttpRequest
   {
     string url;
     std::pair<int64_t, int64_t> range;
-    ChunksDownloadStrategy::ResultT result;
+    ChunksDownloadStrategy::ResultT result = ChunksDownloadStrategy::ENoFreeServers;
     while ((result = m_strategy.NextChunk(url, range)) == ChunksDownloadStrategy::ENextChunk)
     {
+      int64_t const begRange = range.first;
+      int64_t const endRange = range.second;
+
       platform::HttpClient client(url);
-      client.SetRange(range.first, range.second);
+      client.SetRange(begRange, endRange);
+      // Stream the chunk body directly into the .downloading file at begRange. The
+      // transport validates 206 + Content-Range against the requested segment before
+      // writing any byte, so no corruption if a mirror returns 200 + full body instead
+      // of a partial response.
+      client.SetReceivedFileSegment({m_downloadingPath, begRange, endRange - begRange + 1, m_progress.m_bytesTotal});
       client.LoadHeaders(true);
 
       auto alive = m_alive;
-      int64_t const begRange = range.first;
-      int64_t const endRange = range.second;
-      int64_t const expectedSize = m_progress.m_bytesTotal;
-
-      auto handle = client.RunHttpRequestAsync(
-          [this, alive, begRange, endRange, expectedSize](platform::HttpClient::Result result)
+      auto handle = client.RunHttpRequestAsync([this, alive, begRange, endRange](platform::HttpClient::Result result)
       {
         if (!alive->load(std::memory_order_acquire))
           return;
-        platform::GuiThread().Push([this, alive, begRange, endRange, expectedSize, result = std::move(result)]() mutable
+        platform::GuiThread().Push([this, alive, begRange, endRange, result = std::move(result)]() mutable
         {
           if (!alive->load(std::memory_order_acquire))
             return;
-          OnChunkFinished(std::move(result), begRange, endRange, expectedSize);
+          OnChunkFinished(std::move(result), begRange, endRange);
         });
       });
 
-      m_chunks.push_back({std::move(handle), range.first});
+      m_chunks.push_back({std::move(handle), begRange});
     }
     return result;
   }
@@ -112,65 +117,14 @@ class FileHttpRequest : public HttpRequest
       m_chunks.erase(it);
   }
 
-  void OnChunkFinished(platform::HttpClient::Result && result, int64_t begRange, int64_t endRange, int64_t expectedSize)
+  void OnChunkFinished(platform::HttpClient::Result && result, int64_t begRange, int64_t endRange)
   {
     ASSERT(IsCalledOnOriginalThread(), ());
 
-    // A ranged chunk request must get 206 Partial Content.
-    // 200 OK means the server ignored the Range header and returned the full file.
+    // The transport (SetReceivedFileSegment) has already validated 206 + Content-Range
+    // and streamed the body to disk. Protocol violations surface as kInconsistentFileSize.
     bool const isRangeRequest = !(begRange == 0 && endRange < 0);
-    bool isChunkOk = result.m_success && (isRangeRequest ? result.m_errorCode == 206 : result.m_errorCode == 200);
-
-    // Validate server file size against expected using Content-Range header.
-    // Content-Range is required in a 206 response (RFC 7233) and contains the total
-    // file size after the slash (e.g., "bytes 0-999/50000"). Content-Length is NOT
-    // used as a fallback because for ranged responses it contains the chunk size,
-    // not the total file size.
-    if (isChunkOk && expectedSize > 0 && isRangeRequest)
-    {
-      int64_t serverSize = -1;
-      auto const crIt = result.m_headers.find("content-range");
-      if (crIt != result.m_headers.end())
-      {
-        auto const slashPos = crIt->second.find('/');
-        if (slashPos != string::npos)
-          (void)strings::to_int(crIt->second.substr(slashPos + 1), serverSize);
-      }
-
-      if (serverSize >= 0 && serverSize != expectedSize)
-      {
-        LOG(LWARNING, ("Server file size", serverSize, "!= expected", expectedSize, "for range", begRange, endRange));
-        isChunkOk = false;
-      }
-      else if (serverSize < 0)
-      {
-        LOG(LWARNING, ("Server didn't send Content-Range for range", begRange, endRange));
-        isChunkOk = false;
-      }
-    }
-
-    // Write chunk data from memory to the download file at the correct offset.
-    if (isChunkOk)
-    {
-      try
-      {
-        if (result.m_serverResponse.empty())
-        {
-          LOG(LWARNING, ("Empty chunk response for range", begRange, endRange));
-          isChunkOk = false;
-        }
-        else
-        {
-          m_writer->Seek(begRange);
-          m_writer->Write(result.m_serverResponse.data(), result.m_serverResponse.size());
-        }
-      }
-      catch (Writer::Exception const & e)
-      {
-        LOG(LWARNING, ("Can't write chunk at", begRange, e.Msg()));
-        isChunkOk = false;
-      }
-    }
+    bool const isChunkOk = result.m_success && (isRangeRequest ? result.m_errorCode == 206 : result.m_errorCode == 200);
 
     string const urlError = m_strategy.ChunkFinished(isChunkOk, {begRange, endRange});
     RemoveChunkByKey(begRange);
@@ -207,45 +161,24 @@ class FileHttpRequest : public HttpRequest
     if (m_status == DownloadStatus::Failed || m_status == DownloadStatus::FileNotFound)
       SaveResumeChunks();
 
-    // 2. Free file handle.
-    CloseWriter();
-
-    // 3. Clean up resume file with chunks range on success.
+    // 2. Clean up resume file with chunks range on success.
     if (m_status == DownloadStatus::Completed)
     {
       Platform::RemoveFileIfExists(m_filePath + RESUME_FILE_EXTENSION);
       Platform::RemoveFileIfExists(m_filePath);
-      base::RenameFileX(m_filePath + DOWNLOADING_FILE_EXTENSION, m_filePath);
+      base::RenameFileX(m_downloadingPath, m_filePath);
     }
 
-    // 4. Finish downloading.
+    // 3. Finish downloading.
     m_onFinish(*this);
   }
 
   void SaveResumeChunks()
   {
-    try
-    {
-      m_writer->Flush();
-      m_strategy.SaveChunks(m_progress.m_bytesTotal, m_filePath + RESUME_FILE_EXTENSION);
-    }
-    catch (Writer::Exception const & e)
-    {
-      LOG(LWARNING, ("Can't flush writer", e.Msg()));
-    }
-  }
-
-  void CloseWriter()
-  {
-    try
-    {
-      m_writer.reset();
-    }
-    catch (Writer::Exception const & e)
-    {
-      LOG(LWARNING, ("Can't close file correctly", e.Msg()));
-      m_status = DownloadStatus::Failed;
-    }
+    // No writer flush needed — each chunk's transport closes its own file handle
+    // before the completion callback fires. Completed chunks are durable on disk
+    // (modulo kernel buffer flushing, same as the historical FileWriter::Flush() path).
+    m_strategy.SaveChunks(m_progress.m_bytesTotal, m_filePath + RESUME_FILE_EXTENSION);
   }
 
 public:
@@ -255,6 +188,7 @@ public:
     , m_strategy(urls)
     , m_alive(std::make_shared<std::atomic<bool>>(true))
     , m_filePath(filePath)
+    , m_downloadingPath(filePath + DOWNLOADING_FILE_EXTENSION)
     , m_goodChunksCount(0)
     , m_doCleanProgressFiles(doCleanProgressFiles)
   {
@@ -269,7 +203,7 @@ public:
     {
       uint64_t size = 0;
       // The file must exist and be large enough to cover all completed chunks.
-      if (base::GetFileSize(filePath + DOWNLOADING_FILE_EXTENSION, size) && size <= static_cast<uint64_t>(fileSize) &&
+      if (base::GetFileSize(m_downloadingPath, size) && size <= static_cast<uint64_t>(fileSize) &&
           static_cast<int64_t>(size) >= m_strategy.RequiredFileSize())
       {
         openMode = FileWriter::OP_WRITE_EXISTING;
@@ -283,9 +217,12 @@ public:
       }
     }
 
-    std::unique_ptr<FileWriter> writer(new FileWriter(filePath + DOWNLOADING_FILE_EXTENSION, openMode));
-    m_writer.swap(writer);
-    Platform::DisableBackupForFile(filePath + DOWNLOADING_FILE_EXTENSION);
+    // Create/validate the .downloading file, then close it immediately. Each chunk's
+    // transport opens its own random-access handle at the chunk's begin offset.
+    {
+      FileWriter writer(m_downloadingPath, openMode);
+    }
+    Platform::DisableBackupForFile(m_downloadingPath);
     StartChunks();
   }
 
@@ -297,14 +234,15 @@ public:
       chunk.m_handle.Cancel();
     m_chunks.clear();
 
-    if (m_status == DownloadStatus::InProgress)
+    // Delete temp files synchronously. Any still-in-flight transport writes will land
+    // on the unlinked inode (POSIX: data goes to limbo, inode reclaimed when last fd
+    // closes) or fail silently (Windows) — either way, no interaction with a potential
+    // new download that reuses the same path. A deferred-cleanup scheme here would
+    // introduce a cancel+retry race where the cleanup deletes the NEW download's file.
+    if (m_status == DownloadStatus::InProgress && m_doCleanProgressFiles)
     {
-      CloseWriter();
-      if (m_doCleanProgressFiles)
-      {
-        Platform::RemoveFileIfExists(m_filePath + DOWNLOADING_FILE_EXTENSION);
-        Platform::RemoveFileIfExists(m_filePath + RESUME_FILE_EXTENSION);
-      }
+      Platform::RemoveFileIfExists(m_downloadingPath);
+      Platform::RemoveFileIfExists(m_filePath + RESUME_FILE_EXTENSION);
     }
   }
 

--- a/libs/platform/platform_tests/http_client_test.cpp
+++ b/libs/platform/platform_tests/http_client_test.cpp
@@ -1115,4 +1115,274 @@ UNIT_TEST(HttpClient_Post_NoContentResponse)
   TEST(result.m_serverResponse.empty(), (result.m_serverResponse));
 }
 
+// =====================================================================
+// SetReceivedFileSegment: ranged streaming into an existing file at offset.
+// Matches Python test_server routes under /unit_tests/segment/*.
+// =====================================================================
+
+// Must match SEGMENT_TEST_TOTAL_SIZE in tools/python/test_server/server/ResponseProvider.py.
+int constexpr kSegmentTestTotalSize = 1000;
+// Must match SEGMENT_TEST_RANGE_END in ResponseProvider.py (inclusive end).
+int64_t constexpr kSegmentTestRangeEnd = 99;
+int64_t constexpr kSegmentTestRangeBytes = kSegmentTestRangeEnd + 1;  // 100 bytes: offsets 0..99.
+
+char constexpr kUrlSegmentOk[] = "http://localhost:34568/unit_tests/segment/ok";
+char constexpr kUrlSegmentIgnoreRange[] = "http://localhost:34568/unit_tests/segment/ignore_range";
+char constexpr kUrlSegmentMissingCR[] = "http://localhost:34568/unit_tests/segment/missing_content_range";
+char constexpr kUrlSegmentShortBody[] = "http://localhost:34568/unit_tests/segment/short_body";
+char constexpr kUrlSegmentOverflowBody[] = "http://localhost:34568/unit_tests/segment/overflow_body";
+char constexpr kUrlSegmentUnknownTotal[] = "http://localhost:34568/unit_tests/segment/unknown_total";
+
+// Create a temp file pre-filled with a known sentinel byte pattern so tests can verify
+// that only the target segment was modified.
+string MakeSegmentTargetFile(uint8_t sentinel)
+{
+  string const path = GetPlatform().TmpPathForFile("http_segment_test_", ".tmp");
+  string const pattern(static_cast<size_t>(kSegmentTestTotalSize), static_cast<char>(sentinel));
+  FileWriter writer(path);
+  writer.Write(pattern.data(), pattern.size());
+  return path;
+}
+
+// The test server's segment_test_body(n) returns bytes i%256 for i in 0..n-1.
+uint8_t ExpectedSegmentByte(int64_t i)
+{
+  return static_cast<uint8_t>(i % 256);
+}
+
+UNIT_TEST(HttpClient_Segment_Success_NonZeroOffset)
+{
+  // Request bytes 200-299 into an existing file; verify only that segment is overwritten.
+  int64_t const offset = 200;
+  int64_t const bytes = 100;
+  string const path = MakeSegmentTargetFile(0xAB);
+
+  HttpClient client(kUrlSegmentOk);
+  client.SetRange(offset, offset + bytes - 1);
+  client.SetReceivedFileSegment({path, offset, bytes, kSegmentTestTotalSize});
+  client.LoadHeaders(true);
+  auto result = RunAsync(client);
+
+  TEST(result.m_success, ("errorCode:", result.m_errorCode));
+  TEST_EQUAL(result.m_errorCode, 206, ());
+  TEST(result.m_serverResponse.empty(), ("segment mode must leave m_serverResponse empty"));
+
+  FileReader reader(path);
+  string data;
+  reader.ReadAsString(data);
+  TEST_EQUAL(static_cast<int64_t>(data.size()), kSegmentTestTotalSize, ());
+  for (int64_t i = 0; i < kSegmentTestTotalSize; ++i)
+  {
+    uint8_t const got = static_cast<uint8_t>(data[i]);
+    uint8_t const expected = (i >= offset && i < offset + bytes) ? ExpectedSegmentByte(i) : 0xAB;
+    TEST_EQUAL(got, expected, ("byte at", i));
+  }
+  base::DeleteFileX(path);
+}
+
+UNIT_TEST(HttpClient_Segment_Success_OpenEndedRange)
+{
+  // SetRange with end=-1 means "from offset to end of resource". The server responds with
+  // Content-Range spanning offset..total-1, so expectedBytes must cover the whole tail.
+  int64_t const offset = 500;
+  int64_t const bytes = kSegmentTestTotalSize - offset;
+  string const path = MakeSegmentTargetFile(0xCD);
+
+  HttpClient client(kUrlSegmentOk);
+  client.SetRange(offset);  // end = -1 → open-ended.
+  client.SetReceivedFileSegment({path, offset, bytes, kSegmentTestTotalSize});
+  client.LoadHeaders(true);
+  auto result = RunAsync(client);
+
+  TEST(result.m_success, ("errorCode:", result.m_errorCode));
+  TEST_EQUAL(result.m_errorCode, 206, ());
+
+  FileReader reader(path);
+  string data;
+  reader.ReadAsString(data);
+  for (int64_t i = offset; i < kSegmentTestTotalSize; ++i)
+    TEST_EQUAL(static_cast<uint8_t>(data[i]), ExpectedSegmentByte(i), ("byte at", i));
+  base::DeleteFileX(path);
+}
+
+UNIT_TEST(HttpClient_Segment_WrongExpectedTotal)
+{
+  // Client claims total size is 9999, server says 1000. Must fail with kInconsistentFileSize
+  // BEFORE any byte is written.
+  string const path = MakeSegmentTargetFile(0xEF);
+
+  HttpClient client(kUrlSegmentOk);
+  client.SetRange(0, kSegmentTestRangeEnd);
+  client.SetReceivedFileSegment({path, 0, kSegmentTestRangeBytes, /*expectedTotal=*/9999});
+  client.LoadHeaders(true);
+  auto result = RunAsync(client);
+
+  TEST(!result.m_success, ());
+  TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
+
+  // File must be unchanged (sentinel bytes preserved).
+  FileReader reader(path);
+  string data;
+  reader.ReadAsString(data);
+  for (size_t i = 0; i < data.size(); ++i)
+    TEST_EQUAL(static_cast<uint8_t>(data[i]), 0xEF, ("byte at", i));
+  base::DeleteFileX(path);
+}
+
+UNIT_TEST(HttpClient_Segment_IgnoredRange_Returns200)
+{
+  // Server ignores Range header and returns 200 + full body. Segment-mode client must
+  // refuse to write and flag the protocol violation.
+  string const path = MakeSegmentTargetFile(0x11);
+
+  HttpClient client(kUrlSegmentIgnoreRange);
+  client.SetRange(0, kSegmentTestRangeEnd);
+  client.SetReceivedFileSegment({path, 0, kSegmentTestRangeBytes, kSegmentTestTotalSize});
+  auto result = RunAsync(client);
+
+  TEST(!result.m_success, ());
+  TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
+
+  // File untouched.
+  FileReader reader(path);
+  string data;
+  reader.ReadAsString(data);
+  for (size_t i = 0; i < data.size(); ++i)
+    TEST_EQUAL(static_cast<uint8_t>(data[i]), 0x11, ("byte at", i));
+  base::DeleteFileX(path);
+}
+
+UNIT_TEST(HttpClient_Segment_MissingContentRange)
+{
+  // Server returns 206 without Content-Range header. RFC 7233 §4.1 violation.
+  string const path = MakeSegmentTargetFile(0x22);
+
+  HttpClient client(kUrlSegmentMissingCR);
+  client.SetRange(0, kSegmentTestRangeEnd);
+  client.SetReceivedFileSegment({path, 0, kSegmentTestRangeBytes, kSegmentTestTotalSize});
+  auto result = RunAsync(client);
+
+  TEST(!result.m_success, ());
+  TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
+
+  FileReader reader(path);
+  string data;
+  reader.ReadAsString(data);
+  for (size_t i = 0; i < data.size(); ++i)
+    TEST_EQUAL(static_cast<uint8_t>(data[i]), 0x22, ("byte at", i));
+  base::DeleteFileX(path);
+}
+
+UNIT_TEST(HttpClient_Segment_ShortBody)
+{
+  // Server advertises 100 bytes via Content-Range but delivers only 50.
+  // Header validation passes; underflow is detected at finish.
+  string const path = MakeSegmentTargetFile(0x33);
+
+  HttpClient client(kUrlSegmentShortBody);
+  client.SetRange(0, kSegmentTestRangeEnd);
+  client.SetReceivedFileSegment({path, 0, kSegmentTestRangeBytes, kSegmentTestTotalSize});
+  auto result = RunAsync(client);
+
+  TEST(!result.m_success, ());
+  TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
+  base::DeleteFileX(path);
+}
+
+UNIT_TEST(HttpClient_Segment_OverflowBody)
+{
+  // Server advertises 100 bytes via Content-Range but delivers 150.
+  // Overflow is detected mid-stream and the request is aborted.
+  string const path = MakeSegmentTargetFile(0x44);
+
+  HttpClient client(kUrlSegmentOverflowBody);
+  client.SetRange(0, kSegmentTestRangeEnd);
+  client.SetReceivedFileSegment({path, 0, kSegmentTestRangeBytes, kSegmentTestTotalSize});
+  auto result = RunAsync(client);
+
+  TEST(!result.m_success, ());
+  TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
+  base::DeleteFileX(path);
+}
+
+UNIT_TEST(HttpClient_Segment_UnknownTotal_Rejected)
+{
+  // Server returns 206 with "Content-Range: bytes 0-99/*" and a 100-byte body.
+  // The range start/end match, but the total is "*". When the caller supplied an
+  // expected total size, this must fail: a mirror could serve a byte-range from
+  // a different file version that happens to match offset/length, and we'd silently
+  // write corrupt data. Matches the pre-segment-rewrite downloader behavior, which
+  // rejected Content-Range values without a numeric total.
+  string const path = MakeSegmentTargetFile(0x66);
+
+  HttpClient client(kUrlSegmentUnknownTotal);
+  client.SetRange(0, kSegmentTestRangeEnd);
+  client.SetReceivedFileSegment({path, 0, kSegmentTestRangeBytes, kSegmentTestTotalSize});
+  auto result = RunAsync(client);
+
+  TEST(!result.m_success, ());
+  TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
+
+  // File untouched — no bytes written before validation failure.
+  FileReader reader(path);
+  string data;
+  reader.ReadAsString(data);
+  for (size_t i = 0; i < data.size(); ++i)
+    TEST_EQUAL(static_cast<uint8_t>(data[i]), 0x66, ("byte at", i));
+  base::DeleteFileX(path);
+}
+
+UNIT_TEST(HttpClient_Segment_404_PreservesHttpCode)
+{
+  // 404 for a ranged request must surface as errorCode=404 so the downloader can
+  // distinguish FileNotFound from other failures (kInconsistentFileSize, kWriteException).
+  string const path = MakeSegmentTargetFile(0x55);
+
+  HttpClient client(kTestUrl404);
+  client.SetRange(0, kSegmentTestRangeEnd);
+  client.SetReceivedFileSegment({path, 0, kSegmentTestRangeBytes, kSegmentTestTotalSize});
+  auto result = RunAsync(client);
+
+  TEST(!result.m_success, ());
+  TEST_EQUAL(result.m_errorCode, 404, ("404 must propagate, not become kInconsistentFileSize"));
+  base::DeleteFileX(path);
+}
+
+UNIT_TEST(HttpClient_Segment_MissingTarget_WriteException)
+{
+  // Segment mode requires the target file to already exist (m_writer creates the
+  // .downloading file before chunks start). If the file is missing, opening with
+  // ExistingOnly fails → kWriteException.
+  string const path = GetPlatform().TmpPathForFile("http_segment_missing_", ".tmp");
+  // Do NOT create the file.
+
+  HttpClient client(kUrlSegmentOk);
+  client.SetRange(0, kSegmentTestRangeEnd);
+  client.SetReceivedFileSegment({path, 0, kSegmentTestRangeBytes, kSegmentTestTotalSize});
+  auto result = RunAsync(client);
+
+  TEST(!result.m_success, ());
+  TEST_EQUAL(result.m_errorCode, HttpClient::kWriteException, ());
+}
+
+UNIT_TEST(HttpClient_Segment_NoSegment_ExistingBehaviorUnchanged)
+{
+  // Regression guard: without SetReceivedFileSegment, SetReceivedFile still truncates
+  // and writes the full body as before.
+  string const path = GetPlatform().TmpPathForFile("http_segment_regression_", ".tmp");
+
+  HttpClient client(kTestUrl1);
+  client.SetReceivedFile(path);
+  auto result = RunAsync(client);
+  TEST(result.m_success, ("errorCode:", result.m_errorCode));
+  TEST_EQUAL(result.m_errorCode, 200, ());
+  TEST(result.m_serverResponse.empty(), ());
+
+  FileReader reader(path);
+  string data;
+  reader.ReadAsString(data);
+  TEST_EQUAL(data, "Test1", ());
+  base::DeleteFileX(path);
+}
+
 }  // namespace http_client_test

--- a/tools/python/test_server/server/ResponseProvider.py
+++ b/tools/python/test_server/server/ResponseProvider.py
@@ -167,6 +167,14 @@ class ResponseProvider:
                 "/unit_tests/basic_auth": self.test_basic_auth,
                 "/unit_tests/set_cookies_lowercase": self.test_set_cookies_lowercase,
                 "/unit_tests/set_cookies_uppercase": self.test_set_cookies_uppercase,
+                # Segment-mode (ReceivedFileSegment) failure routes.
+                # SEGMENT_TEST_TOTAL_SIZE (1000) is the advertised total file size.
+                "/unit_tests/segment/ignore_range": self.test_segment_ignore_range,
+                "/unit_tests/segment/missing_content_range": self.test_segment_missing_content_range,
+                "/unit_tests/segment/short_body": self.test_segment_short_body,
+                "/unit_tests/segment/overflow_body": self.test_segment_overflow_body,
+                "/unit_tests/segment/unknown_total": self.test_segment_unknown_total,
+                "/unit_tests/segment/ok": self.test_segment_ok,
             }.get(url, self.test_404)()
         except Exception as e:
             logging.error("test_server: Can't build server response", exc_info=e)
@@ -347,6 +355,59 @@ class ResponseProvider:
     def test_set_cookies_uppercase(self):
         """Return Set-Cookie with all-uppercase header name."""
         return Payload("ok", 200, {"SET-COOKIE": "upper=yes; Path=/"})
+
+    # --- Segment-mode (ReceivedFileSegment) failure-injection routes. ---
+    # These routes exist to test HttpClient::SetReceivedFileSegment error handling.
+    # SEGMENT_TEST_TOTAL_SIZE must match the value in http_client_test.cpp.
+    SEGMENT_TEST_TOTAL_SIZE = 1000
+    SEGMENT_TEST_RANGE_END = 99  # Inclusive end of the test range (100 bytes: 0-99).
+
+    def segment_test_body(self, size):
+        """Returns a deterministic byte sequence of the given size (values 0,1,2,...,255,0,...)."""
+        return bytes(i % 256 for i in range(size))
+
+    def test_segment_ignore_range(self):
+        """Always returns 200 OK with the full file body, ignoring any Range header.
+        Simulates a mis-configured mirror that doesn't honor partial requests.
+        Segment-mode clients must detect this and fail with kInconsistentFileSize
+        before any byte is written to the target file."""
+        body = self.segment_test_body(self.SEGMENT_TEST_TOTAL_SIZE)
+        return Payload(body, 200, {})
+
+    def test_segment_missing_content_range(self):
+        """Returns 206 Partial Content but WITHOUT a Content-Range header.
+        Spec violation per RFC 7233 §4.1 - segment-mode clients must reject this."""
+        body = self.segment_test_body(self.SEGMENT_TEST_RANGE_END + 1)
+        return Payload(body, 206, {})
+
+    def test_segment_short_body(self):
+        """Returns 206 with Content-Range advertising 100 bytes (0-99/1000), but the
+        body has only 50 bytes. Tests segment-underflow detection at finish."""
+        body = self.segment_test_body(50)
+        return Payload(body, 206, {"Content-Range": "bytes 0-{end}/{total}".format(
+            end=self.SEGMENT_TEST_RANGE_END, total=self.SEGMENT_TEST_TOTAL_SIZE)})
+
+    def test_segment_overflow_body(self):
+        """Returns 206 with Content-Range advertising 100 bytes (0-99/1000), but the
+        body has 150 bytes. Tests segment-overflow detection (abort mid-stream)."""
+        body = self.segment_test_body(150)
+        return Payload(body, 206, {"Content-Range": "bytes 0-{end}/{total}".format(
+            end=self.SEGMENT_TEST_RANGE_END, total=self.SEGMENT_TEST_TOTAL_SIZE)})
+
+    def test_segment_unknown_total(self):
+        """Returns 206 with Content-Range: bytes 0-99/* and a correct 100-byte body.
+        RFC 7233 allows "*" for unknown total, but segment-mode clients that supply
+        an expected total must reject it (different file version / mirror drift)."""
+        body = self.segment_test_body(self.SEGMENT_TEST_RANGE_END + 1)
+        return Payload(body, 206, {"Content-Range": "bytes 0-{end}/*".format(end=self.SEGMENT_TEST_RANGE_END)})
+
+    def test_segment_ok(self):
+        """Returns 206 with correct Content-Range and exact byte count. Happy-path
+        reference. Honors the Range header like test1/test_47_kb via chunk_requested()."""
+        body = self.segment_test_body(self.SEGMENT_TEST_TOTAL_SIZE)
+        self.check_byterange(self.SEGMENT_TEST_TOTAL_SIZE)
+        headers = self.chunked_response_header(self.SEGMENT_TEST_TOTAL_SIZE)
+        return Payload(self.trim_message(body), self.response_code, headers)
 
     def kill(self):
         logging.debug("Kill called in ResponseProvider")


### PR DESCRIPTION
- Fixes an OOM on Android
- Separates segments/chunks download on all platforms
- Stricter chunk validation and corner-case handling
- Tests coverage
- Updated gradle to the latest version to fix errors in the latest Android Studio