### PR TITLE
[ios] Refine NavigationDashboard modal snap points

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardModalPresentationStepStrategy.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardModalPresentationStepStrategy.swift
@@ -1,7 +1,9 @@
 enum NavigationDashboardModalPresentationStep: Int, CaseIterable, ModalPresentationStep {
   case expanded
   case regular
+  case halfScreen
   case compact
+  case estimates
   case hidden
 }
 
@@ -12,17 +14,48 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
     static let compactHeightOffset: CGFloat = 300
     static let fullScreenHeightFactorPortrait: CGFloat = 0.1
     static let halfScreenHeightFactorPortrait: CGFloat = 0.55
+    static let halfScreenOriginFactorPortrait: CGFloat = 0.5
     static let topInset: CGFloat = 8
   }
+
+  static let halfScreenActivationHeightFactor: CGFloat = 2.0 / 3.0
 
   typealias Step = NavigationDashboardModalPresentationStep
 
   static func == (lhs: NavigationDashboardModalPresentationStepStrategy, rhs: NavigationDashboardModalPresentationStepStrategy) -> Bool {
-    lhs.regularHeigh == rhs.regularHeigh && lhs.compactHeight == rhs.compactHeight
+    lhs.regularHeigh == rhs.regularHeigh &&
+      lhs.compactBaseHeight == rhs.compactBaseHeight &&
+      lhs.estimatesHeight == rhs.estimatesHeight &&
+      lhs.compactDiscoverabilityOffset == rhs.compactDiscoverabilityOffset &&
+      lhs.shouldUseCompactDiscoverabilityOffset == rhs.shouldUseCompactDiscoverabilityOffset &&
+      lhs.shouldShowHalfScreenStep == rhs.shouldShowHalfScreenStep &&
+      lhs.shouldShowEstimatesStep == rhs.shouldShowEstimatesStep
   }
 
   var regularHeigh: CGFloat = .zero
-  var compactHeight: CGFloat = .zero
+  var compactBaseHeight: CGFloat = .zero
+  var estimatesHeight: CGFloat = .zero
+  var compactDiscoverabilityOffset: CGFloat = .zero
+  var shouldUseCompactDiscoverabilityOffset = true
+  var shouldShowHalfScreenStep = false
+  var shouldShowEstimatesStep = false
+
+  var compactHeight: CGFloat {
+    compactBaseHeight + (shouldUseCompactDiscoverabilityOffset ? compactDiscoverabilityOffset : 0)
+  }
+
+  var steps: [Step] {
+    var availableSteps: [Step] = [.expanded, .regular]
+    if shouldShowHalfScreenStep {
+      availableSteps.append(.halfScreen)
+    }
+    availableSteps.append(.compact)
+    if shouldShowEstimatesStep {
+      availableSteps.append(.estimates)
+    }
+    availableSteps.append(.hidden)
+    return availableSteps
+  }
 
   func upperTo(_ step: Step) -> Step {
     switch step {
@@ -30,10 +63,14 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
       return .expanded
     case .regular:
       return .expanded
+    case .halfScreen:
+      return .regular
     case .compact:
-      return .regular
+      return shouldShowHalfScreenStep ? .halfScreen : .regular
+    case .estimates:
+      return .compact
     case .hidden:
-      return .regular
+      return shouldShowEstimatesStep ? .estimates : .compact
     }
   }
 
@@ -42,20 +79,27 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
     case .expanded:
       return .regular
     case .regular:
+      return shouldShowHalfScreenStep ? .halfScreen : .compact
+    case .halfScreen:
       return .compact
     case .compact:
-      return .compact
+      return shouldShowEstimatesStep ? .estimates : .compact
+    case .estimates:
+      return .estimates
     case .hidden:
       return .hidden
     }
   }
 
