### PR TITLE
[ios] CarPlay refactoring

### DIFF
--- a/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
+++ b/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
@@ -1,0 +1,74 @@
+import UIKit
+
+@objc(MainSceneDelegate)
+final class MainSceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(_ scene: UIScene,
+             willConnectTo _: UISceneSession,
+             options connectionOptions: UIScene.ConnectionOptions) {
+    guard let windowScene = scene as? UIWindowScene,
+          let sceneWindow = windowScene.windows.first
+    else {
+      assertionFailure("Main UIWindowScene is missing the storyboard-loaded window.")
+      return
+    }
+    window = sceneWindow
+    MapsAppDelegate.theApp().window = sceneWindow
+
+    // Route cold-launch payloads delivered via the scene. Pre-UIScene iOS received these via
+    // UIApplication launchOptions / application:openURL: and deferred deep-link handling until
+    // MapViewController was ready. Mirror that deferred flow by seeding DeepLinkHandler here;
+    // MapViewController.viewDidLoad drains it via handleDeepLinkAndReset().
+    if let launchURL = connectionOptions.urlContexts.first?.url {
+      DeepLinkHandler.shared.applicationDidFinishLaunching([.url: launchURL])
+    }
+    for userActivity in connectionOptions.userActivities {
+      self.scene(scene, continue: userActivity)
+    }
+    if let shortcutItem = connectionOptions.shortcutItem {
+      self.windowScene(windowScene, performActionFor: shortcutItem, completionHandler: { _ in })
+    }
+  }
+
+  // MARK: - Lifecycle forwarding
+
+  func sceneDidBecomeActive(_: UIScene) {
+    MapsAppDelegate.theApp().applicationDidBecomeActive(.shared)
+  }
+
+  func sceneWillResignActive(_: UIScene) {
+    MapsAppDelegate.theApp().applicationWillResignActive(.shared)
+  }
+
+  func sceneWillEnterForeground(_: UIScene) {
+    MapsAppDelegate.theApp().applicationWillEnterForeground(.shared)
+  }
+
+  func sceneDidEnterBackground(_: UIScene) {
+    MapsAppDelegate.theApp().applicationDidEnterBackground(.shared)
+  }
+
+  // MARK: - URL / user activity / shortcut forwarding
+
+  func scene(_: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    let app = MapsAppDelegate.theApp()
+    for context in URLContexts {
+      _ = app.application(.shared, open: context.url, options: [:])
+    }
+  }
+
+  func scene(_: UIScene, continue userActivity: NSUserActivity) {
+    _ = MapsAppDelegate.theApp().application(.shared,
+                                             continue: userActivity,
+                                             restorationHandler: { _ in })
+  }
+
+  func windowScene(_: UIWindowScene,
+                   performActionFor shortcutItem: UIApplicationShortcutItem,
+                   completionHandler: @escaping (Bool) -> Void) {
+    MapsAppDelegate.theApp().application(.shared,
+                                         performActionFor: shortcutItem,
+                                         completionHandler: completionHandler)
+  }
+}

--- a/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
+++ b/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
@@ -20,8 +20,11 @@ final class MainSceneDelegate: UIResponder, UIWindowSceneDelegate {
     // UIApplication launchOptions / application:openURL: and deferred deep-link handling until
     // MapViewController was ready. Mirror that deferred flow by seeding DeepLinkHandler here;
     // MapViewController.viewDidLoad drains it via handleDeepLinkAndReset().
-    if let launchURL = connectionOptions.urlContexts.first?.url {
-      DeepLinkHandler.shared.applicationDidFinishLaunching([.url: launchURL])
+    if !connectionOptions.urlContexts.isEmpty {
+      if let launchURL = connectionOptions.urlContexts.first?.url {
+        DeepLinkHandler.shared.applicationDidFinishLaunching([.url: launchURL])
+      }
+      self.scene(scene, openURLContexts: connectionOptions.urlContexts)
     }
     for userActivity in connectionOptions.userActivities {
       self.scene(scene, continue: userActivity)
@@ -52,9 +55,10 @@ final class MainSceneDelegate: UIResponder, UIWindowSceneDelegate {
   // MARK: - URL / user activity / shortcut forwarding
 
   func scene(_: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-    let app = MapsAppDelegate.theApp()
     for context in URLContexts {
-      _ = app.application(.shared, open: context.url, options: [:])
+      _ = MapsAppDelegate.theApp().application(.shared,
+                                               open: context.url,
+                                               options: context.options.asDictionary)
     }
   }
 
@@ -70,5 +74,23 @@ final class MainSceneDelegate: UIResponder, UIWindowSceneDelegate {
     MapsAppDelegate.theApp().application(.shared,
                                          performActionFor: shortcutItem,
                                          completionHandler: completionHandler)
+  }
+}
+
+private extension UIScene.OpenURLOptions {
+  var asDictionary: [UIApplication.OpenURLOptionsKey: Any] {
+    var options: [UIApplication.OpenURLOptionsKey: Any] = [
+      .openInPlace: openInPlace,
+    ]
+    if let sourceApplication {
+      options[.sourceApplication] = sourceApplication
+    }
+    if let annotation {
+      options[.annotation] = annotation
+    }
+    if let eventAttribution {
+      options[.eventAttribution] = eventAttribution
+    }
+    return options
   }
 }

--- a/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
+++ b/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
@@ -1,0 +1,114 @@
+import UIKit
+
+@objc(MainSceneDelegate)
+final class MainSceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(_ scene: UIScene,
+             willConnectTo session: UISceneSession,
+             options connectionOptions: UIScene.ConnectionOptions) {
+    guard let windowScene = scene as? UIWindowScene else {
+      assertionFailure("Main scene is not a UIWindowScene.")
+      return
+    }
+    let app = MapsAppDelegate.theApp()
+    guard app.connectedWindow == nil else {
+      // The app shares one map renderer and navigation stack between the phone and CarPlay.
+      // Keep CarPlay's separate scene, but reject an additional phone window.
+      UIApplication.shared.requestSceneSessionDestruction(session, options: nil)
+      return
+    }
+
+    // Build the window around the single shared root navigation controller. On a CarPlay-first cold
+    // launch CarPlayService may have already created it (so the map could render on the head unit);
+    // reusing it here keeps one MapViewController and one Drape engine across both scenes instead of
+    // instantiating a second map. We create the window explicitly (no UISceneStoryboardFile) so the
+    // system does not auto-load a duplicate MapViewController from the storyboard.
+    let sceneWindow = UIWindow(windowScene: windowScene)
+    window = sceneWindow
+    app.window = sceneWindow
+    sceneWindow.rootViewController = app.mainNavigationController
+
+    // File URLs must be imported synchronously while their security-scoped resources are available.
+    // Queue every other URL before showing the window because makeKeyAndVisible() can trigger the
+    // map's appearance callbacks, and MapViewController.viewDidAppear drains the cold-launch queue.
+    let launchURLContexts = sorted(connectionOptions.urlContexts)
+    for context in launchURLContexts where context.url.isFileURL {
+      _ = app.handleOpenURL(context.url, openInPlace: context.options.openInPlace)
+    }
+    let launchUniversalLinks = connectionOptions.userActivities
+      .filter { $0.activityType == NSUserActivityTypeBrowsingWeb }
+      .compactMap(\.webpageURL)
+      .sorted { $0.absoluteString < $1.absoluteString }
+    DeepLinkHandler.shared.prepareForColdLaunch(
+      urls: launchURLContexts.filter { !$0.url.isFileURL }.map(\.url),
+      universalLinks: launchUniversalLinks
+    )
+    ThemeManager.invalidate()
+    sceneWindow.makeKeyAndVisible()
+
+    // CarPlay scene can connect before the main phone scene; now that the window is ready, attach the
+    // shared map view to the CarPlay controller if it was deferred.
+    CarPlayService.shared.attachMapIfNeeded()
+
+    // Route the remaining cold-launch payloads delivered via the scene.
+    for userActivity in connectionOptions.userActivities
+      where userActivity.activityType != NSUserActivityTypeBrowsingWeb || userActivity.webpageURL == nil {
+      self.scene(scene, continue: userActivity)
+    }
+    if let shortcutItem = connectionOptions.shortcutItem {
+      self.windowScene(windowScene, performActionFor: shortcutItem, completionHandler: { _ in })
+    }
+  }
+
+  func sceneDidDisconnect(_ scene: UIScene) {
+    guard let sceneWindow = window, sceneWindow.windowScene === scene else { return }
+
+    let app = MapsAppDelegate.theApp()
+    if app.window === sceneWindow {
+      app.window = nil
+    }
+    window = nil
+  }
+
+  func sceneDidBecomeActive(_ scene: UIScene) {
+    MapsAppDelegate.theApp().sceneDidBecomeActive(scene)
+  }
+
+  func sceneWillResignActive(_ scene: UIScene) {
+    MapsAppDelegate.theApp().sceneWillResignActive(scene)
+  }
+
+  func sceneWillEnterForeground(_ scene: UIScene) {
+    MapsAppDelegate.theApp().sceneWillEnterForeground(scene)
+  }
+
+  func sceneDidEnterBackground(_ scene: UIScene) {
+    MapsAppDelegate.theApp().sceneDidEnterBackground(scene)
+  }
+
+  // MARK: - URL / user activity / shortcut forwarding
+
+  func scene(_: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    let app = MapsAppDelegate.theApp()
+    for context in sorted(URLContexts) {
+      _ = app.handleOpenURL(context.url, openInPlace: context.options.openInPlace)
+    }
+  }
+
+  func scene(_: UIScene, continue userActivity: NSUserActivity) {
+    _ = MapsAppDelegate.theApp().handleUserActivity(userActivity)
+  }
+
+  func windowScene(_: UIWindowScene,
+                   performActionFor shortcutItem: UIApplicationShortcutItem,
+                   completionHandler: @escaping (Bool) -> Void) {
+    MapsAppDelegate.theApp().handleShortcutItem(shortcutItem, completionHandler: completionHandler)
+  }
+
+  private func sorted(_ URLContexts: Set<UIOpenURLContext>) -> [UIOpenURLContext] {
+    URLContexts.sorted { lhs, rhs in
+      lhs.url.absoluteString < rhs.url.absoluteString
+    }
+  }
+}

--- a/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
+++ b/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
@@ -16,6 +16,10 @@ final class MainSceneDelegate: UIResponder, UIWindowSceneDelegate {
     window = sceneWindow
     MapsAppDelegate.theApp().window = sceneWindow
 
+    // CarPlay scene can connect before the main phone scene; once the main window is ready,
+    // retry attaching the shared map view to the CarPlay controller if it was deferred.
+    CarPlayService.shared.attachMapIfNeeded()
+
     // Route cold-launch payloads delivered via the scene. Pre-UIScene iOS received these via
     // UIApplication launchOptions / application:openURL: and deferred deep-link handling until
     // MapViewController was ready. Mirror that deferred flow by seeding DeepLinkHandler here;

--- a/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
+++ b/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
@@ -1,0 +1,87 @@
+import UIKit
+
+@objc(MainSceneDelegate)
+final class MainSceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow? {
+    get { MapsAppDelegate.theApp().window }
+    set { MapsAppDelegate.theApp().window = newValue }
+  }
+
+  func scene(_ scene: UIScene,
+             willConnectTo _: UISceneSession,
+             options connectionOptions: UIScene.ConnectionOptions) {
+    guard let windowScene = scene as? UIWindowScene else {
+      assertionFailure("Main scene is not a UIWindowScene.")
+      return
+    }
+    let app = MapsAppDelegate.theApp()
+
+    // Build the window around the single shared root navigation controller. On a CarPlay-first cold
+    // launch CarPlayService may have already created it (so the map could render on the head unit);
+    // reusing it here keeps one MapViewController and one Drape engine across both scenes instead of
+    // instantiating a second map. We create the window explicitly (no UISceneStoryboardFile) so the
+    // system does not auto-load a duplicate MapViewController from the storyboard. The manifest does
+    // not enable multiple scenes, so this is the only phone window; a reconnect after a disconnect
+    // re-hosts the same navigation controller.
+    let sceneWindow = UIWindow(windowScene: windowScene)
+    window = sceneWindow
+    sceneWindow.rootViewController = app.mainNavigationController
+
+    // File URLs must be imported synchronously while their security-scoped resources are available.
+    // Keep the last non-file URL before showing the window because makeKeyAndVisible() can trigger the
+    // map's appearance callbacks, and MapViewController.viewDidAppear handles the pending cold-launch link.
+    // In practice the set always holds a single URL: iOS delivers one link per call.
+    for context in connectionOptions.urlContexts {
+      if context.url.isFileURL {
+        _ = DeepLinkHandler.shared.applicationDidOpenUrl(context.url, openInPlace: context.options.openInPlace)
+      } else {
+        DeepLinkHandler.shared.prepareForColdLaunch(url: context.url)
+      }
+    }
+    for userActivity in connectionOptions.userActivities
+      where userActivity.activityType == NSUserActivityTypeBrowsingWeb {
+      if let url = userActivity.webpageURL {
+        DeepLinkHandler.shared.prepareForColdLaunch(universalLink: url)
+      }
+    }
+    // The launch-time invalidation runs before an app window exists, so refresh again to apply its style.
+    ThemeManager.invalidate()
+    sceneWindow.makeKeyAndVisible()
+
+    // Route the remaining cold-launch payloads delivered via the scene.
+    for userActivity in connectionOptions.userActivities
+      where userActivity.activityType != NSUserActivityTypeBrowsingWeb || userActivity.webpageURL == nil {
+      self.scene(scene, continue: userActivity)
+    }
+    if let shortcutItem = connectionOptions.shortcutItem {
+      self.windowScene(windowScene, performActionFor: shortcutItem, completionHandler: { _ in })
+    }
+  }
+
+  func sceneDidDisconnect(_: UIScene) {
+    // The shared navigation controller and the map outlive the window (CarPlay may still show it).
+    window = nil
+  }
+
+  // Activation and background transitions are handled app-wide by MapsAppDelegate through the
+  // UIApplication notifications; forwarding them per scene would background the framework while
+  // CarPlay keeps the app in the foreground.
+
+  // MARK: - URL / user activity / shortcut forwarding
+
+  func scene(_: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    for context in URLContexts {
+      _ = DeepLinkHandler.shared.applicationDidOpenUrl(context.url, openInPlace: context.options.openInPlace)
+    }
+  }
+
+  func scene(_: UIScene, continue userActivity: NSUserActivity) {
+    _ = MapsAppDelegate.theApp().handleUserActivity(userActivity)
+  }
+
+  func windowScene(_: UIWindowScene,
+                   performActionFor shortcutItem: UIApplicationShortcutItem,
+                   completionHandler: @escaping (Bool) -> Void) {
+    MapsAppDelegate.theApp().handleShortcutItem(shortcutItem, completionHandler: completionHandler)
+  }
+}

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
@@ -1,15 +1,21 @@
 #import "MWMNavigationController.h"
 
 @class MapViewController;
-@class MWMCarPlayService;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MapsAppDelegate : UIResponder <UIApplicationDelegate>
 
-@property(nonatomic) UIWindow * window;
+@property(nonatomic, strong, nullable) UIWindow * window;
 
-@property(nonatomic, readonly) MWMCarPlayService * carplayService;
+// The connected main window, or nil before MainSceneDelegate attaches it (e.g. a CarPlay-first
+// cold launch, where only the CarPlay scene exists). Use this instead of `window` when the phone
+// scene may not have connected yet.
+@property(nonatomic, readonly, nullable) UIWindow * connectedWindow;
+
+// The Main storyboard's root navigation controller. Lazily instantiated so a single shared
+// MapViewController exists even before the phone window scene connects.
+@property(nonatomic, readonly) UINavigationController * mainNavigationController;
 @property(nonatomic, readonly) MapViewController * mapViewController;
 @property(nonatomic, readonly) BOOL isDrapeEngineCreated;
 
@@ -21,6 +27,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)customizeAppearance;
 + (void)customizeAppearanceForNavigationBar:(UINavigationBar *)navigationBar;
+
+- (BOOL)handleOpenURL:(NSURL *)url openInPlace:(BOOL)openInPlace NS_SWIFT_NAME(handleOpenURL(_:openInPlace:));
+- (BOOL)handleUserActivity:(NSUserActivity *)userActivity NS_SWIFT_NAME(handleUserActivity(_:));
+- (void)handleShortcutItem:(UIApplicationShortcutItem *)shortcutItem
+         completionHandler:(void (^)(BOOL))completionHandler NS_SWIFT_NAME(handleShortcutItem(_:completionHandler:));
+
+// Aggregate phone and CarPlay scene transitions into application-wide lifecycle events.
+- (void)sceneDidBecomeActive:(UIScene *)scene NS_SWIFT_NAME(sceneDidBecomeActive(_:));
+- (void)sceneWillResignActive:(UIScene *)scene NS_SWIFT_NAME(sceneWillResignActive(_:));
+- (void)sceneWillEnterForeground:(UIScene *)scene NS_SWIFT_NAME(sceneWillEnterForeground(_:));
+- (void)sceneDidEnterBackground:(UIScene *)scene NS_SWIFT_NAME(sceneDidEnterBackground(_:));
 
 - (void)showMap;
 

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
@@ -34,6 +34,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)isTestsEnvironment;
 
+// UIApplicationDelegate callbacks forwarded by MainSceneDelegate once UIScene is adopted.
+// Re-declared here so Swift sees them on the concrete MapsAppDelegate type.
+- (void)applicationDidBecomeActive:(UIApplication *)application;
+- (void)applicationWillResignActive:(UIApplication *)application;
+- (void)applicationDidEnterBackground:(UIApplication *)application;
+- (void)applicationWillEnterForeground:(UIApplication *)application;
+- (BOOL)application:(UIApplication *)app
+            openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options;
+- (BOOL)application:(UIApplication *)application
+    continueUserActivity:(NSUserActivity *)userActivity
+      restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler;
+- (void)application:(UIApplication *)application
+    performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem
+               completionHandler:(void (^)(BOOL))completionHandler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
@@ -2,7 +2,6 @@
 #import "MWMNavigationController.h"
 
 @class MapViewController;
-@class MWMCarPlayService;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -14,7 +13,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic) UIWindow * window;
 
-@property(nonatomic, readonly) MWMCarPlayService * carplayService;
 @property(nonatomic, readonly) MapViewController * mapViewController;
 @property(nonatomic, readonly) BOOL isDrapeEngineCreated;
 

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
@@ -34,22 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)isTestsEnvironment;
 
-// UIApplicationDelegate callbacks forwarded by MainSceneDelegate once UIScene is adopted.
-// Re-declared here so Swift sees them on the concrete MapsAppDelegate type.
-- (void)applicationDidBecomeActive:(UIApplication *)application;
-- (void)applicationWillResignActive:(UIApplication *)application;
-- (void)applicationDidEnterBackground:(UIApplication *)application;
-- (void)applicationWillEnterForeground:(UIApplication *)application;
-- (BOOL)application:(UIApplication *)app
-            openURL:(NSURL *)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options;
-- (BOOL)application:(UIApplication *)application
-    continueUserActivity:(NSUserActivity *)userActivity
-      restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler;
-- (void)application:(UIApplication *)application
-    performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem
-               completionHandler:(void (^)(BOOL))completionHandler;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
@@ -1,15 +1,18 @@
 #import "MWMNavigationController.h"
 
 @class MapViewController;
-@class MWMCarPlayService;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MapsAppDelegate : UIResponder <UIApplicationDelegate>
 
-@property(nonatomic) UIWindow * window;
+// The connected main window, or nil before MainSceneDelegate attaches it (e.g. a CarPlay-first
+// cold launch, where only the CarPlay scene exists).
+@property(nonatomic, strong, nullable) UIWindow * window;
 
-@property(nonatomic, readonly) MWMCarPlayService * carplayService;
+// The Main storyboard's root navigation controller. Lazily instantiated so a single shared
+// MapViewController exists even before the phone window scene connects.
+@property(nonatomic, readonly) UINavigationController * mainNavigationController;
 @property(nonatomic, readonly) MapViewController * mapViewController;
 @property(nonatomic, readonly) BOOL isDrapeEngineCreated;
 
@@ -21,6 +24,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)customizeAppearance;
 + (void)customizeAppearanceForNavigationBar:(UINavigationBar *)navigationBar;
+
+// User activities and quick actions are delivered to MainSceneDelegate; their handling lives here
+// because it needs the app-wide search and map plumbing.
+- (BOOL)handleUserActivity:(NSUserActivity *)userActivity NS_SWIFT_NAME(handleUserActivity(_:));
+- (void)handleShortcutItem:(UIApplicationShortcutItem *)shortcutItem
+         completionHandler:(void (^)(BOOL))completionHandler NS_SWIFT_NAME(handleShortcutItem(_:completionHandler:));
 
 - (void)showMap;
 

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
@@ -14,7 +14,6 @@
 #import "NSDate+TimeDistance.h"
 #import "SwiftBridge.h"
 
