### PR TITLE
[android] Improve elevation profile chart gestures and setup

### DIFF
--- a/android/app/src/main/java/app/organicmaps/ChartController.java
+++ b/android/app/src/main/java/app/organicmaps/ChartController.java
@@ -60,9 +60,8 @@ public class ChartController implements OnChartValueSelectedListener
     mMaxAltitude = view.findViewById(R.id.highest_altitude);
     mMinAltitude = view.findViewById(R.id.lowest_altitude);
 
-    ElevationChartUtils.setupChart(mChart, mContext);
+    ElevationChartUtils.setupTrackChart(mChart, mContext);
     mChart.setOnChartValueSelectedListener(this);
-    ElevationChartUtils.initAxes(mChart, mContext, ElevationChartUtils.TRACK_X_LABEL_COUNT);
   }
 
   public void setData(@Nullable Track track, @NonNull ElevationInfo info, @NonNull TrackStatistics stats)

--- a/android/app/src/main/java/app/organicmaps/routing/RouteElevationChartController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RouteElevationChartController.java
@@ -48,9 +48,7 @@ public class RouteElevationChartController
     if (mChart == null)
       return;
 
-    ElevationChartUtils.setupChart(mChart, mContext);
-    mChart.setDragEnabled(true);
-    ElevationChartUtils.initAxes(mChart, mContext, ElevationChartUtils.ROUTE_X_LABEL_COUNT);
+    ElevationChartUtils.setupRouteChart(mChart, mContext);
     mChart.setOnChartValueSelectedListener(new OnChartValueSelectedListener() {
       @Override
       public void onValueSelected(Entry e, Highlight h)

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/ElevationChartUtils.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/ElevationChartUtils.java
@@ -17,8 +17,8 @@ import java.util.List;
 
 public final class ElevationChartUtils
 {
-  public static final int TRACK_X_LABEL_COUNT = 6;
-  public static final int ROUTE_X_LABEL_COUNT = 3;
+  private static final int TRACK_X_LABEL_COUNT = 6;
+  private static final int ROUTE_X_LABEL_COUNT = 3;
 
   private static final int CHART_Y_LABEL_COUNT = 3;
   private static final int CHART_FILL_ALPHA = (int) (0.12 * 255);
@@ -28,11 +28,22 @@ public final class ElevationChartUtils
 
   private ElevationChartUtils() {}
 
-  public static void setupChart(@NonNull LineChart chart, @NonNull Context context)
+  public static void setupTrackChart(@NonNull LineChart chart, @NonNull Context context)
+  {
+    int topOffset = context.getResources().getDimensionPixelSize(R.dimen.margin_quarter);
+    setupCommon(chart, context, topOffset, TRACK_X_LABEL_COUNT);
+  }
+
+  public static void setupRouteChart(@NonNull LineChart chart, @NonNull Context context)
+  {
+    setupCommon(chart, context, 0, ROUTE_X_LABEL_COUNT);
+  }
+
+  private static void setupCommon(@NonNull LineChart chart, @NonNull Context context, int topOffset, int xLabelCount)
   {
     chart.setBackgroundColor(ThemeUtils.getColor(context, R.attr.cardBackground));
     chart.setTouchEnabled(true);
-    chart.setHighlightPerDragEnabled(true);
+    chart.setHighlightPerDragEnabled(false);
     chart.setHighlighter(new InterpolatingHighlighter(chart));
     chart.setRenderer(new SmoothLineChartRenderer(chart, chart.getAnimator(), chart.getViewPortHandler()));
     chart.setDrawGridBackground(false);
@@ -40,15 +51,15 @@ public final class ElevationChartUtils
     chart.setScaleYEnabled(false);
     chart.setExtraTopOffset(0);
     int sideOffset = context.getResources().getDimensionPixelSize(R.dimen.margin_base);
-    int topOffset = 0;
     chart.setViewPortOffsets(sideOffset, topOffset, sideOffset,
                              context.getResources().getDimensionPixelSize(R.dimen.margin_base_plus_quarter));
     chart.getDescription().setEnabled(false);
     chart.setDrawBorders(false);
     chart.getLegend().setEnabled(false);
+    initAxes(chart, context, xLabelCount);
   }
 
-  public static void initAxes(@NonNull LineChart chart, @NonNull Context context, int xLabelCount)
+  private static void initAxes(@NonNull LineChart chart, @NonNull Context context, int xLabelCount)
   {
     XAxis x = chart.getXAxis();
     x.setLabelCount(xLabelCount, false);

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/ElevationProfileChart.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/ElevationProfileChart.java
@@ -1,12 +1,26 @@
 package app.organicmaps.widget.placepage;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
+import android.view.ViewConfiguration;
 import com.github.mikephil.charting.charts.LineChart;
+import com.github.mikephil.charting.components.YAxis;
+import com.github.mikephil.charting.highlight.Highlight;
+import com.github.mikephil.charting.utils.MPPointD;
 
 public class ElevationProfileChart extends LineChart
 {
+  private static final float CAPTURE_RADIUS_DP = 22f;
+
+  private boolean mIsSelecting;
+  private boolean mSelectConfirmed;
+  private float mMarkerScreenX;
+  private float mTouchStartX;
+  private float mLastHighlightedX = Float.NaN;
+  private int mTouchSlop;
+
   public ElevationProfileChart(Context context)
   {
     super(context);
@@ -23,14 +37,144 @@ public class ElevationProfileChart extends LineChart
   }
 
   @Override
+  protected void init()
+  {
+    super.init();
+    mTouchSlop = ViewConfiguration.get(getContext()).getScaledTouchSlop();
+  }
+
+  @Override
   public boolean onInterceptTouchEvent(MotionEvent ev)
   {
     getParent().requestDisallowInterceptTouchEvent(true);
-    return hasZoom() || super.onInterceptTouchEvent(ev);
+    return super.onInterceptTouchEvent(ev);
   }
 
-  private boolean hasZoom()
+  @SuppressLint("ClickableViewAccessibility")
+  @Override
+  public boolean onTouchEvent(MotionEvent event)
   {
-    return getScaleX() < 1 || getScaleY() < 1;
+    if (!mTouchEnabled)
+      return super.onTouchEvent(event);
+
+    final int action = event.getActionMasked();
+
+    if (action == MotionEvent.ACTION_DOWN)
+    {
+      mLastHighlightedX = Float.NaN;
+      mMarkerScreenX = getCurrentHighlightScreenX();
+      mIsSelecting = !isZoomedIn() || isTouchNearHighlight(event.getX(), mMarkerScreenX);
+      // When zoomed, highlight immediately. When not zoomed, wait for finger
+      // to move past touchSlop to distinguish drag from pinch-zoom start.
+      mSelectConfirmed = isZoomedIn();
+      mTouchStartX = event.getX();
+    }
+
+    // Second finger → zoom, stop selecting.
+    if (action == MotionEvent.ACTION_POINTER_DOWN)
+    {
+      mIsSelecting = false;
+      // Preserve current marker position if the user already dragged it.
+      if (mSelectConfirmed || isZoomedIn())
+        mMarkerScreenX = getCurrentHighlightScreenX();
+      mSelectConfirmed = false;
+      if (hasHighlight())
+        performHighlightAtScreenX(mMarkerScreenX);
+    }
+
+    // SELECT: marker follows finger on drag; taps delegated to super's onSingleTapUp.
+    if (mIsSelecting)
+    {
+      if (action == MotionEvent.ACTION_MOVE)
+      {
+        if (!mSelectConfirmed && Math.abs(event.getX() - mTouchStartX) > mTouchSlop)
+          mSelectConfirmed = true;
+        if (mSelectConfirmed)
+          performHighlightAtScreenX(event.getX());
+      }
+      if (isZoomedIn())
+      {
+        // Super doesn't see events when zoomed, so handle taps ourselves.
+        if (action == MotionEvent.ACTION_UP)
+          performHighlightAtScreenX(event.getX());
+        return true;
+      }
+      // Reset mLastHighlighted so super's onSingleTapUp → performHighlight
+      // doesn't toggle OFF the highlight we're about to set.
+      if (action == MotionEvent.ACTION_UP)
+        mChartTouchListener.setLastHighlighted(null);
+      return super.onTouchEvent(event);
+    }
+
+    // PAN / ZOOM: chart moves, marker stays at fixed screen-X.
+    boolean result = super.onTouchEvent(event);
+    if (action == MotionEvent.ACTION_MOVE && hasHighlight())
+      performHighlightAtScreenX(mMarkerScreenX);
+    return result;
+  }
+
+  @Override
+  public void computeScroll()
+  {
+    float prevLowestX = getLowestVisibleX();
+    super.computeScroll();
+    // During deceleration (fling) the viewport changes without touch events.
+    // Keep the marker at its fixed screen position.
+    if (!mIsSelecting && getLowestVisibleX() != prevLowestX && hasHighlight())
+      performHighlightAtScreenX(mMarkerScreenX);
+  }
+
+  private boolean hasHighlight()
+  {
+    final Highlight[] h = getHighlighted();
+    return h != null && h.length > 0;
+  }
+
+  private boolean isZoomedIn()
+  {
+    // Threshold above 1.0 to ignore floating-point jitter around the default scale.
+    return getViewPortHandler().getScaleX() > 1.01f;
+  }
+
+  private float getCurrentHighlightScreenX()
+  {
+    final Highlight[] highlighted = getHighlighted();
+    if (highlighted == null || highlighted.length == 0)
+      return getWidth() / 2f;
+
+    // The user-selected highlight is always last: ChartController.selectAtDistance()
+    // passes [curPos, h] in that order; RouteElevationChartController uses a single highlight.
+    final Highlight last = highlighted[highlighted.length - 1];
+    final MPPointD pix = getTransformer(YAxis.AxisDependency.LEFT).getPixelForValues(last.getX(), last.getY());
+    final float result = (float) pix.x;
+    MPPointD.recycleInstance(pix);
+    return result;
+  }
+
+  private boolean isTouchNearHighlight(float touchX, float highlightScreenX)
+  {
+    if (!hasHighlight())
+      return false;
+
+    final float captureRadiusPx = CAPTURE_RADIUS_DP * getResources().getDisplayMetrics().density;
+    return Math.abs(touchX - highlightScreenX) <= captureRadiusPx;
+  }
+
+  private void performHighlightAtScreenX(float screenX)
+  {
+    if (getHighlighter() == null)
+      return;
+    // Cheap pre-check: convert screen → data X without allocating a Highlight.
+    final MPPointD pos = getTransformer(YAxis.AxisDependency.LEFT).getValuesByTouchPoint(screenX, 0);
+    final float dataX = (float) pos.x;
+    MPPointD.recycleInstance(pos);
+    if (dataX == mLastHighlightedX)
+      return;
+    final Highlight h = getHighlighter().getHighlight(screenX, 0);
+    if (h != null)
+    {
+      mLastHighlightedX = h.getX();
+      highlightValue(h, true);
+    }
   }
 }


### PR DESCRIPTION
## Summary                                                                                                                                               
  - Separate touch gestures in the elevation profile chart: SELECT (marker follows finger) vs PAN/ZOOM (marker stays at fixed screen position), matching   
  iOS behavior                                                                                                                                             
  - When zoomed in, tap/drag near the marker moves it; tap/drag elsewhere scrolls the chart while the marker stays at its screen position                  
  - Anti-flicker touchSlop prevents marker jump when starting pinch-zoom from non-zoomed state                                                         
  - Marker position preserved during fling deceleration via `computeScroll()` override                                                                     
  - Fix highlight toggle on tap (MPAndroidChart's `performHighlight` toggling)                                                                             
  - Add top inset (4dp) for track chart so highlight line isn't clipped at peaks                                                                           
  - Refactor `setupChart()` to use `setupTrackChart`/`setupRouteChart`                     
  - Make `initAxes()` and label count constants private 


https://github.com/user-attachments/assets/73af3b36-7ce8-4db2-b38a-3060dd8168c7

https://github.com/user-attachments/assets/0f8fe21c-c8f5-4451-bbad-e4c56bd4ed8c


