### PR TITLE
[android] Track current top in PlacePage layout change listener

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
@@ -233,11 +233,11 @@ public class PlacePageController
 
       final int topInset = mCurrentWindowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
       if (mPlacePage.getHeight() >= mCoordinator.getHeight() - topInset)
-        mPlacePageDistanceToTopObserver.onChanged(oldTop);
+        mPlacePageDistanceToTopObserver.onChanged(top);
 
       if (top != oldTop)
       {
-        mDistanceToTop = oldTop;
+        mDistanceToTop = top;
         mViewModel.setPlacePageDistanceToTop(mDistanceToTop);
       }
     });


### PR DESCRIPTION
Follow-up regression fix for https://github.com/organicmaps/organicmaps/pull/12034 and https://github.com/organicmaps/organicmaps/pull/12043

CC @Sergueille

The listener was passing oldTop, the view's previous top, to both mPlacePageDistanceToTopObserver.onChanged(...) and mDistanceToTop. onLayoutChange's top argument is the new position and oldTop is the previous one, so the controller was caching a stale Y for the sheet.

mDistanceToTop feeds animatePeekHeight's initial height, the native map visible rect via updateMapViewport, and the status-bar-background crossfade in the LiveData observer. onSlide hides the bug during drag because it continuously rewrites mDistanceToTop to bottomSheet.getTop(), but content-driven layout passes (e.g. opening hours expanding) don't fire onSlide, so the stale value leaked through: the crossfade and viewport lagged the sheet by one layout frame.

Pass top in both places so the cached distance matches the sheet's actual post-layout position.