### PR TITLE
[core] Add location-based CurrentCountry listener

### DIFF
--- a/android/libs/car/src/main/java/app/organicmaps/car/screens/NavigationScreen.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/screens/NavigationScreen.java
@@ -25,11 +25,13 @@ import app.organicmaps.car.util.Colors;
 import app.organicmaps.car.util.ThemeUtils;
 import app.organicmaps.car.util.UiHelpers;
 import app.organicmaps.routing.NavigationService;
+import app.organicmaps.sdk.CountryMetadata;
 import app.organicmaps.sdk.Framework;
 import app.organicmaps.sdk.OrganicMaps;
 import app.organicmaps.sdk.car.RoutingUtils;
 import app.organicmaps.sdk.car.renderer.Renderer;
 import app.organicmaps.sdk.car.screens.BaseMapScreen;
+import app.organicmaps.sdk.location.CurrentCountryManager;
 import app.organicmaps.sdk.location.LocationListener;
 import app.organicmaps.sdk.location.LocationUtils;
 import app.organicmaps.sdk.routing.JunctionInfo;
@@ -41,7 +43,8 @@ import app.organicmaps.sdk.util.log.Logger;
 import java.util.List;
 import java.util.Objects;
 
-public class NavigationScreen extends BaseMapScreen implements RoutingController.Container, NavigationManagerCallback
+public class NavigationScreen extends BaseMapScreen
+    implements RoutingController.Container, NavigationManagerCallback, CurrentCountryManager.OnCountryChangedListener
 {
   private static final String TAG = NavigationScreen.class.getSimpleName();
 
@@ -57,6 +60,9 @@ public class NavigationScreen extends BaseMapScreen implements RoutingController
 
   @NonNull
   private Trip mTrip = new Trip.Builder().setLoading(true).build();
+
+  @NonNull
+  private CountryMetadata.DrivingSide mDrivingSide = CountryMetadata.DrivingSide.Right;
 
   // This value is used to decide whether to display the "trip finished" toast or not
   // False: trip is finished -> show toast
@@ -151,6 +157,7 @@ public class NavigationScreen extends BaseMapScreen implements RoutingController
     ThemeUtils.update(getCarContext());
     mNavigationManager.setNavigationManagerCallback(this);
     mNavigationManager.navigationStarted();
+    getOrganicMapsContext().getCurrentCountryManager().addListener(this);
 
     getLocationHelper().addListener(mLocationListener);
     if (LocationUtils.checkFineLocationPermission(getCarContext()))
@@ -181,6 +188,12 @@ public class NavigationScreen extends BaseMapScreen implements RoutingController
     mNavigationManager.navigationEnded();
     mNavigationManager.clearNavigationManagerCallback();
     getSurfaceRenderer().hideSpeedLimit();
+    getOrganicMapsContext().getCurrentCountryManager().removeListener(this);
+  }
+
+  public void onCountryChanged(@NonNull String countryId)
+  {
+    mDrivingSide = CountryMetadata.getDrivingSide(countryId);
   }
 
   @NonNull