-#import <CarPlay/CarPlay.h>
 #import <CoreSpotlight/CoreSpotlight.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #import <UserNotifications/UserNotifications.h>
@@ -60,15 +59,23 @@ void InitLocalizedStrings()
 
 using namespace osm_auth_ios;
 
-@interface MapsAppDelegate () <MWMStorageObserver, CPApplicationDelegate>
+@interface MapsAppDelegate () <MWMStorageObserver>
 
 @property(nonatomic) NSInteger standbyCounter;
 @property(nonatomic) BOOL standbyDisabledForDownloads;
 @property(nonatomic) MWMBackgroundFetchScheduler * backgroundFetchScheduler;
 
+- (void)handleApplicationDidBecomeActive;
+- (void)handleApplicationWillResignActive;
+- (void)handleApplicationWillEnterForeground;
+- (void)handleApplicationDidEnterBackground;
+
 @end
 
 @implementation MapsAppDelegate
+{
+  UINavigationController * _mainNavigationController;
+}
 
 + (MapsAppDelegate *)theApp
 {
@@ -110,6 +117,55 @@ using namespace osm_auth_ios;
   [TrackRecordingManager.shared setup];
 }
 
+#pragma mark - Application lifecycle
+
+- (BOOL)hasActiveSceneExcludingScene:(UIScene *)excludedScene
+{
+  for (UIScene * scene in UIApplication.sharedApplication.connectedScenes)
+    if (scene != excludedScene && scene.activationState == UISceneActivationStateForegroundActive)
+      return YES;
+  return NO;
+}
+
+- (BOOL)hasForegroundSceneExcludingScene:(UIScene *)excludedScene
+{
+  for (UIScene * scene in UIApplication.sharedApplication.connectedScenes)
+  {
+    if (scene == excludedScene)
+      continue;
+    if (scene.activationState == UISceneActivationStateForegroundActive ||
+        scene.activationState == UISceneActivationStateForegroundInactive)
+    {
+      return YES;
+    }
+  }
+  return NO;
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene
+{
+  if (![self hasActiveSceneExcludingScene:scene])
+    [self handleApplicationDidBecomeActive];
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene
+{
+  if (![self hasActiveSceneExcludingScene:scene])
+    [self handleApplicationWillResignActive];
+}
+
+- (void)sceneWillEnterForeground:(UIScene *)scene
+{
+  if (![self hasForegroundSceneExcludingScene:scene])
+    [self handleApplicationWillEnterForeground];
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene
+{
+  if (![self hasForegroundSceneExcludingScene:scene])
+    [self handleApplicationDidEnterBackground];
+}
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   NSLog(@"application:didFinishLaunchingWithOptions: %@", launchOptions);
@@ -133,12 +189,17 @@ using namespace osm_auth_ios;
   return YES;
 }
 
+- (void)handleShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler
+{
+  [self.mapViewController performAction:shortcutItem.type];
+  completionHandler(YES);
+}
+
 - (void)application:(UIApplication *)application
     performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem
                completionHandler:(void (^)(BOOL))completionHandler
 {
-  [self.mapViewController performAction:shortcutItem.type];
-  completionHandler(YES);
+  [self handleShortcutItem:shortcutItem completionHandler:completionHandler];
 }
 
 - (void)runBackgroundTasks:(NSArray<BackgroundFetchTask *> * _Nonnull)tasks
@@ -161,6 +222,11 @@ using namespace osm_auth_ios;
 
 - (void)applicationDidEnterBackground:(UIApplication *)application
 {
+  [self handleApplicationDidEnterBackground];
+}
+
+- (void)handleApplicationDidEnterBackground
+{
   LOG(LINFO, ("applicationDidEnterBackground - begin"));
   [DeepLinkHandler.shared reset];
 
@@ -173,6 +239,11 @@ using namespace osm_auth_ios;
 
 - (void)applicationWillResignActive:(UIApplication *)application
 {
+  [self handleApplicationWillResignActive];
+}
+
+- (void)handleApplicationWillResignActive
+{
   LOG(LINFO, ("applicationWillResignActive - begin"));
   [self.mapViewController onGetFocus:NO];
   auto & f = GetFramework();
@@ -183,6 +254,11 @@ using namespace osm_auth_ios;
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application
+{
+  [self handleApplicationWillEnterForeground];
+}
+
+- (void)handleApplicationWillEnterForeground
 {
   LOG(LINFO, ("applicationWillEnterForeground - begin"));
   if (!GpsTracker::Instance().IsEnabled())
@@ -203,6 +279,11 @@ using namespace osm_auth_ios;
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application
+{
+  [self handleApplicationDidBecomeActive];
+}
+
+- (void)handleApplicationDidBecomeActive
 {
   LOG(LINFO, ("applicationDidBecomeActive - begin"));
 
@@ -232,9 +313,7 @@ using namespace osm_auth_ios;
   return isTests;
 }
 
-- (BOOL)application:(UIApplication *)application
-    continueUserActivity:(NSUserActivity *)userActivity
-      restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
+- (BOOL)handleUserActivity:(NSUserActivity *)userActivity
 {
   if ([userActivity.activityType isEqualToString:CSSearchableItemActionType])
   {
@@ -255,6 +334,13 @@ using namespace osm_auth_ios;
   return NO;
 }
 
+- (BOOL)application:(UIApplication *)application
+    continueUserActivity:(NSUserActivity *)userActivity
+      restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
+{
+  return [self handleUserActivity:userActivity];
+}
+
 + (void)customizeAppearanceForNavigationBar:(UINavigationBar *)navigationBar
 {
   auto backImage =
@@ -270,12 +356,19 @@ using namespace osm_auth_ios;
   [self customizeAppearanceForNavigationBar:[UINavigationBar appearance]];
 }
 
+- (BOOL)handleOpenURL:(NSURL *)url openInPlace:(BOOL)openInPlace
+{
+  NSDictionary<UIApplicationOpenURLOptionsKey, id> * options =
+      @{UIApplicationOpenURLOptionsOpenInPlaceKey: @(openInPlace)};
+  return [DeepLinkHandler.shared applicationDidOpenUrl:url options:options];
+}
+
 - (BOOL)application:(UIApplication *)app
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
 {
   NSLog(@"application:openURL: %@ options: %@", url, options);
-  return [DeepLinkHandler.shared applicationDidOpenUrl:url options:options];
+  return [self handleOpenURL:url openInPlace:[options[UIApplicationOpenURLOptionsOpenInPlaceKey] boolValue]];
 }
 
 - (void)showMap
@@ -337,18 +430,31 @@ using namespace osm_auth_ios;
 
 #pragma mark - Properties
 
+- (UIWindow *)connectedWindow
+{
+  return self.window;
+}
+
+- (UINavigationController *)mainNavigationController
+{
+  // Lazily load the Main storyboard's root navigation controller so a single shared MapViewController
+  // (and its Drape engine) exists even on a CarPlay-first cold launch, before MainSceneDelegate connects
+  // the phone window scene. Both the phone scene and CarPlayService reuse this same instance.
+  if (!_mainNavigationController)
+  {
+    UIStoryboard * storyboard = [UIStoryboard instance:MWMStoryboardMain];
+    _mainNavigationController = (UINavigationController *)[storyboard instantiateInitialViewController];
+  }
+  return _mainNavigationController;
+}
+
 - (MapViewController *)mapViewController
 {
-  for (id vc in [(UINavigationController *)self.window.rootViewController viewControllers])
+  for (id vc in self.mainNavigationController.viewControllers)
     if ([vc isKindOfClass:[MapViewController class]])
       return vc;
   NSAssert(false, @"Please check the logic");
   return nil;
-}
-
-- (MWMCarPlayService *)carplayService
-{
-  return [MWMCarPlayService shared];
 }
 
 #pragma mark - TTS
@@ -414,22 +520,6 @@ using namespace osm_auth_ios;
     return NO;
 
   return YES;
-}
-
-#pragma mark - CPApplicationDelegate implementation
-
-- (void)application:(UIApplication *)application
-    didConnectCarInterfaceController:(CPInterfaceController *)interfaceController
-                            toWindow:(CPWindow *)window
-{
-  [self.carplayService setupWithWindow:window interfaceController:interfaceController];
-}
-
-- (void)application:(UIApplication *)application
-    didDisconnectCarInterfaceController:(CPInterfaceController *)interfaceController
-                             fromWindow:(CPWindow *)window
-{
-  [self.carplayService destroy];
 }
 
 @end

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
@@ -14,7 +14,6 @@
 #import "NSDate+TimeDistance.h"
 #import "SwiftBridge.h"
 
-#import <CarPlay/CarPlay.h>
 #import <CoreSpotlight/CoreSpotlight.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #import <UserNotifications/UserNotifications.h>
@@ -60,7 +59,7 @@ void InitLocalizedStrings()
 
 using namespace osm_auth_ios;
 
-@interface MapsAppDelegate () <MWMStorageObserver, CPApplicationDelegate>
+@interface MapsAppDelegate () <MWMStorageObserver>
 
 @property(nonatomic) NSInteger standbyCounter;
 @property(nonatomic) BOOL standbyDisabledForDownloads;
@@ -378,11 +377,6 @@ using namespace osm_auth_ios;
   return nil;
 }
 
-- (MWMCarPlayService *)carplayService
-{
-  return [MWMCarPlayService shared];
-}
-
 #pragma mark - TTS
 
 - (void)enableTTSForTheFirstTime
@@ -446,22 +440,6 @@ using namespace osm_auth_ios;
     return NO;
 
   return YES;
-}
-
-#pragma mark - CPApplicationDelegate implementation
-
-- (void)application:(UIApplication *)application
-    didConnectCarInterfaceController:(CPInterfaceController *)interfaceController
-                            toWindow:(CPWindow *)window
-{
-  [self.carplayService setupWithWindow:window interfaceController:interfaceController];
-}
-
-- (void)application:(UIApplication *)application
-    didDisconnectCarInterfaceController:(CPInterfaceController *)interfaceController
-                             fromWindow:(CPWindow *)window
-{
-  [self.carplayService destroy];
 }
 
 @end

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
@@ -14,7 +14,6 @@
 #import "NSDate+TimeDistance.h"
 #import "SwiftBridge.h"
 
-#import <CarPlay/CarPlay.h>
 #import <CoreSpotlight/CoreSpotlight.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #import <UserNotifications/UserNotifications.h>
@@ -58,7 +57,7 @@ void InitLocalizedStrings()
 
 using namespace osm_auth_ios;
 
-@interface MapsAppDelegate () <MWMStorageObserver, CPApplicationDelegate>
+@interface MapsAppDelegate () <MWMStorageObserver>
 
 @property(nonatomic) NSInteger standbyCounter;
 @property(nonatomic) BOOL standbyDisabledForDownloads;
@@ -67,6 +66,9 @@ using namespace osm_auth_ios;
 @end
 
 @implementation MapsAppDelegate
+{
+  UINavigationController * _mainNavigationController;
+}
 
 + (MapsAppDelegate *)theApp
 {
@@ -108,10 +110,40 @@ using namespace osm_auth_ios;
   [TrackRecordingManager.shared setup];
 }
 
+#pragma mark - Application lifecycle
+
+// With UIScene adopted, UIKit reports activation and background transitions per scene and no
+// longer calls the UIApplicationDelegate lifecycle methods. The framework, rendering and location
+// updates must follow the application as a whole: stay active while any scene (phone or CarPlay)
+// is in the foreground and go to background only when all of them are. That aggregate is exactly
+// what the app-wide UIApplication notifications express, and UIKit keeps posting them for
+// scene-based apps.
+- (void)observeApplicationLifecycle
+{
+  NSNotificationCenter * nc = NSNotificationCenter.defaultCenter;
+  [nc addObserver:self
+         selector:@selector(handleApplicationDidBecomeActive:)
+             name:UIApplicationDidBecomeActiveNotification
+           object:nil];
+  [nc addObserver:self
+         selector:@selector(handleApplicationWillResignActive:)
+             name:UIApplicationWillResignActiveNotification
+           object:nil];
+  [nc addObserver:self
+         selector:@selector(handleApplicationWillEnterForeground:)
+             name:UIApplicationWillEnterForegroundNotification
+           object:nil];
+  [nc addObserver:self
+         selector:@selector(handleApplicationDidEnterBackground:)
+             name:UIApplicationDidEnterBackgroundNotification
+           object:nil];
+}
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   NSLog(@"application:didFinishLaunchingWithOptions: %@", launchOptions);
 
+  [self observeApplicationLifecycle];
   InitLocalizedStrings();
   [MWMThemeManager invalidate];
 
@@ -126,14 +158,12 @@ using namespace osm_auth_ios;
   if (![MapsAppDelegate isTestsEnvironment])
     [[iCloudSynchronizaionManager shared] start];
 
-  [[DeepLinkHandler shared] applicationDidFinishLaunching:launchOptions];
-  // application:openUrl:options is called later for deep links if YES is returned.
+  // Launch URLs, user activities and quick actions arrive with the scene connection options in
+  // MainSceneDelegate; launchOptions carries none of them for a scene-based app.
   return YES;
 }
 
-- (void)application:(UIApplication *)application
-    performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem
-               completionHandler:(void (^)(BOOL))completionHandler
+- (void)handleShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler
 {
   [self.mapViewController performAction:shortcutItem.type];
   completionHandler(YES);
@@ -157,7 +187,7 @@ using namespace osm_auth_ios;
   DeleteFramework();
 }
 
-- (void)applicationDidEnterBackground:(UIApplication *)application
+- (void)handleApplicationDidEnterBackground:(NSNotification *)notification
 {
   LOG(LINFO, ("applicationDidEnterBackground - begin"));
   [DeepLinkHandler.shared reset];
@@ -169,7 +199,7 @@ using namespace osm_auth_ios;
   LOG(LINFO, ("applicationDidEnterBackground - end"));
 }
 
-- (void)applicationWillResignActive:(UIApplication *)application
+- (void)handleApplicationWillResignActive:(NSNotification *)notification
 {
   LOG(LINFO, ("applicationWillResignActive - begin"));
   [self.mapViewController onGetFocus:NO];
@@ -180,7 +210,7 @@ using namespace osm_auth_ios;
   LOG(LINFO, ("applicationWillResignActive - end"));
 }
 
-- (void)applicationWillEnterForeground:(UIApplication *)application
+- (void)handleApplicationWillEnterForeground:(NSNotification *)notification
 {
   LOG(LINFO, ("applicationWillEnterForeground - begin"));
   if (!GpsTracker::Instance().IsEnabled())
@@ -200,7 +230,7 @@ using namespace osm_auth_ios;
   LOG(LINFO, ("applicationWillEnterForeground - end"));
 }
 
-- (void)applicationDidBecomeActive:(UIApplication *)application
+- (void)handleApplicationDidBecomeActive:(NSNotification *)notification
 {
   LOG(LINFO, ("applicationDidBecomeActive - begin"));
 
@@ -230,9 +260,7 @@ using namespace osm_auth_ios;
   return isTests;
 }
 
-- (BOOL)application:(UIApplication *)application
-    continueUserActivity:(NSUserActivity *)userActivity
-      restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
+- (BOOL)handleUserActivity:(NSUserActivity *)userActivity
 {
   if ([userActivity.activityType isEqualToString:CSSearchableItemActionType])
   {
@@ -268,17 +296,9 @@ using namespace osm_auth_ios;
   [self customizeAppearanceForNavigationBar:[UINavigationBar appearance]];
 }
 
-- (BOOL)application:(UIApplication *)app
-            openURL:(NSURL *)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
-{
-  NSLog(@"application:openURL: %@ options: %@", url, options);
-  return [DeepLinkHandler.shared applicationDidOpenUrl:url options:options];
-}
-
 - (void)showMap
 {
-  [(UINavigationController *)self.window.rootViewController popToRootViewControllerAnimated:YES];
+  [self.mainNavigationController popToRootViewControllerAnimated:YES];
 }
 
 - (void)updateApplicationIconBadgeNumber
@@ -335,18 +355,26 @@ using namespace osm_auth_ios;
 
 #pragma mark - Properties
 
+- (UINavigationController *)mainNavigationController
+{
+  // Lazily load the Main storyboard's root navigation controller so a single shared MapViewController
+  // (and its Drape engine) exists even on a CarPlay-first cold launch, before MainSceneDelegate connects
+  // the phone window scene. Both the phone scene and CarPlayService reuse this same instance.
+  if (!_mainNavigationController)
+  {
+    UIStoryboard * storyboard = [UIStoryboard instance:MWMStoryboardMain];
+    _mainNavigationController = (UINavigationController *)[storyboard instantiateInitialViewController];
+  }
+  return _mainNavigationController;
+}
+
 - (MapViewController *)mapViewController
 {
-  for (id vc in [(UINavigationController *)self.window.rootViewController viewControllers])
+  for (id vc in self.mainNavigationController.viewControllers)
     if ([vc isKindOfClass:[MapViewController class]])
       return vc;
   NSAssert(false, @"Please check the logic");
   return nil;
-}
-
-- (MWMCarPlayService *)carplayService
-{
-  return [MWMCarPlayService shared];
 }
 
 #pragma mark - TTS
@@ -412,22 +440,6 @@ using namespace osm_auth_ios;
     return NO;
 
   return YES;
-}
-
-#pragma mark - CPApplicationDelegate implementation
-
-- (void)application:(UIApplication *)application
-    didConnectCarInterfaceController:(CPInterfaceController *)interfaceController
-                            toWindow:(CPWindow *)window
-{
-  [self.carplayService setupWithWindow:window interfaceController:interfaceController];
-}
-
-- (void)application:(UIApplication *)application
-    didDisconnectCarInterfaceController:(CPInterfaceController *)interfaceController
-                             fromWindow:(CPWindow *)window
-{
-  [self.carplayService destroy];
 }
 
 @end

--- a/iphone/Maps/Core/CarPlay/CarPlayRouter.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayRouter.swift
@@ -339,6 +339,11 @@ extension CarPlayRouter: RoutingManagerListener {
         }
         return
       }
+      // Building a route disables following in the core. Resume it when an active CarPlay
+      // navigation session requested the rebuild (for example, after changing route options).
+      if routeSession != nil, !manager.isOnRoute {
+        manager.startRoute()
+      }
       if let info = manager.routeInfo {
         previewTrip?.routeChoices.first?.userInfo = info
         if routeSession == nil {

--- a/iphone/Maps/Core/CarPlay/CarPlaySceneDelegate.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlaySceneDelegate.swift
@@ -1,0 +1,32 @@
+import CarPlay
+
+@objc(CarPlaySceneDelegate)
+final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
+  func sceneDidBecomeActive(_ scene: UIScene) {
+    MapsAppDelegate.theApp().sceneDidBecomeActive(scene)
+  }
+
+  func sceneWillResignActive(_ scene: UIScene) {
+    MapsAppDelegate.theApp().sceneWillResignActive(scene)
+  }
+
+  func sceneWillEnterForeground(_ scene: UIScene) {
+    MapsAppDelegate.theApp().sceneWillEnterForeground(scene)
+  }
+
+  func sceneDidEnterBackground(_ scene: UIScene) {
+    MapsAppDelegate.theApp().sceneDidEnterBackground(scene)
+  }
+
+  func templateApplicationScene(_: CPTemplateApplicationScene,
+                                didConnect interfaceController: CPInterfaceController,
+                                to window: CPWindow) {
+    CarPlayService.shared.setup(window: window, interfaceController: interfaceController)
+  }
+
+  func templateApplicationScene(_: CPTemplateApplicationScene,
+                                didDisconnect _: CPInterfaceController,
+                                from _: CPWindow) {
+    CarPlayService.shared.destroy()
+  }
+}

--- a/iphone/Maps/Core/CarPlay/CarPlaySceneDelegate.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlaySceneDelegate.swift
@@ -1,0 +1,16 @@
+import CarPlay
+
+@objc(CarPlaySceneDelegate)
+final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
+  func templateApplicationScene(_: CPTemplateApplicationScene,
+                                didConnect interfaceController: CPInterfaceController,
+                                to window: CPWindow) {
+    CarPlayService.shared.setup(window: window, interfaceController: interfaceController)
+  }
+
+  func templateApplicationScene(_: CPTemplateApplicationScene,
+                                didDisconnect _: CPInterfaceController,
+                                from _: CPWindow) {
+    CarPlayService.shared.destroy()
+  }
+}

--- a/iphone/Maps/Core/CarPlay/CarPlaySceneDelegate.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlaySceneDelegate.swift
@@ -1,0 +1,18 @@
+import CarPlay
+
+@objc(CarPlaySceneDelegate)
+final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
+  /// Activation and background transitions are handled app-wide by MapsAppDelegate through the
+  /// UIApplication notifications, so this delegate only tracks the CarPlay connection itself.
+  func templateApplicationScene(_: CPTemplateApplicationScene,
+                                didConnect interfaceController: CPInterfaceController,
+                                to window: CPWindow) {
+    CarPlayService.shared.setup(window: window, interfaceController: interfaceController)
+  }
+
+  func templateApplicationScene(_: CPTemplateApplicationScene,
+                                didDisconnect _: CPInterfaceController,
+                                from _: CPWindow) {
+    CarPlayService.shared.destroy()
+  }
+}

