### PR TITLE
[android] Improve route elevation profile and fix RTL layout

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/RouteElevationChartController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RouteElevationChartController.java
@@ -2,7 +2,6 @@ package app.organicmaps.routing;
 
 import android.content.Context;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -46,13 +45,6 @@ public class RouteElevationChartController
     mMaxAltitude = view.findViewById(R.id.highest_altitude);
     mMinAltitude = view.findViewById(R.id.lowest_altitude);
 
-    if (mMinAltitude != null)
-    {
-      final ViewGroup.MarginLayoutParams lp = (ViewGroup.MarginLayoutParams) mMinAltitude.getLayoutParams();
-      lp.bottomMargin -= mContext.getResources().getDimensionPixelSize(R.dimen.margin_half);
-      mMinAltitude.setLayoutParams(lp);
-    }
-
     if (mChart == null)
       return;
 
@@ -83,10 +75,10 @@ public class RouteElevationChartController
     mListener = listener;
   }
 
-  public void fitScreen()
+  public void clearSelection()
   {
     if (mChart != null)
-      mChart.fitScreen();
+      mChart.highlightValue(null, false);
   }
 
   public void setData(@Nullable RouteAltitudeData data)
@@ -102,13 +94,8 @@ public class RouteElevationChartController
         mMaxAltitude.setText("");
       if (mMinAltitude != null)
         mMinAltitude.setText("");
-      if (mListener != null)
-        mListener.onElevationPointDeselected();
       return;
     }
-
-    if (mListener != null)
-      mListener.onElevationPointDeselected();
 
     List<Entry> values = new ArrayList<>();
     for (int i = 0; i < data.getSize(); i++)

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -38,6 +38,7 @@ import app.organicmaps.sdk.routing.TransitRouteInfo;
 import app.organicmaps.sdk.routing.TransitStepInfo;
 import app.organicmaps.sdk.util.Distance;
 import app.organicmaps.sdk.util.Graphics;
+import app.organicmaps.sdk.util.StringUtils;
 import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
@@ -204,6 +205,9 @@ final class RoutingBottomMenuController implements View.OnClickListener
 
   void hideAltitudeChartAndRoutingDetails()
   {
+    mRouteElevationChartController.clearSelection();
+    Framework.nativeRouteRemoveElevationActivePoint();
+    mRouteElevationChartController.setData(null);
     UiUtils.hide(mAltitudeChartFrame, mTransitFrame);
   }
 