@@ -284,7 +297,8 @@ public class NavigationScreen extends BaseMapScreen implements RoutingController
   private void updateTrip(@Nullable Location location)
   {
     final RoutingInfo info = Framework.nativeGetRouteFollowingInfo();
-    mTrip = RoutingUtils.createTrip(getCarContext(), info, RoutingController.get().getEndPoint(), Colors.DISTANCE);
+    mTrip = RoutingUtils.createTrip(getCarContext(), info, mDrivingSide, RoutingController.get().getEndPoint(),
+                                    Colors.DISTANCE);
     mNavigationManager.updateTrip(mTrip);
     if (info != null)
       updateSpeedLimit(info, location);

--- a/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingHelpers.java
+++ b/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingHelpers.java
@@ -7,6 +7,7 @@ import androidx.car.app.model.Distance;
 import androidx.car.app.navigation.model.LaneDirection;
 import androidx.car.app.navigation.model.Maneuver;
 import androidx.core.graphics.drawable.IconCompat;
+import app.organicmaps.sdk.CountryMetadata;
 import app.organicmaps.sdk.routing.CarDirection;
 import app.organicmaps.sdk.routing.LaneWay;
 
@@ -51,7 +52,7 @@ public final class RoutingHelpers
 
   @NonNull
   public static Maneuver createManeuver(@NonNull final CarContext context, @NonNull CarDirection carDirection,
-                                        int roundaboutExitNum)
+                                        int roundaboutExitNum, @NonNull CountryMetadata.DrivingSide drivingSide)
   {
     final int maneuverType = switch (carDirection)
     {
@@ -64,8 +65,13 @@ public final class RoutingHelpers
       case TurnSlightLeft -> Maneuver.TYPE_TURN_SLIGHT_LEFT;
       case UTurnLeft -> Maneuver.TYPE_U_TURN_LEFT;
       case UTurnRight -> Maneuver.TYPE_U_TURN_RIGHT;
-      // TODO (AndrewShkrob): add support for CW (clockwise) directions
-      case EnterRoundAbout, LeaveRoundAbout, StayOnRoundAbout -> Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW;
+      case EnterRoundAbout, LeaveRoundAbout, StayOnRoundAbout ->
+      {
+        if (drivingSide == CountryMetadata.DrivingSide.Right)
+          yield Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW;
+        else
+          yield Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CW;
+      }
       case StartAtEndOfStreet -> Maneuver.TYPE_DEPART;
       case ReachedYourDestination -> Maneuver.TYPE_DESTINATION;
       case ExitHighwayToLeft -> Maneuver.TYPE_OFF_RAMP_SLIGHT_LEFT;

--- a/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingUtils.java
+++ b/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingUtils.java
@@ -15,6 +15,7 @@ import androidx.car.app.navigation.model.Step;
 import androidx.car.app.navigation.model.TravelEstimate;
 import androidx.car.app.navigation.model.Trip;
 import androidx.core.graphics.drawable.IconCompat;
+import app.organicmaps.sdk.CountryMetadata;
 import app.organicmaps.sdk.bookmarks.data.MapObject;
 import app.organicmaps.sdk.routing.LaneInfo;
 import app.organicmaps.sdk.routing.LaneWay;
@@ -33,7 +34,8 @@ public final class RoutingUtils
 
   @NonNull
   public static Trip createTrip(@NonNull final CarContext context, @Nullable final RoutingInfo info,
-                                @Nullable MapObject endPoint, @NonNull CarColor distanceColor)
+                                @NonNull CountryMetadata.DrivingSide drivingSide, @Nullable MapObject endPoint,
+                                @NonNull CarColor distanceColor)
   {
     final Trip.Builder builder = new Trip.Builder();
 
@@ -59,21 +61,24 @@ public final class RoutingUtils
                            createTravelEstimate(info.distToTarget, info.totalTimeInSeconds, distanceColor));
 
     // TODO (AndrewShkrob): Use real distance and time estimates
-    builder.addStep(createCurrentStep(context, info), createTravelEstimate(info.distToTurn, 0, distanceColor));
+    builder.addStep(createCurrentStep(context, info, drivingSide),
+                    createTravelEstimate(info.distToTurn, 0, distanceColor));
     if (!TextUtils.isEmpty(info.nextStreet))
-      builder.addStep(createNextStep(context, info), createTravelEstimate(Distance.EMPTY, 0, distanceColor));
+      builder.addStep(createNextStep(context, info, drivingSide),
+                      createTravelEstimate(Distance.EMPTY, 0, distanceColor));
     return builder.build();
   }
 
   @NonNull