--- a/iphone/Maps/Core/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayService.swift
@@ -147,6 +147,19 @@ final class CarPlayService: NSObject {
     }
   }
 
+  @objc func attachMapIfNeeded() {
+    guard isCarplayActivated,
+          let window,
+          let carplayVC = window.rootViewController as? CarPlayMapViewController,
+          let mapVC = MapViewController.shared() else { return }
+    guard carplayVC.mapView == nil else { return }
+
+    currentPositionMode = mapVC.currentPositionMode
+    mapVC.enableCarPlayRepresentation()
+    carplayVC.addMapView(mapVC.mapView, mapButtonSafeAreaLayoutGuide: window.mapButtonSafeAreaLayoutGuide)
+    mapVC.add(self)
+  }
+
   @objc func destroy() {
     if isCarplayActivated {
       switchScreenToPhone()
@@ -175,16 +188,10 @@ final class CarPlayService: NSObject {
   }
 
   private func applyRootViewController() {
-    guard let window = window else { return }
-    let carplaySotyboard = UIStoryboard.instance(.carPlay)
-    let carplayVC = carplaySotyboard.instantiateInitialViewController() as! CarPlayMapViewController
-    window.rootViewController = carplayVC
-    if let mapVC = MapViewController.shared() {
-      currentPositionMode = mapVC.currentPositionMode
-      mapVC.enableCarPlayRepresentation()
-      carplayVC.addMapView(mapVC.mapView, mapButtonSafeAreaLayoutGuide: window.mapButtonSafeAreaLayoutGuide)
-      mapVC.add(self)
-    }
+    guard let window else { return }
+    let vc = UIStoryboard.instance(.carPlay).instantiateInitialViewController() as! CarPlayMapViewController
+    window.rootViewController = vc
+    attachMapIfNeeded()
   }
 
   private func applyBaseRootTemplate() {

--- a/iphone/Maps/Core/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayService.swift
@@ -100,16 +100,29 @@ final class CarPlayService: NSObject {
       title: L("car_continue_in_the_car"),
       style: .default,
       handler: { [weak self] _ in
-        self?.savedInterfaceController?.dismissTemplate(animated: false)
-        self?.showOnCarplay()
+        self?.savedInterfaceController?.dismissTemplate(animated: false) { _, error in
+          if let error {
+            LOG(.warning, "Failed to dismiss CarPlay alert: \(error.localizedDescription)")
+          }
+          self?.showOnCarplay()
+        }
       }
     )
     let alert = CPAlertTemplate(
       titleVariants: [L("car_used_on_the_phone_screen")],
       actions: [switchToCarAction]
     )
-    savedInterfaceController?.dismissTemplate(animated: false)
-    savedInterfaceController?.presentTemplate(alert, animated: false)
+    savedInterfaceController?.dismissTemplate(animated: false) { [weak self] _, error in
+      guard let self else { return }
+      if let error {
+        LOG(.warning, "Failed to dismiss CarPlay alert: \(error.localizedDescription)")
+      }
+      self.savedInterfaceController?.presentTemplate(alert, animated: false) { _, error in
+        if let error {
+          LOG(.warning, "Failed to present CarPlay alert: \(error.localizedDescription)")
+        }
+      }
+    }
   }
 
   private func switchScreenToPhone() {
@@ -198,49 +211,86 @@ final class CarPlayService: NSObject {
     let mapTemplate = MapTemplateBuilder.buildBaseTemplate(positionMode: currentPositionMode)
     mapTemplate.mapDelegate = self
     mapTemplate.tripEstimateStyle = rootTemplateStyle
-    interfaceController?.setRootTemplate(mapTemplate, animated: true)
-    FrameworkHelper.rotateMap(0.0, animated: false)
+    interfaceController?.setRootTemplate(mapTemplate, animated: true) { _, error in
+      if let error {
+        LOG(.warning, "Failed to set CarPlay root template: \(error.localizedDescription)")
+      }
+      FrameworkHelper.rotateMap(0.0, animated: false)
+    }
   }
 
   private func applyNavigationRootTemplate(trip: CPTrip, routeInfo: RouteInfo) {
     let mapTemplate = MapTemplateBuilder.buildNavigationTemplate()
     mapTemplate.mapDelegate = self
-    interfaceController?.setRootTemplate(mapTemplate, animated: true)
-    router?.startNavigationSession(forTrip: trip, template: mapTemplate)
-    if let estimates = createEstimates(routeInfo: routeInfo) {
-      mapTemplate.tripEstimateStyle = rootTemplateStyle
-      mapTemplate.updateEstimates(estimates, for: trip)
-    }
+    interfaceController?.setRootTemplate(mapTemplate, animated: true) { [weak self] _, error in
+      guard let self else { return }
+      if let error {
+        LOG(.warning, "Failed to set CarPlay navigation template: \(error.localizedDescription)")
+      }
+      self.router?.startNavigationSession(forTrip: trip, template: mapTemplate)
+      if let estimates = self.createEstimates(routeInfo: routeInfo) {
+        mapTemplate.tripEstimateStyle = rootTemplateStyle
+        mapTemplate.updateEstimates(estimates, for: trip)
+      }
 
-    if let carplayVC = carplayVC {
-      carplayVC.updateCurrentSpeed(routeInfo.speedMps, speedLimitMps: routeInfo.speedLimitMps)
-      carplayVC.showSpeedControl()
+      if let carplayVC = self.carplayVC {
+        carplayVC.updateCurrentSpeed(routeInfo.speedMps, speedLimitMps: routeInfo.speedLimitMps)
+        carplayVC.showSpeedControl()
+      }
     }
   }
 
   func pushTemplate(_ templateToPush: CPTemplate, animated: Bool) {
-    if let interfaceController = interfaceController {
-      switch templateToPush {
-      case let list as CPListTemplate:
-        list.delegate = self
-      case let search as CPSearchTemplate:
-        search.delegate = self
-      case let map as CPMapTemplate:
-        map.mapDelegate = self
-      default:
-        break
+    guard let interfaceController else {
+      LOG(.error, "Failed to push CarPlay template: interfaceController is nil")
+      return
+    }
+    switch templateToPush {
+    case let search as CPSearchTemplate:
+      search.delegate = self
+    case let map as CPMapTemplate:
+      map.mapDelegate = self
+    default:
+      break
+    }
+    interfaceController.pushTemplate(templateToPush, animated: animated) { _, error in
+      if let error {
+        LOG(.warning, "Failed to push CarPlay template: \(error.localizedDescription)")
       }
-      interfaceController.pushTemplate(templateToPush, animated: animated)
     }
   }
 
   func popTemplate(animated: Bool) {
-    interfaceController?.popTemplate(animated: animated)
+    interfaceController?.popTemplate(animated: animated) { _, error in
+      if let error {
+        LOG(.warning, "Failed to pop CarPlay template: \(error.localizedDescription)")
+      }
+    }
   }
 
   func presentAlert(_ template: CPAlertTemplate, animated: Bool) {
-    interfaceController?.dismissTemplate(animated: false)
-    interfaceController?.presentTemplate(template, animated: animated)
+    guard let interfaceController else {
+      LOG(.error, "Failed to present CarPlay template alert: interfaceController is nil")
+      return
+    }
+    if interfaceController.presentedTemplate != nil {
+      interfaceController.dismissTemplate(animated: false) { [weak interfaceController] _, error in
+        if let error {
+          LOG(.warning, "Failed to dismiss CarPlay alert: \(error.localizedDescription)")
+        }
+        interfaceController?.presentTemplate(template, animated: animated) { _, error in
+          if let error {
+            LOG(.warning, "Failed to present CarPlay alert: \(error.localizedDescription)")
+          }
+        }
+      }
+    } else {
+      interfaceController.presentTemplate(template, animated: animated) { _, error in
+        if let error {
+          LOG(.warning, "Failed to present CarPlay alert: \(error.localizedDescription)")
+        }
+      }
+    }
   }
 
   func cancelCurrentTrip() {
@@ -294,7 +344,7 @@ final class CarPlayService: NSObject {
 
     let alert = CPNavigationAlert(titleVariants: [L("trip_finished")],
                                   subtitleVariants: [subtitle],
-                                  imageSet: nil,
+                                  image: nil,
                                   primaryAction: doneAction,
                                   secondaryAction: nil,
                                   duration: 0)
@@ -329,7 +379,11 @@ final class CarPlayService: NSObject {
        let info = presentedTemplate.userInfo as? [String: String],
        let alertType = info[CPConstants.TemplateKey.alert],
        alertType == CPConstants.TemplateType.downloadMap {
-      interfaceController?.dismissTemplate(animated: true)
+      interfaceController?.dismissTemplate(animated: true) { _, error in
+        if let error {
+          LOG(.warning, "Failed to dismiss CarPlay alert: \(error.localizedDescription)")
+        }
+      }
     }
   }
 }
@@ -475,20 +529,30 @@ extension CarPlayService: CPMapTemplateDelegate {
 
     MapTemplateBuilder.configureNavigationUI(mapTemplate: rootMapTemplate)
 
-    if interfaceController.templates.count > 1 {
-      interfaceController.popToRootTemplate(animated: false)
-    }
-    router.startNavigationSession(forTrip: trip, template: rootMapTemplate)
-    router.startRoute()
-    if let estimates = createEstimates(routeInfo: info) {
-      rootMapTemplate.updateEstimates(estimates, for: trip)
+    let startNavigation = { [weak self] in
+      router.startNavigationSession(forTrip: trip, template: rootMapTemplate)
+      router.startRoute()
+      if let estimates = self?.createEstimates(routeInfo: info) {
+        rootMapTemplate.updateEstimates(estimates, for: trip)
+      }
+
+      if let carplayVC = self?.carplayVC {
+        carplayVC.updateCurrentSpeed(info.speedMps, speedLimitMps: info.speedLimitMps)
+        carplayVC.showSpeedControl()
+      }
+      self?.updateVisibleViewPortState(.navigation)
     }
 
-    if let carplayVC = carplayVC {
-      carplayVC.updateCurrentSpeed(info.speedMps, speedLimitMps: info.speedLimitMps)
-      carplayVC.showSpeedControl()
+    if interfaceController.templates.count > 1 {
+      interfaceController.popToRootTemplate(animated: false) { _, error in
+        if let error {
+          LOG(.warning, "Failed to pop CarPlay templates to root: \(error.localizedDescription)")
+        }
+        startNavigation()
+      }
+    } else {
+      startNavigation()
     }
-    updateVisibleViewPortState(.navigation)
   }
 
   func mapTemplate(_: CPMapTemplate, displayStyleFor maneuver: CPManeuver) -> CPManeuverDisplayStyle {
@@ -520,10 +584,10 @@ extension CarPlayService: CPMapTemplateDelegate {
   }
 }
 
-// MARK: - CPListTemplateDelegate implementation
+// MARK: - List Item Selection
 
-extension CarPlayService: CPListTemplateDelegate {
-  func listTemplate(_: CPListTemplate, didSelect item: CPListItem, completionHandler: @escaping () -> Void) {
+extension CarPlayService {
+  func handleSelectedListItem(_ item: CPListItem, completionHandler: @escaping () -> Void) {
     if let userInfo = item.userInfo as? ListItemInfo {
       switch userInfo.type {
       case CPConstants.ListItemType.history:
@@ -533,7 +597,10 @@ extension CarPlayService: CPListTemplateDelegate {
           return
         }
         searchService.searchText(item.text ?? "", forInputLocale: locale, completionHandler: { [weak self] results in
-          guard let self = self else { return }
+          guard let self = self else {
+            completionHandler()
+            return
+          }
           let template = ListTemplateBuilder.buildListTemplate(for: .searchResults(results: results))
           completionHandler()
           self.pushTemplate(template, animated: true)
@@ -555,6 +622,8 @@ extension CarPlayService: CPListTemplateDelegate {
       default:
         completionHandler()
       }
+    } else {
+      completionHandler()
     }
   }
 }
@@ -728,9 +797,23 @@ extension CarPlayService {
       mapTemplate.mapDelegate = self
 
       if interfaceController.templates.count > 1 {
-        interfaceController.popToRootTemplate(animated: false)
+        interfaceController.popToRootTemplate(animated: false) { [weak interfaceController] _, error in
+          if let error {
+            LOG(.warning, "Failed to pop CarPlay templates to root: \(error.localizedDescription)")
+          }
+          interfaceController?.pushTemplate(mapTemplate, animated: false) { _, error in
+            if let error {
+              LOG(.warning, "Failed to push CarPlay preview template: \(error.localizedDescription)")
+            }
+          }
+        }
+        return
       }
-      interfaceController.pushTemplate(mapTemplate, animated: false)
+      interfaceController.pushTemplate(mapTemplate, animated: false) { _, error in
+        if let error {
+          LOG(.warning, "Failed to push CarPlay preview template: \(error.localizedDescription)")
+        }
+      }
     }
   }
 
@@ -754,25 +837,29 @@ extension CarPlayService {
     template.updateEstimates(estimates, for: trip)
   }
 
-  func showRerouteAlert(trips: [CPTrip]) {
+  private func dismissTemplate(_: CPAlertAction? = nil) {
+    interfaceController?.dismissTemplate(animated: true) { _, error in
+      if let error {
+        LOG(.warning, "Failed to dismiss CarPlay template: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  private func showRerouteAlert(trips: [CPTrip]) {
     let yesAction = CPAlertAction(title: L("yes"), style: .default, handler: { [unowned self] _ in
       router?.cancelTrip()
       updateMapTemplateUIToBase()
       preparedToPreviewTrips = trips
-      interfaceController?.dismissTemplate(animated: true)
+      dismissTemplate()
     })
-    let noAction = CPAlertAction(title: L("no"), style: .cancel, handler: { [unowned self] _ in
-      interfaceController?.dismissTemplate(animated: true)
-    })
+    let noAction = CPAlertAction(title: L("no"), style: .cancel, handler: dismissTemplate)
     let alert = CPAlertTemplate(titleVariants: [L("redirect_route_alert")], actions: [noAction, yesAction])
     alert.userInfo = [CPConstants.TemplateKey.alert: CPConstants.TemplateType.redirectRoute]
     presentAlert(alert, animated: true)
   }
 
   func showKeyboardAlert() {
-    let okAction = CPAlertAction(title: L("ok"), style: .default, handler: { [unowned self] _ in
-      interfaceController?.dismissTemplate(animated: true)
-    })
+    let okAction = CPAlertAction(title: L("ok"), style: .default, handler: dismissTemplate)
     let alert = CPAlertTemplate(titleVariants: [L("keyboard_availability_alert")], actions: [okAction])
     presentAlert(alert, animated: true)
   }
@@ -806,9 +893,7 @@ extension CarPlayService {
       return
     }
 
-    let okAction = CPAlertAction(title: L("ok"), style: .cancel, handler: { [unowned self] _ in
-      interfaceController?.dismissTemplate(animated: true)
-    })
+    let okAction = CPAlertAction(title: L("ok"), style: .cancel, handler: dismissTemplate)
     let alert = CPAlertTemplate(titleVariants: titleVariants, actions: [okAction])
     presentAlert(alert, animated: true)
   }
@@ -824,12 +909,12 @@ extension CarPlayService {
       trip.userInfo = info
       preparedToPreviewTrips = [trip]
       router?.updateStartPointAndRebuild(trip: trip)
-      interfaceController?.dismissTemplate(animated: true)
+      dismissTemplate()
     })
     let noAction = CPAlertAction(title: L("cancel"), style: .cancel, handler: { [unowned self] _ in
       FrameworkHelper.rotateMap(0.0, animated: false)
       router?.completeRouteAndRemovePoints()
-      interfaceController?.dismissTemplate(animated: true)
+      dismissTemplate()
     })
     let title = isTypeCorrect ? L("dialog_routing_rebuild_from_current_location_carplay") : L("dialog_routing_rebuild_for_vehicle_carplay")
     let alert = CPAlertTemplate(titleVariants: [title], actions: [noAction, yesAction])

--- a/iphone/Maps/Core/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayService.swift
@@ -74,7 +74,7 @@ final class CarPlayService: NSObject {
     FrameworkHelper.updatePositionArrowOffset(false, offset: 5)
 
     CarPlayWindowScaleAdjuster.updateAppearance(
-      fromWindow: MapsAppDelegate.theApp().window,
+      fromWindow: MapsAppDelegate.theApp().connectedWindow,
       toWindow: window,
       isCarplayActivated: true
     )
@@ -104,8 +104,10 @@ final class CarPlayService: NSObject {
       style: .default,
       handler: { [weak self] _ in
         guard let self else { return }
-        savedInterfaceController?.dismissTemplate(animated: false, completion: templateCompletion)
-        showOnCarplay()
+        savedInterfaceController?.dismissTemplate(animated: false) { [weak self] success, error in
+          self?.templateCompletion(success, error)
+          self?.showOnCarplay()
+        }
       }
     )
     let alert = CPAlertTemplate(
@@ -145,10 +147,29 @@ final class CarPlayService: NSObject {
     if let window {
       CarPlayWindowScaleAdjuster.updateAppearance(
         fromWindow: window,
-        toWindow: MapsAppDelegate.theApp().window,
+        toWindow: MapsAppDelegate.theApp().connectedWindow,
         isCarplayActivated: false
       )
     }
+  }
+
+  func attachMapIfNeeded() {
+    guard isCarplayActivated else { return }
+    guard let window else { return }
+    guard let carplayVC = window.rootViewController as? CarPlayMapViewController else { return }
+    guard carplayVC.mapView == nil else { return }
+
+    // On a CarPlay-first cold launch the phone window scene has not connected yet, so eagerly create
+    // the single shared MapViewController (and its map view / Drape engine) before attaching it here.
+    guard let mapVC = MapViewController.shared() else { return }
+    mapVC.loadViewIfNeeded()
+
+    mapVC.enableCarPlayRepresentation()
+    carplayVC.addMapView(mapVC.mapView, mapButtonSafeAreaLayoutGuide: window.mapButtonSafeAreaLayoutGuide)
+    mapVC.add(self)
+    // The base template may have been built with the default position mode before the map existed;
+    // refresh the leading nav button to the map's actual mode now that the listener is attached.
+    processMyPositionStateModeEvent(mapVC.currentPositionMode)
   }
 
   @objc func destroy() {
@@ -179,16 +200,11 @@ final class CarPlayService: NSObject {
   }
 
   private func applyRootViewController() {
-    guard let window = window else { return }
-    let carplaySotyboard = UIStoryboard.instance(.carPlay)
-    let carplayVC = carplaySotyboard.instantiateInitialViewController() as! CarPlayMapViewController
-    window.rootViewController = carplayVC
-    if let mapVC = MapViewController.shared() {
-      currentPositionMode = mapVC.currentPositionMode
-      mapVC.enableCarPlayRepresentation()
-      carplayVC.addMapView(mapVC.mapView, mapButtonSafeAreaLayoutGuide: window.mapButtonSafeAreaLayoutGuide)
-      mapVC.add(self)
+    guard let window else { return }
+    if !(window.rootViewController is CarPlayMapViewController) {
+      window.rootViewController = UIStoryboard.instance(.carPlay).instantiateInitialViewController()
     }
+    attachMapIfNeeded()
   }
 
   private func applyBaseRootTemplate() {
@@ -422,20 +438,36 @@ extension CarPlayService: CPMapTemplateDelegate {
   func mapTemplate(_: CPMapTemplate, panEndedWith direction: CPMapTemplate.PanDirection) {
     var offset = UIOffset(horizontal: 0.0, vertical: 0.0)
     let offsetStep: CGFloat = 0.25
-    if direction.contains(.up) { offset.vertical -= offsetStep }
-    if direction.contains(.down) { offset.vertical += offsetStep }
-    if direction.contains(.left) { offset.horizontal += offsetStep }
-    if direction.contains(.right) { offset.horizontal -= offsetStep }
+    if direction.contains(.up) {
+      offset.vertical -= offsetStep
+    }
+    if direction.contains(.down) {
+      offset.vertical += offsetStep
+    }
+    if direction.contains(.left) {
+      offset.horizontal += offsetStep
+    }
+    if direction.contains(.right) {
+      offset.horizontal -= offsetStep
+    }
     FrameworkHelper.moveMap(offset)
   }
 
   func mapTemplate(_: CPMapTemplate, panWith direction: CPMapTemplate.PanDirection) {
     var offset = UIOffset(horizontal: 0.0, vertical: 0.0)
     let offsetStep: CGFloat = 0.1
-    if direction.contains(.up) { offset.vertical -= offsetStep }
-    if direction.contains(.down) { offset.vertical += offsetStep }
-    if direction.contains(.left) { offset.horizontal += offsetStep }
-    if direction.contains(.right) { offset.horizontal -= offsetStep }
+    if direction.contains(.up) {
+      offset.vertical -= offsetStep
+    }
+    if direction.contains(.down) {
+      offset.vertical += offsetStep
+    }
+    if direction.contains(.left) {
+      offset.horizontal += offsetStep
+    }
+    if direction.contains(.right) {
+      offset.horizontal -= offsetStep
+    }
     FrameworkHelper.moveMap(offset)
   }
 
@@ -593,7 +625,9 @@ extension CarPlayService: CarPlayRouterListener {
   }
 
   func routeDidFinish(_ trip: CPTrip) {
-    if router?.currentTrip == nil { return }
+    if router?.currentTrip == nil {
+      return
+    }
     router?.finishTrip()
     if let carplayVC = carplayVC {
       carplayVC.hideSpeedControl()

--- a/iphone/Maps/Core/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayService.swift
@@ -48,7 +48,7 @@ final class CarPlayService: NSObject {
   var preparedToPreviewTrips: [CPTrip] = []
   private var searchText = ""
 
-  @objc func setup(window: CPWindow, interfaceController: CPInterfaceController) {
+  func setup(window: CPWindow, interfaceController: CPInterfaceController) {
     LOG(.info, "Settting up service...")
     isCarplayActivated = true
     self.window = window
@@ -72,12 +72,7 @@ final class CarPlayService: NSObject {
     }
     updateContentStyle(configuration.contentStyle)
     FrameworkHelper.updatePositionArrowOffset(false, offset: 5)
-
-    CarPlayWindowScaleAdjuster.updateAppearance(
-      fromWindow: MapsAppDelegate.theApp().window,
-      toWindow: window,
-      isCarplayActivated: true
-    )
+    CarPlayWindowScaleAdjuster.applyCarPlayScale(window)
   }
 
   private var savedInterfaceController: CPInterfaceController?
@@ -104,8 +99,10 @@ final class CarPlayService: NSObject {
       style: .default,
       handler: { [weak self] _ in
         guard let self else { return }
-        savedInterfaceController?.dismissTemplate(animated: false, completion: templateCompletion)
-        showOnCarplay()
+        savedInterfaceController?.dismissTemplate(animated: false) { [weak self] success, error in
+          self?.templateCompletion(success, error)
+          self?.showOnCarplay()
+        }
       }
     )
     let alert = CPAlertTemplate(
@@ -141,17 +138,10 @@ final class CarPlayService: NSObject {
     interfaceController = nil
     ThemeManager.invalidate()
     FrameworkHelper.updatePositionArrowOffset(true, offset: 0)
-
-    if let window {
-      CarPlayWindowScaleAdjuster.updateAppearance(
-        fromWindow: window,
-        toWindow: MapsAppDelegate.theApp().window,
-        isCarplayActivated: false
-      )
-    }
+    CarPlayWindowScaleAdjuster.restorePhoneScale()
   }
 
-  @objc func destroy() {
+  func destroy() {
     if isCarplayActivated {
       switchScreenToPhone()
     }
@@ -168,7 +158,7 @@ final class CarPlayService: NSObject {
 
   private func updateContentStyle(_ contentStyle: CPContentStyle) {
     rootTemplateStyle = contentStyle == .dark ? .dark : .light
-    // Update the current map style in accordance with the CarPLay content theme.
+    // Update the current map style in accordance with the CarPlay content theme.
     ThemeManager.invalidate()
   }
 
@@ -179,16 +169,18 @@ final class CarPlayService: NSObject {
   }
 
   private func applyRootViewController() {
-    guard let window = window else { return }
-    let carplaySotyboard = UIStoryboard.instance(.carPlay)
-    let carplayVC = carplaySotyboard.instantiateInitialViewController() as! CarPlayMapViewController
+    guard let window else { return }
+    // A fresh controller per setup: its constraints and speed/camera state are not designed for reuse.
+    let carplayVC = UIStoryboard.instance(.carPlay).instantiateInitialViewController() as! CarPlayMapViewController
     window.rootViewController = carplayVC
-    if let mapVC = MapViewController.shared() {
-      currentPositionMode = mapVC.currentPositionMode
-      mapVC.enableCarPlayRepresentation()
-      carplayVC.addMapView(mapVC.mapView, mapButtonSafeAreaLayoutGuide: window.mapButtonSafeAreaLayoutGuide)
-      mapVC.add(self)
-    }
+    // On a CarPlay-first cold launch no phone scene exists yet: MapViewController.shared() lazily loads
+    // the Main storyboard, so the single shared map is created right here and later re-hosted by the
+    // phone window unchanged.
+    guard let mapVC = MapViewController.shared() else { return }
+    currentPositionMode = mapVC.currentPositionMode
+    mapVC.enableCarPlayRepresentation()
+    carplayVC.addMapView(mapVC.mapView, mapButtonSafeAreaLayoutGuide: window.mapButtonSafeAreaLayoutGuide)
+    mapVC.add(self)
   }
 
   private func applyBaseRootTemplate() {
@@ -422,20 +414,36 @@ extension CarPlayService: CPMapTemplateDelegate {
   func mapTemplate(_: CPMapTemplate, panEndedWith direction: CPMapTemplate.PanDirection) {
     var offset = UIOffset(horizontal: 0.0, vertical: 0.0)
     let offsetStep: CGFloat = 0.25
-    if direction.contains(.up) { offset.vertical -= offsetStep }
-    if direction.contains(.down) { offset.vertical += offsetStep }
-    if direction.contains(.left) { offset.horizontal += offsetStep }
-    if direction.contains(.right) { offset.horizontal -= offsetStep }
+    if direction.contains(.up) {
+      offset.vertical -= offsetStep
+    }
+    if direction.contains(.down) {
+      offset.vertical += offsetStep
+    }
+    if direction.contains(.left) {
+      offset.horizontal += offsetStep
+    }
+    if direction.contains(.right) {
+      offset.horizontal -= offsetStep
+    }
     FrameworkHelper.moveMap(offset)
   }
 
   func mapTemplate(_: CPMapTemplate, panWith direction: CPMapTemplate.PanDirection) {
     var offset = UIOffset(horizontal: 0.0, vertical: 0.0)
     let offsetStep: CGFloat = 0.1
-    if direction.contains(.up) { offset.vertical -= offsetStep }
-    if direction.contains(.down) { offset.vertical += offsetStep }
-    if direction.contains(.left) { offset.horizontal += offsetStep }
-    if direction.contains(.right) { offset.horizontal -= offsetStep }
+    if direction.contains(.up) {
+      offset.vertical -= offsetStep
+    }
+    if direction.contains(.down) {
+      offset.vertical += offsetStep
+    }
+    if direction.contains(.left) {
+      offset.horizontal += offsetStep
+    }
+    if direction.contains(.right) {
+      offset.horizontal -= offsetStep
+    }
     FrameworkHelper.moveMap(offset)
   }
 
@@ -593,7 +601,9 @@ extension CarPlayService: CarPlayRouterListener {
   }
 
   func routeDidFinish(_ trip: CPTrip) {
-    if router?.currentTrip == nil { return }
+    if router?.currentTrip == nil {
+      return
+    }
     router?.finishTrip()
     if let carplayVC = carplayVC {
       carplayVC.hideSpeedControl()

--- a/iphone/Maps/Core/CarPlay/CarPlayWindowScaleAdjuster.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayWindowScaleAdjuster.swift
@@ -1,49 +1,61 @@
-import Foundation
 import UIKit
 
 enum CarPlayWindowScaleAdjuster {
   static func updateAppearance(
-    fromWindow sourceWindow: UIWindow,
-    toWindow destinationWindow: UIWindow,
+    fromWindow sourceWindow: UIWindow?,
+    toWindow destinationWindow: UIWindow?,
     isCarplayActivated: Bool
   ) {
-    let sourceContentScale = sourceWindow.screen.scale
-    let destinationContentScale = destinationWindow.screen.scale
+    mapView?.graphicContextDidInitializeHandler = nil
 
-    if abs(sourceContentScale - destinationContentScale) > 0.1 {
-      if isCarplayActivated {
-        updateVisualScale(to: destinationContentScale)
-      } else {
-        updateVisualScaleToMain()
+    guard let destinationWindow else {
+      // CarPlay can disconnect before the phone scene connects. Restore the default visual scale so
+      // the lazily-created map is ready when the phone window eventually appears. If the graphics
+      // context is not initialized, no CarPlay scale could have been applied and there is nothing to
+      // restore; clearing the readiness handler above also cancels a pending CarPlay-scale update.
+      if !isCarplayActivated, isGraphicContextInitialized {
+        mapView?.updateVisualScaleToMain()
+      }
+      return
+    }
+
+    let sourceContentScale = sourceWindow?.traitCollection.displayScale
+    let destinationContentScale = destinationWindow.traitCollection.displayScale
+
+    // With a CarPlay-first launch there is no phone window to compare against, but the map was
+    // created with the phone's default visual scale and still needs the CarPlay display scale.
+    if let sourceContentScale, abs(sourceContentScale - destinationContentScale) <= 0.1 {
+      return
+    }
+    if isCarplayActivated {
+      updateWhenGraphicContextIsReady { mapView in
+        mapView.updateVisualScale(to: destinationContentScale)
+      }
+    } else {
+      updateWhenGraphicContextIsReady { mapView in
+        mapView.updateVisualScaleToMain()
       }
     }
   }
 
-  private static func updateVisualScale(to scale: CGFloat) {
-    if isGraphicContextInitialized {
-      mapViewController?.mapView.updateVisualScale(to: scale)
-    } else {
-      DispatchQueue.main.async {
-        updateVisualScale(to: scale)
-      }
+  private static func updateWhenGraphicContextIsReady(_ update: @escaping (EAGLView) -> Void) {
+    guard let mapView else { return }
+    guard !mapView.graphicContextInitialized else {
+      update(mapView)
+      return
     }
-  }
 
-  private static func updateVisualScaleToMain() {
-    if isGraphicContextInitialized {
-      mapViewController?.mapView.updateVisualScaleToMain()
-    } else {
-      DispatchQueue.main.async {
-        updateVisualScaleToMain()
-      }
+    mapView.graphicContextDidInitializeHandler = { [weak mapView] in
+      guard let mapView else { return }
+      update(mapView)
     }
   }
 
   private static var isGraphicContextInitialized: Bool {
-    mapViewController?.mapView.graphicContextInitialized ?? false
+    mapView?.graphicContextInitialized ?? false
   }
 
-  private static var mapViewController: MapViewController? {
-    MapViewController.shared()
+  private static var mapView: EAGLView? {
+    MapViewController.shared()?.mapView
   }
 }

--- a/iphone/Maps/Core/CarPlay/CarPlayWindowScaleAdjuster.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayWindowScaleAdjuster.swift
@@ -1,49 +1,54 @@
-import Foundation
-import UIKit
+import CarPlay
 
+/// Drape derives its visual scale from the phone screen. While the map is shown on a CarPlay display
+/// with a different pixel density it must use the CarPlay scale, and get the phone scale back when the
+/// map returns to the phone.
 enum CarPlayWindowScaleAdjuster {
-  static func updateAppearance(
-    fromWindow sourceWindow: UIWindow,
-    toWindow destinationWindow: UIWindow,
-    isCarplayActivated: Bool
-  ) {
-    let sourceContentScale = sourceWindow.screen.scale
-    let destinationContentScale = destinationWindow.screen.scale
+  /// The phone scale to return to, set while the CarPlay scale is applied.
+  private static var phoneScale: CGFloat?
 
-    if abs(sourceContentScale - destinationContentScale) > 0.1 {
-      if isCarplayActivated {
-        updateVisualScale(to: destinationContentScale)
-      } else {
-        updateVisualScaleToMain()
-      }
+  static func applyCarPlayScale(_ window: CPWindow) {
+    guard let mapView else { return }
+    // displayScale is 0 until the trait collection is resolved. There is no retry, so log it: the map
+    // would silently stay at the phone scale for the whole CarPlay session.
+    let carPlayScale = window.traitCollection.displayScale
+    guard carPlayScale >= 1.0 else {
+      LOG(.warning, "Unresolved CarPlay display scale, the map is left at the phone scale.")
+      return
     }
-  }
+    // Not mapView.contentScaleFactor: the map view is already hosted by the CarPlay window here, while
+    // the engine was created with the scale EAGLView takes from the main screen.
+    let phoneContentScale = UIScreen.main.nativeScale
+    guard abs(carPlayScale - phoneContentScale) > 0.1 else { return }
 
-  private static func updateVisualScale(to scale: CGFloat) {
-    if isGraphicContextInitialized {
-      mapViewController?.mapView.updateVisualScale(to: scale)
+    // The map may still be creating its Drape engine (e.g. on a CarPlay-first launch): defer the update
+    // until the graphics context exists.
+    if mapView.graphicContextInitialized {
+      apply(carPlayScale, phoneScale: phoneContentScale, to: mapView)
     } else {
-      DispatchQueue.main.async {
-        updateVisualScale(to: scale)
+      mapView.graphicContextDidInitializeHandler = { [weak mapView] in
+        if let mapView {
+          apply(carPlayScale, phoneScale: phoneContentScale, to: mapView)
+        }
       }
     }
   }
 
-  private static func updateVisualScaleToMain() {
-    if isGraphicContextInitialized {
-      mapViewController?.mapView.updateVisualScaleToMain()
-    } else {
-      DispatchQueue.main.async {
-        updateVisualScaleToMain()
-      }
-    }
+  static func restorePhoneScale() {
+    guard let mapView else { return }
+    // Cancel a CarPlay-scale update that is still waiting for the graphics context.
+    mapView.graphicContextDidInitializeHandler = nil
+    guard let scale = phoneScale else { return }
+    phoneScale = nil
+    mapView.updateVisualScale(withContentScaleFactor: scale)
   }
 
-  private static var isGraphicContextInitialized: Bool {
-    mapViewController?.mapView.graphicContextInitialized ?? false
+  private static func apply(_ carPlayScale: CGFloat, phoneScale: CGFloat, to mapView: EAGLView) {
+    self.phoneScale = phoneScale
+    mapView.updateVisualScale(withContentScaleFactor: carPlayScale)
   }
 
-  private static var mapViewController: MapViewController? {
-    MapViewController.shared()
+  private static var mapView: EAGLView? {
+    MapViewController.shared()?.mapView
   }
 }

--- a/iphone/Maps/Core/CarPlay/Template Builders/ListTemplateBuilder.swift
+++ b/iphone/Maps/Core/CarPlay/Template Builders/ListTemplateBuilder.swift
@@ -81,7 +81,9 @@ final class ListTemplateBuilder {
     let bookmarkManager = BookmarksManager.shared()
     let categories = bookmarkManager.sortedUserCategories()
     let items: [CPListItem] = categories.compactMap { category in
-      if category.bookmarksCount == 0 { return nil }
+      if category.bookmarksCount == 0 {
+        return nil
+      }
       let placesString = category.placesCountTitle()
       let item = CPListItem(text: category.title, detailText: placesString)
       item.userInfo = ListItemInfo(type: CPConstants.ListItemType.bookmarkLists,

--- a/iphone/Maps/Core/CarPlay/Template Builders/ListTemplateBuilder.swift
+++ b/iphone/Maps/Core/CarPlay/Template Builders/ListTemplateBuilder.swift
@@ -66,6 +66,7 @@ final class ListTemplateBuilder {
       let item = CPListItem(text: text, detailText: nil, image: UIImage(named: "ic_carplay_recent"))
       item.userInfo = ListItemInfo(type: CPConstants.ListItemType.history,
                                    metadata: nil)
+      configureSelection(for: item)
       return item
     }
     let section = CPListSection(items: items)
@@ -81,6 +82,7 @@ final class ListTemplateBuilder {
       let item = CPListItem(text: category.title, detailText: placesString)
       item.userInfo = ListItemInfo(type: CPConstants.ListItemType.bookmarkLists,
                                    metadata: CategoryInfo(category: category))
+      configureSelection(for: item)
       return item
     }
     let section = CPListSection(items: items)
@@ -95,6 +97,7 @@ final class ListTemplateBuilder {
       item.userInfo = ListItemInfo(type: CPConstants.ListItemType.bookmarks,
                                    metadata: BookmarkInfo(categoryId: categoryId,
                                                           bookmarkId: bookmark.bookmarkId))
+      configureSelection(for: item)
       return item
     }
     if #available(iOS 15.0, *) {
@@ -116,10 +119,21 @@ final class ListTemplateBuilder {
       let item = CPListItem(text: object.title, detailText: object.address)
       item.userInfo = ListItemInfo(type: CPConstants.ListItemType.searchResults,
                                    metadata: SearchResultInfo(originalRow: object.originalRow))
+      configureSelection(for: item)
       items.append(item)
     }
     let section = CPListSection(items: items)
     template.updateSections([section])
+  }
+
+  private class func configureSelection(for item: CPListItem) {
+    item.handler = { selectableItem, completion in
+      guard let listItem = selectableItem as? CPListItem else {
+        completion()
+        return
+      }
+      CarPlayService.shared.handleSelectedListItem(listItem, completionHandler: completion)
+    }
   }
 
   // MARK: - CPBarButton builder

--- a/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
+++ b/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
@@ -3,7 +3,9 @@
 
   private(set) var isLaunchedByDeeplink = false
   private(set) var isLaunchedByUniversalLink = false
+  private(set) var hasPendingColdLaunchDeepLink = false
   private(set) var url: URL?
+  private var pendingURLs: [URL] = []
 
   override private init() {
     super.init()
@@ -11,9 +13,20 @@
 
   func applicationDidFinishLaunching(_ options: [UIApplication.LaunchOptionsKey: Any]? = nil) {
     if let launchDeeplink = options?[UIApplication.LaunchOptionsKey.url] as? URL {
-      isLaunchedByDeeplink = true
-      url = launchDeeplink
+      prepareForColdLaunch(urls: [launchDeeplink])
     }
+  }
+
+  func prepareForColdLaunch(urls: [URL] = [], universalLinks: [URL] = []) {
+    let convertedUniversalLinks = universalLinks.compactMap(convertUniversalLink)
+    let launchURLs = urls + convertedUniversalLinks
+    guard let firstURL = launchURLs.first else { return }
+
+    isLaunchedByDeeplink = !urls.isEmpty
+    isLaunchedByUniversalLink = !convertedUniversalLinks.isEmpty
+    hasPendingColdLaunchDeepLink = true
+    url = firstURL
+    pendingURLs = Array(launchURLs.dropFirst())
   }
 
   func applicationDidOpenUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
@@ -26,9 +39,8 @@
       return handleFileImport(url: url, openInPlace: openInPlace)
     }
 
-    // On the cold start, isLaunchedByDeeplink is set and handleDeepLink() call is delayed
-    // until the map view will be fully initialized.
-    guard !isLaunchedByDeeplink else { return true }
+    // Cold-launch links are delayed until the map view is fully initialized.
+    guard !hasPendingColdLaunchDeepLink else { return true }
 
     // On the hot start, link can be processed immediately.
     self.url = url
@@ -36,18 +48,18 @@
   }
 
   func applicationDidReceiveUniversalLink(_ universalLink: URL) -> Bool {
-    // Convert http(s)://omaps.app/ENCODEDCOORDS/NAME to om://ENCODEDCOORDS/NAME
-    url = URL(string: universalLink.absoluteString
-      .replacingOccurrences(of: "http://omaps.app", with: "om:/")
-      .replacingOccurrences(of: "https://omaps.app", with: "om:/"))
+    guard let convertedURL = convertUniversalLink(universalLink) else { return false }
+    url = convertedURL
     isLaunchedByUniversalLink = true
-    return handleDeepLink(url: url!)
+    return handleDeepLink(url: convertedURL)
   }
 
   func reset() {
     isLaunchedByDeeplink = false
     isLaunchedByUniversalLink = false
+    hasPendingColdLaunchDeepLink = false
     url = nil
+    pendingURLs.removeAll()
   }
 
   func getBackUrl() -> String? {
@@ -63,13 +75,19 @@
   }
 
   func handleDeepLinkAndReset() -> Bool {
-    if let url {
-      let result = handleDeepLink(url: url)
-      reset()
-      return result
+    guard let url else {
+      LOG(.error, "handleDeepLink is called with nil URL")
+      return false
     }
-    LOG(.error, "handleDeepLink is called with nil URL")
-    return false
+
+    let urls = [url] + pendingURLs
+    var handled = false
+    for url in urls {
+      self.url = url
+      handled = handleDeepLink(url: url) || handled
+    }
+    reset()
+    return handled
   }
 
   private func handleFileImport(url: URL, openInPlace: Bool) -> Bool {
@@ -105,6 +123,13 @@
     }
     reset()
     return error == nil && copyError == nil
+  }
+
+  private func convertUniversalLink(_ universalLink: URL) -> URL? {
+    // Convert http(s)://omaps.app/ENCODEDCOORDS/NAME to om://ENCODEDCOORDS/NAME.
+    URL(string: universalLink.absoluteString
+      .replacingOccurrences(of: "http://omaps.app", with: "om:/")
+      .replacingOccurrences(of: "https://omaps.app", with: "om:/"))
   }
 
   private func copyFileToTemporaryDirectory(_ url: URL) throws -> URL {

--- a/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
+++ b/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
@@ -1,52 +1,53 @@
 @objc @objcMembers class DeepLinkHandler: NSObject {
   static let shared = DeepLinkHandler()
 
-  private(set) var isLaunchedByDeeplink = false
-  private(set) var isLaunchedByUniversalLink = false
+  private(set) var isLaunchedByDeepLink = false
+  private(set) var hasPendingColdLaunchDeepLink = false
   private(set) var url: URL?
 
   override private init() {
     super.init()
   }
 
-  func applicationDidFinishLaunching(_ options: [UIApplication.LaunchOptionsKey: Any]? = nil) {
-    if let launchDeeplink = options?[UIApplication.LaunchOptionsKey.url] as? URL {
-      isLaunchedByDeeplink = true
-      url = launchDeeplink
-    }
+  /// Keeps the last link received during a cold launch. It is handled by handleDeepLinkAndReset()
+  /// once the map is ready, because the place page and viewport animations need an initialized map.
+  func prepareForColdLaunch(url: URL) {
+    isLaunchedByDeepLink = true
+    hasPendingColdLaunchDeepLink = true
+    self.url = url
   }
 
-  func applicationDidOpenUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-    // File reading should be processed synchronously to avoid permission issues (the Files app will close the file for reading when the application:openURL:options returns).
+  func prepareForColdLaunch(universalLink: URL) {
+    guard let url = convertUniversalLink(universalLink) else { return }
+    prepareForColdLaunch(url: url)
+  }
+
+  func applicationDidOpenUrl(_ url: URL, openInPlace: Bool = false) -> Bool {
+    // Files must be imported synchronously: the security-scoped access granted for the URL ends when
+    // the scene delegate returns.
     if url.isFileURL {
-      // UIApplication.openURL options are deprecated for scene-based apps. When scenes are adopted,
-      // handle UIApplication.OpenURLOptionsKey.openInPlace via the scene URL context instead.
-      // https://developer.apple.com/documentation/uikit/uiapplication/openurloptionskey/openinplace?language=objc
-      let openInPlace = options[.openInPlace] as? Bool ?? false
       return handleFileImport(url: url, openInPlace: openInPlace)
     }
 
-    // On the cold start, isLaunchedByDeeplink is set and handleDeepLink() call is delayed
-    // until the map view will be fully initialized.
-    guard !isLaunchedByDeeplink else { return true }
+    self.url = url
+    // Set before handling: handleDeepLink() opens the screen that reads getInAppFeatureHighlightData().
+    isLaunchedByDeepLink = true
+
+    // A link arriving before the map is ready supersedes the previous pending link.
+    guard !hasPendingColdLaunchDeepLink else { return true }
 
     // On the hot start, link can be processed immediately.
-    self.url = url
     return handleDeepLink(url: url)
   }
 
   func applicationDidReceiveUniversalLink(_ universalLink: URL) -> Bool {
-    // Convert http(s)://omaps.app/ENCODEDCOORDS/NAME to om://ENCODEDCOORDS/NAME
-    url = URL(string: universalLink.absoluteString
-      .replacingOccurrences(of: "http://omaps.app", with: "om:/")
-      .replacingOccurrences(of: "https://omaps.app", with: "om:/"))
-    isLaunchedByUniversalLink = true
-    return handleDeepLink(url: url!)
+    guard let url = convertUniversalLink(universalLink) else { return false }
+    return applicationDidOpenUrl(url)
   }
 
   func reset() {
-    isLaunchedByDeeplink = false
-    isLaunchedByUniversalLink = false
+    isLaunchedByDeepLink = false
+    hasPendingColdLaunchDeepLink = false
     url = nil
   }
 
@@ -57,26 +58,27 @@
   }
 
   func getInAppFeatureHighlightData() -> DeepLinkInAppFeatureHighlightData? {
-    guard isLaunchedByUniversalLink || isLaunchedByDeeplink, let url else { return nil }
-    reset()
+    guard isLaunchedByDeepLink, let url else { return nil }
+    // Highlight the feature once, but keep the URL: goBack() still reads getBackUrl() from it.
+    isLaunchedByDeepLink = false
     return DeepLinkInAppFeatureHighlightData(DeepLinkParser.parseAndSetApiURL(url))
   }
 
   func handleDeepLinkAndReset() -> Bool {
-    if let url {
-      let result = handleDeepLink(url: url)
-      reset()
-      return result
+    guard let url else {
+      LOG(.error, "handleDeepLink is called with nil URL")
+      return false
     }
-    LOG(.error, "handleDeepLink is called with nil URL")
-    return false
+
+    let handled = handleDeepLink(url: url)
+    reset()
+    return handled
   }
 
   private func handleFileImport(url: URL, openInPlace: Bool) -> Bool {
     LOG(.info, "handleFileImport: \(url), openInPlace: \(openInPlace)")
     guard openInPlace else {
       DeepLinkParser.addBookmarksFile(url, isTemporaryFile: true)
-      reset()
       return true
     }
 
@@ -103,8 +105,14 @@
     if let copyError {
       LOG(.error, "Failed to copy file for import: \(copyError)")
     }
-    reset()
     return error == nil && copyError == nil
+  }
+
+  private func convertUniversalLink(_ universalLink: URL) -> URL? {
+    // Convert http(s)://omaps.app/ENCODEDCOORDS/NAME to om://ENCODEDCOORDS/NAME.
+    URL(string: universalLink.absoluteString
+      .replacingOccurrences(of: "http://omaps.app", with: "om:/")
+      .replacingOccurrences(of: "https://omaps.app", with: "om:/"))
   }
 
   private func copyFileToTemporaryDirectory(_ url: URL) throws -> URL {

--- a/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
+++ b/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
@@ -137,6 +137,7 @@
 - (void)stopRoutingAndRemoveRoutePoints:(BOOL)flag
 {
   self.rm.CloseRouting(flag);
+  [MWMThemeManager invalidate];
 }
 
 - (void)deleteSavedRoutePoints
@@ -194,6 +195,7 @@
 {
   [self saveRoute];
   self.rm.FollowRoute();
+  [MWMThemeManager invalidate];
 }
 
 - (MWMSpeedCameraManagerMode)speedCameraMode

--- a/iphone/Maps/Core/MapRendering/EAGLView.h
+++ b/iphone/Maps/Core/MapRendering/EAGLView.h
@@ -10,6 +10,7 @@
 @property(nonatomic, readonly) BOOL drapeEngineCreated;
 @property(nonatomic, readonly) CGSize pixelSize;
 @property(nonatomic, readonly) BOOL graphicContextInitialized;
+@property(nonatomic, copy, nullable) void (^graphicContextDidInitializeHandler)(void);
 
 - (void)createDrapeEngine;
 - (void)deallocateNative;

--- a/iphone/Maps/Core/MapRendering/EAGLView.h
+++ b/iphone/Maps/Core/MapRendering/EAGLView.h
@@ -1,5 +1,7 @@
 @class MWMMapWidgets;
 
+NS_ASSUME_NONNULL_BEGIN
+
 // This class wraps the CAEAGLLayer from CoreAnimation into a convenient UIView subclass.
 // The view content is basically an EAGL surface you render your OpenGL scene into.
 // Note that setting the view non-opaque will only work if the EAGL surface has an alpha channel.
@@ -10,11 +12,16 @@
 @property(nonatomic, readonly) BOOL drapeEngineCreated;
 @property(nonatomic, readonly) CGSize pixelSize;
 @property(nonatomic, readonly) BOOL graphicContextInitialized;
+/// A one-shot callback reserved for a deferred CarPlay visual-scale update.
+@property(nonatomic, copy, nullable) void (^graphicContextDidInitializeHandler)(void);
 
 - (void)createDrapeEngine;
 - (void)deallocateNative;
 - (void)setPresentAvailable:(BOOL)available;
-- (void)updateVisualScaleTo:(CGFloat)visualScale;
-- (void)updateVisualScaleToMain;
+/// Takes a screen content scale factor (UIScreen.nativeScale, CPWindow.traitCollection.displayScale),
+/// not a visual scale: the conversion is done here, exactly like on the engine creation.
+- (void)updateVisualScaleWithContentScaleFactor:(CGFloat)contentScaleFactor;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/iphone/Maps/Core/MapRendering/EAGLView.mm
+++ b/iphone/Maps/Core/MapRendering/EAGLView.mm
@@ -112,7 +112,16 @@ class GraphicsContextFactory;
         @{kEAGLDrawablePropertyRetainedBacking: @NO, kEAGLDrawablePropertyColorFormat: kEAGLColorFormatRGBA8};
   }
   auto & f = GetFramework();
-  f.SetGraphicsContextInitializationHandler([self]() { self.graphicContextInitialized = YES; });
+  f.SetGraphicsContextInitializationHandler([self]()
+  {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      self.graphicContextInitialized = YES;
+      void (^handler)(void) = self.graphicContextDidInitializeHandler;
+      self.graphicContextDidInitializeHandler = nil;
+      if (handler)
+        handler();
+    });
+  });
 }
 
 - (void)createDrapeEngine

--- a/iphone/Maps/Core/MapRendering/EAGLView.mm
+++ b/iphone/Maps/Core/MapRendering/EAGLView.mm
@@ -112,7 +112,14 @@ class GraphicsContextFactory;
         @{kEAGLDrawablePropertyRetainedBacking: @NO, kEAGLDrawablePropertyColorFormat: kEAGLColorFormatRGBA8};
   }
   auto & f = GetFramework();
-  f.SetGraphicsContextInitializationHandler([self]() { self.graphicContextInitialized = YES; });
+  f.SetGraphicsContextInitializationHandler([self]()
+  {
+    self.graphicContextInitialized = YES;
+    void (^handler)(void) = self.graphicContextDidInitializeHandler;
+    self.graphicContextDidInitializeHandler = nil;
+    if (handler)
+      handler();
+  });
 }
 
 - (void)createDrapeEngine
@@ -145,7 +152,9 @@ class GraphicsContextFactory;
   p.m_surfaceHeight = height;
   p.m_visualScale = df::CSF2VS(self.contentScaleFactor);
   p.m_hints.m_isFirstLaunch = [FirstSession isFirstSession];
-  p.m_hints.m_isLaunchByDeepLink = DeepLinkHandler.shared.isLaunchedByDeeplink;
+  // Custom-scheme and universal links alike: the pending link sets the viewport, so Drape must not
+  // start following the current position.
+  p.m_hints.m_isLaunchByDeepLink = DeepLinkHandler.shared.hasPendingColdLaunchDeepLink;
 
   [self.widgetsManager setupWidgets:p];
   GetFramework().CreateDrapeEngine(make_ref(m_factory), std::move(p));
@@ -195,17 +204,12 @@ class GraphicsContextFactory;
   return _widgetsManager;
 }
 
-- (void)updateVisualScaleTo:(CGFloat)visualScale
+- (void)updateVisualScaleWithContentScaleFactor:(CGFloat)contentScaleFactor
 {
-  LOG(LINFO, ("The visual scale is being updated to:", visualScale));
-  GetFramework().UpdateVisualScale(visualScale);
-}
-
-- (void)updateVisualScaleToMain
-{
-  CGFloat const visualScale = UIScreen.mainScreen.scale;
-  LOG(LINFO, ("The visual scale is being updated to the main scale:", visualScale));
-  GetFramework().UpdateVisualScale(visualScale);
+  // Convert and clamp like createDrapeEngine: an external display may report a scale below kMinVisualScale.
+  double const vs = df::CSF2VS(contentScaleFactor);
+  LOG(LINFO, ("The visual scale is being updated to:", vs));
+  GetFramework().UpdateVisualScale(vs);
 }
 
 @end

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -245,7 +245,8 @@ using namespace routing;
 
 + (void)disableFollowMode
 {
-  GetFramework().GetRoutingManager().DisableFollowMode();
+  if (GetFramework().GetRoutingManager().DisableFollowMode())
+    [MWMThemeManager invalidate];
 }
 + (void)enableTurnNotifications:(BOOL)active
 {
@@ -449,6 +450,7 @@ using namespace routing;
       if (p1.isMyPosition && lastLocation)
       {
         rm.FollowRoute();
+        [MWMThemeManager invalidate];
         [[MWMMapViewControlsManager manager] onRouteStart];
       }
       else
@@ -489,6 +491,7 @@ using namespace routing;
 + (void)doStop:(BOOL)removeRoutePoints
 {
   GetFramework().GetRoutingManager().CloseRouting(removeRoutePoints);
+  [MWMThemeManager invalidate];
   if (removeRoutePoints)
     GetFramework().GetRoutingManager().DeleteSavedRoutePoints();
 }

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -8,6 +8,7 @@
 #import "MWMMapViewControlsManager.h"
 #import "MWMNavigationDashboardManager+Entity.h"
 #import "MWMRoutePoint+CPP.h"
+#import "MWMRoutingManager.h"
 #import "MWMStorage+UI.h"
 #import "MapsAppDelegate.h"
 #import "SwiftBridge.h"
@@ -436,7 +437,6 @@ using namespace routing;
 
 + (void)start
 {
-  [self saveRoute];
   auto const doStart = ^{
     auto & rm = GetFramework().GetRoutingManager();
     auto const routePoints = rm.GetRoutePoints();
@@ -448,11 +448,15 @@ using namespace routing;
       CLLocation * lastLocation = [MWMLocationManager lastLocation];
       if (p1.isMyPosition && lastLocation)
       {
-        rm.FollowRoute();
+        [[MWMRoutingManager routingManager] startRoute];
         [[MWMMapViewControlsManager manager] onRouteStart];
       }
       else
       {
+        // The route is not followed here, and only following saves the points, so save them for
+        // restoreRouteIfNeeded.
+        [self saveRoute];
+
         BOOL const needToRebuild = lastLocation && [MWMLocationManager isStarted] && !p2.isMyPosition;
 
         [[MWMAlertViewController activeAlertController]
@@ -488,9 +492,9 @@ using namespace routing;
 
 + (void)doStop:(BOOL)removeRoutePoints
 {
-  GetFramework().GetRoutingManager().CloseRouting(removeRoutePoints);
+  [[MWMRoutingManager routingManager] stopRoutingAndRemoveRoutePoints:removeRoutePoints];
   if (removeRoutePoints)
-    GetFramework().GetRoutingManager().DeleteSavedRoutePoints();
+    [[MWMRoutingManager routingManager] deleteSavedRoutePoints];
 }
 
 - (void)updateFollowingInfo

--- a/iphone/Maps/Core/Theme/Core/StyleManager.swift
+++ b/iphone/Maps/Core/Theme/Core/StyleManager.swift
@@ -27,10 +27,10 @@
     }
 
     let appDelegate = UIApplication.shared.delegate as! MapsAppDelegate
-    if let vc = appDelegate.window.rootViewController?.presentedViewController {
+    if let vc = appDelegate.connectedWindow?.rootViewController?.presentedViewController {
       vc.applyTheme()
       updateView(vc.view)
-    } else if let vcs = appDelegate.window.rootViewController?.children {
+    } else if let vcs = appDelegate.connectedWindow?.rootViewController?.children {
       for vc in vcs {
         vc.applyTheme()
       }

--- a/iphone/Maps/Core/Theme/Core/StyleManager.swift
+++ b/iphone/Maps/Core/Theme/Core/StyleManager.swift
@@ -27,10 +27,10 @@
     }
 
     let appDelegate = UIApplication.shared.delegate as! MapsAppDelegate
-    if let vc = appDelegate.window.rootViewController?.presentedViewController {
+    if let vc = appDelegate.window?.rootViewController?.presentedViewController {
       vc.applyTheme()
       updateView(vc.view)
-    } else if let vcs = appDelegate.window.rootViewController?.children {
+    } else if let vcs = appDelegate.window?.rootViewController?.children {
       for vc in vcs {
         vc.applyTheme()
       }

--- a/iphone/Maps/Core/Theme/Renderers/UISearchBarRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/UISearchBarRenderer.swift
@@ -12,7 +12,9 @@ extension UISearchBar {
   }
 
   @objc override func sw_didMoveToWindow() {
-    guard MapsAppDelegate.theApp().window === window else {
+    // A nil app window (a CarPlay-first launch, or a disconnected phone scene) must not match a
+    // view that is leaving the hierarchy: nil === nil is true.
+    guard let appWindow = MapsAppDelegate.theApp().window, appWindow === window else {
       sw_didMoveToWindow()
       return
     }

--- a/iphone/Maps/Core/Theme/Renderers/UITextFieldRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/UITextFieldRenderer.swift
@@ -7,7 +7,9 @@ extension UITextField {
   }
 
   @objc override func sw_didMoveToWindow() {
-    guard MapsAppDelegate.theApp().window === window else {
+    // A nil app window (a CarPlay-first launch, or a disconnected phone scene) must not match a
+    // view that is leaving the hierarchy: nil === nil is true.
+    guard let appWindow = MapsAppDelegate.theApp().window, appWindow === window else {
       sw_didMoveToWindow()
       return
     }

--- a/iphone/Maps/Extensions/Views/UIView+SetStyle.swift
+++ b/iphone/Maps/Extensions/Views/UIView+SetStyle.swift
@@ -5,7 +5,9 @@ private enum AssociatedKeys {
 
 @objc extension UIView: StyleApplicable {
   func sw_didMoveToWindow() {
-    guard MapsAppDelegate.theApp().window === window else {
+    // A nil app window (a CarPlay-first launch, or a disconnected phone scene) must not match a
+    // view that is leaving the hierarchy: nil === nil is true.
+    guard let appWindow = MapsAppDelegate.theApp().window, appWindow === window else {
       sw_didMoveToWindow()
       return
     }

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		BB7626B61E85599C0031D71C /* icudt78l.dat in Resources */ = {isa = PBXBuildFile; fileRef = BB7626B41E8559980031D71C /* icudt78l.dat */; };
 		ED0B1C312BC2951F00FB8EDD /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = ED0B1C302BC2951F00FB8EDD /* PrivacyInfo.xcprivacy */; };
 		ED1ADA332BC6B1B40029209F /* CarPlayServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */; };
+		AB0CA7A50000000000000004 /* CarPlaySceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0CA7A50000000000000003 /* CarPlaySceneDelegateTests.swift */; };
 		ED2506E22F83F86D00945FC4 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED2506DE2F83F52A00945FC4 /* Colors.xcassets */; };
 		ED2D74382D14337500660FBF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED2D74342D14337500660FBF /* Assets.xcassets */; };
 		ED2D743A2D14337500660FBF /* AppLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2D742C2D14337500660FBF /* AppLogo.swift */; };
@@ -458,6 +459,7 @@
 		ED82C74E2F90186300FA103D /* CarplayPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6862F90186300FA103D /* CarplayPlaceholderView.swift */; };
 		ED82C74F2F90186300FA103D /* CarPlayRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6872F90186300FA103D /* CarPlayRouter.swift */; };
 		ED82C7502F90186300FA103D /* CarPlayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6882F90186300FA103D /* CarPlayService.swift */; };
+		AB0CA7A50000000000000002 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0CA7A50000000000000001 /* CarPlaySceneDelegate.swift */; };
 		ED82C7512F90186300FA103D /* CarPlayWindowScaleAdjuster.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6892F90186300FA103D /* CarPlayWindowScaleAdjuster.swift */; };
 		ED82C7522F90186300FA103D /* CPConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C68A2F90186300FA103D /* CPConstants.swift */; };
 		ED82C7532F90186300FA103D /* CPViewPortState.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C68B2F90186300FA103D /* CPViewPortState.swift */; };
@@ -879,6 +881,7 @@
 		ED097E762BB80C320006ED01 /* OMapsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OMapsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED0B1C302BC2951F00FB8EDD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayServiceTests.swift; sourceTree = "<group>"; };
+		AB0CA7A50000000000000003 /* CarPlaySceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegateTests.swift; sourceTree = "<group>"; };
 		ED2506DE2F83F52A00945FC4 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		ED2D742C2D14337500660FBF /* AppLogo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogo.swift; sourceTree = "<group>"; };
 		ED2D742D2D14337500660FBF /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
@@ -1415,6 +1418,7 @@
 		ED82C6862F90186300FA103D /* CarplayPlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarplayPlaceholderView.swift; sourceTree = "<group>"; };
 		ED82C6872F90186300FA103D /* CarPlayRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayRouter.swift; sourceTree = "<group>"; };
 		ED82C6882F90186300FA103D /* CarPlayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayService.swift; sourceTree = "<group>"; };
+		AB0CA7A50000000000000001 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
 		ED82C6892F90186300FA103D /* CarPlayWindowScaleAdjuster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayWindowScaleAdjuster.swift; sourceTree = "<group>"; };
 		ED82C68A2F90186300FA103D /* CPConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPConstants.swift; sourceTree = "<group>"; };
 		ED82C68B2F90186300FA103D /* CPViewPortState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPViewPortState.swift; sourceTree = "<group>"; };
@@ -1981,6 +1985,7 @@
 			isa = PBXGroup;
 			children = (
 				ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */,
+				AB0CA7A50000000000000003 /* CarPlaySceneDelegateTests.swift */,
 			);
 			path = CarPlay;
 			sourceTree = "<group>";
@@ -3442,6 +3447,7 @@
 				ED82C6852F90186300FA103D /* Templates Data */,
 				ED82C6862F90186300FA103D /* CarplayPlaceholderView.swift */,
 				ED82C6872F90186300FA103D /* CarPlayRouter.swift */,
+				AB0CA7A50000000000000001 /* CarPlaySceneDelegate.swift */,
 				ED82C6882F90186300FA103D /* CarPlayService.swift */,
 				ED82C6892F90186300FA103D /* CarPlayWindowScaleAdjuster.swift */,
 				ED82C68A2F90186300FA103D /* CPConstants.swift */,
@@ -4564,6 +4570,7 @@
 				ED82C74D2F90186300FA103D /* SearchResultInfo.swift in Sources */,
 				ED82C74E2F90186300FA103D /* CarplayPlaceholderView.swift in Sources */,
 				ED82C74F2F90186300FA103D /* CarPlayRouter.swift in Sources */,
+				AB0CA7A50000000000000002 /* CarPlaySceneDelegate.swift in Sources */,
 				ED82C7502F90186300FA103D /* CarPlayService.swift in Sources */,
 				ED82C7512F90186300FA103D /* CarPlayWindowScaleAdjuster.swift in Sources */,
 				ED82C7522F90186300FA103D /* CPConstants.swift in Sources */,
@@ -4862,6 +4869,7 @@
 				EDF838C12C00B9D6007E4E67 /* iCloudDirectoryMonitorTests.swift in Sources */,
 				EDF838C02C00B9D0007E4E67 /* DefaultLocalDirectoryMonitorTests.swift in Sources */,
 				ED1ADA332BC6B1B40029209F /* CarPlayServiceTests.swift in Sources */,
+				AB0CA7A50000000000000004 /* CarPlaySceneDelegateTests.swift in Sources */,
 				EDF838C32C00B9D6007E4E67 /* UbiquitousDirectoryMonitorDelegateMock.swift in Sources */,
 				EDF838BE2C00B9D0007E4E67 /* LocalDirectoryMonitorDelegateMock.swift in Sources */,
 				EDC4E3692C5E6F5B009286A2 /* MockRecentlyDeletedCategoriesManager.swift in Sources */,

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		ED0B1C312BC2951F00FB8EDD /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = ED0B1C302BC2951F00FB8EDD /* PrivacyInfo.xcprivacy */; };
 		ED1ADA332BC6B1B40029209F /* CarPlayServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */; };
 		AB0CA7A50000000000000004 /* CarPlaySceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0CA7A50000000000000003 /* CarPlaySceneDelegateTests.swift */; };
+		AB0CA7A50000000000000008 /* MainSceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0CA7A50000000000000007 /* MainSceneDelegateTests.swift */; };
 		ED2506E22F83F86D00945FC4 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED2506DE2F83F52A00945FC4 /* Colors.xcassets */; };
 		ED2D74382D14337500660FBF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED2D74342D14337500660FBF /* Assets.xcassets */; };
 		ED2D743A2D14337500660FBF /* AppLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2D742C2D14337500660FBF /* AppLogo.swift */; };
@@ -443,6 +444,7 @@
 		ED82C66F2F90180300FA103D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED82C4EF2F90180300FA103D /* LaunchScreen.storyboard */; };
 		ED82C6702F90180300FA103D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED82C4F02F90180300FA103D /* Main.storyboard */; };
 		ED82C7402F90186300FA103D /* MapsAppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6732F90186300FA103D /* MapsAppDelegate.mm */; };
+		AB0CA7A50000000000000006 /* MainSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0CA7A50000000000000005 /* MainSceneDelegate.swift */; };
 		ED82C7412F90186300FA103D /* BackgroundFetchTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6752F90186300FA103D /* BackgroundFetchTask.swift */; };
 		ED82C7422F90186300FA103D /* BackgroundFetchScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6772F90186300FA103D /* BackgroundFetchScheduler.swift */; };
 		ED82C7432F90186300FA103D /* BackgroundFetchTaskFrameworkType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6782F90186300FA103D /* BackgroundFetchTaskFrameworkType.swift */; };
@@ -882,6 +884,7 @@
 		ED0B1C302BC2951F00FB8EDD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayServiceTests.swift; sourceTree = "<group>"; };
 		AB0CA7A50000000000000003 /* CarPlaySceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegateTests.swift; sourceTree = "<group>"; };
+		AB0CA7A50000000000000007 /* MainSceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSceneDelegateTests.swift; sourceTree = "<group>"; };
 		ED2506DE2F83F52A00945FC4 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		ED2D742C2D14337500660FBF /* AppLogo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogo.swift; sourceTree = "<group>"; };
 		ED2D742D2D14337500660FBF /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
@@ -1402,6 +1405,7 @@
 		ED82C6712F90186300FA103D /* DownloadIndicatorProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DownloadIndicatorProtocol.h; sourceTree = "<group>"; };
 		ED82C6722F90186300FA103D /* MapsAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MapsAppDelegate.h; sourceTree = "<group>"; };
 		ED82C6732F90186300FA103D /* MapsAppDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MapsAppDelegate.mm; sourceTree = "<group>"; };
+		AB0CA7A50000000000000005 /* MainSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSceneDelegate.swift; sourceTree = "<group>"; };
 		ED82C6752F90186300FA103D /* BackgroundFetchTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundFetchTask.swift; sourceTree = "<group>"; };
 		ED82C6772F90186300FA103D /* BackgroundFetchScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundFetchScheduler.swift; sourceTree = "<group>"; };
 		ED82C6782F90186300FA103D /* BackgroundFetchTaskFrameworkType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundFetchTaskFrameworkType.swift; sourceTree = "<group>"; };
@@ -1977,6 +1981,7 @@
 			isa = PBXGroup;
 			children = (
 				4B4153B92BF970BD00EE4B02 /* CarPlay */,
+				AB0CA7A50000000000000007 /* MainSceneDelegateTests.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -3392,6 +3397,7 @@
 			isa = PBXGroup;
 			children = (
 				ED82C6712F90186300FA103D /* DownloadIndicatorProtocol.h */,
+				AB0CA7A50000000000000005 /* MainSceneDelegate.swift */,
 				ED82C6722F90186300FA103D /* MapsAppDelegate.h */,
 				ED82C6732F90186300FA103D /* MapsAppDelegate.mm */,
 			);
@@ -4554,6 +4560,7 @@
 				ED82C5872F90180300FA103D /* NavigationDashboardInteractor.swift in Sources */,
 				ED82C5882F90180300FA103D /* NavigationDashboardModalPresentationStepStrategy.swift in Sources */,
 				ED82C5892F90180300FA103D /* NavigationDashboardPresenter.swift in Sources */,
+				AB0CA7A50000000000000006 /* MainSceneDelegate.swift in Sources */,
 				ED82C7402F90186300FA103D /* MapsAppDelegate.mm in Sources */,
 				ED82C7412F90186300FA103D /* BackgroundFetchTask.swift in Sources */,
 				ED82C7422F90186300FA103D /* BackgroundFetchScheduler.swift in Sources */,
@@ -4870,6 +4877,7 @@
 				EDF838C02C00B9D0007E4E67 /* DefaultLocalDirectoryMonitorTests.swift in Sources */,
 				ED1ADA332BC6B1B40029209F /* CarPlayServiceTests.swift in Sources */,
 				AB0CA7A50000000000000004 /* CarPlaySceneDelegateTests.swift in Sources */,
+				AB0CA7A50000000000000008 /* MainSceneDelegateTests.swift in Sources */,
 				EDF838C32C00B9D6007E4E67 /* UbiquitousDirectoryMonitorDelegateMock.swift in Sources */,
 				EDF838BE2C00B9D0007E4E67 /* LocalDirectoryMonitorDelegateMock.swift in Sources */,
 				EDC4E3692C5E6F5B009286A2 /* MockRecentlyDeletedCategoriesManager.swift in Sources */,

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -470,6 +470,7 @@
 		ED82C74D2F90186300FA103D /* SearchResultInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6842F90186300FA103D /* SearchResultInfo.swift */; };
 		ED82C74E2F90186300FA103D /* CarplayPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6862F90186300FA103D /* CarplayPlaceholderView.swift */; };
 		ED82C74F2F90186300FA103D /* CarPlayRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6872F90186300FA103D /* CarPlayRouter.swift */; };
+		AB0CA7A50000000000000002 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0CA7A50000000000000001 /* CarPlaySceneDelegate.swift */; };
 		ED82C7502F90186300FA103D /* CarPlayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6882F90186300FA103D /* CarPlayService.swift */; };
 		ED82C7512F90186300FA103D /* CarPlayWindowScaleAdjuster.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6892F90186300FA103D /* CarPlayWindowScaleAdjuster.swift */; };
 		ED82C7522F90186300FA103D /* CPConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C68A2F90186300FA103D /* CPConstants.swift */; };
@@ -611,6 +612,9 @@
 		ED86256C2FEECAB70057BF82 /* MWMSettings+MapTiles.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED86256E2FEECAB70057BF82 /* MWMSettings+MapTiles.mm */; };
 		ED8A91E02D759B50009E063B /* LocalizableTypes.strings in Resources */ = {isa = PBXBuildFile; fileRef = ED8A91DE2D759B50009E063B /* LocalizableTypes.strings */; };
 		ED8F0F852FE962BF00780C0F /* SettingsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F0F842FE962BF00780C0F /* SettingsModels.swift */; };
+		ED91432C300168020081DF0B /* MainSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED91432B300168020081DF0B /* MainSceneDelegate.swift */; };
+		ED914330300168200081DF0B /* MainSceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED91432F300168200081DF0B /* MainSceneDelegateTests.swift */; };
+		ED914332300168CF0081DF0B /* CarPlaySceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED914331300168CF0081DF0B /* CarPlaySceneDelegateTests.swift */; };
 		ED9BEED62FFEB5C8008DB423 /* ColorGridViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9BEED52FFEB5C8008DB423 /* ColorGridViewController.swift */; };
 		ED9DDF9D2D6F6F7900645BC8 /* TrackRecordingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9DDF9B2D6F6DA300645BC8 /* TrackRecordingManagerTests.swift */; };
 		EDAA00012F91000000FA103D /* SearchCategoryIconRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAA00022F91000000FA103D /* SearchCategoryIconRenderer.swift */; };
@@ -1426,6 +1430,7 @@
 		ED82C6842F90186300FA103D /* SearchResultInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultInfo.swift; sourceTree = "<group>"; };
 		ED82C6862F90186300FA103D /* CarplayPlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarplayPlaceholderView.swift; sourceTree = "<group>"; };
 		ED82C6872F90186300FA103D /* CarPlayRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayRouter.swift; sourceTree = "<group>"; };
+		AB0CA7A50000000000000001 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
 		ED82C6882F90186300FA103D /* CarPlayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayService.swift; sourceTree = "<group>"; };
 		ED82C6892F90186300FA103D /* CarPlayWindowScaleAdjuster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayWindowScaleAdjuster.swift; sourceTree = "<group>"; };
 		ED82C68A2F90186300FA103D /* CPConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPConstants.swift; sourceTree = "<group>"; };
@@ -1685,6 +1690,9 @@
 		ED8A920C2D759BA9009E063B /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/LocalizableTypes.strings; sourceTree = "<group>"; };
 		ED8A920D2D759BAA009E063B /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/LocalizableTypes.strings; sourceTree = "<group>"; };
 		ED8F0F842FE962BF00780C0F /* SettingsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsModels.swift; sourceTree = "<group>"; };
+		ED91432B300168020081DF0B /* MainSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSceneDelegate.swift; sourceTree = "<group>"; };
+		ED91432F300168200081DF0B /* MainSceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSceneDelegateTests.swift; sourceTree = "<group>"; };
+		ED914331300168CF0081DF0B /* CarPlaySceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegateTests.swift; sourceTree = "<group>"; };
 		ED9BEED52FFEB5C8008DB423 /* ColorGridViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorGridViewController.swift; sourceTree = "<group>"; };
 		ED9DDF9B2D6F6DA300645BC8 /* TrackRecordingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackRecordingManagerTests.swift; sourceTree = "<group>"; };
 		EDAA00022F91000000FA103D /* SearchCategoryIconRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCategoryIconRenderer.swift; sourceTree = "<group>"; };
@@ -1975,6 +1983,7 @@
 		4B4153B82BF970B800EE4B02 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				ED91432F300168200081DF0B /* MainSceneDelegateTests.swift */,
 				4B4153B92BF970BD00EE4B02 /* CarPlay */,
 			);
 			path = Classes;
@@ -1983,6 +1992,7 @@
 		4B4153B92BF970BD00EE4B02 /* CarPlay */ = {
 			isa = PBXGroup;
 			children = (
+				ED914331300168CF0081DF0B /* CarPlaySceneDelegateTests.swift */,
 				ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */,
 			);
 			path = CarPlay;
@@ -3476,6 +3486,7 @@
 		ED82C6742F90186300FA103D /* AppDelegate */ = {
 			isa = PBXGroup;
 			children = (
+				ED91432B300168020081DF0B /* MainSceneDelegate.swift */,
 				ED82C6722F90186300FA103D /* MapsAppDelegate.h */,
 				ED82C6732F90186300FA103D /* MapsAppDelegate.mm */,
 			);
@@ -3531,6 +3542,7 @@
 				ED82C6852F90186300FA103D /* Templates Data */,
 				ED82C6862F90186300FA103D /* CarplayPlaceholderView.swift */,
 				ED82C6872F90186300FA103D /* CarPlayRouter.swift */,
+				AB0CA7A50000000000000001 /* CarPlaySceneDelegate.swift */,
 				ED82C6882F90186300FA103D /* CarPlayService.swift */,
 				ED82C6892F90186300FA103D /* CarPlayWindowScaleAdjuster.swift */,
 				ED82C68A2F90186300FA103D /* CPConstants.swift */,
@@ -4545,6 +4557,7 @@
 				ED82C5472F90180300FA103D /* MWMEditorTextTableViewCell.m in Sources */,
 				ED82C5482F90180300FA103D /* MWMNoteCell.m in Sources */,
 				ED82C5492F90180300FA103D /* MWMCuisineEditorViewController.mm in Sources */,
+				ED91432C300168020081DF0B /* MainSceneDelegate.swift in Sources */,
 				ED82C54A2F90180300FA103D /* MWMOpeningHoursAddClosedTableViewCell.mm in Sources */,
 				ED82C54B2F90180300FA103D /* MWMOpeningHoursAddScheduleTableViewCell.mm in Sources */,
 				ED82C54C2F90180300FA103D /* MWMOpeningHoursAllDayTableViewCell.mm in Sources */,
@@ -4625,6 +4638,7 @@
 				ED82C74D2F90186300FA103D /* SearchResultInfo.swift in Sources */,
 				ED82C74E2F90186300FA103D /* CarplayPlaceholderView.swift in Sources */,
 				ED82C74F2F90186300FA103D /* CarPlayRouter.swift in Sources */,
+				AB0CA7A50000000000000002 /* CarPlaySceneDelegate.swift in Sources */,
 				ED82C7502F90186300FA103D /* CarPlayService.swift in Sources */,
 				ED82C7512F90186300FA103D /* CarPlayWindowScaleAdjuster.swift in Sources */,
 				ED3597152FB611FF00ECC6D2 /* UIFont+Fonts.swift in Sources */,
@@ -4955,6 +4969,7 @@
 				EDC4E3692C5E6F5B009286A2 /* MockRecentlyDeletedCategoriesManager.swift in Sources */,
 				ED9DDF9D2D6F6F7900645BC8 /* TrackRecordingManagerTests.swift in Sources */,
 				EDF838BF2C00B9D0007E4E67 /* SynchronizationStateManagerTests.swift in Sources */,
+				ED914330300168200081DF0B /* MainSceneDelegateTests.swift in Sources */,
 				ED810EC52D566E9B00ECDE2C /* SearchOnMapTests.swift in Sources */,
 				4B83AE4B2C2E642100B0C3BC /* TTSTesterTest.m in Sources */,
 				EDF838C22C00B9D6007E4E67 /* MetadataItemStubs.swift in Sources */,
@@ -4962,6 +4977,7 @@
 				4B4153B52BF9695500EE4B02 /* MWMTextToSpeechTests.mm in Sources */,
 				EDF838C42C00B9D6007E4E67 /* FileManagerMock.swift in Sources */,
 				EDBAB6F52E980421007962B5 /* GeoNavigationToOMURLConverterTests.swift in Sources */,
+				ED914332300168CF0081DF0B /* CarPlaySceneDelegateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -470,6 +470,7 @@
 		ED82C74D2F90186300FA103D /* SearchResultInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6842F90186300FA103D /* SearchResultInfo.swift */; };
 		ED82C74E2F90186300FA103D /* CarplayPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6862F90186300FA103D /* CarplayPlaceholderView.swift */; };
 		ED82C74F2F90186300FA103D /* CarPlayRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6872F90186300FA103D /* CarPlayRouter.swift */; };
+		AB0CA7A50000000000000002 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0CA7A50000000000000001 /* CarPlaySceneDelegate.swift */; };
 		ED82C7502F90186300FA103D /* CarPlayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6882F90186300FA103D /* CarPlayService.swift */; };
 		ED82C7512F90186300FA103D /* CarPlayWindowScaleAdjuster.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C6892F90186300FA103D /* CarPlayWindowScaleAdjuster.swift */; };
 		ED82C7522F90186300FA103D /* CPConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C68A2F90186300FA103D /* CPConstants.swift */; };
@@ -611,6 +612,10 @@
 		ED86256C2FEECAB70057BF82 /* MWMSettings+MapTiles.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED86256E2FEECAB70057BF82 /* MWMSettings+MapTiles.mm */; };
 		ED8A91E02D759B50009E063B /* LocalizableTypes.strings in Resources */ = {isa = PBXBuildFile; fileRef = ED8A91DE2D759B50009E063B /* LocalizableTypes.strings */; };
 		ED8F0F852FE962BF00780C0F /* SettingsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F0F842FE962BF00780C0F /* SettingsModels.swift */; };
+		ED91432C300168020081DF0B /* MainSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED91432B300168020081DF0B /* MainSceneDelegate.swift */; };
+		ED914330300168200081DF0B /* MainSceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED91432F300168200081DF0B /* MainSceneDelegateTests.swift */; };
+		ED91433B3001A0000081DF0B /* DeepLinkHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED91433A3001A0000081DF0B /* DeepLinkHandlerTests.swift */; };
+		ED914332300168CF0081DF0B /* CarPlaySceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED914331300168CF0081DF0B /* CarPlaySceneDelegateTests.swift */; };
 		ED9BEED62FFEB5C8008DB423 /* ColorGridViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9BEED52FFEB5C8008DB423 /* ColorGridViewController.swift */; };
 		ED9DDF9D2D6F6F7900645BC8 /* TrackRecordingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9DDF9B2D6F6DA300645BC8 /* TrackRecordingManagerTests.swift */; };
 		EDAA00012F91000000FA103D /* SearchCategoryIconRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAA00022F91000000FA103D /* SearchCategoryIconRenderer.swift */; };
