### PR TITLE
[ios] Fix compile time warning

### DIFF
--- a/iphone/Maps/Categories/UIApplication+LoadingOverlay.swift
+++ b/iphone/Maps/Categories/UIApplication+LoadingOverlay.swift
@@ -3,7 +3,7 @@ extension UIApplication {
 
   @objc
   func showLoadingOverlay(completion: (() -> Void)? = nil) {
-    guard let window = windows.first(where: { $0.isKeyWindow }) else {
+    guard let window = activeKeyWindow else {
       completion?()
       return
     }

--- a/iphone/Maps/Categories/UIImage+RGBAData.m
+++ b/iphone/Maps/Categories/UIImage+RGBAData.m
@@ -13,7 +13,7 @@ static void releaseCallback(void * info, void const * data, size_t size)
   size_t bitsPerComponent = 8;
   size_t bitsPerPixel = bitsPerComponent * bytesPerPixel;
   size_t bytesPerRow = bytesPerPixel * width;
-  CGBitmapInfo bitmapInfo = kCGBitmapByteOrderDefault | kCGImageAlphaLast;
+  CGBitmapInfo bitmapInfo = kCGBitmapByteOrderDefault | (CGBitmapInfo)kCGImageAlphaLast;
 
   CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
   CFDataRef cfData = (__bridge_retained CFDataRef)data;

--- a/iphone/Maps/Categories/UIWindowScene+KeyWindow.swift
+++ b/iphone/Maps/Categories/UIWindowScene+KeyWindow.swift
@@ -1,10 +1,10 @@
-extension UIWindowScene {
-  var keyWindow: UIWindow? {
-    windows.first(where: \.isKeyWindow)
-  }
-}
-
 extension UIApplication {
+  var allConnectedWindows: [UIWindow] {
+    connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .flatMap(\.windows)
+  }
+
   var activeWindowScenes: [UIWindowScene] {
     connectedScenes
       .compactMap { $0 as? UIWindowScene }

--- a/iphone/Maps/Categories/UIWindowScene+KeyWindow.swift
+++ b/iphone/Maps/Categories/UIWindowScene+KeyWindow.swift
@@ -1,0 +1,25 @@
+extension UIWindowScene {
+  var keyWindow: UIWindow? {
+    windows.first(where: \.isKeyWindow)
+  }
+}
+
+extension UIApplication {
+  var activeWindowScenes: [UIWindowScene] {
+    connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .filter { $0.activationState == .foregroundActive }
+  }
+
+  var activeKeyWindow: UIWindow? {
+    foregroundActiveScene?.keyWindow
+  }
+
+  var activeWindows: [UIWindow] {
+    activeWindowScenes.flatMap(\.windows)
+  }
+
+  var foregroundActiveScene: UIWindowScene? {
+    activeWindowScenes.first(where: { $0.keyWindow != nil }) ?? activeWindowScenes.first
+  }
+}

--- a/iphone/Maps/Classes/CarPlay/Template Builders/ListTemplateBuilder.swift
+++ b/iphone/Maps/Classes/CarPlay/Template Builders/ListTemplateBuilder.swift
@@ -127,13 +127,9 @@ final class ListTemplateBuilder {
   private class func buildBarButton(type: BarButtonType, action: ((CPBarButton) -> Void)?) -> CPBarButton {
     switch type {
     case .bookmarks:
-      let button = CPBarButton(type: .image, handler: action)
-      button.image = UIImage(named: "ic_carplay_bookmark")
-      return button
+      CPBarButton(image: UIImage.icCarplayBookmark, handler: action)
     case .search:
-      let button = CPBarButton(type: .image, handler: action)
-      button.image = UIImage(named: "ic_carplay_keyboard")
-      return button
+      CPBarButton(image: UIImage.icCarplayKeyboard, handler: action)
     }
   }
 }

--- a/iphone/Maps/Classes/CarPlay/Template Builders/MapTemplateBuilder.swift
+++ b/iphone/Maps/Classes/CarPlay/Template Builders/MapTemplateBuilder.swift
@@ -172,37 +172,21 @@ final class MapTemplateBuilder {
   private class func buildBarButton(type: BarButtonType, action: ((CPBarButton) -> Void)?) -> CPBarButton {
     switch type {
     case .dismissPaning:
-      let button = CPBarButton(type: .text, handler: action)
-      button.title = L("done")
-      return button
+      CPBarButton(title: L("done"), handler: action)
     case .destination:
-      let button = CPBarButton(type: .text, handler: action)
-      button.title = L("pick_destination")
-      return button
+      CPBarButton(title: L("pick_destination"), handler: action)
     case .recenter:
-      let button = CPBarButton(type: .text, handler: action)
-      button.title = L("follow_my_position")
-      return button
+      CPBarButton(title: L("follow_my_position"), handler: action)
     case .settings:
-      let button = CPBarButton(type: .image, handler: action)
-      button.image = UIImage(named: "ic_carplay_settings")
-      return button
+      CPBarButton(image: UIImage.icCarplaySettings, handler: action)
     case .mute:
-      let button = CPBarButton(type: .image, handler: action)
-      button.image = UIImage(named: "ic_carplay_unmuted")
-      return button
+      CPBarButton(image: UIImage.icCarplayUnmuted, handler: action)
     case .unmute:
-      let button = CPBarButton(type: .image, handler: action)
-      button.image = UIImage(named: "ic_carplay_muted")
-      return button
+      CPBarButton(image: UIImage.icCarplayMuted, handler: action)
     case .redirectRoute:
-      let button = CPBarButton(type: .image, handler: action)
-      button.image = UIImage(named: "ic_carplay_redirect_route")
-      return button
+      CPBarButton(image: UIImage.icCarplayRedirectRoute, handler: action)
     case .endRoute:
-      let button = CPBarButton(type: .text, handler: action)
-      button.title = L("navigation_stop_button").capitalized
-      return button
+      CPBarButton(title: L("navigation_stop_button").capitalized, handler: action)
     }
   }
 }

--- a/iphone/Maps/Classes/Components/CopyableLabel.swift
+++ b/iphone/Maps/Classes/Components/CopyableLabel.swift
@@ -34,7 +34,7 @@ class CopyableLabel: UILabel {
 
   override func copy(_: Any?) {
     UIPasteboard.general.string = text
-    UIMenuController.shared.setMenuVisible(false, animated: true)
+    UIMenuController.shared.hideMenu(from: self)
   }
 
   override var canBecomeFirstResponder: Bool {

--- a/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
+++ b/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
@@ -70,10 +70,7 @@ final class Toast: NSObject {
 
   private func show(withAlignment alignment: Alignment, pinToSafeArea: Bool) {
     Self.hideAll()
-    guard let view = UIApplication.shared.connectedScenes
-      .compactMap({ $0 as? UIWindowScene })
-      .flatMap(\.windows)
-      .first(where: \.isKeyWindow) else { return }
+    guard let view = UIApplication.shared.activeKeyWindow else { return }
     view.addSubview(blurView)
 
     let leadingConstraint = blurView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: Constants.horizontalOffset)

--- a/iphone/Maps/Classes/CustomViews/MapViewControls/MWMMapViewControlsManager.mm
+++ b/iphone/Maps/Classes/CustomViews/MapViewControls/MWMMapViewControlsManager.mm
@@ -72,11 +72,11 @@ NSString * const kMapToCategorySelectorSegue = @"MapToCategorySelectorSegue";
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
+  MapViewController * ownerController = self.ownerController;
   BOOL const isMenuViewUnderStatusBar = self.menuState == MWMBottomMenuStateActive;
   BOOL const isDirectionViewUnderStatusBar = !self.isDirectionViewHidden;
-  BOOL const isAddPlaceUnderStatusBar =
-      [self.ownerController.view hasSubviewWithViewClass:[MWMAddPlaceNavigationBar class]];
-  BOOL const isNightMode = self.ownerController.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark;
+  BOOL const isAddPlaceUnderStatusBar = [ownerController.view hasSubviewWithViewClass:[MWMAddPlaceNavigationBar class]];
+  BOOL const isNightMode = ownerController.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark;
   BOOL const isSomethingUnderStatusBar =
       isDirectionViewUnderStatusBar || isMenuViewUnderStatusBar || isAddPlaceUnderStatusBar;
 

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
@@ -43,13 +43,16 @@
 
 - (id<NavigationDashboardView>)navigationDashboardView
 {
-  if (_navigationDashboardView)
-    return _navigationDashboardView;
+  id<NavigationDashboardView> navigationDashboardView = _navigationDashboardView;
+  if (navigationDashboardView)
+    return navigationDashboardView;
+
   NavigationDashboardViewController * routePreviewViewController = [NavigationDashboardBuilder buildWithDelegate:self];
   [routePreviewViewController addTo:self.parentViewController];
-  _navigationDashboardView = routePreviewViewController.interactor;
+  navigationDashboardView = routePreviewViewController.interactor;
+  _navigationDashboardView = navigationDashboardView;
   _availableAreaView = routePreviewViewController.availableAreaView;
-  return _navigationDashboardView;
+  return navigationDashboardView;
 }
 
 - (SearchOnMapManager *)searchManager
@@ -104,15 +107,16 @@
 
 - (void)onRouteReady:(BOOL)hasWarnings
 {
+  id<NavigationDashboardView> navigationDashboardView = self.navigationDashboardView;
   if (self.state != MWMNavigationDashboardStateNavigation)
     self.state = MWMNavigationDashboardStateReady;
   if ([MWMRouter hasActiveDrivingOptions])
   {
-    [self.navigationDashboardView setDrivingOptionState:MWMDrivingOptionsStateChange];
+    [navigationDashboardView setDrivingOptionState:MWMDrivingOptionsStateChange];
   }
   else
   {
-    [self.navigationDashboardView
+    [navigationDashboardView
         setDrivingOptionState:hasWarnings ? MWMDrivingOptionsStateDefine : MWMDrivingOptionsStateNone];
   }
 }

--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -1010,42 +1010,46 @@ NSString * const kSettingsSegue = @"Map2Settings";
   return YES;
 }
 
-- (NSArray *)keyCommands
+- (NSArray<UIKeyCommand *> *)keyCommands
 {
-  NSArray * commands = @[
-    [UIKeyCommand keyCommandWithInput:UIKeyInputDownArrow
-                        modifierFlags:0
-                               action:@selector(zoomOut)],  // Alternative, not shown when holding CMD
-    [UIKeyCommand keyCommandWithInput:@"-"
-                        modifierFlags:UIKeyModifierCommand
-                               action:@selector(zoomOut)
-                 discoverabilityTitle:@"Zoom Out"],
-    [UIKeyCommand keyCommandWithInput:UIKeyInputUpArrow
-                        modifierFlags:0
-                               action:@selector(zoomIn)],  // Alternative, not shown when holding CMD
-    [UIKeyCommand keyCommandWithInput:@"="
-                        modifierFlags:UIKeyModifierCommand
-                               action:@selector(zoomIn)],  // Alternative, not shown when holding CMD
-    [UIKeyCommand keyCommandWithInput:@"+"
-                        modifierFlags:UIKeyModifierCommand
-                               action:@selector(zoomIn)
-                 discoverabilityTitle:@"Zoom In"],
-    [UIKeyCommand keyCommandWithInput:UIKeyInputEscape
-                        modifierFlags:0
-                               action:@selector(goBack)
-                 discoverabilityTitle:@"Go Back"],
-    [UIKeyCommand keyCommandWithInput:@"0"
-                        modifierFlags:UIKeyModifierCommand
-                               action:@selector(switchPositionMode)
-                 discoverabilityTitle:@"Switch position mode"]
-  ];
+  UIKeyCommand * downArrow = [UIKeyCommand keyCommandWithInput:UIKeyInputDownArrow
+                                                 modifierFlags:0
+                                                        action:@selector(zoomOut)];
+
+  UIKeyCommand * zoomOut = [UIKeyCommand keyCommandWithInput:@"-"
+                                               modifierFlags:UIKeyModifierCommand
+                                                      action:@selector(zoomOut)];
+  zoomOut.discoverabilityTitle = @"Zoom Out";
+
+  UIKeyCommand * upArrow = [UIKeyCommand keyCommandWithInput:UIKeyInputUpArrow
+                                               modifierFlags:0
+                                                      action:@selector(zoomIn)];
+
+  UIKeyCommand * zoomInEquals = [UIKeyCommand keyCommandWithInput:@"="
+                                                    modifierFlags:UIKeyModifierCommand
+                                                           action:@selector(zoomIn)];
+
+  UIKeyCommand * zoomInPlus = [UIKeyCommand keyCommandWithInput:@"+"
+                                                  modifierFlags:UIKeyModifierCommand
+                                                         action:@selector(zoomIn)];
+  zoomInPlus.discoverabilityTitle = @"Zoom In";
+
+  UIKeyCommand * escape = [UIKeyCommand keyCommandWithInput:UIKeyInputEscape modifierFlags:0 action:@selector(goBack)];
+  escape.discoverabilityTitle = @"Go Back";
+
+  UIKeyCommand * switchPositionMode = [UIKeyCommand keyCommandWithInput:@"0"
+                                                          modifierFlags:UIKeyModifierCommand
+                                                                 action:@selector(switchPositionMode)];
+  switchPositionMode.discoverabilityTitle = @"Switch position mode";
+
+  NSArray<UIKeyCommand *> * commands =
+      @[downArrow, zoomOut, upArrow, zoomInEquals, zoomInPlus, escape, switchPositionMode];
 
   for (UIKeyCommand * command in commands)
     command.wantsPriorityOverSystemBehavior = YES;
 
   return commands;
 }
-
 - (void)zoomOut
 {
   GetFramework().Scale(Framework::SCALE_MIN, true);

--- a/iphone/Maps/Common/MWMMacros.h
+++ b/iphone/Maps/Common/MWMMacros.h
@@ -1,3 +1,3 @@
-#define IPAD   (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
+#define IPAD   (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
 
 #define L(str) NSLocalizedString(str, nil)

--- a/iphone/Maps/Core/Location/MWMLocationManager.mm
+++ b/iphone/Maps/Core/Location/MWMLocationManager.mm
@@ -497,10 +497,12 @@ void setShowLocationAlert(BOOL needShow)
 
 // Delegate's method didChangeAuthorizationStatus is used to handle the authorization status when the application
 // finishes launching or user changes location access in the application settings.
-- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status
+
+- (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager
 {
-  LOG(LWARNING, ("CLLocationManagerDelegate: Authorization status has changed to", DebugPrint(status)));
-  switch (status)
+  LOG(LWARNING,
+      ("CLLocationManagerDelegate: Authorization status has changed to", DebugPrint(manager.authorizationStatus)));
+  switch (manager.authorizationStatus)
   {
   case kCLAuthorizationStatusAuthorizedWhenInUse:
   case kCLAuthorizationStatusAuthorizedAlways: [self startUpdatingLocationFor:manager]; break;
@@ -568,7 +570,7 @@ void setShowLocationAlert(BOOL needShow)
   if ([CLLocationManager locationServicesEnabled])
   {
     CLLocationManager * locationManager = self.locationManager;
-    switch (CLLocationManager.authorizationStatus)
+    switch (locationManager.authorizationStatus)
     {
     case kCLAuthorizationStatusAuthorizedWhenInUse:
     case kCLAuthorizationStatusAuthorizedAlways:

--- a/iphone/Maps/Core/RateUs/RateUsManager.swift
+++ b/iphone/Maps/Core/RateUs/RateUsManager.swift
@@ -19,7 +19,7 @@ final class RateUsManager: NSObject {
 
 private extension SKStoreReviewController {
   static func requestReviewInCurrentScene() {
-    if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+    if let scene = UIApplication.shared.foregroundActiveScene {
       requestReview(in: scene)
       return
     }

--- a/iphone/Maps/Core/RateUs/RateUsManager.swift
+++ b/iphone/Maps/Core/RateUs/RateUsManager.swift
@@ -19,10 +19,10 @@ final class RateUsManager: NSObject {
 
 private extension SKStoreReviewController {
   static func requestReviewInCurrentScene() {
-    if let scene = UIApplication.shared.foregroundActiveScene {
-      requestReview(in: scene)
+    guard let scene = UIApplication.shared.foregroundActiveScene else {
+      LOG(.error, "Attempt to display SKStoreReviewController in a non-active scene.")
       return
     }
-    requestReview()
+    requestReview(in: scene)
   }
 }

--- a/iphone/Maps/Core/Routing/MWMRouterTransitStepInfo.mm
+++ b/iphone/Maps/Core/Routing/MWMRouterTransitStepInfo.mm
@@ -14,14 +14,13 @@ MWMRouterTransitType convertType(TransitType type)
   case TransitType::Train: return MWMRouterTransitTypeTrain;
   case TransitType::LightRail: return MWMRouterTransitTypeLightRail;
   case TransitType::Monorail: return MWMRouterTransitTypeMonorail;
-  }
-
   // This is temporary solution for compiling iOS project after adding new
   // TransitType values. When these values will be approved we'll add them
   // above in switch(type) and remove this line.
   // TODO(o.khlopkova) Replace this return with more cases when transit
   // types are ready.
-  return MWMRouterTransitTypePedestrian;
+  default: return MWMRouterTransitTypePedestrian;
+  }
 }
 
 UIColor * convertColor(uint32_t colorARGB)

--- a/iphone/Maps/Core/Search/MWMSearch+CoreSpotlight.mm
+++ b/iphone/Maps/Core/Search/MWMSearch+CoreSpotlight.mm
@@ -23,7 +23,7 @@
   for (auto const & categoryKey : categoriesKeys)
   {
     CSSearchableItemAttributeSet * attrSet =
-        [[CSSearchableItemAttributeSet alloc] initWithItemContentType:static_cast<NSString *>(kUTTypeItem)];
+        [[CSSearchableItemAttributeSet alloc] initWithItemContentType:static_cast<NSString *>(UTTypeItem)];
 
     NSString * categoryName = nil;
     NSMutableDictionary<NSString *, NSString *> * localizedStrings = [@{} mutableCopy];

--- a/iphone/Maps/Core/Search/MWMSearch+CoreSpotlight.mm
+++ b/iphone/Maps/Core/Search/MWMSearch+CoreSpotlight.mm
@@ -1,7 +1,7 @@
 #import <CoreApi/AppInfo.h>
 #import <CoreApi/Framework.h>
 #import <CoreSpotlight/CoreSpotlight.h>
-#import <MobileCoreServices/MobileCoreServices.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import "MWMSearch+CoreSpotlight.h"
 #import "MWMSettings.h"
 
@@ -22,8 +22,7 @@
 
   for (auto const & categoryKey : categoriesKeys)
   {
-    CSSearchableItemAttributeSet * attrSet =
-        [[CSSearchableItemAttributeSet alloc] initWithItemContentType:static_cast<NSString *>(UTTypeItem)];
+    CSSearchableItemAttributeSet * attrSet = [[CSSearchableItemAttributeSet alloc] initWithContentType:UTTypeItem];
 
     NSString * categoryName = nil;
     NSMutableDictionary<NSString *, NSString *> * localizedStrings = [@{} mutableCopy];

--- a/iphone/Maps/Core/Theme/Core/StyleManager.swift
+++ b/iphone/Maps/Core/Theme/Core/StyleManager.swift
@@ -22,7 +22,7 @@
   }
 
   func update() {
-    for window in UIApplication.shared.activeWindows {
+    for window in UIApplication.shared.allConnectedWindows {
       updateView(window.rootViewController?.view)
     }
 

--- a/iphone/Maps/Core/Theme/Core/StyleManager.swift
+++ b/iphone/Maps/Core/Theme/Core/StyleManager.swift
@@ -22,7 +22,7 @@
   }
 
   func update() {
-    for window in UIApplication.shared.windows {
+    for window in UIApplication.shared.activeWindows {
       updateView(window.rootViewController?.view)
     }
 

--- a/iphone/Maps/Core/Theme/Extensions/UIFont+monospaced.swift
+++ b/iphone/Maps/Core/Theme/Extensions/UIFont+monospaced.swift
@@ -6,8 +6,8 @@ extension UIFont {
     let attributes: [UIFontDescriptor.AttributeName: Any] = [
       .featureSettings: [
         [
-          UIFontDescriptor.FeatureKey.featureIdentifier: kNumberSpacingType,
-          UIFontDescriptor.FeatureKey.typeIdentifier: kMonospacedNumbersSelector,
+          UIFontDescriptor.FeatureKey.type: kNumberSpacingType,
+          UIFontDescriptor.FeatureKey.selector: kMonospacedNumbersSelector,
         ],
       ],
     ]

--- a/iphone/Maps/Core/WebImage/IMWMWebImage.h
+++ b/iphone/Maps/Core/WebImage/IMWMWebImage.h
@@ -12,7 +12,7 @@ typedef void (^MWMWebImageCompletion)(UIImage * _Nullable image, NSError * _Null
 
 @protocol IMWMWebImage
 
-- (id<IMWMImageTask>)imageWithUrl:(NSURL *)url completion:(MWMWebImageCompletion)completion;
+- (id<IMWMImageTask>)imageWithUrl:(NSURL *)url callback:(MWMWebImageCompletion)callback;
 - (void)cleanup;
 
 @end

--- a/iphone/Maps/Core/WebImage/MWMWebImage.h
+++ b/iphone/Maps/Core/WebImage/MWMWebImage.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithImageCahce:(id<IMWMImageCache>)imageCache imageCoder:(id<IMWMImageCoder>)imageCoder;
-- (id<IMWMImageTask>)imageWithUrl:(NSURL *)url completion:(MWMWebImageCompletion)completion;
+- (id<IMWMImageTask>)imageWithUrl:(NSURL *)url callback:(MWMWebImageCompletion)callback;
 - (void)cleanup;
 
 @end

--- a/iphone/Maps/Core/WebImage/MWMWebImage.m
+++ b/iphone/Maps/Core/WebImage/MWMWebImage.m
@@ -54,7 +54,7 @@
   return self;
 }
 
-- (id<IMWMImageTask>)imageWithUrl:(NSURL *)url completion:(MWMWebImageCompletion)completion
+- (id<IMWMImageTask>)imageWithUrl:(NSURL *)url callback:(MWMWebImageCompletion)callback
 {
   MWMWebImageTask * imageTask = [MWMWebImageTask new];
   NSString * cacheKey = url.absoluteString;
@@ -65,7 +65,7 @@
 
                       if (image)
                       {
-                        completion(image, nil);
+                        callback(image, nil);
                       }
                       else
                       {
@@ -82,7 +82,7 @@
 
                               dispatch_async(dispatch_get_main_queue(), ^{
                                 if (!imageTask.cancelled)
-                                  completion(image, error);
+                                  callback(image, error);
                               });
                             }];
                         imageTask.dataTask = dataTask;

--- a/iphone/Maps/Core/WebImage/UIImageView+WebImage.m
+++ b/iphone/Maps/Core/WebImage/UIImageView+WebImage.m
@@ -18,31 +18,31 @@ static char kAssociatedObjectKey;
 {
   id<IMWMImageTask> task = [[MWMWebImage defaultWebImage]
       imageWithUrl:url
-        completion:^(UIImage * image, NSError * error) {
-          objc_setAssociatedObject(self, &kAssociatedObjectKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-          if (!image)
-          {
+          callback:^(UIImage * image, NSError * error) {
+            objc_setAssociatedObject(self, &kAssociatedObjectKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            if (!image)
+            {
+              if (completion)
+                completion(nil, error);
+              return;
+            }
+
+            if (duration > 0)
+            {
+              [UIView transitionWithView:self
+                                duration:duration
+                                 options:UIViewAnimationOptionTransitionCrossDissolve
+                              animations:^{ self.image = image; }
+                              completion:nil];
+            }
+            else
+            {
+              self.image = image;
+            }
+
             if (completion)
-              completion(nil, error);
-            return;
-          }
-
-          if (duration > 0)
-          {
-            [UIView transitionWithView:self
-                              duration:duration
-                               options:UIViewAnimationOptionTransitionCrossDissolve
-                            animations:^{ self.image = image; }
-                            completion:nil];
-          }
-          else
-          {
-            self.image = image;
-          }
-
-          if (completion)
-            completion(image, nil);
-        }];
+              completion(image, nil);
+          }];
   objc_setAssociatedObject(self, &kAssociatedObjectKey, task, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 		993DF12B23F6BDB100AC231A /* StyleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DF0FF23F6BDB100AC231A /* StyleManager.swift */; };
 		993DF12C23F6BDB100AC231A /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DF10023F6BDB100AC231A /* Theme.swift */; };
 		993DF12D23F6BDB100AC231A /* GlobalStyleSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DF10123F6BDB100AC231A /* GlobalStyleSheet.swift */; };
+		9E9A0D922F0C8C2E00112233 /* UIWindowScene+KeyWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9A0D912F0C8C2E00112233 /* UIWindowScene+KeyWindow.swift */; };
 		993F5508237C622700545511 /* DeepLinkRouteStrategyAdapter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 993F54F9237C622700545511 /* DeepLinkRouteStrategyAdapter.mm */; };
 		993F5513237C622700545511 /* DeepLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993F5505237C622700545511 /* DeepLinkHandler.swift */; };
 		994F790723E85C5900660E75 /* DifficultyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994F790623E85C5900660E75 /* DifficultyView.swift */; };
@@ -1242,6 +1243,7 @@
 		993DF0FF23F6BDB100AC231A /* StyleManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleManager.swift; sourceTree = "<group>"; };
 		993DF10023F6BDB100AC231A /* Theme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		993DF10123F6BDB100AC231A /* GlobalStyleSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlobalStyleSheet.swift; sourceTree = "<group>"; };
+		9E9A0D912F0C8C2E00112233 /* UIWindowScene+KeyWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindowScene+KeyWindow.swift"; sourceTree = "<group>"; };
 		993F54F9237C622700545511 /* DeepLinkRouteStrategyAdapter.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DeepLinkRouteStrategyAdapter.mm; sourceTree = "<group>"; };
 		993F5503237C622700545511 /* DeepLinkRouteStrategyAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeepLinkRouteStrategyAdapter.h; sourceTree = "<group>"; };
 		993F5505237C622700545511 /* DeepLinkHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeepLinkHandler.swift; sourceTree = "<group>"; };
@@ -2329,6 +2331,7 @@
 				471A7BB7247FE3C300A0D4C1 /* URL+Query.swift */,
 				EDC3573A2B7B5029001AE9CA /* CALayer+SetCorner.swift */,
 				ED79A5AC2BD7BA0F00952D1F /* UIApplication+LoadingOverlay.swift */,
+				9E9A0D912F0C8C2E00112233 /* UIWindowScene+KeyWindow.swift */,
 				49AB95972CB2FE5300468EA2 /* UIButton+ImagePadding.swift */,
 				ED18EF842DBA38A500B383A0 /* NSLayoutConstraint+WithPriority.swift */,
 			);
@@ -4635,6 +4638,7 @@
 				995739042355CAA30019AEE7 /* PageIndicator.swift in Sources */,
 				470F0B7D238842EA006AEC94 /* ExpandableLabel.swift in Sources */,
 				B33D21AF20DAF9F000BAD749 /* Toast.swift in Sources */,
+				9E9A0D922F0C8C2E00112233 /* UIWindowScene+KeyWindow.swift in Sources */,
 				6741A9D41BF340DE002C974C /* MWMAlertViewController.mm in Sources */,
 				34D3B0181E389D05004100F9 /* EditorAdditionalNamePlaceholderTableViewCell.swift in Sources */,
 				EDA6D3FA2E5EF97100D6C1F3 /* InfoItemView.swift in Sources */,

--- a/iphone/Maps/UI/DocumentPicker/FileType.swift
+++ b/iphone/Maps/UI/DocumentPicker/FileType.swift
@@ -9,6 +9,8 @@ extension FileType {
     case .gpx: return "gpx"
     case .geoJson: return "geojson"
     case .json: return "json"
+    @unknown default:
+      fatalError("Unexpected FileType: \(self)")
     }
   }
 
@@ -20,6 +22,8 @@ extension FileType {
     case .gpx: return "com.topografix.gpx"
     case .geoJson: return "public.geojson"
     case .json: return "public.json"
+    @unknown default:
+      fatalError("Unexpected FileType: \(self)")
     }
   }
 

--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -471,7 +471,7 @@ extension PlacePageViewController: UIScrollViewDelegate {
 
   private func updateContentOffsetForTitleEditing() {
     guard !isiPad else { return }
-    var keyboardHeight = MWMKeyboard.keyboardHeight()
+    let keyboardHeight = MWMKeyboard.keyboardHeight()
     var yOffset: CGFloat?
     if keyboardHeight > 0 {
       let yOffsetFromKeyboard = layout.headerViewController.view.height

--- a/libs/platform/platform_ios.mm
+++ b/libs/platform/platform_ios.mm
@@ -37,7 +37,7 @@
 
 Platform::Platform()
 {
-  m_isTablet = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad);
+  m_isTablet = UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad;
 
   NSBundle * bundle = NSBundle.mainBundle;
   NSString * path = [bundle resourcePath];


### PR DESCRIPTION
This PR addresses most compile-time warnings. 

However, some should be fixed separately (as separate PRs):
1. The CarPlay delegate and numerous methods are deprecated in iOS 14. A different API with callbacks is used. It's better to handle this separately and test to prevent regressions.
2. Warning `'contentEdgeInsets' was deprecated in iOS 15.0: This property is ignored when using UIButtonConfiguration` and similar ones remain because disabling them might break the current custom style+renderer flow and appearance. Unfortunately, we do not use configurations anywhere, and there's no way to disable this warning.
3. MapsDelegate warings `'setMinimumBackgroundFetchInterval:' is deprecated: first deprecated in iOS 13.0 - Use a BGAppRefreshTask in the BackgroundTasks framework instead` required more solid refactoring to move to the another api too.