### PR TITLE
[rendering] Fix route not rendered after horizontal world wrap

### DIFF
--- a/libs/drape/overlay_handle.cpp
+++ b/libs/drape/overlay_handle.cpp
@@ -1,12 +1,12 @@
 #include "drape/overlay_handle.hpp"
 
-#include "base/internal/message.hpp"
 #include "base/macros.hpp"
 
 #include "indexer/drawing_rule_def.hpp"
 
+#include "geometry/mercator.hpp"
+
 #include <algorithm>
-#include <sstream>
 
 namespace dp
 {
@@ -174,7 +174,12 @@ m2::RectD SquareHandle::GetPixelRect(ScreenBase const & screen, bool perspective
   if (perspective)
     return GetPixelRectPerspective(screen);
 
-  m2::PointD const pxPivot = screen.GtoP(m_gbPivot) + m_pxOffset;
+  // Tile-base coordinates already have valid alignment via the tile offset and tile-based identity.
+  m2::PointD gbPivot = m_gbPivot;
+  if (m_id.m_tileCoords == OverlayID::NoCoordinates())
+    gbPivot.x = mercator::NearestWrapX(gbPivot.x, screen.GetOrg().x);
+
+  m2::PointD const pxPivot = screen.GtoP(gbPivot) + m_pxOffset;
   m2::RectD result(pxPivot - m_pxHalfSize, pxPivot + m_pxHalfSize);
   m2::PointD offset(0.0, 0.0);
 

--- a/libs/drape/overlay_handle.hpp
+++ b/libs/drape/overlay_handle.hpp
@@ -39,9 +39,12 @@ uint64_t constexpr kPriorityMaskAll = std::numeric_limits<uint64_t>::max();
 
 struct OverlayID
 {
+  // Should be the same as TileKey::NoCoordinates()
+  static m2::PointI NoCoordinates() { return {-1, -1}; }
+
   FeatureID m_featureId;
   kml::MarkId m_markId = kml::kInvalidMarkId;
-  m2::PointI m_tileCoords{-1, -1};
+  m2::PointI m_tileCoords = NoCoordinates();
   uint32_t m_index = 0;
 
   OverlayID() = default;

--- a/libs/drape/overlay_tree.cpp
+++ b/libs/drape/overlay_tree.cpp
@@ -3,6 +3,8 @@
 #include "drape/constants.hpp"
 #include "drape/debug_renderer.hpp"
 
+#include "geometry/mercator.hpp"
+
 #include <algorithm>
 
 namespace dp
@@ -461,9 +463,11 @@ bool OverlayTree::GetSelectedFeatureRect(ScreenBase const & screen, m2::RectD & 
   return false;
 }
 
-void OverlayTree::Select(m2::PointD const & glbPoint, TOverlayContainer & result) const
+void OverlayTree::Select(m2::PointD glbPoint, TOverlayContainer & result) const
 {
   ScreenBase const & screen = GetModelView();
+
+  glbPoint.x = mercator::NearestWrapX(glbPoint.x, screen.GetOrg().x);
   m2::PointD const pxPoint = screen.GtoP(glbPoint);
 
   double const kSearchRectHalfSize = 10.0;

--- a/libs/drape/overlay_tree.hpp
+++ b/libs/drape/overlay_tree.hpp
@@ -9,7 +9,6 @@
 #include "base/buffer_vector.hpp"
 
 #include <array>
-#include <memory>
 #include <unordered_set>
 #include <vector>
 
@@ -72,7 +71,7 @@ public:
   HandlesCache const & GetHandlesCache() const { return m_handlesCache; }
 
   void Select(m2::RectD const & rect, TOverlayContainer & result) const;
-  void Select(m2::PointD const & glbPoint, TOverlayContainer & result) const;
+  void Select(m2::PointD glbPoint, TOverlayContainer & result) const;
 
   void SetDisplacementEnabled(bool enabled);
 

--- a/libs/drape_frontend/colored_symbol_shape.cpp
+++ b/libs/drape_frontend/colored_symbol_shape.cpp
@@ -74,9 +74,8 @@ ColoredSymbolShape::ColoredSymbolShape(m2::PointD const & mercatorPt, ColoredSym
                                        TileKey const & tileKey, uint32_t textIndex, bool needOverlay)
   : m_point(mercatorPt)
   , m_params(params)
-  , m_tileCoords(tileKey.GetTileCoords())
+  , m_tile(tileKey)
   , m_textIndex(textIndex)
-  , m_tileXOffset(tileKey.GetTileXOffset())
   , m_needOverlay(needOverlay)
 {}
 
@@ -85,9 +84,8 @@ ColoredSymbolShape::ColoredSymbolShape(m2::PointD const & mercatorPt, ColoredSym
                                        std::vector<m2::PointF> const & overlaySizes)
   : m_point(mercatorPt)
   , m_params(params)
-  , m_tileCoords(tileKey.GetTileCoords())
+  , m_tile(tileKey)
   , m_textIndex(textIndex)
-  , m_tileXOffset(tileKey.GetTileXOffset())
   , m_needOverlay(true)
   , m_overlaySizes(overlaySizes)
 {}
@@ -267,13 +265,12 @@ void ColoredSymbolShape::Draw(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::
   if (buffer.empty())
     return;
 
-  dp::OverlayID overlayId(m_params.m_featureId, m_params.m_markId, m_tileCoords, m_textIndex);
-
-  m2::PointD const pivot(m_point.x + m_tileXOffset, m_point.y);
-
   drape_ptr<dp::OverlayHandle> handle;
   if (m_needOverlay)
   {
+    dp::OverlayID overlayId(m_params.m_featureId, m_params.m_markId, m_tile.coords, m_textIndex);
+    m2::PointD const pivot(m_point.x + m_tile.xOffset, m_point.y);
+
     if (!m_overlaySizes.empty())
     {
       handle = make_unique_dp<DynamicSquareHandle>(

--- a/libs/drape_frontend/colored_symbol_shape.hpp
+++ b/libs/drape_frontend/colored_symbol_shape.hpp
@@ -25,9 +25,8 @@ private:
 
   m2::PointD const m_point;
   ColoredSymbolViewParams m_params;
-  m2::PointI const m_tileCoords;
+  TileWithOffset m_tile;
   uint32_t const m_textIndex;
-  double const m_tileXOffset;
   bool const m_needOverlay;
   std::vector<m2::PointF> m_overlaySizes;
 };

--- a/libs/drape_frontend/drape_api_renderer.cpp
+++ b/libs/drape_frontend/drape_api_renderer.cpp
@@ -1,8 +1,7 @@
 #include "drape_frontend/drape_api_renderer.hpp"
-#include "drape_frontend/shape_view_params.hpp"
+#include "drape_frontend/screen_operations.hpp"
 #include "drape_frontend/visual_params.hpp"
 
-#include "drape/overlay_handle.hpp"
 #include "drape/vertex_array_buffer.hpp"
 
 #include <algorithm>
@@ -50,7 +49,7 @@ void DrapeApiRenderer::Render(ref_ptr<dp::GraphicsContext> context, ref_ptr<gpu:
   auto const & glyphParams = df::VisualParams::Instance().GetGlyphVisualParams();
   for (auto const & property : m_properties)
   {
-    math::Matrix<float, 4, 4> const mv = screen.GetModelView(property->m_center, kShapeCoordScalar);
+    auto const mv = AdjustedScreen(screen, property->m_center).GetShapeModelView();
     for (auto const & bucket : property->m_buckets)
     {
       auto program = mng->GetProgram(bucket.first.GetProgram<gpu::Program>());

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -25,8 +25,6 @@
 #include "indexer/drawing_rules.hpp"
 #include "indexer/scales.hpp"
 
-#include "geometry/any_rect2d.hpp"
-
 #include "platform/trace.hpp"
 
 #include "base/assert.hpp"
@@ -44,7 +42,6 @@
 #include <limits>
 #include <memory>
 #include <thread>
-#include <utility>
 
 namespace df
 {
@@ -1323,6 +1320,7 @@ void FrontendRenderer::ProcessSelection(ref_ptr<SelectObjectMessage> msg)
       dp::TOverlayContainer selectResult;
       if (m_overlayTree->IsNeedUpdate())
         BuildOverlayTree(modelView);
+      // Expect that msg->GetPosition() is in canonical mercator coordinates.
       m_overlayTree->Select(msg->GetPosition(), selectResult);
       for (ref_ptr<dp::OverlayHandle> const & handle : selectResult)
         offsetZ = std::max(offsetZ, handle->GetPivotZ());
@@ -1996,8 +1994,7 @@ void FrontendRenderer::OnTap(m2::PointD const & pt, bool isLongTap)
   ScreenBase const & screen = m_userEventStream.GetCurrentScreen();
   bool isMyPosition = false;
 
-  m2::PointD const pxPoint2d = screen.P3dtoP(pt);
-  m2::PointD mercator = screen.PtoG(pxPoint2d);
+  m2::PointD mercator = PtoGWrap(screen.P3dtoP(pt), screen);
 
   // Long tap should show/hide the interface. There is no need to detect tapped features.
   if (isLongTap)
@@ -2008,7 +2005,7 @@ void FrontendRenderer::OnTap(m2::PointD const & pt, bool isLongTap)
 
   if (m_myPositionController->IsModeHasPosition())
   {
-    m2::PointD const pixelPos = screen.PtoP3d(screen.GtoP(m_myPositionController->Position()));
+    m2::PointD const pixelPos = screen.PtoP3d(GtoPWrap(m_myPositionController->Position(), screen));
     isMyPosition = selectRect.IsPointInside(pixelPos);
     if (isMyPosition)
       mercator = m_myPositionController->Position();
@@ -2692,10 +2689,8 @@ void FrontendRenderer::RenderLayer::Sort(ref_ptr<dp::OverlayTree> overlayTree)
 // static
 m2::AnyRectD TapInfo::GetDefaultTapRect(m2::PointD const & mercator, ScreenBase const & screen)
 {
-  m2::AnyRectD result;
-  double const halfSize = VisualParams::Instance().GetTouchRectRadius();
-  screen.GetTouchRect(screen.GtoP(mercator), halfSize, result);
-  return result;
+  double const r = VisualParams::Instance().GetTouchRectRadius() * screen.GetScale();
+  return m2::AnyRectD(mercator, screen.GetAngleD(), m2::RectD(-r, -r, r, r));
 }
 
 // static
@@ -2703,13 +2698,13 @@ m2::AnyRectD TapInfo::GetBookmarkTapRect(m2::PointD const & mercator, ScreenBase
 {
   static int constexpr kBmTouchPixelIncrease = 20;
 
-  m2::AnyRectD result;
   double const bmAddition = kBmTouchPixelIncrease * VisualParams::Instance().GetVisualScale();
   double const halfSize = VisualParams::Instance().GetTouchRectRadius();
   double const pxWidth = halfSize;
   double const pxHeight = halfSize + bmAddition;
-  screen.GetTouchRect(screen.GtoP(mercator) + m2::PointD(0, bmAddition), pxWidth, pxHeight, result);
-  return result;
+
+  // No need in GtoPWrap since screen.GetTouchRect makes PtoG inside :)
+  return screen.GetTouchRect(screen.GtoP(mercator) + m2::PointD(0, bmAddition), pxWidth, pxHeight);
 }
 
 // static
@@ -2717,11 +2712,11 @@ m2::AnyRectD TapInfo::GetRoutingPointTapRect(m2::PointD const & mercator, Screen
 {
   static int constexpr kRoutingPointTouchPixelIncrease = 20;
 
-  m2::AnyRectD result;
-  double const bmAddition = kRoutingPointTouchPixelIncrease * VisualParams::Instance().GetVisualScale();
-  double const halfSize = VisualParams::Instance().GetTouchRectRadius();
-  screen.GetTouchRect(screen.GtoP(mercator), halfSize + bmAddition, result);
-  return result;
+  double const r = (kRoutingPointTouchPixelIncrease * VisualParams::Instance().GetVisualScale() +
+                    VisualParams::Instance().GetTouchRectRadius()) *
+                   screen.GetScale();
+
+  return m2::AnyRectD(mercator, screen.GetAngleD(), m2::RectD(-r, -r, r, r));
 }
 
 // static

--- a/libs/drape_frontend/map_shape.hpp
+++ b/libs/drape_frontend/map_shape.hpp
@@ -99,4 +99,26 @@ public:
 
   Type GetType() const override { return Message::Type::OverlayMapShapeReaded; }
 };
+
+struct TileWithOffset
+{
+  m2::PointI coords;
+  double xOffset;
+
+  // TextShape and ColoredSymboShape may have default TileKey().
+  TileWithOffset(TileKey const & key)
+  {
+    if (key.m_zoomLevel != TileKey::kNoZoom)
+    {
+      coords = key.GetTileCoords();
+      xOffset = key.GetTileXOffset();
+    }
+    else
+    {
+      coords = TileKey::NoCoordinates();
+      xOffset = 0;
+    }
+  }
+};
+
 }  // namespace df

--- a/libs/drape_frontend/my_position.cpp
+++ b/libs/drape_frontend/my_position.cpp
@@ -11,7 +11,6 @@
 #include "drape/constants.hpp"
 #include "drape/glsl_func.hpp"
 #include "drape/glsl_types.hpp"
-#include "drape/overlay_handle.hpp"
 #include "drape/render_bucket.hpp"
 
 namespace df
@@ -111,8 +110,7 @@ void MyPosition::RenderAccuracy(ref_ptr<dp::GraphicsContext> context, ref_ptr<gp
   gpu::ShapesProgramParams params;
   frameValues.SetTo(params);
   TileKey const key = GetTileKeyByPoint(adjustedPos, ClipTileZoomByMaxDataZoom(zoomLevel));
-  math::Matrix<float, 4, 4> mv = key.GetTileBasedModelView(screen);
-  params.m_modelView = glsl::make_mat4(mv.m_data);
+  params.m_modelView = glsl::make_mat4(key.GetTileBasedModelView(screen).m_data);
 
   auto const pos =
       static_cast<m2::PointF>(MapShape::ConvertToLocal(adjustedPos, key.GetGlobalRect().Center(), kShapeCoordScalar));
@@ -135,11 +133,11 @@ void MyPosition::RenderMyPosition(ref_ptr<dp::GraphicsContext> context, ref_ptr<
   }
   else
   {
+    /// @todo Copy-paste block from the above RenderAccuracy.
     gpu::ShapesProgramParams params;
     frameValues.SetTo(params);
     TileKey const key = GetTileKeyByPoint(adjustedPos, ClipTileZoomByMaxDataZoom(zoomLevel));
-    math::Matrix<float, 4, 4> mv = key.GetTileBasedModelView(screen);
-    params.m_modelView = glsl::make_mat4(mv.m_data);
+    params.m_modelView = glsl::make_mat4(key.GetTileBasedModelView(screen).m_data);
 
     auto const pos =
         static_cast<m2::PointF>(MapShape::ConvertToLocal(adjustedPos, key.GetGlobalRect().Center(), kShapeCoordScalar));

--- a/libs/drape_frontend/render_group.cpp
+++ b/libs/drape_frontend/render_group.cpp
@@ -8,11 +8,8 @@
 
 #include "geometry/screenbase.hpp"
 
-#include "base/stl_helpers.hpp"
-
 #include <algorithm>
 #include <sstream>
-#include <utility>
 
 namespace df
 {
@@ -83,10 +80,7 @@ void RenderGroup::Render(ref_ptr<dp::GraphicsContext> context, ref_ptr<gpu::Prog
   frameValues.SetTo(m_params);
 
   // Set tile-based model-view matrix.
-  {
-    math::Matrix<float, 4, 4> mv = GetTileKey().GetTileBasedModelView(screen);
-    m_params.m_modelView = glsl::make_mat4(mv.m_data);
-  }
+  m_params.m_modelView = glsl::make_mat4(GetTileKey().GetTileBasedModelView(screen).m_data);
 
   auto const & glyphParams = df::VisualParams::Instance().GetGlyphVisualParams();
   if (program == gpu::Program::TextOutlined || program3d == gpu::Program::TextOutlinedBillboard)

--- a/libs/drape_frontend/route_renderer.cpp
+++ b/libs/drape_frontend/route_renderer.cpp
@@ -3,9 +3,6 @@
 #include "drape_frontend/shape_view_params.hpp"
 #include "drape_frontend/visual_params.hpp"
 
-#include "geometry/mercator.hpp"
-#include "geometry/rect_intersect.hpp"
-
 #include "shaders/programs.hpp"
 
 #include "drape/drape_routine.hpp"
@@ -457,8 +454,7 @@ void RouteRenderer::RenderSubroute(ref_ptr<dp::GraphicsContext> context, ref_ptr
   // Set up parameters.
   gpu::RouteProgramParams params;
   frameValues.SetTo(params);
-  auto const mv = adjScreen.GetShapeModelView();
-  params.m_modelView = glsl::make_mat4(mv.m_data);
+  params.m_modelView = glsl::make_mat4(adjScreen.GetShapeModelView().m_data);
   params.m_color = glsl::ToVec4(df::GetColorConstant(style.m_color));
   params.m_routeParams = glsl::vec4(currentHalfWidth, screenHalfWidth, dist, trafficShown ? 1.0f : 0.0f);
 
@@ -514,8 +510,7 @@ void RouteRenderer::RenderSubrouteArrows(ref_ptr<dp::GraphicsContext> context, r
   // Set up parameters.
   gpu::RouteProgramParams params;
   frameValues.SetTo(params);
-  auto const mv = adjScreen.GetShapeModelView();
-  params.m_modelView = glsl::make_mat4(mv.m_data);
+  params.m_modelView = glsl::make_mat4(adjScreen.GetShapeModelView().m_data);
   auto const arrowHalfWidth = static_cast<float>(currentHalfWidth * kArrowHeightFactor);
   params.m_arrowHalfWidth = arrowHalfWidth;
 

--- a/libs/drape_frontend/route_renderer.cpp
+++ b/libs/drape_frontend/route_renderer.cpp
@@ -445,10 +445,13 @@ void RouteRenderer::RenderSubroute(ref_ptr<dp::GraphicsContext> context, ref_ptr
   ASSERT_LESS(styleIndex, subrouteInfo.m_subroute->m_style.size(), ());
   auto const & style = subrouteInfo.m_subroute->m_style[styleIndex];
 
+  // Shift route into the wrapped world copy nearest to the current viewport.
+  AdjustedScreen adjScreen(screen, subrouteData->m_pivot);
+
   // Set up parameters.
   gpu::RouteProgramParams params;
   frameValues.SetTo(params);
-  math::Matrix<float, 4, 4> mv = screen.GetModelView(subrouteData->m_pivot, kShapeCoordScalar);
+  auto const mv = adjScreen.GetShapeModelView();
   params.m_modelView = glsl::make_mat4(mv.m_data);
   params.m_color = glsl::ToVec4(df::GetColorConstant(style.m_color));
   params.m_routeParams = glsl::vec4(currentHalfWidth, screenHalfWidth, dist, trafficShown ? 1.0f : 0.0f);
@@ -478,7 +481,7 @@ void RouteRenderer::RenderSubroute(ref_ptr<dp::GraphicsContext> context, ref_ptr
   mng->GetParamsSetter()->Apply(context, prg, params);
 
   // Render buckets.
-  auto const & clipRect = screen.ClipRect();
+  auto const clipRect = adjScreen.GetClipRect();
   CHECK_EQUAL(subrouteData->m_renderProperty.m_buckets.size(), subrouteData->m_renderProperty.m_boundingBoxes.size(),
               ());
   for (size_t i = 0; i < subrouteData->m_renderProperty.m_buckets.size(); ++i)
@@ -499,10 +502,13 @@ void RouteRenderer::RenderSubrouteArrows(ref_ptr<dp::GraphicsContext> context, r
   dp::RenderState const & state = subrouteInfo.m_arrowsData->m_renderProperty.m_state;
   float const currentHalfWidth = GetCurrentHalfWidth(subrouteInfo);
 
+  // Shift arrows into the wrapped world copy nearest to the current viewport.
+  AdjustedScreen adjScreen(screen, subrouteInfo.m_arrowsData->m_pivot);
+
   // Set up parameters.
   gpu::RouteProgramParams params;
   frameValues.SetTo(params);
-  math::Matrix<float, 4, 4> mv = screen.GetModelView(subrouteInfo.m_arrowsData->m_pivot, kShapeCoordScalar);
+  auto const mv = adjScreen.GetShapeModelView();
   params.m_modelView = glsl::make_mat4(mv.m_data);
   auto const arrowHalfWidth = static_cast<float>(currentHalfWidth * kArrowHeightFactor);
   params.m_arrowHalfWidth = arrowHalfWidth;
@@ -516,7 +522,7 @@ void RouteRenderer::RenderSubrouteArrows(ref_ptr<dp::GraphicsContext> context, r
   dp::ApplyState(context, prg, state);
   mng->GetParamsSetter()->Apply(context, prg, params);
 
-  auto const & clipRect = screen.ClipRect();
+  auto const clipRect = adjScreen.GetClipRect();
   CHECK_EQUAL(subrouteInfo.m_arrowsData->m_renderProperty.m_buckets.size(),
               subrouteInfo.m_arrowsData->m_renderProperty.m_boundingBoxes.size(), ());
   for (size_t i = 0; i < subrouteInfo.m_arrowsData->m_renderProperty.m_buckets.size(); ++i)
@@ -544,7 +550,7 @@ void RouteRenderer::RenderSubrouteMarkers(ref_ptr<dp::GraphicsContext> context, 
   // Set up parameters.
   gpu::RouteProgramParams params;
   frameValues.SetTo(params);
-  math::Matrix<float, 4, 4> mv = screen.GetModelView(subrouteInfo.m_markersData->m_pivot, kShapeCoordScalar);
+  auto const mv = AdjustedScreen(screen, subrouteInfo.m_markersData->m_pivot).GetShapeModelView();
   params.m_modelView = glsl::make_mat4(mv.m_data);
   params.m_routeParams = glsl::vec4(currentHalfWidth, dist, 0.0f, 0.0f);
   params.m_angleCosSin =

--- a/libs/drape_frontend/route_renderer.cpp
+++ b/libs/drape_frontend/route_renderer.cpp
@@ -4,6 +4,7 @@
 #include "drape_frontend/visual_params.hpp"
 
 #include "geometry/mercator.hpp"
+#include "geometry/rect_intersect.hpp"
 
 #include "shaders/programs.hpp"
 
@@ -154,6 +155,22 @@ std::vector<ArrowBorders> CalculateArrowBorders(m2::RectD screenRect, double scr
   std::vector<ArrowBorders> newArrowBorders;
   newArrowBorders.reserve(kAverageArrowsCount);
   auto const & polyline = subroute->m_polyline;
+
+  auto const intersectsScreen = [&screenRect, &polyline](double startDistance, double endDistance)
+  {
+    auto p1 = polyline.GetPointByDistance(startDistance);
+    if (screenRect.IsPointInside(p1))
+      return true;
+    auto p2 = polyline.GetPointByDistance(endDistance);
+    if (screenRect.IsPointInside(p2))
+      return true;
+
+    return false;
+    /// @todo Reasonable or overhead?
+    // int code1 = 0, code2 = 0;
+    // return m2::Intersect(screenRect, p1, p2, code1, code2);
+  };
+
   for (size_t i = 0; i < turns.size(); i++)
   {
     ArrowBorders arrowBorders;
@@ -167,25 +184,8 @@ std::vector<ArrowBorders> CalculateArrowBorders(m2::RectD screenRect, double scr
       continue;
     }
 
-    auto adjustX = [refX = screenRect.Center().x](m2::PointD pt)
-    {
-      pt.x = mercator::NearestWrapX(pt.x, refX);
-      return pt;
-    };
-
-    m2::PointD pt = adjustX(polyline.GetPointByDistance(arrowBorders.m_startDistance));
-    if (screenRect.IsPointInside(pt))
-    {
+    if (intersectsScreen(arrowBorders.m_startDistance, arrowBorders.m_endDistance))
       newArrowBorders.push_back(arrowBorders);
-      continue;
-    }
-
-    pt = adjustX(polyline.GetPointByDistance(arrowBorders.m_endDistance));
-    if (screenRect.IsPointInside(pt))
-    {
-      newArrowBorders.push_back(arrowBorders);
-      continue;
-    }
   }
 
   // Merge intersected borders and clip them.
@@ -244,10 +244,14 @@ void RouteRenderer::PrepareRouteArrows(ScreenBase const & screen, PrepareRouteAr
 
     if (zoom < kArrowAppearingZoomLevel)
     {
+      subrouteInfo.m_arrowsPrepareInProgress = false;
       subrouteInfo.m_arrowsData.reset();
       subrouteInfo.m_arrowBorders.clear();
       continue;
     }
+
+    if (subrouteInfo.m_arrowsPrepareInProgress)
+      continue;
 
     // Calculate arrow borders.
     double dist = kInvalidDistance;
@@ -256,10 +260,11 @@ void RouteRenderer::PrepareRouteArrows(ScreenBase const & screen, PrepareRouteAr
 
     // We run asynchronous task to calculate new positions of route arrows.
     auto const subrouteId = subrouteInfo.m_subrouteId;
-    auto const screenRect = screen.ClipRect();
+    auto const screenRect = AdjustedScreen(screen, subrouteInfo.m_subroute->m_polyline.Front()).GetClipRect();
     auto const screenScale = screen.GetScale();
     auto const subrouteLength = subrouteInfo.m_length;
     auto subroute = subrouteInfo.m_subroute;
+    subrouteInfo.m_arrowsPrepareInProgress = true;
     dp::DrapeRoutine::RunSequential([subrouteId, screenRect, screenScale, halfWidth, subroute = std::move(subroute),
                                      subrouteLength, dist, prepareCallback]()
     {
@@ -280,6 +285,7 @@ void RouteRenderer::CacheRouteArrows(ScreenBase const & screen, dp::DrapeID subr
     return;
 
   auto & subrouteInfo = *it;
+  subrouteInfo.m_arrowsPrepareInProgress = false;
 
   double zoom = 0.0;
   float halfWidth = 0.0;

--- a/libs/drape_frontend/route_renderer.hpp
+++ b/libs/drape_frontend/route_renderer.hpp
@@ -49,6 +49,7 @@ public:
 
     drape_ptr<SubrouteArrowsData> m_arrowsData;
     std::vector<ArrowBorders> m_arrowBorders;
+    bool m_arrowsPrepareInProgress = false;
     float m_baseHalfWidth = 0.0f;
 
     drape_ptr<SubrouteMarkersData> m_markersData;

--- a/libs/drape_frontend/screen_operations.cpp
+++ b/libs/drape_frontend/screen_operations.cpp
@@ -1,5 +1,6 @@
 #include "screen_operations.hpp"
 
+#include "drape_frontend/shape_view_params.hpp"
 #include "drape_frontend/visual_params.hpp"
 
 #include "indexer/scales.hpp"
@@ -241,6 +242,18 @@ void NormalizeScreenOriginX(ScreenBase & screen)
 m2::PointD AdjustPointForViewport(m2::PointD const & pt, ScreenBase const & screen)
 {
   return {mercator::NearestWrapX(pt.x, screen.GetOrg().x), pt.y};
+}
+
+AdjustedScreen::AdjustedScreen(ScreenBase const & screen, m2::PointD const & pivot) : m_screen(screen)
+{
+  double const wrapX = mercator::NearestWrapX(pivot.x, screen.GetOrg().x);
+  m_wrapPivot = {wrapX, pivot.y};
+  m_offsetWrapX = pivot.x - wrapX;
+}
+
+ScreenBase::Matrix3dT AdjustedScreen::GetShapeModelView() const
+{
+  return m_screen.GetModelView(m_wrapPivot, kShapeCoordScalar);
 }
 
 }  // namespace df

--- a/libs/drape_frontend/screen_operations.cpp
+++ b/libs/drape_frontend/screen_operations.cpp
@@ -244,6 +244,18 @@ m2::PointD AdjustPointForViewport(m2::PointD const & pt, ScreenBase const & scre
   return {mercator::NearestWrapX(pt.x, screen.GetOrg().x), pt.y};
 }
 
+m2::PointD GtoPWrap(m2::PointD const & pt, ScreenBase const & screen)
+{
+  return screen.GtoP(AdjustPointForViewport(pt, screen));
+}
+
+m2::PointD PtoGWrap(m2::PointD const & pt, ScreenBase const & screen)
+{
+  auto mercator = screen.PtoG(pt);
+  mercator.x = mercator::WrapX(mercator.x);
+  return mercator;
+}
+
 AdjustedScreen::AdjustedScreen(ScreenBase const & screen, m2::PointD const & pivot) : m_screen(screen)
 {
   double const wrapX = mercator::NearestWrapX(pivot.x, screen.GetOrg().x);

--- a/libs/drape_frontend/screen_operations.hpp
+++ b/libs/drape_frontend/screen_operations.hpp
@@ -37,6 +37,9 @@ void NormalizeScreenOriginX(ScreenBase & screen);
 /// for correct rendering when the viewport extends past the antimeridian.
 m2::PointD AdjustPointForViewport(m2::PointD const & pt, ScreenBase const & screen);
 
+m2::PointD GtoPWrap(m2::PointD const & pt, ScreenBase const & screen);
+m2::PointD PtoGWrap(m2::PointD const & pt, ScreenBase const & screen);
+
 class AdjustedScreen
 {
   ScreenBase const & m_screen;

--- a/libs/drape_frontend/screen_operations.hpp
+++ b/libs/drape_frontend/screen_operations.hpp
@@ -30,10 +30,28 @@ bool ApplyScale(m2::PointD const & pixelScaleCenter, double factor, ScreenBase &
 /// Wraps the screen origin X into [-540, 540] to prevent unbounded coordinate growth
 /// when scrolling continuously past the antimeridian. The +-540 threshold (1.5 world widths)
 /// gives a buffer before normalization kicks in, minimizing tile cache churn.
+/// @todo Find places where we can safely call this Normalization?
 void NormalizeScreenOriginX(ScreenBase & screen);
 
 /// Adjusts a point's X coordinate to be within 180 degrees of the screen origin,
 /// for correct rendering when the viewport extends past the antimeridian.
 m2::PointD AdjustPointForViewport(m2::PointD const & pt, ScreenBase const & screen);
+
+class AdjustedScreen
+{
+  ScreenBase const & m_screen;
+  m2::PointD m_wrapPivot;
+  double m_offsetWrapX;
+
+public:
+  AdjustedScreen(ScreenBase const & screen, m2::PointD const & pivot);
+  ScreenBase::Matrix3dT GetShapeModelView() const;
+  m2::RectD GetClipRect() const
+  {
+    auto r = m_screen.ClipRect();
+    r.Offset(m_offsetWrapX, 0);
+    return r;
+  }
+};
 
 }  // namespace df

--- a/libs/drape_frontend/selection_shape.cpp
+++ b/libs/drape_frontend/selection_shape.cpp
@@ -78,7 +78,7 @@ std::optional<m2::PointD> SelectionShape::GetPixelPosition(ScreenBase const & sc
     posZ = 0.0;
   }
 
-  m2::PointD const pt = screen.GtoP(pos);
+  m2::PointD const pt = GtoPWrap(pos, screen);
   if (!screen.IsReverseProjection3d(pt))
     return screen.PtoP3d(pt, -posZ);
   return {};

--- a/libs/drape_frontend/selection_shape.cpp
+++ b/libs/drape_frontend/selection_shape.cpp
@@ -132,8 +132,7 @@ void SelectionShape::Render(ref_ptr<dp::GraphicsContext> context, ref_ptr<gpu::P
     geomParams.m_lineParams = glsl::vec2(currentHalfWidth, screenHalfWidth);
     for (auto const & geometry : m_selectionGeometry)
     {
-      auto const mv = AdjustedScreen(screen, geometry->GetPivot()).GetShapeModelView();
-      geomParams.m_modelView = glsl::make_mat4(mv.m_data);
+      geomParams.m_modelView = glsl::make_mat4(AdjustedScreen(screen, geometry->GetPivot()).GetShapeModelView().m_data);
       geometry->Render(context, mng, geomParams);
     }
   }

--- a/libs/drape_frontend/selection_shape.cpp
+++ b/libs/drape_frontend/selection_shape.cpp
@@ -10,8 +10,6 @@
 
 #include "drape/texture_manager.hpp"
 
-#include "geometry/point3d.hpp"
-
 #include <array>
 
 namespace df
@@ -94,7 +92,7 @@ void SelectionShape::Render(ref_ptr<dp::GraphicsContext> context, ref_ptr<gpu::P
 
   if (m_selectionGeometry.empty())
   {
-    m2::PointD const adjustedPos = df::AdjustPointForViewport(m_position, screen);
+    m2::PointD const adjustedPos = AdjustPointForViewport(m_position, screen);
 
     gpu::ShapesProgramParams params;
     frameValues.SetTo(params);
@@ -134,7 +132,7 @@ void SelectionShape::Render(ref_ptr<dp::GraphicsContext> context, ref_ptr<gpu::P
     geomParams.m_lineParams = glsl::vec2(currentHalfWidth, screenHalfWidth);
     for (auto const & geometry : m_selectionGeometry)
     {
-      math::Matrix<float, 4, 4> mv = screen.GetModelView(geometry->GetPivot(), kShapeCoordScalar);
+      auto const mv = AdjustedScreen(screen, geometry->GetPivot()).GetShapeModelView();
       geomParams.m_modelView = glsl::make_mat4(mv.m_data);
       geometry->Render(context, mng, geomParams);
     }

--- a/libs/drape_frontend/text_shape.cpp
+++ b/libs/drape_frontend/text_shape.cpp
@@ -1,5 +1,6 @@
 #include "drape_frontend/text_shape.hpp"
 #include "drape_frontend/render_state_extension.hpp"
+#include "drape_frontend/screen_operations.hpp"
 #include "drape_frontend/text_handle.hpp"
 #include "drape_frontend/text_layout.hpp"
 #include "drape_frontend/visual_params.hpp"
@@ -13,7 +14,6 @@
 #include "drape/utils/vertex_decl.hpp"
 
 #include <algorithm>
-#include <utility>
 
 namespace df
 {
@@ -84,7 +84,7 @@ public:
     {
       if (IsBillboard())
       {
-        m2::PointD const pxPivot(screen.GtoP(m2::PointD(m_pivot)));
+        m2::PointD const pxPivot = GetPixelPivot(screen);
         m2::PointD const pxPivotPerspective(screen.PtoP3d(pxPivot, -m_pivotZ));
 
         m2::RectD pxRectPerspective = GetPixelRect(screen, false);
@@ -96,7 +96,7 @@ public:
       return GetPixelRectPerspective(screen);
     }
 
-    m2::PointD pivot(screen.GtoP(m2::PointD(m_pivot)) + m2::PointD(m_offset));
+    m2::PointD pivot(GetPixelPivot(screen) + m2::PointD(m_offset));
     double x = pivot.x;
     double y = pivot.y;
     if (m_anchor & dp::Left)
@@ -132,6 +132,17 @@ public:
   bool IsBound() const override { return !m_isOptional; }
 
 private:
+  m2::PointD GetPixelPivot(ScreenBase const & screen) const
+  {
+    // Tile-base coordinates already have valid alignment via the tile offset and tile-based identity.
+    m2::PointD wrapPivot(m_pivot);
+    if (GetOverlayID().m_tileCoords == TileKey::NoCoordinates())
+      wrapPivot = df::AdjustPointForViewport(wrapPivot, screen);
+
+    return screen.GtoP(wrapPivot);
+  }
+
+private:
   m2::PointF m_pivot;
   m2::PointF m_offset;
   m2::PointF m_size;
@@ -147,8 +158,7 @@ TextShape::TextShape(m2::PointD const & basePoint, TextViewParams const & params
                      uint32_t textIndex)
   : m_basePoint(basePoint)
   , m_params(params)
-  , m_tileCoords(tileKey.GetTileCoords())
-  , m_tileXOffset(tileKey.GetTileXOffset())
+  , m_tile(tileKey)
   , m_symbolAnchor(symbolAnchor)
   , m_symbolOffset(symbolOffset)
   , m_textIndex(textIndex)
@@ -161,8 +171,7 @@ TextShape::TextShape(m2::PointD const & basePoint, TextViewParams const & params
                      dp::Anchor symbolAnchor, uint32_t textIndex)
   : m_basePoint(basePoint)
   , m_params(params)
-  , m_tileCoords(tileKey.GetTileCoords())
-  , m_tileXOffset(tileKey.GetTileXOffset())
+  , m_tile(tileKey)
   , m_symbolSizes(symbolSizes)
   , m_symbolAnchor(symbolAnchor)
   , m_symbolOffset(symbolOffset)
@@ -316,10 +325,10 @@ void TextShape::DrawSubStringPlain(ref_ptr<dp::GraphicsContext> context, Straigh
 
   m2::PointF const & pixelSize = layout.GetPixelSize();
 
-  dp::OverlayID overlayId(m_params.m_featureId, m_params.m_markId, m_tileCoords, m_textIndex);
+  dp::OverlayID overlayId(m_params.m_featureId, m_params.m_markId, m_tile.coords, m_textIndex);
   drape_ptr<StraightTextHandle> handle = make_unique_dp<StraightTextHandle>(
       overlayId, layout.GetGlyphs(), m_params.m_titleDecl.m_anchor,
-      glsl::vec2(m_basePoint.x + m_tileXOffset, m_basePoint.y), glsl::vec2(pixelSize.x, pixelSize.y), finalOffset,
+      glsl::vec2(m_basePoint.x + m_tile.xOffset, m_basePoint.y), glsl::vec2(pixelSize.x, pixelSize.y), finalOffset,
       GetOverlayPriority(), textures, isOptional, std::move(dynamicBuffer), m_params.m_minVisibleScale, true);
   if (m_symbolSizes.size() > 1)
     handle->SetDynamicSymbolSizes(layout, m_symbolSizes, m_symbolAnchor);
@@ -368,10 +377,10 @@ void TextShape::DrawSubStringOutlined(ref_ptr<dp::GraphicsContext> context, Stra
 
   m2::PointF const & pixelSize = layout.GetPixelSize();
 
-  dp::OverlayID overlayId(m_params.m_featureId, m_params.m_markId, m_tileCoords, m_textIndex);
+  dp::OverlayID overlayId(m_params.m_featureId, m_params.m_markId, m_tile.coords, m_textIndex);
   drape_ptr<StraightTextHandle> handle = make_unique_dp<StraightTextHandle>(
       overlayId, layout.GetGlyphs(), m_params.m_titleDecl.m_anchor,
-      glsl::vec2(m_basePoint.x + m_tileXOffset, m_basePoint.y), glsl::vec2(pixelSize.x, pixelSize.y), finalOffset,
+      glsl::vec2(m_basePoint.x + m_tile.xOffset, m_basePoint.y), glsl::vec2(pixelSize.x, pixelSize.y), finalOffset,
       GetOverlayPriority(), textures, isOptional, std::move(dynamicBuffer), m_params.m_minVisibleScale, true);
   if (m_symbolSizes.size() > 1)
     handle->SetDynamicSymbolSizes(layout, m_symbolSizes, m_symbolAnchor);

--- a/libs/drape_frontend/text_shape.hpp
+++ b/libs/drape_frontend/text_shape.hpp
@@ -49,8 +49,7 @@ private:
 
   m2::PointD m_basePoint;
   TextViewParams m_params;
-  m2::PointI m_tileCoords;
-  double m_tileXOffset;
+  TileWithOffset m_tile;
   std::vector<m2::PointF> m_symbolSizes;
   dp::Anchor m_symbolAnchor;
   m2::PointF m_symbolOffset;

--- a/libs/drape_frontend/tile_key.cpp
+++ b/libs/drape_frontend/tile_key.cpp
@@ -4,6 +4,7 @@
 #include "drape_frontend/tile_utils.hpp"
 
 #include "geometry/mercator.hpp"
+#include "geometry/screenbase.hpp"
 
 #include "base/string_utils.hpp"
 
@@ -28,8 +29,6 @@ int WrapTileX(int x, uint8_t zoomLevel)
   return ((x - minX) % numTiles + numTiles) % numTiles + minX;
 }
 }  // namespace
-
-TileKey::TileKey() : m_x(-1), m_y(-1), m_zoomLevel(0), m_generation(0), m_userMarksGeneration(0) {}
 
 TileKey::TileKey(int x, int y, uint8_t zoomLevel)
   : m_x(x)

--- a/libs/drape_frontend/tile_key.hpp
+++ b/libs/drape_frontend/tile_key.hpp
@@ -3,17 +3,22 @@
 #include "drape_frontend/batcher_bucket.hpp"
 
 #include "geometry/rect2d.hpp"
-#include "geometry/screenbase.hpp"
 
 #include "base/matrix.hpp"
 
 #include <string>
 
+class ScreenBase;
+
 namespace df
 {
 struct TileKey
 {
-  TileKey();
+  static constexpr int kNoCoord = -1;
+  static constexpr uint8_t kNoZoom = 0;
+  static m2::PointI NoCoordinates() { return {kNoCoord, kNoCoord}; }
+
+  TileKey() : m_x(kNoCoord), m_y(kNoCoord), m_zoomLevel(kNoZoom), m_generation(0), m_userMarksGeneration(0) {}
   TileKey(int x, int y, uint8_t zoomLevel);
   TileKey(TileKey const & key, uint64_t generation, uint64_t userMarksGeneration);
 

--- a/libs/drape_frontend/traffic_renderer.cpp
+++ b/libs/drape_frontend/traffic_renderer.cpp
@@ -139,8 +139,7 @@ void TrafficRenderer::RenderTraffic(ref_ptr<dp::GraphicsContext> context, ref_pt
 
       gpu::TrafficProgramParams params;
       frameValues.SetTo(params);
-      math::Matrix<float, 4, 4> const mv = renderData.m_tileKey.GetTileBasedModelView(screen);
-      params.m_modelView = glsl::make_mat4(mv.m_data);
+      params.m_modelView = glsl::make_mat4(renderData.m_tileKey.GetTileBasedModelView(screen).m_data);
       params.m_opacity = opacity;
       mng->GetParamsSetter()->Apply(context, program, params);
       renderData.m_bucket->Render(context, true /* draw as line */);
@@ -156,8 +155,7 @@ void TrafficRenderer::RenderTraffic(ref_ptr<dp::GraphicsContext> context, ref_pt
 
         gpu::TrafficProgramParams params;
         frameValues.SetTo(params);
-        math::Matrix<float, 4, 4> const mv = renderData.m_tileKey.GetTileBasedModelView(screen);
-        params.m_modelView = glsl::make_mat4(mv.m_data);
+        params.m_modelView = glsl::make_mat4(renderData.m_tileKey.GetTileBasedModelView(screen).m_data);
         params.m_opacity = opacity;
         // Here we reinterpret light/dark colors as left/right sizes by road classes.
         params.m_lightArrowColor = glsl::vec3(CalculateHalfWidth(screen, RoadClass::Class0, true /* left */),
@@ -207,8 +205,7 @@ void TrafficRenderer::RenderTraffic(ref_ptr<dp::GraphicsContext> context, ref_pt
 
       gpu::TrafficProgramParams params;
       frameValues.SetTo(params);
-      math::Matrix<float, 4, 4> const mv = renderData.m_tileKey.GetTileBasedModelView(screen);
-      params.m_modelView = glsl::make_mat4(mv.m_data);
+      params.m_modelView = glsl::make_mat4(renderData.m_tileKey.GetTileBasedModelView(screen).m_data);
       params.m_opacity = opacity;
       params.m_outline = outline;
       params.m_lightArrowColor = glsl::ToVec3(lightArrowColor);

--- a/libs/drape_frontend/transit_scheme_renderer.cpp
+++ b/libs/drape_frontend/transit_scheme_renderer.cpp
@@ -180,8 +180,7 @@ void TransitSchemeRenderer::RenderLinesCaps(ref_ptr<dp::GraphicsContext> context
 
     gpu::TransitProgramParams params;
     frameValues.SetTo(params);
-    auto const mv = AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView();
-    params.m_modelView = glsl::make_mat4(mv.m_data);
+    params.m_modelView = glsl::make_mat4(AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView().m_data);
     params.m_lineHalfWidth = pixelHalfWidth;
     params.m_maxRadius = kTransitLineHalfWidth;
     mng->GetParamsSetter()->Apply(context, program, params);
@@ -202,8 +201,7 @@ void TransitSchemeRenderer::RenderLines(ref_ptr<dp::GraphicsContext> context, re
 
     gpu::TransitProgramParams params;
     frameValues.SetTo(params);
-    auto const mv = AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView();
-    params.m_modelView = glsl::make_mat4(mv.m_data);
+    params.m_modelView = glsl::make_mat4(AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView().m_data);
     params.m_lineHalfWidth = pixelHalfWidth;
     mng->GetParamsSetter()->Apply(context, program, params);
 
@@ -224,8 +222,7 @@ void TransitSchemeRenderer::RenderMarkers(ref_ptr<dp::GraphicsContext> context, 
 
     gpu::TransitProgramParams params;
     frameValues.SetTo(params);
-    auto const mv = AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView();
-    params.m_modelView = glsl::make_mat4(mv.m_data);
+    params.m_modelView = glsl::make_mat4(AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView().m_data);
     params.m_params = glsl::vec3(static_cast<float>(cos(screen.GetAngle())), static_cast<float>(sin(screen.GetAngle())),
                                  pixelHalfWidth);
     mng->GetParamsSetter()->Apply(context, program, params);
@@ -247,8 +244,7 @@ void TransitSchemeRenderer::RenderText(ref_ptr<dp::GraphicsContext> context, ref
 
     gpu::MapProgramParams params;
     frameValues.SetTo(params);
-    auto const mv = AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView();
-    params.m_modelView = glsl::make_mat4(mv.m_data);
+    params.m_modelView = glsl::make_mat4(AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView().m_data);
     params.m_contrastGamma = glsl::vec2(glyphParams.m_outlineContrast, glyphParams.m_outlineGamma);
     params.m_isOutlinePass = 1.0f;
     mng->GetParamsSetter()->Apply(context, program, params);
@@ -277,8 +273,7 @@ void TransitSchemeRenderer::RenderStubs(ref_ptr<dp::GraphicsContext> context, re
 
     gpu::MapProgramParams params;
     frameValues.SetTo(params);
-    auto const mv = AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView();
-    params.m_modelView = glsl::make_mat4(mv.m_data);
+    params.m_modelView = glsl::make_mat4(AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView().m_data);
     mng->GetParamsSetter()->Apply(context, program, params);
 
     renderData.m_bucket->Render(context, false /* draw as line */);

--- a/libs/drape_frontend/transit_scheme_renderer.cpp
+++ b/libs/drape_frontend/transit_scheme_renderer.cpp
@@ -2,7 +2,7 @@
 
 #include "drape_frontend/debug_rect_renderer.hpp"
 #include "drape_frontend/postprocess_renderer.hpp"
-#include "drape_frontend/shape_view_params.hpp"
+#include "drape_frontend/screen_operations.hpp"
 #include "drape_frontend/visual_params.hpp"
 
 #include "drape/graphics_context.hpp"
@@ -180,7 +180,7 @@ void TransitSchemeRenderer::RenderLinesCaps(ref_ptr<dp::GraphicsContext> context
 
     gpu::TransitProgramParams params;
     frameValues.SetTo(params);
-    math::Matrix<float, 4, 4> mv = screen.GetModelView(renderData.m_pivot, kShapeCoordScalar);
+    auto const mv = AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView();
     params.m_modelView = glsl::make_mat4(mv.m_data);
     params.m_lineHalfWidth = pixelHalfWidth;
     params.m_maxRadius = kTransitLineHalfWidth;
@@ -202,7 +202,7 @@ void TransitSchemeRenderer::RenderLines(ref_ptr<dp::GraphicsContext> context, re
 
     gpu::TransitProgramParams params;
     frameValues.SetTo(params);
-    math::Matrix<float, 4, 4> mv = screen.GetModelView(renderData.m_pivot, kShapeCoordScalar);
+    auto const mv = AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView();
     params.m_modelView = glsl::make_mat4(mv.m_data);
     params.m_lineHalfWidth = pixelHalfWidth;
     mng->GetParamsSetter()->Apply(context, program, params);
@@ -224,7 +224,7 @@ void TransitSchemeRenderer::RenderMarkers(ref_ptr<dp::GraphicsContext> context, 
 
     gpu::TransitProgramParams params;
     frameValues.SetTo(params);
-    math::Matrix<float, 4, 4> mv = screen.GetModelView(renderData.m_pivot, kShapeCoordScalar);
+    auto const mv = AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView();
     params.m_modelView = glsl::make_mat4(mv.m_data);
     params.m_params = glsl::vec3(static_cast<float>(cos(screen.GetAngle())), static_cast<float>(sin(screen.GetAngle())),
                                  pixelHalfWidth);
@@ -247,7 +247,7 @@ void TransitSchemeRenderer::RenderText(ref_ptr<dp::GraphicsContext> context, ref
 
     gpu::MapProgramParams params;
     frameValues.SetTo(params);
-    math::Matrix<float, 4, 4> mv = screen.GetModelView(renderData.m_pivot, kShapeCoordScalar);
+    auto const mv = AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView();
     params.m_modelView = glsl::make_mat4(mv.m_data);
     params.m_contrastGamma = glsl::vec2(glyphParams.m_outlineContrast, glyphParams.m_outlineGamma);
     params.m_isOutlinePass = 1.0f;
@@ -277,7 +277,7 @@ void TransitSchemeRenderer::RenderStubs(ref_ptr<dp::GraphicsContext> context, re
 
     gpu::MapProgramParams params;
     frameValues.SetTo(params);
-    math::Matrix<float, 4, 4> mv = screen.GetModelView(renderData.m_pivot, kShapeCoordScalar);
+    auto const mv = AdjustedScreen(screen, renderData.m_pivot).GetShapeModelView();
     params.m_modelView = glsl::make_mat4(mv.m_data);
     mng->GetParamsSetter()->Apply(context, program, params);
 

--- a/libs/geometry/screenbase.cpp
+++ b/libs/geometry/screenbase.cpp
@@ -278,18 +278,11 @@ void ScreenBase::PtoG(m2::RectD const & pxRect, m2::RectD & glbRect) const
   glbRect = m2::RectD(PtoG(pxRect.LeftTop()), PtoG(pxRect.RightBottom()));
 }
 
-void ScreenBase::GetTouchRect(m2::PointD const & pixPoint, double pixRadius, m2::AnyRectD & glbRect) const
-{
-  double const r = pixRadius * m_Scale;
-  glbRect = m2::AnyRectD(PtoG(pixPoint), m_Angle, m2::RectD(-r, -r, r, r));
-}
-
-void ScreenBase::GetTouchRect(m2::PointD const & pixPoint, double const pxWidth, double const pxHeight,
-                              m2::AnyRectD & glbRect) const
+m2::AnyRectD ScreenBase::GetTouchRect(m2::PointD const & pixPoint, double const pxWidth, double const pxHeight) const
 {
   double const width = pxWidth * m_Scale;
   double const height = pxHeight * m_Scale;
-  glbRect = m2::AnyRectD(PtoG(pixPoint), m_Angle, m2::RectD(-width, -height, width, height));
+  return m2::AnyRectD(PtoG(pixPoint), m_Angle, m2::RectD(-width, -height, width, height));
 }
 
 bool IsPanningAndRotate(ScreenBase const & s1, ScreenBase const & s2)

--- a/libs/geometry/screenbase.hpp
+++ b/libs/geometry/screenbase.hpp
@@ -41,6 +41,7 @@ public:
   void SetScale(double scale);
 
   double GetAngle() const { return m_Angle.val(); }
+  ang::AngleD GetAngleD() const { return m_Angle; }
   void SetAngle(double angle);
 
   m2::PointD const & GetOrg() const { return m_Org; }
@@ -58,9 +59,7 @@ public:
   void MatchGandP(m2::PointD const & g, m2::PointD const & p);
   void MatchGandP3d(m2::PointD const & g, m2::PointD const & p3d);
 
-  void GetTouchRect(m2::PointD const & pixPoint, double pixRadius, m2::AnyRectD & glbRect) const;
-  void GetTouchRect(m2::PointD const & pixPoint, double const pxWidth, double const pxHeight,
-                    m2::AnyRectD & glbRect) const;
+  m2::AnyRectD GetTouchRect(m2::PointD const & pixPoint, double const pxWidth, double const pxHeight) const;
 
   MatrixT const & GtoPMatrix() const { return m_GtoP; }
   MatrixT const & PtoGMatrix() const { return m_PtoG; }

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -2677,12 +2677,6 @@ private:
 };
 }  // namespace
 
-UserMark const * BookmarkManager::FindNearestUserMark(m2::AnyRectD const & rect) const
-{
-  CHECK_THREAD_CHECKER(m_threadChecker, ());
-  return FindNearestUserMark([&rect](UserMark::Type) { return rect; }, [](UserMark::Type) { return false; });
-}
-
 UserMark const * BookmarkManager::FindNearestUserMark(TTouchRectHolder const & holder,
                                                       TFindOnlyVisibleChecker const & findOnlyVisible) const
 {

--- a/libs/map/bookmark_manager.hpp
+++ b/libs/map/bookmark_manager.hpp
@@ -297,7 +297,6 @@ public:
   using TFindOnlyVisibleChecker = std::function<bool(UserMark::Type)>;
   UserMark const * FindNearestUserMark(TTouchRectHolder const & holder,
                                        TFindOnlyVisibleChecker const & findOnlyVisible) const;
-  UserMark const * FindNearestUserMark(m2::AnyRectD const & rect) const;
   UserMark const * FindMarkInRect(kml::MarkGroupId groupId, m2::AnyRectD const & rect, bool findOnlyVisible,
                                   double & d) const;
 

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1017,11 +1017,6 @@ void Framework::ShowRect(m2::AnyRectD const & rect, bool animation, bool useVisi
     m_drapeEngine->SetModelViewAnyRect(rect, animation, useVisibleViewport);
 }
 
-void Framework::GetTouchRect(m2::PointD const & center, uint32_t pxRadius, m2::AnyRectD & rect)
-{
-  m_currentModelView.GetTouchRect(center, static_cast<double>(pxRadius), rect);
-}
-
 void Framework::SetViewportListener(TViewportChangedFn const & fn)
 {
   m_viewportChangedFn = fn;
@@ -1447,6 +1442,20 @@ bool Framework::GetDistanceAndAzimut(m2::PointD const & point, double lat, doubl
 
   // This constant and return value is using for arrow/flag choice.
   return (d < 25000.0);
+}
+
+m2::PointD Framework::PtoG(m2::PointD const & p) const
+{
+  auto pt = m_currentModelView.PtoG(p);
+  pt.x = mercator::WrapX(pt.x);
+  return pt;
+}
+
+m2::PointD Framework::P3dtoG(m2::PointD const & p) const
+{
+  auto pt = m_currentModelView.PtoG(m_currentModelView.P3dtoP(p));
+  pt.x = mercator::WrapX(pt.x);
+  return pt;
 }
 
 void Framework::CreateDrapeEngine(ref_ptr<dp::GraphicsContextFactory> contextFactory, DrapeCreationParams && params)

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -487,11 +487,11 @@ public:
   bool GetDistanceAndAzimut(m2::PointD const & point, double lat, double lon, double north,
                             platform::Distance & distance, double & azimut);
 
-  /// @name Manipulating with model view
-  m2::PointD PtoG(m2::PointD const & p) const { return m_currentModelView.PtoG(p); }
-  m2::PointD P3dtoG(m2::PointD const & p) const { return m_currentModelView.PtoG(m_currentModelView.P3dtoP(p)); }
-  m2::PointD GtoP(m2::PointD const & p) const { return m_currentModelView.GtoP(p); }
-  m2::PointD GtoP3d(m2::PointD const & p) const { return m_currentModelView.PtoP3d(m_currentModelView.GtoP(p)); }
+  /// @name For Desktop only.
+  /// @{
+  m2::PointD PtoG(m2::PointD const & p) const;
+  m2::PointD P3dtoG(m2::PointD const & p) const;
+  /// @}
 
   /// Show all model by it's world rect.
   void ShowAll();
@@ -508,8 +508,6 @@ public:
   /// - Check minimal visible scale according to downloaded countries.
   void ShowRect(m2::RectD const & rect, int maxScale = -1, bool animation = true, bool useVisibleViewport = false);
   void ShowRect(m2::AnyRectD const & rect, bool animation = true, bool useVisibleViewport = false);
-
-  void GetTouchRect(m2::PointD const & center, uint32_t pxRadius, m2::AnyRectD & rect);
 
   void SetViewportListener(TViewportChangedFn const & fn);
 

--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -308,25 +308,20 @@ UNIT_CLASS_TEST(Runner, Bookmarks_ExportKML)
 
 namespace
 {
+// Same as in Framework::BuildPlacePageInfo.
 UserMark const * GetMark(Framework & fm, m2::PointD const & pt)
 {
-  m2::AnyRectD rect;
-  fm.GetTouchRect(fm.GtoP(pt), 20, rect);
-
-  return fm.GetBookmarkManager().FindNearestUserMark(rect);
+  double constexpr kEps = 1.0E-7;
+  m2::AnyRectD const rect(pt, ang::AngleD(0.0), m2::RectD(-kEps, -kEps, kEps, kEps));
+  return fm.GetBookmarkManager().FindNearestUserMark([&rect](UserMark::Type) { return rect; },
+                                                     [](UserMark::Type) { return false; });
 }
 
 Bookmark const * GetBookmark(Framework & fm, m2::PointD const & pt)
 {
   auto const * mark = GetMark(fm, pt);
-  ASSERT(mark, ());
-  ASSERT(mark->GetMarkType() == UserMark::BOOKMARK, ());
+  TEST(mark && mark->GetMarkType() == UserMark::BOOKMARK, ());
   return dynamic_cast<Bookmark const *>(mark);
-}
-
-Bookmark const * GetBookmarkPxPoint(Framework & fm, m2::PointD const & pt)
-{
-  return GetBookmark(fm, fm.PtoG(pt));
 }
 
 bool IsValidBookmark(Framework & fm, m2::PointD const & pt)
@@ -448,14 +443,12 @@ UNIT_TEST(Bookmarks_Getting)
 
   TEST_EQUAL(bmManager.GetBmGroupsCount(), 3, ());
 
-  TEST(IsValidBookmark(fm, m2::PointD(40, 20)), ());
-  Bookmark const * mark = GetBookmark(fm, m2::PointD(40, 20));
+  Bookmark const * mark = GetBookmark(fm, m2::PointD(41, 20));
   TEST_EQUAL(bmManager.GetCategoryName(mark->GetGroupId()), "cat2", ());
 
   TEST(!IsValidBookmark(fm, m2::PointD(0, 0)), ());
   TEST(!IsValidBookmark(fm, m2::PointD(800, 400)), ());
 
-  TEST(IsValidBookmark(fm, m2::PointD(41, 40)), ());
   mark = GetBookmark(fm, m2::PointD(41, 40));
   TEST_EQUAL(bmManager.GetCategoryName(mark->GetGroupId()), "cat3", ());
 
@@ -566,8 +559,7 @@ UNIT_TEST(Bookmarks_AddingMoving)
   fm.OnSize(800, 400);
   fm.ShowRect(m2::RectD(0, 0, 80, 40));
 
-  m2::PointD constexpr globalPoint = m2::PointD(40, 20);
-  m2::PointD const pixelPoint = fm.GtoP(globalPoint);
+  m2::PointD constexpr globalPoint(40, 20);
 
   BookmarkManager & bmManager = fm.GetBookmarkManager();
   bmManager.EnableTestMode(true);
@@ -580,7 +572,7 @@ UNIT_TEST(Bookmarks_AddingMoving)
   kml::SetDefaultStr(bm1.m_name, "name");
   bm1.m_point = globalPoint;
   auto const * pBm1 = bmManager.GetEditSession().CreateBookmark(std::move(bm1), cat1);
-  Bookmark const * mark = GetBookmarkPxPoint(fm, pixelPoint);
+  Bookmark const * mark = GetBookmark(fm, globalPoint);
   TEST_EQUAL(bmManager.GetCategoryName(mark->GetGroupId()), "cat1", ());
 
   kml::BookmarkData bm2;
@@ -589,7 +581,7 @@ UNIT_TEST(Bookmarks_AddingMoving)
   bm2.m_color.m_predefinedColor = kml::PredefinedColor::Blue;
   auto const * pBm11 = bmManager.GetEditSession().CreateBookmark(std::move(bm2), cat1);
   TEST_EQUAL(pBm1->GetGroupId(), pBm11->GetGroupId(), ());
-  mark = GetBookmarkPxPoint(fm, pixelPoint);
+  mark = GetBookmark(fm, globalPoint);
   TEST_EQUAL(bmManager.GetCategoryName(mark->GetGroupId()), "cat1", ());
   TEST_EQUAL(kml::GetDefaultStr(mark->GetName()), "name2", ());
   TEST_EQUAL(mark->GetColor(), kml::PredefinedColor::Blue, ());
@@ -602,7 +594,7 @@ UNIT_TEST(Bookmarks_AddingMoving)
   auto const * pBm2 = bmManager.GetEditSession().CreateBookmark(std::move(bm3), cat2);
   TEST_NOT_EQUAL(pBm1->GetGroupId(), pBm2->GetGroupId(), ());
   TEST_EQUAL(bmManager.GetBmGroupsCount(), 2, ());
-  mark = GetBookmarkPxPoint(fm, pixelPoint);
+  mark = GetBookmark(fm, globalPoint);
   TEST_EQUAL(bmManager.GetCategoryName(mark->GetGroupId()), "cat1", ());
   TEST_EQUAL(bmManager.GetUserMarkIds(cat1).size(), 2, ("Bookmark wasn't moved from one category to another"));
   TEST_EQUAL(kml::GetDefaultStr(mark->GetName()), "name2", ());


### PR DESCRIPTION
Route line, arrows, and markers disappeared when the user dragged the map horizontally past the antimeridian (360° wrap). The antimeridian commit (3b4a6e8c7f) made X dragging unconstrained so the screen origin can move far beyond the canonical [-180, 180] Mercator range, but the route renderer was not adapted to this new coordinate model.

Root cause: route geometry is pre-built once with a canonical pivot and canonical bounding boxes. After the viewport wraps, two things fail:

1. Bounding box culling: route bboxes (e.g. x∈[10,40]) no longer intersect the shifted ClipRect (e.g. x∈[300,480]), so all render buckets are skipped.

2. ModelView transform: GetModelView() uses the canonical pivot while the GtoP matrix is built for the shifted screen origin, placing the route geometry an entire world-width off-screen in pixel space.

Fix: at render time, compute a single xOffset via GetViewportXOffset() from the pivot to the current screen origin. Use it to adjust both the ModelView pivot and the bounding boxes before the intersection test. This shifts the pre-built GPU geometry into the correct world copy without rebuilding any buffers — matching the tile system's approach.

Applied to RenderSubroute, RenderSubrouteArrows (pivot + bbox), and RenderSubrouteMarkers (pivot only, no bbox culling). RenderPreviewData is unchanged — its pivot already tracks the screen center each frame.

Also extracted GetViewportXOffset() as a public helper from the existing AdjustPointForViewport(), to allow computing the raw offset for bounding box shifts without constructing a point.