-  private static Step createCurrentStep(@NonNull final CarContext context, @NonNull RoutingInfo info)
+  private static Step createCurrentStep(@NonNull final CarContext context, @NonNull RoutingInfo info,
+                                        @NonNull CountryMetadata.DrivingSide drivingSide)
   {
     final Step.Builder builder = new Step.Builder();
     builder.setCue(RoadShieldUtils.createStreetTextWithShields(RoutingUtils::createRoadShieldSpan, info.nextStreet,
                                                                info.nextStreetRoadShields, 40f, /* drawOutline */
                                                                false));
     builder.setRoad(info.nextStreet);
-    builder.setManeuver(RoutingHelpers.createManeuver(context, info.carDirection, info.exitNum));
+    builder.setManeuver(RoutingHelpers.createManeuver(context, info.carDirection, info.exitNum, drivingSide));
     if (info.lanes != null)
     {
       for (final LaneInfo laneInfo : info.lanes)
@@ -93,13 +98,14 @@ public final class RoutingUtils
   }
 
   @NonNull
-  private static Step createNextStep(@NonNull final CarContext context, @NonNull RoutingInfo info)
+  private static Step createNextStep(@NonNull final CarContext context, @NonNull RoutingInfo info,
+                                     @NonNull CountryMetadata.DrivingSide drivingSide)
   {
     final Step.Builder builder = new Step.Builder();
     builder.setCue(RoadShieldUtils.createStreetTextWithShields(RoutingUtils::createRoadShieldSpan, info.nextNextStreet,
                                                                info.nextNextStreetRoadShields, 40f,
                                                                /* drawOutline */ false));
-    builder.setManeuver(RoutingHelpers.createManeuver(context, info.nextCarDirection, 0));
+    builder.setManeuver(RoutingHelpers.createManeuver(context, info.nextCarDirection, 0, drivingSide));
 
     return builder.build();
   }

--- a/android/sdk/src/main/cpp/CMakeLists.txt
+++ b/android/sdk/src/main/cpp/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SRC
   app/organicmaps/sdk/routing/TransitRouteInfo.hpp
   app/organicmaps/sdk/routing/TransitStepInfo.hpp
   app/organicmaps/sdk/ChoosePositionMode.cpp
+  app/organicmaps/sdk/CountryMetadata.cpp
   app/organicmaps/sdk/MapStyle.cpp
   app/organicmaps/sdk/OrganicMaps.cpp
   app/organicmaps/sdk/Router.cpp
@@ -77,6 +78,7 @@ set(SRC
   app/organicmaps/sdk/editor/OsmOAuth.cpp
   app/organicmaps/sdk/Framework.cpp
   app/organicmaps/sdk/isolines/IsolinesManager.cpp
+  app/organicmaps/sdk/location/CurrentCountryManager.cpp
   app/organicmaps/sdk/LocationState.cpp
   app/organicmaps/sdk/Map.cpp
   app/organicmaps/sdk/MapManager.cpp

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/CountryMetadata.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/CountryMetadata.cpp
@@ -1,0 +1,16 @@
+#include "app/organicmaps/sdk/Framework.hpp"
+
+#include "app/organicmaps/sdk/core/jni_helper.hpp"
+
+#include "platform/country_file.hpp"
+
+extern "C"
+{
+// static int nativeGetDrivingSide(@NonNull String countryId);
+JNIEXPORT jint Java_app_organicmaps_sdk_CountryMetadata_nativeGetDrivingSide(JNIEnv * env, jclass, jstring countryId)
+{
+  std::string const countryName = jni::ToNativeString(env, countryId);
+  auto const mwmId = frm()->GetDataSource().GetMwmIdByCountryFile(platform::CountryFile(countryName));
+  return mwmId.GetInfo()->GetRegionData().IsRightDrivingSide() ? 1 : 0;
+}
+}

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/location/CurrentCountryManager.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/location/CurrentCountryManager.cpp
@@ -1,0 +1,25 @@
+#include "app/organicmaps/sdk/Framework.hpp"
+
+#include "app/organicmaps/sdk/core/jni_helper.hpp"
+#include "app/organicmaps/sdk/core/jni_java_methods.hpp"
+
+extern "C"
+{
+// static void nativeSetListener(@NonNull OnCountryChangedListener listener);
+JNIEXPORT void Java_app_organicmaps_sdk_location_CurrentCountryManager_nativeSetListener(JNIEnv *, jclass,
+                                                                                         jobject listener)
+{
+  frm()->SetLocationCountryChangedListener([listener = make_global_ref(listener)](storage::CountryId const & countryId)
+  {
+    JNIEnv * env = jni::GetEnv();
+    jmethodID methodID = jni::GetMethodID(env, *listener, "onCountryChanged", "(Ljava/lang/String;)V");
+    env->CallVoidMethod(*listener, methodID, jni::TScopedLocalRef(env, jni::ToJavaString(env, countryId)).get());
+  });
+}
+
+// static void nativeRemoveListener();
+JNIEXPORT void Java_app_organicmaps_sdk_location_CurrentCountryManager_nativeRemoveListener(JNIEnv *, jclass)
+{
+  frm()->SetLocationCountryChangedListener(nullptr);
+}
+}

--- a/android/sdk/src/main/java/app/organicmaps/sdk/CountryMetadata.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/CountryMetadata.java
@@ -1,0 +1,27 @@
+package app.organicmaps.sdk;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+
+public final class CountryMetadata
+{
+  public enum DrivingSide
+  {
+    Left, // e.g. England, Japan, Australia
+    Right // e.g. USA, Germany
+  }
+
+  @NonNull
+  public static DrivingSide getDrivingSide(@NonNull String countryId)
+  {
+    return switch (nativeGetDrivingSide(countryId))
+    {
+      case 0 -> DrivingSide.Left;
+      case 1 -> DrivingSide.Right;
+      default -> throw new IllegalStateException("Unexpected driving side value");
+    };
+  }
+
+  @IntRange(from = 0, to = 1)
+  private static native int nativeGetDrivingSide(@NonNull String countryId);
+}

--- a/android/sdk/src/main/java/app/organicmaps/sdk/OrganicMaps.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/OrganicMaps.java
@@ -10,6 +10,7 @@ import app.organicmaps.sdk.bookmarks.data.BookmarkManager;
 import app.organicmaps.sdk.bookmarks.data.Icon;
 import app.organicmaps.sdk.downloader.Android7RootCertificateWorkaround;
 import app.organicmaps.sdk.editor.OsmOAuth;
+import app.organicmaps.sdk.location.CurrentCountryManager;
 import app.organicmaps.sdk.location.LocationHelper;
 import app.organicmaps.sdk.location.SensorHelper;
 import app.organicmaps.sdk.maplayer.isolines.IsolinesManager;
@@ -46,6 +47,8 @@ public final class OrganicMaps implements DefaultLifecycleObserver
   private final IsolinesManager mIsolinesManager;
   @NonNull
   private final SubwayManager mSubwayManager;
+  @NonNull
+  private final CurrentCountryManager mCurrentCountryManager;
 
   @NonNull
   private final LocationHelper mLocationHelper;
@@ -77,6 +80,12 @@ public final class OrganicMaps implements DefaultLifecycleObserver
   public IsolinesManager getIsolinesManager()
   {
     return mIsolinesManager;
+  }
+
+  @NonNull
+  public CurrentCountryManager getCurrentCountryManager()
+  {
+    return mCurrentCountryManager;
   }
 
   @NonNull
@@ -120,6 +129,7 @@ public final class OrganicMaps implements DefaultLifecycleObserver
     mLocationHelper = new LocationHelper(mContext, mSensorHelper);
     mIsolinesManager = new IsolinesManager();
     mSubwayManager = new SubwayManager(mContext);
+    mCurrentCountryManager = new CurrentCountryManager();
 
     ConnectionState.INSTANCE.initialize(mContext);
   }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/location/CurrentCountryManager.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/location/CurrentCountryManager.java
@@ -1,0 +1,45 @@
+package app.organicmaps.sdk.location;
+
+import androidx.annotation.NonNull;
+import java.util.Objects;
+import org.chromium.base.ObserverList;
+
+public final class CurrentCountryManager
+{
+  public interface OnCountryChangedListener
+  {
+    void onCountryChanged(String countryId);
+  }
+
+  @NonNull
+  private final ObserverList<OnCountryChangedListener> mListeners = new ObserverList<>();
+  @NonNull
+  private final OnCountryChangedListener mListener = this::notifyListeners;
+
+  public void addListener(@NonNull OnCountryChangedListener listener)
+  {
+    mListeners.addObserver(Objects.requireNonNull(listener));
+
+    if (mListeners.size() == 1)
+      nativeSetListener(mListener);
+  }
+
+  public void removeListener(@NonNull OnCountryChangedListener listener)
+  {
+    mListeners.removeObserver(Objects.requireNonNull(listener));
+
+    if (mListeners.isEmpty())
+      nativeRemoveListener();
+  }
+
+  private void notifyListeners(@NonNull String countryId)
+  {
+    for (final OnCountryChangedListener listener : mListeners)
+    {
+      listener.onCountryChanged(countryId);
+    }
+  }
+
+  private static native void nativeSetListener(@NonNull OnCountryChangedListener listener);
+  private static native void nativeRemoveListener();
+}

--- a/libs/geometry/mercator.hpp
+++ b/libs/geometry/mercator.hpp
@@ -91,11 +91,11 @@ inline double LonToX(double lon)
   return lon;
 }
 
