### PR TITLE
[ios] Check bm/track existence before deletion from the list

### DIFF
--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInteractor.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInteractor.swift
@@ -122,10 +122,18 @@ extension BookmarksListInteractor: IBookmarksListInteractor {
   }
 
   func deleteBookmark(_ bookmarkId: MWMMarkID) {
+    guard bookmarksManager.hasBookmark(bookmarkId) else {
+      LOG(.error, "Bookmark \(bookmarkId) does not exist")
+      return
+    }
     bookmarksManager.deleteBookmark(bookmarkId)
   }
 
   func deleteTrack(_ trackId: MWMTrackID) {
+    guard bookmarksManager.hasTrack(trackId) else {
+      LOG(.error, "Track \(trackId) does not exist")
+      return
+    }
     bookmarksManager.deleteTrack(trackId)
   }
 


### PR DESCRIPTION
Should fix the crash with trailing swipe deletion.
<img width="500" height="1012" alt="image" src="https://github.com/user-attachments/assets/3f8ae99a-1b62-49f8-b3b1-d2f4f5d03118" />