-  var first: Step {
-    .expanded
-  }
-
-  var last: Step {
-    .compact
+  func resolvedStep(_ step: Step) -> Step {
+    switch step {
+    case .halfScreen where !shouldShowHalfScreenStep:
+      return .regular
+    case .estimates where !shouldShowEstimatesStep:
+      return .compact
+    default:
+      return step
+    }
   }
 
   func frame(_ step: Step, for _: UIView, in containerViewController: UIViewController) -> CGRect {
@@ -80,11 +124,21 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
         } else {
           frame.origin.y = containerSize.height * Constants.halfScreenHeightFactorPortrait
         }
+      case .halfScreen:
+        frame.origin.y = max(containerSize.height * Constants.halfScreenOriginFactorPortrait, safeAreaInsets.top + Constants.topInset)
       case .compact:
         if compactHeight != 0 {
           frame.origin.y = containerSize.height - compactHeight
         } else {
           frame.origin.y = containerSize.height * Constants.halfScreenHeightFactorPortrait
+        }
+      case .estimates:
+        if estimatesHeight != 0 {
+          frame.origin.y = containerSize.height - estimatesHeight
+        } else {
+          frame.origin.y = compactHeight != 0
+            ? containerSize.height - compactHeight
+            : containerSize.height * Constants.halfScreenHeightFactorPortrait
         }
       case .hidden:
         frame.origin.y = containerSize.height
@@ -104,11 +158,21 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
           } else {
             frame.origin.y = containerSize.height * Constants.halfScreenHeightFactorPortrait
           }
+        case .halfScreen:
+          frame.origin.y = max(containerSize.height * Constants.halfScreenOriginFactorPortrait, safeAreaInsets.top + Constants.topInset)
         case .compact:
           if compactHeight != 0 {
             frame.origin.y = containerSize.height - compactHeight
           } else {
             frame.origin.y = containerSize.height * Constants.halfScreenHeightFactorPortrait
+          }
+        case .estimates:
+          if estimatesHeight != 0 {
+            frame.origin.y = containerSize.height - estimatesHeight
+          } else {
+            frame.origin.y = compactHeight != 0
+              ? containerSize.height - compactHeight
+              : containerSize.height * Constants.halfScreenHeightFactorPortrait
           }
         case .hidden:
           frame.origin.y = containerSize.height
@@ -117,10 +181,13 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
         frame.size.width = Constants.iPadWidth
         frame.origin.x = safeAreaInsets.left
         switch step {
-        case .expanded, .regular:
+        case .expanded, .regular, .halfScreen:
           frame.origin.y = Constants.topInset
         case .compact:
           frame.origin.y = containerSize.height - (compactHeight != 0 ? compactHeight : Constants.compactHeightOffset)
+        case .estimates:
+          let height = estimatesHeight != 0 ? estimatesHeight : compactHeight
+          frame.origin.y = containerSize.height - (height != 0 ? height : Constants.compactHeightOffset)
         case .hidden:
           frame.origin.y = containerSize.height
         }

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardModalPresentationStepStrategy.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardModalPresentationStepStrategy.swift
@@ -23,7 +23,7 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
   typealias Step = NavigationDashboardModalPresentationStep
 
   static func == (lhs: NavigationDashboardModalPresentationStepStrategy, rhs: NavigationDashboardModalPresentationStepStrategy) -> Bool {
-    lhs.regularHeigh == rhs.regularHeigh &&
+    lhs.regularHeight == rhs.regularHeight &&
       lhs.compactBaseHeight == rhs.compactBaseHeight &&
       lhs.estimatesHeight == rhs.estimatesHeight &&
       lhs.compactDiscoverabilityOffset == rhs.compactDiscoverabilityOffset &&
@@ -32,7 +32,7 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
       lhs.shouldShowEstimatesStep == rhs.shouldShowEstimatesStep
   }
 
-  var regularHeigh: CGFloat = .zero
+  var regularHeight: CGFloat = .zero
   var compactBaseHeight: CGFloat = .zero
   var estimatesHeight: CGFloat = .zero
   var compactDiscoverabilityOffset: CGFloat = .zero
@@ -119,8 +119,8 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
       case .expanded:
         frame.origin.y = safeAreaInsets.top + Constants.topInset
       case .regular:
-        if regularHeigh != 0 {
-          frame.origin.y = max(containerSize.height - regularHeigh, safeAreaInsets.top + Constants.topInset)
+        if regularHeight != 0 {
+          frame.origin.y = max(containerSize.height - regularHeight, safeAreaInsets.top + Constants.topInset)
         } else {
           frame.origin.y = containerSize.height * Constants.halfScreenHeightFactorPortrait
         }
@@ -153,8 +153,8 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
         case .expanded:
           frame.origin.y = safeAreaInsets.top + Constants.topInset
         case .regular:
-          if regularHeigh != 0 {
-            frame.origin.y = max(containerSize.height - regularHeigh, safeAreaInsets.top + Constants.topInset)
+          if regularHeight != 0 {
+            frame.origin.y = max(containerSize.height - regularHeight, safeAreaInsets.top + Constants.topInset)
           } else {
             frame.origin.y = containerSize.height * Constants.halfScreenHeightFactorPortrait
           }

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
@@ -180,6 +180,10 @@ final class NavigationDashboardViewController: UIViewController {
 
   @objc
   private func handlePan(_ gesture: UIPanGestureRecognizer) {
+    let didMeaningfullyDrag = abs(gesture.translation(in: availableAreaView).y) > Constants.panGestureThreshold
+    if didMeaningfullyDrag, presentationStepStrategy.shouldUseCompactDiscoverabilityOffset {
+      presentationStepStrategy.shouldUseCompactDiscoverabilityOffset = false
+    }
     presentationStepsController.handlePan(gesture)
   }
 
@@ -361,20 +365,43 @@ final class NavigationDashboardViewController: UIViewController {
   }
 
   private func updatePresentationStep(_ step: NavigationDashboardModalPresentationStep) {
-    availableAreaView.layoutIfNeeded()
+    view.layoutIfNeeded()
     let regularHeight = routePointsView.contentBottom.y
       + bottomActionsMenu.frame.height
       + Constants.startButtonSpacing
 
-    let compactHeight = routePointsView.origin.y
+    let compactBaseHeight = routePointsView.origin.y
       + bottomActionsMenu.frame.height
       + Constants.startButtonSpacing
-      + Constants.routePointsDiscoverabilityPadding
 
-    let shouldForceContentFrameUpdate = presentationStepStrategy.regularHeigh != regularHeight || presentationStepStrategy.compactHeight != compactHeight
+    let estimatesBottom = estimatesStackView.convert(CGPoint(x: .zero, y: estimatesStackView.bounds.maxY), to: availableAreaView).y
+    let estimatesHeight = estimatesBottom
+      + bottomActionsMenu.frame.height
+      + Constants.startButtonSpacing
+
+    let containerHeight = view.bounds.height
+    let shouldShowHalfScreenStep = traitCollection.verticalSizeClass == .regular &&
+      containerHeight > 0 &&
+      regularHeight > containerHeight * NavigationDashboardModalPresentationStepStrategy.halfScreenActivationHeightFactor
+    let shouldShowEstimatesStep = !elevationProfileView.isHidden && estimatesHeight < compactBaseHeight
+
+    let shouldForceContentFrameUpdate =
+      presentationStepStrategy.regularHeigh != regularHeight ||
+      presentationStepStrategy.compactBaseHeight != compactBaseHeight ||
+      presentationStepStrategy.estimatesHeight != estimatesHeight ||
+      presentationStepStrategy.compactDiscoverabilityOffset != Constants.routePointsDiscoverabilityPadding ||
+      presentationStepStrategy.shouldShowEstimatesStep != shouldShowEstimatesStep ||
+      presentationStepStrategy.shouldShowHalfScreenStep != shouldShowHalfScreenStep
+
     presentationStepStrategy.regularHeigh = regularHeight
-    presentationStepStrategy.compactHeight = compactHeight
-    presentationStepsController.setStep(step, forced: shouldForceContentFrameUpdate)
+    presentationStepStrategy.compactBaseHeight = compactBaseHeight
+    presentationStepStrategy.estimatesHeight = estimatesHeight
+    presentationStepStrategy.compactDiscoverabilityOffset = Constants.routePointsDiscoverabilityPadding
+    presentationStepStrategy.shouldShowEstimatesStep = shouldShowEstimatesStep
+    presentationStepStrategy.shouldShowHalfScreenStep = shouldShowHalfScreenStep
+
+    let resolvedStep = presentationStepStrategy.resolvedStep(step)
+    presentationStepsController.setStep(resolvedStep, forced: shouldForceContentFrameUpdate || resolvedStep != step)
   }
 
   private func close() {

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationDashboardViewController.swift
@@ -27,6 +27,7 @@ final class NavigationDashboardViewController: UIViewController {
 
     static let routePointsDiscoverabilityPadding: CGFloat = 20
     static let panGestureThreshold: CGFloat = 5
+    static let meaningfulDragThreshold: CGFloat = 10
   }
 
   typealias StepsController = ModalPresentationStepsController<NavigationDashboardModalPresentationStep>
@@ -180,7 +181,7 @@ final class NavigationDashboardViewController: UIViewController {
 
   @objc
   private func handlePan(_ gesture: UIPanGestureRecognizer) {
-    let didMeaningfullyDrag = abs(gesture.translation(in: availableAreaView).y) > Constants.panGestureThreshold
+    let didMeaningfullyDrag = abs(gesture.translation(in: availableAreaView).y) > Constants.meaningfulDragThreshold
     if didMeaningfullyDrag, presentationStepStrategy.shouldUseCompactDiscoverabilityOffset {
       presentationStepStrategy.shouldUseCompactDiscoverabilityOffset = false
     }
@@ -372,7 +373,6 @@ final class NavigationDashboardViewController: UIViewController {
 
     let compactBaseHeight = routePointsView.origin.y
       + bottomActionsMenu.frame.height
-      + Constants.startButtonSpacing
 
     let estimatesBottom = estimatesStackView.convert(CGPoint(x: .zero, y: estimatesStackView.bounds.maxY), to: availableAreaView).y
     let estimatesHeight = estimatesBottom
@@ -386,14 +386,13 @@ final class NavigationDashboardViewController: UIViewController {
     let shouldShowEstimatesStep = !elevationProfileView.isHidden && estimatesHeight < compactBaseHeight
 
     let shouldForceContentFrameUpdate =
-      presentationStepStrategy.regularHeigh != regularHeight ||
+      presentationStepStrategy.regularHeight != regularHeight ||
       presentationStepStrategy.compactBaseHeight != compactBaseHeight ||
       presentationStepStrategy.estimatesHeight != estimatesHeight ||
-      presentationStepStrategy.compactDiscoverabilityOffset != Constants.routePointsDiscoverabilityPadding ||
       presentationStepStrategy.shouldShowEstimatesStep != shouldShowEstimatesStep ||
       presentationStepStrategy.shouldShowHalfScreenStep != shouldShowHalfScreenStep
 
-    presentationStepStrategy.regularHeigh = regularHeight
+    presentationStepStrategy.regularHeight = regularHeight
     presentationStepStrategy.compactBaseHeight = compactBaseHeight
     presentationStepStrategy.estimatesHeight = estimatesHeight
     presentationStepStrategy.compactDiscoverabilityOffset = Constants.routePointsDiscoverabilityPadding


### PR DESCRIPTION
This PR updates the modal presentation step logic:
- use the actual container height to decide when half-screen mode should be available
- keep the initial compact state with extra discoverability offset only for the first appearance in a session
- remove that extra offset after the first meaningful manual drag
- keep a separate `estimates` step only when the elevation chart is visible and that step is actually distinct from compact
- keep the half-screen snap point at 1/2 of the container height

## Results
![Simulator Screen Recording - iPhone 17 - 2026-04-14 at 13 10 25](https://github.com/user-attachments/assets/d318baf0-b2a5-4f49-8b17-24360e3721f5)

![Simulator Screen Recording - iPhone 17 - 2026-04-14 at 13 09 52](https://github.com/user-attachments/assets/d1ef1713-bfbc-4e66-bd00-7c4470bf8d53)


iPad
<img width="400" height="1000" alt="image" src="https://github.com/user-attachments/assets/c7a93e3d-1643-4195-a6c2-7d8a60777b75" />
<img width="400" height="1000" alt="image" src="https://github.com/user-attachments/assets/15cdbfcc-5eea-4e0d-904b-46172243a4ea" />