-inline double MetersToMercator(double meters)
+constexpr double MetersToMercator(double meters)
 {
   return meters * Bounds::kDegreesInMeter;
 }
-inline double MercatorToMeters(double mercator)
+constexpr double MercatorToMeters(double mercator)
 {
   return mercator * Bounds::kMetersInDegree;
 }

--- a/libs/indexer/feature_meta.cpp
+++ b/libs/indexer/feature_meta.cpp
@@ -246,6 +246,13 @@ bool RegionData::IsSingleLanguage(int8_t const lang) const
   return value.front() == lang;
 }
 
+bool RegionData::IsRightDrivingSide() const
+{
+  auto const value = Get(RegionData::Type::RD_DRIVING);
+  // May be not set. Let's check for left driving side which must always be set
+  return value != "l";
+}
+
 void RegionData::AddPublicHoliday(int8_t month, int8_t offset)
 {
   std::string value(Get(RegionData::Type::RD_PUBLIC_HOLIDAYS));

--- a/libs/indexer/feature_meta.hpp
+++ b/libs/indexer/feature_meta.hpp
@@ -234,6 +234,8 @@ public:
   bool HasLanguage(int8_t const lang) const;
   bool IsSingleLanguage(int8_t const lang) const;
 
+  bool IsRightDrivingSide() const;
+
   void AddPublicHoliday(int8_t month, int8_t offset);
   // No public holidays getters until we know what to do with these.
 

--- a/libs/map/CMakeLists.txt
+++ b/libs/map/CMakeLists.txt
@@ -37,6 +37,8 @@ set(SRC
   gps_tracker.hpp
   isolines_manager.cpp
   isolines_manager.hpp
+  location_country_tracker.cpp
+  location_country_tracker.hpp
   mwm_url.cpp
   mwm_url.hpp
   place_page_info.cpp

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -253,6 +253,9 @@ void Framework::OnUserPositionChanged(m2::PointD const & position, bool hasPosit
 
   m_routingManager.SetUserCurrentPosition(position);
   m_trafficManager.UpdateMyPosition(TrafficManager::MyPosition(position));
+
+  if (hasPosition)
+    m_locationCountryTracker.OnLocationUpdate(position);
 }
 
 void Framework::OnViewportChanged(ScreenBase const & screen)
@@ -1174,6 +1177,11 @@ void Framework::SetCurrentCountryChangedListener(TCurrentCountryChanged listener
   m_lastReportedCountry = kInvalidCountryId;
 }
 
+void Framework::SetLocationCountryChangedListener(TCurrentCountryChanged listener)
+{
+  m_locationCountryTracker.SetListener(std::move(listener));
+}
+
 void Framework::MemoryWarning()
 {
   LOG(LINFO, ("MemoryWarning"));
@@ -1214,6 +1222,7 @@ void Framework::InitCountryInfoGetter()
 
   // Storage::GetAffiliations() pointer never changed.
   m_infoGetter->SetAffiliations(m_storage.GetAffiliations());
+  m_locationCountryTracker.SetInfoGetter(*m_infoGetter);
 }
 
 void Framework::InitSearchAPI(size_t numThreads)

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -5,6 +5,7 @@
 #include "map/bookmark_manager.hpp"
 #include "map/features_fetcher.hpp"
 #include "map/isolines_manager.hpp"
+#include "map/location_country_tracker.hpp"
 #include "map/mwm_url.hpp"
 #include "map/place_page_info.hpp"
 #include "map/position_provider.hpp"
@@ -342,6 +343,11 @@ public:
   /// Guarantees that listener is called in the main thread context.
   void SetCurrentCountryChangedListener(TCurrentCountryChanged listener);
 
+  storage::CountryId GetLastLocationCountry() const { return m_locationCountryTracker.GetCountryId(); }
+  /// Like SetCurrentCountryChangedListener, but fires when the user's GPS location
+  /// moves to a different country. Guarantees that listener is called in the main thread context.
+  void SetLocationCountryChangedListener(TCurrentCountryChanged listener);
+
   std::vector<std::string> GetRegionsCountryIdByRect(m2::RectD const & rect, bool rough) const;
   std::vector<MwmSet::MwmId> GetMwmsByRect(m2::RectD const & rect, bool rough) const;
 
@@ -455,6 +461,7 @@ private:
 
   storage::CountryId m_lastReportedCountry;
   TCurrentCountryChanged m_currentCountryChanged;
+  LocationCountryTracker m_locationCountryTracker;
 
   void OnUpdateGpsTrackPointsCallback(std::vector<std::pair<size_t, location::GpsInfo>> && toAdd,
                                       std::pair<size_t, size_t> const & toRemove,

--- a/libs/map/location_country_tracker.cpp
+++ b/libs/map/location_country_tracker.cpp
@@ -1,0 +1,61 @@
+#include "map/location_country_tracker.hpp"
+
+#include "platform/platform.hpp"
+
+void LocationCountryTracker::SetListener(TCountryChangedFn listener)
+{
+  m_listener = std::move(listener);
+  m_currentCountry = storage::kInvalidCountryId;
+  m_currentCountryRect = m2::RectD();
+  m_lastCheckedPos = m2::PointD::Zero();
+}
+
+void LocationCountryTracker::OnLocationUpdate(m2::PointD const & position)
+{
+  if (!m_infoGetter || !m_listener)
+    return;
+
+  // Distance threshold: skip if barely moved since last check.
+  if (m_currentCountry != storage::kInvalidCountryId)
+  {
+    if (m_lastCheckedPos.SquaredLength(position) < kDistPrecalculated)
+      return;
+  }
+
+  if (bool expected = false; !m_queryInFlight.compare_exchange_strong(expected, true))
+    return;
+
+  m_lastCheckedPos = position;
+
+  GetPlatform().RunTask(Platform::Thread::Background, [this, position]() { RunQuery(position); });
+}
+
+void LocationCountryTracker::RunQuery(m2::PointD const & position)
+{
+  if (!m_infoGetter)
+  {
+    m_queryInFlight.store(false);
+    return;
+  }
+  auto const newCountryId = m_infoGetter->GetRegionCountryId(position);
+  bool const changed = (newCountryId != m_currentCountry);
+
+  if (changed)
+  {
+    m_currentCountry = newCountryId;
+    m_currentCountryRect =
+        (newCountryId != storage::kInvalidCountryId) ? m_infoGetter->GetLimitRectForLeaf(newCountryId) : m2::RectD();
+  }
+
+  // Mark query as done *before* posting to GUI, so new updates can schedule a new query.
+  m_queryInFlight.store(false);
+
+  if (changed)
+  {
+    GetPlatform().RunTask(Platform::Thread::Gui, [this, newCountryId]()
+    {
+      if (m_listener)
+        m_listener(newCountryId);
+    });
+  }
+}

--- a/libs/map/location_country_tracker.hpp
+++ b/libs/map/location_country_tracker.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "storage/country_info_getter.hpp"
+#include "storage/storage_defines.hpp"
+
+#include "geometry/mercator.hpp"
+#include "geometry/point2d.hpp"
+
+#include <atomic>
+#include <functional>
+
+/// Tracks which country the user's GPS position is in.
+class LocationCountryTracker
+{
+  // Precalculated value that's needed during the runtime check.
+  // The value is based on minimal distance in meters
+  static double constexpr kDistPrecalculated = []
+  {
+    double constexpr minDistanceM = 500.0;
+    double constexpr distMer = mercator::MetersToMercator(minDistanceM);
+    return distMer * distMer;
+  }();
+
+public:
+  using TCountryChangedFn = std::function<void(storage::CountryId const &)>;
+
+  void SetInfoGetter(storage::CountryInfoGetter const & infoGetter) { m_infoGetter = &infoGetter; }
+  void SetListener(TCountryChangedFn listener);
+  void OnLocationUpdate(m2::PointD const & position);
+
+  storage::CountryId GetCountryId() const { return m_currentCountry; }
+
+private:
+  void RunQuery(m2::PointD const & position);
+
+  storage::CountryInfoGetter const * m_infoGetter = nullptr;
+  TCountryChangedFn m_listener;
+
+  storage::CountryId m_currentCountry = storage::kInvalidCountryId;
+  m2::PointD m_lastCheckedPos = m2::PointD::Zero();
+  m2::RectD m_currentCountryRect;
+
+  std::atomic<bool> m_queryInFlight{false};
+};

--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -5,6 +5,8 @@
 
 #include "map/framework.hpp"
 
+#include "storage/storage_defines.hpp"
+
 #include "routing/maxspeeds.hpp"
 
 #include "geometry/point2d.hpp"
@@ -121,6 +123,8 @@ void MapWidget::CreateEngine()
 
   m_framework.CreateDrapeEngine(make_ref(m_contextFactory), std::move(p));
   m_framework.SetViewportListener(std::bind(&MapWidget::OnViewportChanged, this, std::placeholders::_1));
+  m_framework.SetLocationCountryChangedListener([](storage::CountryId const & countryId)
+  { LOG(LDEBUG, ("User's location has changed to", countryId)); });
 }
 
 void MapWidget::ScalePlus()

--- a/xcode/map/map.xcodeproj/project.pbxproj
+++ b/xcode/map/map.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0831F23C200E53600034C365 /* bookmarks_search_params.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0831F23B200E53600034C365 /* bookmarks_search_params.hpp */; };
+		16FE429A2F92D7E500D926D8 /* location_country_tracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 16FE42992F92D7E500D926D8 /* location_country_tracker.cpp */; };
+		16FE429B2F92D7E500D926D8 /* location_country_tracker.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 16FE42982F92D7E500D926D8 /* location_country_tracker.hpp */; };
 		34583BCF1C88556800F94664 /* place_page_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 34583BCD1C88556800F94664 /* place_page_info.cpp */; };
 		34583BD01C88556800F94664 /* place_page_info.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 34583BCE1C88556800F94664 /* place_page_info.hpp */; };
 		347B60761DD9926D0050FA24 /* traffic_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 347B60741DD9926D0050FA24 /* traffic_manager.cpp */; };
