### PR TITLE
[platform] Drop internal logging from GetFile{Creation,Modification}Time

### DIFF
--- a/iphone/CoreApi/CoreApi/Bookmarks/RecentlyDeletedCategory/RecentlyDeletedCategory.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/RecentlyDeletedCategory/RecentlyDeletedCategory.mm
@@ -3,6 +3,8 @@
 #include <platform/platform_ios.h>
 #include <map/bookmark_helpers.hpp>
 
+#include "base/logging.hpp"
+
 @implementation RecentlyDeletedCategory
 
 - (instancetype)initTitle:(NSString *)title fileURL:(NSURL *)fileURL deletionDate:(NSDate *)deletionDate
@@ -30,8 +32,16 @@
     _title = [NSString stringWithCString:name.c_str() encoding:NSUTF8StringEncoding];
     auto const pathString = [NSString stringWithCString:filePath.c_str() encoding:NSUTF8StringEncoding];
     _fileURL = [NSURL fileURLWithPath:pathString];
-    NSTimeInterval creationTime = Platform::GetFileCreationTime(filePath);
-    _deletionDate = [NSDate dateWithTimeIntervalSince1970:creationTime];
+    auto const creationTime = Platform::GetFileCreationTime(filePath);
+    if (creationTime > 0)
+    {
+      _deletionDate = [NSDate dateWithTimeIntervalSince1970:static_cast<NSTimeInterval>(creationTime)];
+    }
+    else
+    {
+      LOG(LWARNING, ("GetFileCreationTime failed for", filePath, "- using current time as deletion date"));
+      _deletionDate = [NSDate date];
+    }
   }
   return self;
 }

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -246,7 +246,11 @@ bool GetSortingType(std::string const & typeStr, BookmarkManager::SortingType & 
 
 kml::Timestamp FileModificationTimestamp(std::string const & fullFilePath)
 {
-  return kml::TimestampClock::from_time_t(Platform::GetFileModificationTime(fullFilePath));
+  auto const t = Platform::GetFileModificationTime(fullFilePath);
+  if (t > 0)
+    return kml::TimestampClock::from_time_t(t);
+  LOG(LWARNING, ("GetFileModificationTime failed for", fullFilePath, "- using current time"));
+  return kml::TimestampClock::now();
 }
 }  // namespace
 

--- a/libs/platform/platform.hpp
+++ b/libs/platform/platform.hpp
@@ -224,9 +224,11 @@ public:
   static bool GetFileSizeByFullPath(std::string const & filePath, uint64_t & size);
   //@}
 
-  /// @return 0 in case of failure.
+  /// @return 0 if the file does not exist or cannot be stat'd.
+  /// On Linux, when the underlying filesystem does not expose birth time, returns the earliest
+  /// of atime/mtime/ctime as a fallback (see Orbstack issue #2064).
   static time_t GetFileCreationTime(std::string const & path);
-  /// @return 0 in case of failure.
+  /// @return 0 if the file does not exist or cannot be stat'd.
   static time_t GetFileModificationTime(std::string const & path);
   /// @return true on success.
   static bool SetFileModificationTime(std::string const & path, time_t modTime);

--- a/libs/platform/platform_android.cpp
+++ b/libs/platform/platform_android.cpp
@@ -230,12 +230,11 @@ void Platform::GetSystemFontNames(FilesList & res) const
 // static
 time_t Platform::GetFileCreationTime(std::string const & path)
 {
+  // Note: Android's plain stat() does not expose birth time. Using st_atim as an approximation
+  // is a pre-existing behavior quirk; statx would require API >= 30 (current minSdk is 21).
   struct stat st;
   if (0 == stat(path.c_str(), &st))
     return st.st_atim.tv_sec;
-
-  LOG(LERROR, ("GetFileCreationTime stat failed for", path, "with error", strerror(errno)));
-  // TODO(AB): Refactor to return std::optional<time_t>.
   return 0;
 }
 
@@ -245,9 +244,6 @@ time_t Platform::GetFileModificationTime(std::string const & path)
   struct stat st;
   if (0 == stat(path.c_str(), &st))
     return st.st_mtim.tv_sec;
-
-  LOG(LERROR, ("GetFileModificationTime stat failed for", path, "with error", strerror(errno)));
-  // TODO(AB): Refactor to return std::optional<time_t>.
   return 0;
 }
 

--- a/libs/platform/platform_linux.cpp
+++ b/libs/platform/platform_linux.cpp
@@ -268,24 +268,16 @@ time_t Platform::GetFileCreationTime(std::string const & path)
   if (0 == statx(AT_FDCWD, path.c_str(), 0, STATX_BTIME, &st))
   {
     // Orbstack on MacOS returns zero birth time, see https://github.com/orbstack/orbstack/issues/2064
-    if (st.stx_btime.tv_sec != 0)
+    if ((st.stx_mask & STATX_BTIME) && st.stx_btime.tv_sec != 0)
       return st.stx_btime.tv_sec;
-
-    LOG(LWARNING, ("statx returned zero birth time for", path,
-                   ", using the earliest time from access, modification or status change instead."));
+    // Filesystem does not expose birth time; fall back to the earliest of access/mod/ctime.
     return std::min(st.stx_atime.tv_sec, std::min(st.stx_mtime.tv_sec, st.stx_ctime.tv_sec));
   }
-
-  // Possible for example when settings.ini is absent (unit tests or the first launch).
-  LOG(LWARNING, ("GetFileCreationTime statx failed for", path, "with error", strerror(errno)));
 #else
   struct stat st;
   if (0 == stat(path.c_str(), &st))
     return std::min(st.st_atim.tv_sec, st.st_mtim.tv_sec);
