### PR TITLE
[tests] Change default HTTP port for tests

### DIFF
--- a/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
+++ b/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
@@ -25,9 +25,9 @@ using namespace downloader;
 using namespace std::placeholders;
 using std::bind, std::string, std::vector;
 
-char constexpr kTestUrl1[] = "http://localhost:34568/unit_tests/1.txt";
-char constexpr kTestUrl404[] = "http://localhost:34568/unit_tests/notexisting_unittest";
-char constexpr kTestUrlBigFile[] = "http://localhost:34568/unit_tests/47kb.file";
+char constexpr kTestUrl1[] = "http://localhost:24568/unit_tests/1.txt";
+char constexpr kTestUrl404[] = "http://localhost:24568/unit_tests/notexisting_unittest";
+char constexpr kTestUrlBigFile[] = "http://localhost:24568/unit_tests/47kb.file";
 
 // Should match file size in tools/python/ResponseProvider.py
 int constexpr kBigFileSize = 47684;

--- a/libs/platform/platform_tests/http_client_test.cpp
+++ b/libs/platform/platform_tests/http_client_test.cpp
@@ -23,18 +23,18 @@ namespace http_client_test
 using namespace platform;
 using std::string;
 
-char constexpr kTestUrl1[] = "http://localhost:34568/unit_tests/1.txt";
-char constexpr kTestUrl404[] = "http://localhost:34568/unit_tests/notexisting_unittest";
-char constexpr kTestUrlBigFile[] = "http://localhost:34568/unit_tests/47kb.file";
-char constexpr kTestUrlEchoHeaders[] = "http://localhost:34568/unit_tests/echo_headers";
-char constexpr kTestUrlEchoCookies[] = "http://localhost:34568/unit_tests/echo_cookies";
-char constexpr kTestUrlTimeout[] = "http://localhost:34568/unit_tests/timeout";
-char constexpr kTestUrl500[] = "http://localhost:34568/unit_tests/500";
-char constexpr kTestUrl403[] = "http://localhost:34568/unit_tests/403";
-char constexpr kTestUrlRedirect[] = "http://localhost:34568/unit_tests/redirect_to_1txt";
-char constexpr kTestUrlSetCookies[] = "http://localhost:34568/unit_tests/set_cookies";
-char constexpr kTestUrlMultiSetCookies[] = "http://localhost:34568/unit_tests/multi_set_cookies";
-char constexpr kTestUrlPost[] = "http://localhost:34568/unit_tests/post.php";
+char constexpr kTestUrl1[] = "http://localhost:24568/unit_tests/1.txt";
+char constexpr kTestUrl404[] = "http://localhost:24568/unit_tests/notexisting_unittest";
+char constexpr kTestUrlBigFile[] = "http://localhost:24568/unit_tests/47kb.file";
+char constexpr kTestUrlEchoHeaders[] = "http://localhost:24568/unit_tests/echo_headers";
+char constexpr kTestUrlEchoCookies[] = "http://localhost:24568/unit_tests/echo_cookies";
+char constexpr kTestUrlTimeout[] = "http://localhost:24568/unit_tests/timeout";
+char constexpr kTestUrl500[] = "http://localhost:24568/unit_tests/500";
+char constexpr kTestUrl403[] = "http://localhost:24568/unit_tests/403";
+char constexpr kTestUrlRedirect[] = "http://localhost:24568/unit_tests/redirect_to_1txt";
+char constexpr kTestUrlSetCookies[] = "http://localhost:24568/unit_tests/set_cookies";
+char constexpr kTestUrlMultiSetCookies[] = "http://localhost:24568/unit_tests/multi_set_cookies";
+char constexpr kTestUrlPost[] = "http://localhost:24568/unit_tests/post.php";
 
 int constexpr kBigFileSize = 47684;
 
@@ -806,7 +806,7 @@ UNIT_TEST(HttpClient_Cancel_Idempotent)
 // Basic Auth (SetUserAndPassword)
 // =====================================================================
 
