### PR TITLE
[ios] Fix elevation chart and circular progress color issues

### DIFF
--- a/iphone/Chart/Chart/Views/ChartInfo/ChartInfoView.swift
+++ b/iphone/Chart/Chart/Views/ChartInfo/ChartInfoView.swift
@@ -68,7 +68,7 @@ class ChartInfoView: ExpandedTouchView {
 
   var infoShadowColor: UIColor = .black {
     didSet {
-      pointInfoView.layer.shadowColor = infoShadowColor.cgColor
+      pointInfoView.layer.shadowColor = infoShadowColor.resolvedColor(with: traitCollection).cgColor
     }
   }
 

--- a/iphone/Chart/Chart/Views/ChartInfo/ChartPointInfoView.swift
+++ b/iphone/Chart/Chart/Views/ChartInfo/ChartPointInfoView.swift
@@ -43,7 +43,7 @@ final class ChartPointInfoView: UIView {
 
   override var backgroundColor: UIColor? {
     didSet {
-      maskLayer.fillColor = backgroundColor?.cgColor
+      maskLayer.fillColor = backgroundColor?.resolvedColor(with: traitCollection).cgColor
     }
   }
 

--- a/iphone/Chart/Chart/Views/ChartSegmentLinesView.swift
+++ b/iphone/Chart/Chart/Views/ChartSegmentLinesView.swift
@@ -9,7 +9,7 @@ final class ChartSegmentLinesView: UIView {
 
   var lineColor: UIColor = .gray {
     didSet {
-      shapeLayer.strokeColor = lineColor.cgColor
+      shapeLayer.strokeColor = lineColor.resolvedColor(with: traitCollection).cgColor
     }
   }
 

--- a/iphone/Chart/Chart/Views/ChartView.swift
+++ b/iphone/Chart/Chart/Views/ChartView.swift
@@ -88,7 +88,7 @@ public class ChartView: UIView {
 
   override public var backgroundColor: UIColor? {
     didSet {
-      chartInfoView.tooltipBackgroundColor = backgroundColor ?? .white
+      chartInfoView.tooltipBackgroundColor = backgroundColor?.resolvedColor(with: traitCollection) ?? .white
     }
   }
 

--- a/iphone/Chart/Chart/Views/ChartYAxisView.swift
+++ b/iphone/Chart/Chart/Views/ChartYAxisView.swift
@@ -41,7 +41,7 @@ private class ChartYAxisInnerView: UIView {
 
   var gridColor: UIColor = .white {
     didSet {
-      shapeLayer.strokeColor = gridColor.cgColor
+      shapeLayer.strokeColor = gridColor.resolvedColor(with: traitCollection).cgColor
     }
   }
 

--- a/iphone/Maps/Classes/CustomViews/CircularProgress/MWMCircularProgressView.m
+++ b/iphone/Maps/Classes/CustomViews/CircularProgress/MWMCircularProgressView.m
@@ -131,7 +131,8 @@ static CGFloat angleWithProgress(CGFloat progress)
     return;
   self.backgroundLayer.fillColor = self.progressLayer.fillColor = UIColor.clearColor.CGColor;
   self.backgroundLayer.lineWidth = self.progressLayer.lineWidth = kLineWidth;
-  self.backgroundLayer.strokeColor = self.spinnerBackgroundColor.CGColor;
+  self.backgroundLayer.strokeColor =
+      [self.spinnerBackgroundColor resolvedColorWithTraitCollection:self.traitCollection].CGColor;
   [self updateBackgroundPath];
   self.progressLayer.strokeColor = self.progressLayerColor;
   NSString * imageName = self.images[@(self.state)];


### PR DESCRIPTION
The issues were caused by the logic when some primitive ui elements that are using CGColors (lines, masks) instead of UIColor, are not updated during trait collection changes because CGColor is not dynamic. This requires explicit setting of the valid color (like before). The best place to set the correct color is the renderer because it updates both ui an cg elements.