@@ -1426,6 +1431,7 @@
 		ED82C6842F90186300FA103D /* SearchResultInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultInfo.swift; sourceTree = "<group>"; };
 		ED82C6862F90186300FA103D /* CarplayPlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarplayPlaceholderView.swift; sourceTree = "<group>"; };
 		ED82C6872F90186300FA103D /* CarPlayRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayRouter.swift; sourceTree = "<group>"; };
+		AB0CA7A50000000000000001 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
 		ED82C6882F90186300FA103D /* CarPlayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayService.swift; sourceTree = "<group>"; };
 		ED82C6892F90186300FA103D /* CarPlayWindowScaleAdjuster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayWindowScaleAdjuster.swift; sourceTree = "<group>"; };
 		ED82C68A2F90186300FA103D /* CPConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPConstants.swift; sourceTree = "<group>"; };
@@ -1685,6 +1691,10 @@
 		ED8A920C2D759BA9009E063B /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/LocalizableTypes.strings; sourceTree = "<group>"; };
 		ED8A920D2D759BAA009E063B /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/LocalizableTypes.strings; sourceTree = "<group>"; };
 		ED8F0F842FE962BF00780C0F /* SettingsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsModels.swift; sourceTree = "<group>"; };
+		ED91432B300168020081DF0B /* MainSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSceneDelegate.swift; sourceTree = "<group>"; };
+		ED91432F300168200081DF0B /* MainSceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSceneDelegateTests.swift; sourceTree = "<group>"; };
+		ED91433A3001A0000081DF0B /* DeepLinkHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkHandlerTests.swift; sourceTree = "<group>"; };
+		ED914331300168CF0081DF0B /* CarPlaySceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegateTests.swift; sourceTree = "<group>"; };
 		ED9BEED52FFEB5C8008DB423 /* ColorGridViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorGridViewController.swift; sourceTree = "<group>"; };
 		ED9DDF9B2D6F6DA300645BC8 /* TrackRecordingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackRecordingManagerTests.swift; sourceTree = "<group>"; };
 		EDAA00022F91000000FA103D /* SearchCategoryIconRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCategoryIconRenderer.swift; sourceTree = "<group>"; };
@@ -1955,6 +1965,7 @@
 		4B4153B62BF9709100EE4B02 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				ED91433C3001A0000081DF0B /* DeepLink */,
 				EDBAB6F12E980415007962B5 /* GeoNavigationToOMURLConverterTests */,
 				ED9DDF982D6F6D8000645BC8 /* TrackRecorder */,
 				EDF838AB2C00B9C7007E4E67 /* iCloudTests */,