-char constexpr kTestUrlBasicAuth[] = "http://localhost:34568/unit_tests/basic_auth";
+char constexpr kTestUrlBasicAuth[] = "http://localhost:24568/unit_tests/basic_auth";
 
 UNIT_TEST(HttpClient_BasicAuth_Success)
 {
@@ -877,8 +877,8 @@ UNIT_TEST(HttpClient_MultiSetCookies)
 // Case-insensitive Set-Cookie header parsing
 // =====================================================================
 
-char constexpr kTestUrlSetCookiesLower[] = "http://localhost:34568/unit_tests/set_cookies_lowercase";
-char constexpr kTestUrlSetCookiesUpper[] = "http://localhost:34568/unit_tests/set_cookies_uppercase";
+char constexpr kTestUrlSetCookiesLower[] = "http://localhost:24568/unit_tests/set_cookies_lowercase";
+char constexpr kTestUrlSetCookiesUpper[] = "http://localhost:24568/unit_tests/set_cookies_uppercase";
 
 UNIT_TEST(HttpClient_SetCookie_LowercaseHeader)
 {
@@ -1101,7 +1101,7 @@ UNIT_TEST(HttpClient_Post_BodyData_ResponseToFile)
 // Regression: POST to 204 No Content must not return request body as response
 // =====================================================================
 
-char constexpr kTestUrl204[] = "http://localhost:34568/unit_tests/204";
+char constexpr kTestUrl204[] = "http://localhost:24568/unit_tests/204";
 
 UNIT_TEST(HttpClient_Post_NoContentResponse)
 {
@@ -1126,12 +1126,12 @@ int constexpr kSegmentTestTotalSize = 1000;
 int64_t constexpr kSegmentTestRangeEnd = 99;
 int64_t constexpr kSegmentTestRangeBytes = kSegmentTestRangeEnd + 1;  // 100 bytes: offsets 0..99.
 
-char constexpr kUrlSegmentOk[] = "http://localhost:34568/unit_tests/segment/ok";
-char constexpr kUrlSegmentIgnoreRange[] = "http://localhost:34568/unit_tests/segment/ignore_range";
-char constexpr kUrlSegmentMissingCR[] = "http://localhost:34568/unit_tests/segment/missing_content_range";
-char constexpr kUrlSegmentShortBody[] = "http://localhost:34568/unit_tests/segment/short_body";
-char constexpr kUrlSegmentOverflowBody[] = "http://localhost:34568/unit_tests/segment/overflow_body";
-char constexpr kUrlSegmentUnknownTotal[] = "http://localhost:34568/unit_tests/segment/unknown_total";
+char constexpr kUrlSegmentOk[] = "http://localhost:24568/unit_tests/segment/ok";
+char constexpr kUrlSegmentIgnoreRange[] = "http://localhost:24568/unit_tests/segment/ignore_range";
+char constexpr kUrlSegmentMissingCR[] = "http://localhost:24568/unit_tests/segment/missing_content_range";
+char constexpr kUrlSegmentShortBody[] = "http://localhost:24568/unit_tests/segment/short_body";
+char constexpr kUrlSegmentOverflowBody[] = "http://localhost:24568/unit_tests/segment/overflow_body";
+char constexpr kUrlSegmentUnknownTotal[] = "http://localhost:24568/unit_tests/segment/unknown_total";
 
 // Create a temp file pre-filled with a known sentinel byte pattern so tests can verify
 // that only the target segment was modified.

--- a/libs/storage/storage_tests/test_map_files_downloader.cpp
+++ b/libs/storage/storage_tests/test_map_files_downloader.cpp
@@ -4,6 +4,6 @@ namespace storage
 {
 TestMapFilesDownloader::TestMapFilesDownloader() : HttpMapFilesDownloader()
 {
-  SetServersList({"http://localhost:34568/unit_tests/"});
+  SetServersList({"http://localhost:24568/unit_tests/"});
 }
 }  // namespace storage

--- a/tools/python/test_server/server/ResponseProvider.py
+++ b/tools/python/test_server/server/ResponseProvider.py
@@ -326,7 +326,7 @@ class ResponseProvider:
         return Payload("Forbidden", response_code=403)
 
     def test_redirect_to_1txt(self):
-        return Payload("", 301, {"Location": "http://localhost:34568/unit_tests/1.txt"})
+        return Payload("", 301, {"Location": "http://localhost:24568/unit_tests/1.txt"})
 
     def test_set_cookies(self):
         return Payload("ok", 200, {"Set-Cookie": "session=abc123; Path=/"})

--- a/tools/python/test_server/server/config.py
+++ b/tools/python/test_server/server/config.py
@@ -1,4 +1,4 @@
-PORT = 34568
+PORT = 24568
 
 # timeout for the self destruction timer - how much time
 # passes between the last request and the server killing

--- a/tools/python/test_server/start_server.py
+++ b/tools/python/test_server/start_server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import http.client
 import os
 import subprocess
 import sys
@@ -70,7 +71,7 @@ while True:
                 f"/id returned pid {body!r}, expected {proc.pid} "
                 f"(another server bound to {PORT}?)"
             )
-    except (urllib.error.URLError, TimeoutError, OSError) as ex:
+    except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException) as ex:
         last_error = ex
 
     if time.perf_counter() - start_time >= TIMEOUT_SECONDS:


### PR DESCRIPTION
The previous port matched the ephemeral client ports range and led to failures like [this one on Linux CI](https://github.com/organicmaps/organicmaps/actions/runs/24265983753/job/70860921815#step:13:20):

```
4/35 Test  #1: OmimStartTestServer ..............***Failed    0.27 sec
Traceback (most recent call last):
  File "/home/runner/work/organicmaps/organicmaps/tools/python/test_server/start_server.py", line 62, in <module>
    with urllib.request.urlopen(READY_URL, timeout=1.0) as response:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/request.py", line 215, in urlopen
    return opener.open(url, data, timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/request.py", line 515, in open
    response = self._open(req, data)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/request.py", line 532, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/request.py", line 492, in _call_chain
    result = func(*args)
             ^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/request.py", line 1373, in http_open
    return self.do_open(http.client.HTTPConnection, req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/request.py", line 1348, in do_open
    r = h.getresponse()
        ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/http/client.py", line 1448, in getresponse
    response.begin()
  File "/usr/lib/python3.12/http/client.py", line 336, in begin
    version, status, reason = self._read_status()
                              ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/http/client.py", line 318, in _read_status
    raise BadStatusLine(line)
http.client.BadStatusLine: GET /id HTTP/1.1
```