-
-  LOG(LERROR, ("GetFileCreationTime stat failed for", path, "with error", strerror(errno)));
 #endif
-  // TODO(AB): Refactor to return std::optional<time_t>.
   return 0;
 }
 
@@ -295,9 +287,6 @@ time_t Platform::GetFileModificationTime(std::string const & path)
   struct stat st;
   if (0 == stat(path.c_str(), &st))
     return st.st_mtim.tv_sec;
-
-  LOG(LERROR, ("GetFileModificationTime stat failed for", path, "with error", strerror(errno)));
-  // TODO(AB): Refactor to return std::optional<time_t>.
   return 0;
 }
 

--- a/libs/platform/platform_mac.mm
+++ b/libs/platform/platform_mac.mm
@@ -190,10 +190,6 @@ time_t Platform::GetFileCreationTime(std::string const & path)
   struct stat st;
   if (0 == stat(path.c_str(), &st))
     return st.st_birthtimespec.tv_sec;
-
-  // Possible for example when settings.ini is absent (unit tests or the first launch).
-  LOG(LWARNING, ("GetFileCreationTime stat failed for", path, "with error", strerror(errno)));
-  // TODO(AB): Refactor to return std::optional<time_t>.
   return 0;
 }
 
@@ -203,9 +199,6 @@ time_t Platform::GetFileModificationTime(std::string const & path)
   struct stat st;
   if (0 == stat(path.c_str(), &st))
     return st.st_mtimespec.tv_sec;
-
-  LOG(LERROR, ("GetFileModificationTime stat failed for", path, "with error", strerror(errno)));
-  // TODO(AB): Refactor to return std::optional<time_t>.
   return 0;
 }
 

--- a/libs/platform/platform_tests/platform_test.cpp
+++ b/libs/platform/platform_tests/platform_test.cpp
@@ -327,3 +327,14 @@ UNIT_TEST(SetFileModificationTime)
   TEST(Platform::SetFileModificationTime(fileName, targetTime), ());
   TEST_EQUAL(Platform::GetFileModificationTime(fileName), targetTime, ());
 }
+
+UNIT_TEST(GetFileCreationTime_GetFileModificationTime_MissingFile)
+{
+  std::string const missing = GetPlatform().WritablePathForFile("this-file-definitely-does-not-exist.xyz");
+  // Ensure it's gone before we assert, without logging noise for the common case.
+  if (Platform::IsFileExistsByFullPath(missing))
+    base::DeleteFileX(missing);
+
+  TEST_EQUAL(Platform::GetFileCreationTime(missing), 0, ());
+  TEST_EQUAL(Platform::GetFileModificationTime(missing), 0, ());
+}

--- a/libs/platform/platform_win.cpp
+++ b/libs/platform/platform_win.cpp
@@ -220,10 +220,7 @@ time_t GetFileTime(std::string const & path, FileTimeType fileTimeType)
 {
   HANDLE hFile = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
   if (hFile == INVALID_HANDLE_VALUE)
-  {
-    LOG(LERROR, ("GetFileTime CreateFileA failed for", path, "with error", strerror(errno)));
-    return 0;  // TODO(AB): Refactor to return std::optional<time_t>.
-  }
+    return 0;
 
   SCOPE_GUARD(autoClose, std::bind_front(&CloseHandle, hFile));
 
@@ -238,10 +235,7 @@ time_t GetFileTime(std::string const & path, FileTimeType fileTimeType)
   }
 
   if (!::GetFileTime(hFile, ftCreate, nullptr, ftLastWrite))
-  {
-    LOG(LERROR, ("GetFileTime ::GetFileTime failed for", path, "with error", strerror(errno)));
-    return 0;  // TODO(AB): Refactor to return std::optional<time_t>.
-  }
+    return 0;
 
   ULARGE_INTEGER ull;
   ull.LowPart = ft.dwLowDateTime;
@@ -253,14 +247,12 @@ time_t GetFileTime(std::string const & path, FileTimeType fileTimeType)
 // static
 time_t Platform::GetFileCreationTime(std::string const & path)
 {
-  // TODO(AB): Refactor to return std::optional<time_t>.
   return GetFileTime(path, FileTimeType::Creation);
 }
 
 // static
 time_t Platform::GetFileModificationTime(std::string const & path)
 {
-  // TODO(AB): Refactor to return std::optional<time_t>.
   return GetFileTime(path, FileTimeType::Modification);
 }
 


### PR DESCRIPTION
Previously the Android/Linux/macOS/Windows implementations logged LERROR from inside the stat failure path. This produced noise during unit tests and on first launch when settings.ini does not yet exist (UsageStats::UsageStats called it unconditionally).

The public API keeps its 0-as-no-time return contract, so call sites stay simple; this change is purely about silencing platform-level logging and giving callers a chance to decide the right fallback.

- Android/Linux/macOS/Windows drop internal logging; callers decide.
- Linux combines the STATX_BTIME mask check with the Orbstack tv_sec != 0 guard so that filesystems without birth-time support and Orbstack's zero-btime quirk both fall through to the atime/mtime/ctime fallback (see https://github.com/orbstack/orbstack/issues/2064).
- Windows helper also returns 0 on failure; both public wrappers forward it.
- bookmark_manager.cpp's FileModificationTimestamp now falls back to kml::TimestampClock::now() (plus a warning log) instead of silently returning the epoch timestamp on stat failure.
- iOS RecentlyDeletedCategory now falls back to [NSDate date] (plus a warning) instead of silently showing 1970-01-01.
- Added GetFileCreationTime_GetFileModificationTime_MissingFile unit test as a regression guard against reintroducing logging or a non-zero sentinel on a missing file.