@@ -346,14 +350,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
   void restoreRoutingPanelState(@NonNull Bundle state)
   {
     if (state.getBoolean(STATE_ALTITUDE_CHART_SHOWN))
-    {
-      mAltitudeChartFrame.post(() -> {
-        if (UiUtils.isVisible(mAltitudeChartFrame))
-          mRouteElevationChartController.fitScreen();
-        else
-          showAltitudeChartAndRoutingDetails();
-      });
-    }
+      showAltitudeChartAndRoutingDetails();
 
     String error = state.getString(STATE_ERROR);
     if (!TextUtils.isEmpty(error))
@@ -362,17 +359,14 @@ final class RoutingBottomMenuController implements View.OnClickListener
 
   private void showRouteAltitudeChart()
   {
-    if (RoutingController.get().isVehicleRouterType())
-    {
-      UiUtils.hide(mTimeElevationLine, mAltitudeChart);
-      return;
-    }
-
     UiUtils.hide(mTimeVehicle);
 
     final RouteAltitudeData data = Framework.nativeGetRouteAltitudeData();
     if (data == null || data.getSize() == 0)
     {
+      mRouteElevationChartController.clearSelection();
+      Framework.nativeRouteRemoveElevationActivePoint();
+      mRouteElevationChartController.setData(null);
       UiUtils.hide(mAltitudeChart, mAltitudeDifference);
       return;
     }
@@ -380,9 +374,11 @@ final class RoutingBottomMenuController implements View.OnClickListener
     mRouteElevationChartController.setData(data);
     UiUtils.show(mAltitudeChart);
 
-    mAltitudeDifference.setText(mContext.getString(R.string.route_ascent_descent_format,
-                                                   Framework.nativeFormatAltitude(data.getTotalAscent()),
-                                                   Framework.nativeFormatAltitude(data.getTotalDescent())));
+    final int formatResId =
+        StringUtils.isRtl() ? R.string.route_ascent_descent_format_rtl : R.string.route_ascent_descent_format_ltr;
+    final String ascent = Framework.nativeFormatAltitude(data.getTotalAscent());
+    final String descent = Framework.nativeFormatAltitude(data.getTotalDescent());
+    mAltitudeDifference.setText(mContext.getString(formatResId, ascent, descent));
     UiUtils.show(mAltitudeDifference);
   }
 
@@ -498,6 +494,8 @@ final class RoutingBottomMenuController implements View.OnClickListener
       mListener.onManageRouteOpen();
     else if (id == R.id.btn__save)
     {
+      // Clear elevation preview marker before saving.
+      mRouteElevationChartController.clearSelection();
       Framework.nativeRouteRemoveElevationActivePoint();
       Framework.nativeSaveRoute();
       RoutingController.get().setRouteSaved();

--- a/android/app/src/main/res/layout-h400dp-land/map_buttons_layout_regular.xml
+++ b/android/app/src/main/res/layout-h400dp-land/map_buttons_layout_regular.xml
@@ -24,7 +24,6 @@
       android:layout_alignParentBottom="true"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
-
   </androidx.constraintlayout.widget.ConstraintLayout>
   <include
     layout="@layout/map_status_track_recording"

--- a/android/app/src/main/res/layout-h400dp/map_buttons_layout_regular.xml
+++ b/android/app/src/main/res/layout-h400dp/map_buttons_layout_regular.xml
@@ -24,7 +24,6 @@
       android:layout_alignParentBottom="true"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
-
   </androidx.constraintlayout.widget.ConstraintLayout>
   <include
     layout="@layout/map_status_track_recording"

--- a/android/app/src/main/res/layout-land/altitude_chart_panel.xml
+++ b/android/app/src/main/res/layout-land/altitude_chart_panel.xml
@@ -46,7 +46,8 @@
           tools:visibility="visible" />
     </LinearLayout>
 
-    <include layout="@layout/elevation_profile"
+    <include
+      layout="@layout/route_elevation_profile"
       android:id="@+id/altitude_chart"
       android:layout_width="match_parent"
       android:layout_height="@dimen/route_chart_height"

--- a/android/app/src/main/res/layout-land/map_buttons_layout_regular.xml
+++ b/android/app/src/main/res/layout-land/map_buttons_layout_regular.xml
@@ -24,7 +24,6 @@
       android:layout_alignParentBottom="true"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
-
   </androidx.constraintlayout.widget.ConstraintLayout>
   <include
     layout="@layout/map_status_track_recording"

--- a/android/app/src/main/res/layout-w1020dp-land/altitude_chart_panel.xml
+++ b/android/app/src/main/res/layout-w1020dp-land/altitude_chart_panel.xml
@@ -75,7 +75,8 @@
           android:textSize="@dimen/text_size_routing_plan_detail_arrival"/>
     </LinearLayout>
 
-    <include layout="@layout/elevation_profile"
+    <include
+      layout="@layout/route_elevation_profile"
       android:id="@+id/altitude_chart"
       android:layout_width="0dp"
       android:layout_height="@dimen/route_chart_height"

--- a/android/app/src/main/res/layout/altitude_chart_panel.xml
+++ b/android/app/src/main/res/layout/altitude_chart_panel.xml
@@ -56,7 +56,9 @@
           android:layout_height="wrap_content"
           android:orientation="vertical"
           android:layout_weight="1">
-            <include layout="@layout/elevation_profile"
+
+            <include
+              layout="@layout/route_elevation_profile"
               android:id="@+id/altitude_chart"
               android:layout_width="match_parent"
               android:layout_height="@dimen/route_chart_height" />

--- a/android/app/src/main/res/layout/route_elevation_profile.xml
+++ b/android/app/src/main/res/layout/route_elevation_profile.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="match_parent"
   android:layout_height="@dimen/elevation_profile_content_height"
   android:background="?cardBackground">
@@ -8,11 +7,6 @@
     android:id="@+id/elevation_profile_chart"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />
-  <app.organicmaps.widget.placepage.FloatingMarkerView
-    android:id="@+id/floating_marker"
-    android:visibility="gone"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"/>
   <TextView
     android:id="@+id/highest_altitude"
     android:layout_width="wrap_content"
@@ -36,7 +30,7 @@
     android:layout_alignParentBottom="true"
     android:layout_marginStart="@dimen/margin_half"
     android:layout_marginEnd="@dimen/margin_base_plus"
-    android:layout_marginBottom="@dimen/margin_base_plus"
+    android:layout_marginBottom="@dimen/margin_base"
     android:background="?altitudeBg"
     android:paddingStart="@dimen/margin_quarter_plus"
     android:paddingTop="@dimen/margin_eighth"

--- a/android/app/src/main/res/values/donottranslate.xml
+++ b/android/app/src/main/res/values/donottranslate.xml
@@ -46,7 +46,8 @@
 
   <string name="notification_ticker_ltr" translatable="false">%1$s: %2$s</string>
   <string name="notification_ticker_rtl" translatable="false">%2$s :%1$s</string>
-  <string name="route_ascent_descent_format" translatable="false">↗\u00A0%1$s ↘\u00A0%2$s</string>
+  <string name="route_ascent_descent_format_ltr" translatable="false">↗\u00A0%1$s ↘\u00A0%2$s</string>
+  <string name="route_ascent_descent_format_rtl" translatable="false">↖\u00A0%1$s ↙\u00A0%2$s</string>
 
   <!-- "Report a problem" predefined texts -->
   <string name="problem_does_not_exist" translatable="false">The amenity has gone or never existed. This is an auto-generated note from Organic Maps application: a user reports a POI that is visible on a map (which can be a month old), but cannot be found on the ground.</string>

--- a/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
@@ -360,6 +360,7 @@ public class RoutingController
     // and then app crashes. So, the previous route will be restored on the next app launch.
     saveRoute();
 
+    // Clear stale elevation preview marker.
     Framework.nativeRouteRemoveElevationActivePoint();
     setState(State.NAVIGATION);
 
@@ -455,6 +456,7 @@ public class RoutingController
     setBuildState(BuildState.NONE);
     setState(State.NONE);
 
+    // Clear stale elevation preview marker.
     Framework.nativeRouteRemoveElevationActivePoint();
     applyRemovingIntermediatePointsTransaction();
     if (deleteSavedRoute)

--- a/libs/map/map_tests/track_tests.cpp
+++ b/libs/map/map_tests/track_tests.cpp
@@ -1,6 +1,7 @@
 #include "testing/testing.hpp"
 
 #include "map/elevation_info.hpp"
+#include "map/routing_manager.hpp"
 #include "map/track.hpp"
 #include "map/track_statistics.hpp"
 
@@ -12,6 +13,9 @@
 #include "platform/platform.hpp"
 
 #include "coding/file_reader.hpp"
+
+#include <algorithm>
+#include <vector>
 
 namespace track_tests
 {
@@ -192,6 +196,43 @@ UNIT_TEST(Track_GetPoint_NegativeDistance)
   Track track = MakeTrack({{p1, p2}});
 
   TEST_ALMOST_EQUAL_ABS(track.GetPoint(-1.0), p1.GetPoint(), kEqualPointsEps, ());
+}
+
+// ===================== InterpolateByDistance tests =====================
+
+UNIT_TEST(InterpolatePointAtDistance_NegativeDistance)
+{
+  std::vector<m2::PointD> const points = {{0, 0}, {1, 0}, {2, 0}};
+  std::vector<double> const distances = {1.0, 2.0};
+
+  TEST_ALMOST_EQUAL_ABS(InterpolatePointAtDistance(distances, points, -5.0), points.front(), kEqualPointsEps, ());
+}
+
+UNIT_TEST(InterpolatePointAtDistance_BeyondEnd)
+{
+  std::vector<m2::PointD> const points = {{0, 0}, {1, 0}, {2, 0}};
+  std::vector<double> const distances = {1.0, 2.0};
+
+  TEST_ALMOST_EQUAL_ABS(InterpolatePointAtDistance(distances, points, 100.0), points.back(), kEqualPointsEps, ());
+}
+
+UNIT_TEST(InterpolatePointAtDistance_Midpoint)
+{
+  std::vector<m2::PointD> const points = {{0, 0}, {1, 0}, {2, 0}};
+  std::vector<double> const distances = {1.0, 2.0};
+
+  TEST_ALMOST_EQUAL_ABS(InterpolatePointAtDistance(distances, points, 0.5), m2::PointD(0.5, 0), kEqualPointsEps, ());
+  TEST_ALMOST_EQUAL_ABS(InterpolatePointAtDistance(distances, points, 1.5), m2::PointD(1.5, 0), kEqualPointsEps, ());
+}
+
+// Duplicated points don't cause issues because the algorithm interpolates
+// by cumulative distances, not by pairwise point gaps.
+UNIT_TEST(InterpolatePointAtDistance_DuplicatedPoints)
+{
+  std::vector<m2::PointD> const points = {{0, 0}, {0, 0}, {1, 0}};
+  std::vector<double> const distances = {0.0, 1.0};
+
+  TEST_ALMOST_EQUAL_ABS(InterpolatePointAtDistance(distances, points, 0.5), m2::PointD(0.5, 0), kEqualPointsEps, ());
 }
 
 // ===================== TrackStatistics tests =====================

--- a/libs/map/routing_manager.cpp
+++ b/libs/map/routing_manager.cpp
@@ -1235,14 +1235,9 @@ bool RoutingManager::GetRouteElevationInfo(ElevationInfo & ei) const
   return true;
 }
 
-std::optional<m2::PointD> RoutingManager::GetRoutePointAtDistance(double distanceMeters) const
+m2::PointD InterpolatePointAtDistance(std::vector<double> const & distances, std::vector<m2::PointD> const & points,
+                                      double distanceMeters)
 {
-  auto const * route = m_routingSession.GetRoute();
-  if (!route || !route->IsValid())
-    return std::nullopt;
-
-  auto const & distances = route->GetSegDistanceMeters();
-  auto const & points = route->GetPoly().GetPoints();
   ASSERT_EQUAL(distances.size() + 1, points.size(), ());
 
   if (distanceMeters <= 0)
@@ -1253,10 +1248,24 @@ std::optional<m2::PointD> RoutingManager::GetRoutePointAtDistance(double distanc
 
   auto const it = std::upper_bound(distances.begin(), distances.end(), distanceMeters);
   size_t const idx = std::distance(distances.begin(), it);
-  // distances[idx-1] < distanceMeters <= distances[idx], points[idx] .. points[idx+1]
-  double const segLen = distances[idx] - (idx > 0 ? distances[idx - 1] : 0.0);
-  double const f = segLen > 1e-9 ? (distanceMeters - (idx > 0 ? distances[idx - 1] : 0.0)) / segLen : 0.0;
+  // distances[idx-1] <= distanceMeters < distances[idx], points[idx] .. points[idx+1]
+  double const prevDist = idx > 0 ? distances[idx - 1] : 0.0;
+  double const segLen = distances[idx] - prevDist;
+  // segLen == 0 is unreachable: upper_bound skips duplicates to the first strictly-greater element.
+  ASSERT(segLen > 0, (distanceMeters, prevDist, distances[idx]));
+  double const f = (distanceMeters - prevDist) / segLen;
   return points[idx] + (points[idx + 1] - points[idx]) * f;
+}
+
+std::optional<m2::PointD> RoutingManager::GetRoutePointAtDistance(double distanceMeters) const
+{
+  auto const * route = m_routingSession.GetRoute();
+  if (!route || !route->IsValid())
+    return std::nullopt;
+
+  auto const & distances = route->GetSegDistanceMeters();
+  auto const & points = route->GetPoly().GetPoints();
+  return InterpolatePointAtDistance(distances, points, distanceMeters);
 }
 
 void RoutingManager::SetRouter(RouterType type)

--- a/libs/map/routing_manager.hpp
+++ b/libs/map/routing_manager.hpp
@@ -47,6 +47,9 @@ namespace power_management
 class PowerManager;
 }
 
+m2::PointD InterpolatePointAtDistance(std::vector<double> const & distances, std::vector<m2::PointD> const & points,
+                                      double distanceMeters);
+
 struct RoutePointInfo
 {
   std::string m_name;


### PR DESCRIPTION
## Summary                                                                                                                                               
  - Separate route elevation profile layout from track elevation profile, removing unused `FloatingMarkerView`                                             
  - Fix ascent/descent text rendering in RTL locales using `BidiFormatter`
  - Clear chart data and elevation marker when hiding altitude panel or switching routes                                                                   
  - Simplify `restoreRoutingPanelState` by removing redundant `post()` deferral                                                                            
  - Remove redundant `isVehicleRouterType` guard in `showRouteAltitudeChart()` (already checked by caller)
  - Fix interpolation epsilon in `RoutingManager::GetRoutePointAtDistance` and add unit tests 