@@ -154,6 +156,8 @@
 
 /* Begin PBXFileReference section */
 		0831F23B200E53600034C365 /* bookmarks_search_params.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bookmarks_search_params.hpp; sourceTree = "<group>"; };
+		16FE42982F92D7E500D926D8 /* location_country_tracker.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = location_country_tracker.hpp; sourceTree = "<group>"; };
+		16FE42992F92D7E500D926D8 /* location_country_tracker.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = location_country_tracker.cpp; sourceTree = "<group>"; };
 		34583BCD1C88556800F94664 /* place_page_info.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = place_page_info.cpp; sourceTree = "<group>"; };
 		34583BCE1C88556800F94664 /* place_page_info.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = place_page_info.hpp; sourceTree = "<group>"; };
 		347B60741DD9926D0050FA24 /* traffic_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = traffic_manager.cpp; sourceTree = "<group>"; };
@@ -394,6 +398,8 @@
 		675345BD1A4054AD00A0A8C3 /* map */ = {
 			isa = PBXGroup;
 			children = (
+				16FE42982F92D7E500D926D8 /* location_country_tracker.hpp */,
+				16FE42992F92D7E500D926D8 /* location_country_tracker.cpp */,
 				45201E921CE4AC90008A4842 /* api_mark_point.cpp */,
 				34921F611BFA0A6900737D6E /* api_mark_point.hpp */,
 				45580ABC1E2CBD5E00CD535D /* benchmark_tools.cpp */,
@@ -512,6 +518,7 @@
 				348AB57D1D7EE0C6009F8301 /* chart_generator.hpp in Headers */,
 				3DF528D8237DC82E000ED0D5 /* position_provider.hpp in Headers */,
 				BBFC7E3B202D29C000531BE7 /* user_mark_layer.hpp in Headers */,
+				16FE429B2F92D7E500D926D8 /* location_country_tracker.hpp in Headers */,
 				56C116612090E5670068BBC0 /* extrapolator.hpp in Headers */,
 				BB1C0196241BF73C0067FD5C /* track_mark.hpp in Headers */,
 				675346491A4054E800A0A8C3 /* bookmark_manager.hpp in Headers */,
@@ -688,6 +695,7 @@
 				F6B283051C1B03320081957A /* gps_track_filter.cpp in Sources */,
 				675346481A4054E800A0A8C3 /* bookmark_manager.cpp in Sources */,
 				BBB7060B23E45F3400A7F29A /* isolines_manager.cpp in Sources */,
+				16FE429A2F92D7E500D926D8 /* location_country_tracker.cpp in Sources */,
 				45F6EE9F1FB1C77600019892 /* search_api.cpp in Sources */,
 				BB4E5F251FCC664A00A77250 /* transit_display.cpp in Sources */,
 				675346741A4054E800A0A8C3 /* mwm_url.cpp in Sources */,


### PR DESCRIPTION
Add CurrentCountry listener that tracks user locations and notifies on country change.
Needed to fetch driving side from country metadata and will be required in the future to decide what style for speed limit view to show - square (USA) or circle (ROW)

Implemented driving side listening for providing correct metadata to AA