@@ -1975,6 +1986,7 @@
 		4B4153B82BF970B800EE4B02 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				ED91432F300168200081DF0B /* MainSceneDelegateTests.swift */,
 				4B4153B92BF970BD00EE4B02 /* CarPlay */,
 			);
 			path = Classes;
@@ -1983,6 +1995,7 @@
 		4B4153B92BF970BD00EE4B02 /* CarPlay */ = {
 			isa = PBXGroup;
 			children = (
+				ED914331300168CF0081DF0B /* CarPlaySceneDelegateTests.swift */,
 				ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */,
 			);
 			path = CarPlay;
@@ -3476,6 +3489,7 @@
 		ED82C6742F90186300FA103D /* AppDelegate */ = {
 			isa = PBXGroup;
 			children = (
+				ED91432B300168020081DF0B /* MainSceneDelegate.swift */,
 				ED82C6722F90186300FA103D /* MapsAppDelegate.h */,
 				ED82C6732F90186300FA103D /* MapsAppDelegate.mm */,
 			);
@@ -3531,6 +3545,7 @@
 				ED82C6852F90186300FA103D /* Templates Data */,
 				ED82C6862F90186300FA103D /* CarplayPlaceholderView.swift */,
 				ED82C6872F90186300FA103D /* CarPlayRouter.swift */,
+				AB0CA7A50000000000000001 /* CarPlaySceneDelegate.swift */,
 				ED82C6882F90186300FA103D /* CarPlayService.swift */,
 				ED82C6892F90186300FA103D /* CarPlayWindowScaleAdjuster.swift */,
 				ED82C68A2F90186300FA103D /* CPConstants.swift */,
@@ -4022,6 +4037,14 @@
 				ED9DDF9B2D6F6DA300645BC8 /* TrackRecordingManagerTests.swift */,
 			);
 			path = TrackRecorder;
+			sourceTree = "<group>";
+		};
+		ED91433C3001A0000081DF0B /* DeepLink */ = {
+			isa = PBXGroup;
+			children = (
+				ED91433A3001A0000081DF0B /* DeepLinkHandlerTests.swift */,
+			);
+			path = DeepLink;
 			sourceTree = "<group>";
 		};
 		EDBAB6F12E980415007962B5 /* GeoNavigationToOMURLConverterTests */ = {
@@ -4545,6 +4568,7 @@
 				ED82C5472F90180300FA103D /* MWMEditorTextTableViewCell.m in Sources */,
 				ED82C5482F90180300FA103D /* MWMNoteCell.m in Sources */,
 				ED82C5492F90180300FA103D /* MWMCuisineEditorViewController.mm in Sources */,
+				ED91432C300168020081DF0B /* MainSceneDelegate.swift in Sources */,
 				ED82C54A2F90180300FA103D /* MWMOpeningHoursAddClosedTableViewCell.mm in Sources */,
 				ED82C54B2F90180300FA103D /* MWMOpeningHoursAddScheduleTableViewCell.mm in Sources */,
 				ED82C54C2F90180300FA103D /* MWMOpeningHoursAllDayTableViewCell.mm in Sources */,
@@ -4625,6 +4649,7 @@
 				ED82C74D2F90186300FA103D /* SearchResultInfo.swift in Sources */,
 				ED82C74E2F90186300FA103D /* CarplayPlaceholderView.swift in Sources */,
 				ED82C74F2F90186300FA103D /* CarPlayRouter.swift in Sources */,
+				AB0CA7A50000000000000002 /* CarPlaySceneDelegate.swift in Sources */,
 				ED82C7502F90186300FA103D /* CarPlayService.swift in Sources */,
 				ED82C7512F90186300FA103D /* CarPlayWindowScaleAdjuster.swift in Sources */,
 				ED3597152FB611FF00ECC6D2 /* UIFont+Fonts.swift in Sources */,
@@ -4955,6 +4980,8 @@
 				EDC4E3692C5E6F5B009286A2 /* MockRecentlyDeletedCategoriesManager.swift in Sources */,
 				ED9DDF9D2D6F6F7900645BC8 /* TrackRecordingManagerTests.swift in Sources */,
 				EDF838BF2C00B9D0007E4E67 /* SynchronizationStateManagerTests.swift in Sources */,
+				ED914330300168200081DF0B /* MainSceneDelegateTests.swift in Sources */,
+				ED91433B3001A0000081DF0B /* DeepLinkHandlerTests.swift in Sources */,
 				ED810EC52D566E9B00ECDE2C /* SearchOnMapTests.swift in Sources */,
 				4B83AE4B2C2E642100B0C3BC /* TTSTesterTest.m in Sources */,
 				EDF838C22C00B9D6007E4E67 /* MetadataItemStubs.swift in Sources */,
@@ -4962,6 +4989,7 @@
 				4B4153B52BF9695500EE4B02 /* MWMTextToSpeechTests.mm in Sources */,
 				EDF838C42C00B9D6007E4E67 /* FileManagerMock.swift in Sources */,
 				EDBAB6F52E980421007962B5 /* GeoNavigationToOMURLConverterTests.swift in Sources */,
+				ED914332300168CF0081DF0B /* CarPlaySceneDelegateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iphone/Maps/OMaps.plist
+++ b/iphone/Maps/OMaps.plist
@@ -218,8 +218,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIPrerenderedIcon</key>
 	<true/>
 	<key>UIStatusBarHidden</key>
@@ -362,6 +360,17 @@
 					<string>CarPlay</string>
 					<key>UISceneDelegateClassName</key>
 					<string>CarPlaySceneDelegate</string>
+				</dict>
+			</array>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Main</string>
+					<key>UISceneDelegateClassName</key>
+					<string>MainSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
 				</dict>
 			</array>
 		</dict>

--- a/iphone/Maps/OMaps.plist
+++ b/iphone/Maps/OMaps.plist
@@ -349,5 +349,22 @@
 	</dict>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>CarPlay</string>
+					<key>UISceneDelegateClassName</key>
+					<string>CarPlaySceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/iphone/Maps/OMaps.plist
+++ b/iphone/Maps/OMaps.plist
@@ -218,8 +218,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIPrerenderedIcon</key>
 	<true/>
 	<key>UIStatusBarHidden</key>
@@ -349,5 +347,35 @@
 	</dict>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>CPTemplateApplicationScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>CarPlay</string>
+					<key>UISceneDelegateClassName</key>
+					<string>CarPlaySceneDelegate</string>
+				</dict>
+			</array>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>Main</string>
+					<key>UISceneDelegateClassName</key>
+					<string>MainSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/iphone/Maps/OMaps.plist
+++ b/iphone/Maps/OMaps.plist
@@ -218,8 +218,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIPrerenderedIcon</key>
 	<true/>
 	<key>UIStatusBarHidden</key>
@@ -349,5 +347,35 @@
 	</dict>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>CPTemplateApplicationScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>CarPlay</string>
+					<key>UISceneDelegateClassName</key>
+					<string>CarPlaySceneDelegate</string>
+				</dict>
+			</array>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>Main</string>
+					<key>UISceneDelegateClassName</key>
+					<string>MainSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/iphone/Maps/Tests/Classes/CarPlay/CarPlaySceneDelegateTests.swift
+++ b/iphone/Maps/Tests/Classes/CarPlay/CarPlaySceneDelegateTests.swift
@@ -10,13 +10,9 @@ final class CarPlaySceneDelegateTests: XCTestCase {
     XCTAssertEqual(NSStringFromClass(CarPlaySceneDelegate.self), "CarPlaySceneDelegate")
   }
 
-  func testConformsToCPTemplateApplicationSceneDelegate() {
-    XCTAssertTrue(CarPlaySceneDelegate() is CPTemplateApplicationSceneDelegate)
-  }
-
   func testRespondsToConnectAndDisconnectSelectors() {
     let delegate = CarPlaySceneDelegate()
-    XCTAssertTrue(delegate.responds(to: Selector(("templateApplicationScene:didConnectInterfaceController:toWindow:"))))
-    XCTAssertTrue(delegate.responds(to: Selector(("templateApplicationScene:didDisconnectInterfaceController:fromWindow:"))))
+    XCTAssertTrue(delegate.responds(to: #selector(CarPlaySceneDelegate.templateApplicationScene(_:didConnect:to:))))
+    XCTAssertTrue(delegate.responds(to: #selector(CarPlaySceneDelegate.templateApplicationScene(_:didDisconnect:from:))))
   }
 }

--- a/iphone/Maps/Tests/Classes/CarPlay/CarPlaySceneDelegateTests.swift
+++ b/iphone/Maps/Tests/Classes/CarPlay/CarPlaySceneDelegateTests.swift
@@ -1,0 +1,22 @@
+import CarPlay
+@testable import Organic_Maps__Debug_
+import XCTest
+
+final class CarPlaySceneDelegateTests: XCTestCase {
+  /// OMaps.plist references "CarPlaySceneDelegate" as UISceneDelegateClassName. The Swift class
+  /// needs a stable @objc name for the Obj-C runtime to resolve it, because the Debug product's
+  /// Swift module is mangled to Organic_Maps__Debug_.
+  func testRuntimeClassNameMatchesPlist() {
+    XCTAssertEqual(NSStringFromClass(CarPlaySceneDelegate.self), "CarPlaySceneDelegate")
+  }
+
+  func testConformsToCPTemplateApplicationSceneDelegate() {
+    XCTAssertTrue(CarPlaySceneDelegate() is CPTemplateApplicationSceneDelegate)
+  }
+
+  func testRespondsToConnectAndDisconnectSelectors() {
+    let delegate = CarPlaySceneDelegate()
+    XCTAssertTrue(delegate.responds(to: Selector(("templateApplicationScene:didConnectInterfaceController:toWindow:"))))
+    XCTAssertTrue(delegate.responds(to: Selector(("templateApplicationScene:didDisconnectInterfaceController:fromWindow:"))))
+  }
+}

--- a/iphone/Maps/Tests/Classes/CarPlay/CarPlaySceneDelegateTests.swift
+++ b/iphone/Maps/Tests/Classes/CarPlay/CarPlaySceneDelegateTests.swift
@@ -1,0 +1,22 @@
+import CarPlay
+@testable import Organic_Maps__Debug_
+import XCTest
+
+final class CarPlaySceneDelegateTests: XCTestCase {
+  /// OMaps.plist references "CarPlaySceneDelegate" as UISceneDelegateClassName. The Swift class
+  /// needs a stable @objc name for the Obj-C runtime to resolve it, because the Debug product's
+  /// Swift module is mangled to Organic_Maps__Debug_.
+  func testRuntimeClassNameMatchesPlist() {
+    XCTAssertEqual(NSStringFromClass(CarPlaySceneDelegate.self), "CarPlaySceneDelegate")
+  }
+
+  func testRespondsToConnectAndDisconnectSelectors() {
+    let delegate = CarPlaySceneDelegate()
+    XCTAssertTrue(delegate.responds(to: #selector(CarPlaySceneDelegate.sceneDidBecomeActive(_:))))
+    XCTAssertTrue(delegate.responds(to: #selector(CarPlaySceneDelegate.sceneWillResignActive(_:))))
+    XCTAssertTrue(delegate.responds(to: #selector(CarPlaySceneDelegate.sceneWillEnterForeground(_:))))
+    XCTAssertTrue(delegate.responds(to: #selector(CarPlaySceneDelegate.sceneDidEnterBackground(_:))))
+    XCTAssertTrue(delegate.responds(to: #selector(CarPlaySceneDelegate.templateApplicationScene(_:didConnect:to:))))
+    XCTAssertTrue(delegate.responds(to: #selector(CarPlaySceneDelegate.templateApplicationScene(_:didDisconnect:from:))))
+  }
+}

--- a/iphone/Maps/Tests/Classes/CarPlay/CarPlaySceneDelegateTests.swift
+++ b/iphone/Maps/Tests/Classes/CarPlay/CarPlaySceneDelegateTests.swift
@@ -1,0 +1,17 @@
+import CarPlay
+@testable import Organic_Maps__Debug_
+import XCTest
+
+final class CarPlaySceneDelegateTests: XCTestCase {
+  /// OMaps.plist references the delegate by its bare class name, which the Swift class provides through
+  /// a stable @objc name (the Debug product's Swift module is mangled to Organic_Maps__Debug_).
+  func testManifestCarPlaySceneDelegateResolvesToCarPlaySceneDelegate() throws {
+    let manifest = try XCTUnwrap(Bundle.main.object(forInfoDictionaryKey: "UIApplicationSceneManifest") as? [String: Any])
+    let configurations = try XCTUnwrap(manifest["UISceneConfigurations"] as? [String: [[String: String]]])
+    let carPlay = try XCTUnwrap(configurations["CPTemplateApplicationSceneSessionRoleApplication"]?.first)
+    XCTAssertEqual(carPlay["UISceneClassName"], NSStringFromClass(CPTemplateApplicationScene.self))
+    let className = try XCTUnwrap(carPlay["UISceneDelegateClassName"])
+    XCTAssertTrue(NSClassFromString(className) === CarPlaySceneDelegate.self)
+    XCTAssertTrue(class_conformsToProtocol(CarPlaySceneDelegate.self, CPTemplateApplicationSceneDelegate.self))
+  }
+}

--- a/iphone/Maps/Tests/Classes/MainSceneDelegateTests.swift
+++ b/iphone/Maps/Tests/Classes/MainSceneDelegateTests.swift
@@ -1,0 +1,39 @@
+@testable import Organic_Maps__Debug_
+import UIKit
+import XCTest
+
+final class MainSceneDelegateTests: XCTestCase {
+  /// OMaps.plist references "MainSceneDelegate" as UISceneDelegateClassName. The Swift class
+  /// needs a stable @objc name for the Obj-C runtime to resolve it, because the Debug product's
+  /// Swift module is mangled to Organic_Maps__Debug_.
+  func testRuntimeClassNameMatchesPlist() {
+    XCTAssertEqual(NSStringFromClass(MainSceneDelegate.self), "MainSceneDelegate")
+  }
+
+  func testConformsToUIWindowSceneDelegate() {
+    XCTAssertTrue(MainSceneDelegate() is UIWindowSceneDelegate)
+  }
+
+  // Once UIApplicationSceneManifest declares UIWindowSceneSessionRoleApplication, UIKit stops
+  // calling the matching UIApplicationDelegate methods on MapsAppDelegate. The scene delegate
+  // must implement the scene-side equivalents and forward them; missing any of these regresses
+  // Framework::Enter{Fore,Back}ground, location pause/resume, route saving, deep-link resets,
+  // and the rate-us prompt.
+  func testRespondsToSceneLifecycleSelectors() {
+    let delegate = MainSceneDelegate()
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneDidBecomeActive(_:))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneWillResignActive(_:))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneWillEnterForeground(_:))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneDidEnterBackground(_:))))
+  }
+
+  /// mapswithme:// deep links, imported GPX/KML files, Spotlight/Handoff universal links, and
+  /// Home Screen quick actions are delivered through UIScene once scenes are adopted. Each
+  /// entry point needs its scene-side forwarder on MainSceneDelegate.
+  func testRespondsToLaunchRoutingSelectors() {
+    let delegate = MainSceneDelegate()
+    XCTAssertTrue(delegate.responds(to: Selector(("scene:openURLContexts:"))))
+    XCTAssertTrue(delegate.responds(to: Selector(("scene:continueUserActivity:"))))
+    XCTAssertTrue(delegate.responds(to: Selector(("windowScene:performActionForShortcutItem:completionHandler:"))))
+  }
+}

--- a/iphone/Maps/Tests/Classes/MainSceneDelegateTests.swift
+++ b/iphone/Maps/Tests/Classes/MainSceneDelegateTests.swift
@@ -10,30 +10,14 @@ final class MainSceneDelegateTests: XCTestCase {
     XCTAssertEqual(NSStringFromClass(MainSceneDelegate.self), "MainSceneDelegate")
   }
 
-  func testConformsToUIWindowSceneDelegate() {
-    XCTAssertTrue(MainSceneDelegate() is UIWindowSceneDelegate)
-  }
-
-  // Once UIApplicationSceneManifest declares UIWindowSceneSessionRoleApplication, UIKit stops
-  // calling the matching UIApplicationDelegate methods on MapsAppDelegate. The scene delegate
-  // must implement the scene-side equivalents and forward them; missing any of these regresses
-  // Framework::Enter{Fore,Back}ground, location pause/resume, route saving, deep-link resets,
-  // and the rate-us prompt.
   func testRespondsToSceneLifecycleSelectors() {
     let delegate = MainSceneDelegate()
     XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneDidBecomeActive(_:))))
     XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneWillResignActive(_:))))
     XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneWillEnterForeground(_:))))
     XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneDidEnterBackground(_:))))
-  }
-
-  /// mapswithme:// deep links, imported GPX/KML files, Spotlight/Handoff universal links, and
-  /// Home Screen quick actions are delivered through UIScene once scenes are adopted. Each
-  /// entry point needs its scene-side forwarder on MainSceneDelegate.
-  func testRespondsToLaunchRoutingSelectors() {
-    let delegate = MainSceneDelegate()
-    XCTAssertTrue(delegate.responds(to: Selector(("scene:openURLContexts:"))))
-    XCTAssertTrue(delegate.responds(to: Selector(("scene:continueUserActivity:"))))
-    XCTAssertTrue(delegate.responds(to: Selector(("windowScene:performActionForShortcutItem:completionHandler:"))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.scene(_:openURLContexts:))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.scene(_:continue:))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.windowScene(_:performActionFor:completionHandler:))))
   }
 }

--- a/iphone/Maps/Tests/Classes/MainSceneDelegateTests.swift
+++ b/iphone/Maps/Tests/Classes/MainSceneDelegateTests.swift
@@ -1,0 +1,44 @@
+@testable import Organic_Maps__Debug_
+import UIKit
+import XCTest
+
+final class MainSceneDelegateTests: XCTestCase {
+  override func tearDown() {
+    DeepLinkHandler.shared.reset()
+    super.tearDown()
+  }
+
+  /// OMaps.plist references "MainSceneDelegate" as UISceneDelegateClassName. The Swift class
+  /// needs a stable @objc name for the Obj-C runtime to resolve it, because the Debug product's
+  /// Swift module is mangled to Organic_Maps__Debug_.
+  func testRuntimeClassNameMatchesPlist() {
+    XCTAssertEqual(NSStringFromClass(MainSceneDelegate.self), "MainSceneDelegate")
+  }
+
+  func testRespondsToForwardingSelectors() {
+    let delegate = MainSceneDelegate()
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneDidBecomeActive(_:))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneWillResignActive(_:))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneWillEnterForeground(_:))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneDidEnterBackground(_:))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneDidDisconnect(_:))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.scene(_:openURLContexts:))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.scene(_:continue:))))
+    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.windowScene(_:performActionFor:completionHandler:))))
+  }
+
+  func testColdUniversalLinkIsQueuedUntilMapIsReady() throws {
+    let handler = DeepLinkHandler.shared
+    try handler.prepareForColdLaunch(universalLinks: [XCTUnwrap(URL(string: "https://omaps.app/AbCd/Test"))])
+
+    XCTAssertTrue(handler.hasPendingColdLaunchDeepLink)
+    XCTAssertFalse(handler.isLaunchedByDeeplink)
+    XCTAssertTrue(handler.isLaunchedByUniversalLink)
+    XCTAssertEqual(handler.url?.absoluteString, "om://AbCd/Test")
+  }
+
+  func testApplicationSupportsPhoneAndCarPlayScenesSimultaneously() throws {
+    let manifest = try XCTUnwrap(Bundle.main.object(forInfoDictionaryKey: "UIApplicationSceneManifest") as? [String: Any])
+    XCTAssertEqual(manifest["UIApplicationSupportsMultipleScenes"] as? Bool, true)
+  }
+}

--- a/iphone/Maps/Tests/Classes/MainSceneDelegateTests.swift
+++ b/iphone/Maps/Tests/Classes/MainSceneDelegateTests.swift
@@ -1,0 +1,27 @@
+@testable import Organic_Maps__Debug_
+import UIKit
+import XCTest
+
+final class MainSceneDelegateTests: XCTestCase {
+  private var manifest: [String: Any] {
+    get throws {
+      try XCTUnwrap(Bundle.main.object(forInfoDictionaryKey: "UIApplicationSceneManifest") as? [String: Any])
+    }
+  }
+
+  /// OMaps.plist references the delegate by its bare class name, which the Swift class provides through
+  /// a stable @objc name (the Debug product's Swift module is mangled to Organic_Maps__Debug_).
+  func testManifestPhoneSceneDelegateResolvesToMainSceneDelegate() throws {
+    let configurations = try XCTUnwrap(try manifest["UISceneConfigurations"] as? [String: [[String: String]]])
+    let phone = try XCTUnwrap(configurations["UIWindowSceneSessionRoleApplication"]?.first)
+    let className = try XCTUnwrap(phone["UISceneDelegateClassName"])
+    XCTAssertTrue(NSClassFromString(className) === MainSceneDelegate.self)
+    XCTAssertTrue(class_conformsToProtocol(MainSceneDelegate.self, UIWindowSceneDelegate.self))
+  }
+
+  /// One Drape engine and one navigation stack cannot be hosted by two phone windows, so the app must
+  /// not offer multi-window support; the CarPlay scene does not need it.
+  func testManifestDoesNotEnableMultipleScenes() throws {
+    XCTAssertNotEqual(try manifest["UIApplicationSupportsMultipleScenes"] as? Bool, true)
+  }
+}

--- a/iphone/Maps/Tests/Core/DeepLink/DeepLinkHandlerTests.swift
+++ b/iphone/Maps/Tests/Core/DeepLink/DeepLinkHandlerTests.swift
@@ -1,0 +1,64 @@
+@testable import Organic_Maps__Debug_
+import XCTest
+
+final class DeepLinkHandlerTests: XCTestCase {
+  private let handler = DeepLinkHandler.shared
+
+  override func setUp() {
+    super.setUp()
+    handler.reset()
+  }
+
+  override func tearDown() {
+    handler.reset()
+    super.tearDown()
+  }
+
+  func testColdCustomSchemeLinkIsQueuedUntilMapIsReady() throws {
+    let url = try XCTUnwrap(URL(string: "om://map?ll=52.52,13.405&n=Test"))
+    handler.prepareForColdLaunch(url: url)
+
+    XCTAssertTrue(handler.hasPendingColdLaunchDeepLink)
+    XCTAssertTrue(handler.isLaunchedByDeepLink)
+    XCTAssertEqual(handler.url, url)
+  }
+
+  func testColdUniversalLinkIsConvertedAndQueued() throws {
+    try handler.prepareForColdLaunch(
+      universalLink: XCTUnwrap(URL(string: "https://omaps.app/AbCd/Test"))
+    )
+
+    XCTAssertTrue(handler.hasPendingColdLaunchDeepLink)
+    XCTAssertTrue(handler.isLaunchedByDeepLink)
+    XCTAssertEqual(handler.url?.absoluteString, "om://AbCd/Test")
+  }
+
+  func testLastLinkReceivedBeforeMapIsReadyWins() throws {
+    let coldURL = try XCTUnwrap(URL(string: "om://map?ll=1,2&n=First"))
+    let laterURL = try XCTUnwrap(URL(string: "om://map?ll=3,4&n=Second"))
+    handler.prepareForColdLaunch(url: coldURL)
+
+    XCTAssertTrue(handler.applicationDidOpenUrl(laterURL))
+    XCTAssertEqual(handler.url, laterURL)
+    XCTAssertTrue(handler.isLaunchedByDeepLink)
+  }
+
+  func testUniversalLinkReceivedBeforeMapIsReadyIsNotHandledTwice() throws {
+    try handler.prepareForColdLaunch(url: XCTUnwrap(URL(string: "om://map?ll=1,2&n=First")))
+
+    let universalLink = try XCTUnwrap(URL(string: "https://omaps.app/AbCd/Test"))
+    XCTAssertTrue(handler.applicationDidReceiveUniversalLink(universalLink))
+    XCTAssertTrue(handler.hasPendingColdLaunchDeepLink)
+    XCTAssertTrue(handler.isLaunchedByDeepLink)
+    XCTAssertEqual(handler.url?.absoluteString, "om://AbCd/Test")
+  }
+
+  func testResetClearsColdLaunchState() throws {
+    try handler.prepareForColdLaunch(url: XCTUnwrap(URL(string: "om://map?ll=1,2")))
+    handler.reset()
+
+    XCTAssertFalse(handler.hasPendingColdLaunchDeepLink)
+    XCTAssertFalse(handler.isLaunchedByDeepLink)
+    XCTAssertNil(handler.url)
+  }
+}

--- a/iphone/Maps/Tests/Core/GeoNavigationToOMURLConverterTests/GeoNavigationToOMURLConverterTests.swift
+++ b/iphone/Maps/Tests/Core/GeoNavigationToOMURLConverterTests/GeoNavigationToOMURLConverterTests.swift
@@ -14,7 +14,7 @@ final class GeoNavigationToOMURLConverterTests: XCTestCase {
     let geoUrl = geoURLStub("geo-navigation:///directions?source=\(coordinate1)&destination=\(coordinate2)")
     let omUrl = try XCTUnwrap(converter.convert(geoUrl))
     let routingType = MWMRouter.type()
-    XCTAssertEqual(omUrl.absoluteString, "om://route?sll=\(coordinate1)&saddr=&dll=\(coordinate2)&daddr=&type=\(MWMRouter.string(from: routingType)!)")
+    XCTAssertEqual(omUrl.absoluteString, "om://route?sll=\(coordinate1)&saddr=&dll=\(coordinate2)&daddr=&type=\(MWMRouter.string(from: routingType))")
     let urlType = DeepLinkParser.parseAndSetApiURL(omUrl)
     switch urlType {
     case .route:

--- a/iphone/Maps/Tests/UI/SearchOnMapTests/SearchOnMapTests.swift
+++ b/iphone/Maps/Tests/UI/SearchOnMapTests/SearchOnMapTests.swift
@@ -256,7 +256,7 @@ final class SearchOnMapTests: XCTestCase {
 
   func test_GivenSearchIsActive_WhenPresentationStepUpdate_ThenUpdateSearchMode() {
     interactor.handle(.openSearch)
-    XCTAssertEqual(searchManager.searchMode(), isiPad ? .everywhereAndViewport : .everywhere)
+    XCTAssertEqual(searchManager.searchMode(), .everywhere)
 
     interactor.handle(.didUpdatePresentationStep(.halfScreen))
     XCTAssertEqual(searchManager.searchMode(), .everywhereAndViewport)

--- a/iphone/Maps/Tests/UI/SearchOnMapTests/SearchOnMapTests.swift
+++ b/iphone/Maps/Tests/UI/SearchOnMapTests/SearchOnMapTests.swift
@@ -290,9 +290,7 @@ private class SearchManagerMock: SearchManager {
   static var observers = ListenerContainer<MWMSearchObserver>()
   static var results = SearchOnMap.SearchResults.empty {
     didSet {
-      for observer in observers {
-        observer.onSearchCompleted?()
-      }
+      observers.forEach { $0.onSearchCompleted?() }
     }
   }
 

--- a/iphone/Maps/UI/AvailableArea/TabBarArea.swift
+++ b/iphone/Maps/UI/AvailableArea/TabBarArea.swift
@@ -2,7 +2,8 @@ final class TabBarArea: AvailableArea {
   override var areaFrame: CGRect {
     var areaFrame = frame
     // Spacing is used only for devices with zero bottom safe area (such as SE).
-    let additionalBottomSpacing: CGFloat = MapsAppDelegate.theApp().window.safeAreaInsets.bottom.isZero ? -10 : .zero
+    // window can be nil during a CarPlay-first cold launch, before the phone window scene connects.
+    let additionalBottomSpacing: CGFloat = (MapsAppDelegate.theApp().window?.safeAreaInsets.bottom ?? 0).isZero ? -10 : .zero
     areaFrame.origin.y += additionalBottomSpacing
     return areaFrame
   }

--- a/iphone/Maps/UI/AvailableArea/TabBarArea.swift
+++ b/iphone/Maps/UI/AvailableArea/TabBarArea.swift
@@ -2,7 +2,8 @@ final class TabBarArea: AvailableArea {
   override var areaFrame: CGRect {
     var areaFrame = frame
     // Spacing is used only for devices with zero bottom safe area (such as SE).
-    let additionalBottomSpacing: CGFloat = MapsAppDelegate.theApp().window.safeAreaInsets.bottom.isZero ? -10 : .zero
+    // window can be nil during a CarPlay-first cold launch, before the phone window scene connects.
+    let additionalBottomSpacing: CGFloat = (MapsAppDelegate.theApp().connectedWindow?.safeAreaInsets.bottom ?? 0).isZero ? -10 : .zero
     areaFrame.origin.y += additionalBottomSpacing
     return areaFrame
   }

--- a/iphone/Maps/UI/Map/MapViewController.mm
+++ b/iphone/Maps/UI/Map/MapViewController.mm
@@ -551,7 +551,7 @@ NSString * const kCategorySelectorSegue = @"MapToCategorySelectorSegue";
   [super viewDidAppear:animated];
   // Cold start deep links should be handled when the map is initialized.
   // Otherwise PP container view is nil, or there is no animation/selection of the point.
-  if (DeepLinkHandler.shared.isLaunchedByDeeplink)
+  if (DeepLinkHandler.shared.hasPendingColdLaunchDeepLink)
     (void)[DeepLinkHandler.shared handleDeepLinkAndReset];
 }
 

--- a/iphone/Maps/UI/Map/MapViewController.mm
+++ b/iphone/Maps/UI/Map/MapViewController.mm
@@ -528,7 +528,7 @@ NSString * const kCategorySelectorSegue = @"MapToCategorySelectorSegue";
 
   /// @todo: Uncomment update dialog when will be ready to handle big traffic bursts.
   /*
-  if (!DeepLinkHandler.shared.isLaunchedByDeeplink)
+  if (!DeepLinkHandler.shared.isLaunchedByDeepLink)
   {
     auto const todo = GetFramework().ToDoAfterUpdate();
     switch (todo) {
@@ -549,7 +549,7 @@ NSString * const kCategorySelectorSegue = @"MapToCategorySelectorSegue";
   [super viewDidAppear:animated];
   // Cold start deep links should be handled when the map is initialized.
   // Otherwise PP container view is nil, or there is no animation/selection of the point.
-  if (DeepLinkHandler.shared.isLaunchedByDeeplink)
+  if (DeepLinkHandler.shared.hasPendingColdLaunchDeepLink)
     (void)[DeepLinkHandler.shared handleDeepLinkAndReset];
 }
 

--- a/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/BottomActionsMenu/RouteActionsBottomMenuView.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/BottomActionsMenu/RouteActionsBottomMenuView.swift
@@ -1,12 +1,15 @@
 final class RouteActionsBottomMenuView: UIView {
-  enum Constants {
+  private enum Constants {
     static let height: CGFloat = 44
-    static let insets = UIEdgeInsets(top: 16, left: 16, bottom: MapsAppDelegate.theApp().window.safeAreaInsets.bottom.isZero ? 8 : 0, right: 16)
+    static let topInset: CGFloat = 16
+    static let horizontalInset: CGFloat = 16
+    static let bottomInsetWithoutSafeArea: CGFloat = 8
     fileprivate static let animationDuration: TimeInterval = kDefaultAnimationDuration / 2
     static let spacing: CGFloat = 12
   }
 
   private let stackView = UIStackView()
+  private var bottomConstraint: NSLayoutConstraint?
 
   init() {
     super.init(frame: .zero)
@@ -22,6 +25,11 @@ final class RouteActionsBottomMenuView: UIView {
   /// Prevent touches from being passed to the touch transparent view
   override func touchesBegan(_: Set<UITouch>, with _: UIEvent?) {}
 
+  override func safeAreaInsetsDidChange() {
+    super.safeAreaInsetsDidChange()
+    bottomConstraint?.constant = -Self.bottomInset(for: safeAreaInsets)
+  }
+
   private func setupView() {
     setStyle(.background)
     stackView.axis = .horizontal
@@ -33,11 +41,14 @@ final class RouteActionsBottomMenuView: UIView {
 
   private func layout() {
     addSubview(stackView)
+    let bottomConstraint = stackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor,
+                                                             constant: -Self.bottomInset(for: safeAreaInsets))
+    self.bottomConstraint = bottomConstraint
     NSLayoutConstraint.activate([
-      stackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: Constants.insets.left),
-      stackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -Constants.insets.right),
-      stackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.insets.top),
-      stackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Constants.insets.bottom),
+      stackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: Constants.horizontalInset),
+      stackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -Constants.horizontalInset),
+      stackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.topInset),
+      bottomConstraint,
       stackView.heightAnchor.constraint(equalToConstant: Constants.height),
     ])
   }
@@ -51,5 +62,13 @@ final class RouteActionsBottomMenuView: UIView {
     UIView.animate(withDuration: Constants.animationDuration) {
       self.layer.shadowOpacity = visible ? 0.1 : 0
     }
+  }
+
+  static func reservedContentHeight(for safeAreaInsets: UIEdgeInsets) -> CGFloat {
+    Constants.height + Constants.topInset + bottomInset(for: safeAreaInsets)
+  }
+
+  private static func bottomInset(for safeAreaInsets: UIEdgeInsets) -> CGFloat {
+    safeAreaInsets.bottom.isZero ? Constants.bottomInsetWithoutSafeArea : .zero
   }
 }

--- a/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointsView.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointsView.swift
@@ -1,11 +1,9 @@
 final class RoutePointsView: UIView {
   private enum Constants {
     static var bottomContentInset: CGFloat {
-      let bottomActionBartHeight = RouteActionsBottomMenuView.Constants.height +
-        RouteActionsBottomMenuView.Constants.insets.top +
-        RouteActionsBottomMenuView.Constants.insets.bottom
-      let safeAreaInsets = MapsAppDelegate.theApp().window.safeAreaInsets
-      return bottomActionBartHeight + safeAreaInsets.bottom + safeAreaInsets.top
+      let safeAreaInsets = MapsAppDelegate.theApp().connectedWindow?.safeAreaInsets ?? .zero
+      let bottomActionBarHeight = RouteActionsBottomMenuView.reservedContentHeight(for: safeAreaInsets)
+      return bottomActionBarHeight + safeAreaInsets.bottom + safeAreaInsets.top
     }
   }
 
@@ -42,6 +40,11 @@ final class RoutePointsView: UIView {
     if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
       collectionView.collectionViewLayout.invalidateLayout()
     }
+  }
+
+  override func safeAreaInsetsDidChange() {
+    super.safeAreaInsetsDidChange()
+    updateCollectionViewInset()
   }
 
   private func updateCollectionViewInset() {

--- a/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointsView.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointsView.swift
@@ -1,11 +1,9 @@
 final class RoutePointsView: UIView {
   private enum Constants {
     static var bottomContentInset: CGFloat {
-      let bottomActionBartHeight = RouteActionsBottomMenuView.Constants.height +
-        RouteActionsBottomMenuView.Constants.insets.top +
-        RouteActionsBottomMenuView.Constants.insets.bottom
-      let safeAreaInsets = MapsAppDelegate.theApp().window.safeAreaInsets
-      return bottomActionBartHeight + safeAreaInsets.bottom + safeAreaInsets.top
+      let safeAreaInsets = MapsAppDelegate.theApp().window?.safeAreaInsets ?? .zero
+      let bottomActionBarHeight = RouteActionsBottomMenuView.reservedContentHeight(for: safeAreaInsets)
+      return bottomActionBarHeight + safeAreaInsets.bottom + safeAreaInsets.top
     }
   }
 
@@ -42,6 +40,11 @@ final class RoutePointsView: UIView {
     if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
       collectionView.collectionViewLayout.invalidateLayout()
     }
+  }
+
+  override func safeAreaInsetsDidChange() {
+    super.safeAreaInsetsDidChange()
+    updateCollectionViewInset()
   }
 
   private func updateCollectionViewInset() {

--- a/iphone/Maps/UI/ReusableComponents/CustomAlerts/AlertController/MWMAlertViewController.mm
+++ b/iphone/Maps/UI/ReusableComponents/CustomAlerts/AlertController/MWMAlertViewController.mm
@@ -280,7 +280,7 @@ static NSString * const kAlertControllerNibIdentifier = @"MWMAlertViewController
                      alert.alpha = 1.;
                      alert.transform = CGAffineTransformIdentity;
                    }];
-  [[MapsAppDelegate theApp].window endEditing:YES];
+  [ownerVC.view.window endEditing:YES];
 }
 
 - (void)closeAlert:(nullable MWMVoidBlock)completion


### PR DESCRIPTION
Fixes #12607

Migrates CarPlay off the deprecated `CPApplicationDelegate` to the scene-based `CPTemplateApplicationSceneDelegate`. On recent iOS (and required by the iOS 27 `UIScene` mandate) a scene manifest with only the CarPlay role leaves the main window unloaded, so the phone window adopts `UIScene` as well (`UIWindowSceneSessionRoleApplication` + `MainSceneDelegate`).

### What changed
- New `CarPlaySceneDelegate` + `MainSceneDelegate` and the `UIApplicationSceneManifest`; the legacy `CPApplicationDelegate` hooks and the `UIApplicationDelegate` lifecycle/URL/activity/shortcut methods that UIKit never calls for scene-based apps are removed; CarPlay template calls use the iOS 14 API (the deprecation warnings this PR targets).
- One shared `MapViewController` / Drape engine for both scenes: `MapsAppDelegate.mainNavigationController` lazily loads the Main storyboard, so a **CarPlay-first cold launch** (app started from the head unit while terminated) renders the map with no phone window, and the phone scene later hosts the same instance. Phone views no longer assume that a phone window exists.
- **App lifecycle** is driven by the app-wide `UIApplication` notifications, which UIKit keeps posting for scene-based apps with the aggregate semantics we need: the framework stays active while the phone or the CarPlay scene is in the foreground and goes to background only when both are (also when a scene is torn down abruptly).
- URLs, universal links, user activities and quick actions arrive via the scene; cold-launch links (and links arriving before the map is ready) are queued until the map appears, and Drape starts in the not-following mode for them.
- CarPlay: the visual scale is applied once the graphics context exists and restored only if it was applied; a fresh `CarPlayMapViewController` per setup; the vehicle map theme is refreshed when navigation starts/stops; an active CarPlay navigation session resumes following after a route rebuild.
- `UIApplicationSupportsMultipleScenes` stays `false`: the phone and CarPlay scenes connect together anyway, and the single Drape engine cannot be hosted by two phone windows.
- Tests: manifest-driven scene delegate checks and `DeepLinkHandlerTests`. The last commit fixes two unrelated compile errors that kept the whole `OMapsTests` target from building.

The three review threads previously marked "Fixed" (`connectedWindow`, legacy lifecycle wrappers, extra `EAGLView` dispatch) are now really applied (first fix commit).

### Testing
- `OMaps` (arm64 simulator) builds on every commit; the whole `OMapsTests` suite passes (98 tests).
- iOS 26.5 simulator with the CarPlay display: phone-first launch; Home → background handlers, relaunch → foreground/active; `om://` cold launch handled after the map appears; CarPlay-first cold launch (map created lazily, CarPlay scale applied once the graphics context exists, restored on disconnect); phone and CarPlay scenes connected simultaneously.
- Simulator caveats: the iOS 26.5 CarPlay host crashes (`-[CPSMapTemplateViewController _updateShareButtonVisibility]`, an Apple bug) whenever a map template is shown, so the CarPlay UI itself needs a head unit or the standalone CarPlay Simulator; Debug builds also hit the pre-existing `frontend_renderer.cpp:1807` assert on visual-scale changes (3x phone vs 2x car), to be fixed in drape separately.

### Hardware pass (please verify on a head unit)
1. Phone-first: connect CarPlay while the app runs; the map moves to the car. "Continue on the phone" / "Continue in the car" round trip twice; the speed control and camera info still work during navigation after each round trip.
2. CarPlay-first cold launch: force-quit the app, keep the phone locked, launch from the head unit; the map renders in the car at the car scale. Then unlock, open the app on the phone (placeholder + working UI) and do a round trip.
3. Lock the phone while navigating on CarPlay: the map and route keep updating on the car (no `applicationWillResignActive` / `applicationDidEnterBackground` in the log while the CarPlay scene is in the foreground); switch to another CarPlay app and back.
4. Unplug the cable during navigation, with the phone locked and unlocked: the map returns to the phone at the phone scale, nothing stays frozen, background/foreground handlers are logged as expected.
5. Finish a route while the map is on the phone, then "Continue in the car"; change route options in CarPlay during navigation (following resumes).
6. Cold launch by an `om://` link, by an `omaps.app` universal link, and by opening a KML/GPX from Files.
7. Known gap, deferred to #13268 (display-ownership state machine): if iOS disconnects the phone scene while the map is shown on the phone, the map is not moved back to CarPlay automatically; the CarPlay alert still offers "Continue in the car".
