### PR TITLE
[kml] Drop non-monotonic <gx:Track> timestamps instead of asserting

### DIFF
--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -836,6 +836,33 @@ UNIT_TEST(Kml_Track_Points_And_Timestamps_Sizes_Mismatch)
   TEST_EQUAL(dataFromFile.m_tracksData.size(), 0, ());
 }
 
+UNIT_TEST(Kml_Track_With_Non_Monotonic_Timestamps)
+{
+  std::string_view constexpr input = R"(<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+  <Placemark>
+    <name>Unordered</name>
+    <gx:Track>
+      <when>2001-06-02T00:18:15Z</when>
+      <when>2001-11-28T21:05:28Z</when>
+      <when>2001-06-02T03:26:55Z</when>
+      <gx:coord>-71.107628 42.430950 23</gx:coord>
+      <gx:coord>-71.109236 42.431240 27</gx:coord>
+      <gx:coord>-71.109942 42.434980 45</gx:coord>
+    </gx:Track>
+  </Placemark>
+</kml>)";
+
+  kml::FileData fData;
+  TEST_NO_THROW({ kml::DeserializerKml(fData).Deserialize(MemReader(input)); }, ());
+
+  TEST_EQUAL(fData.m_tracksData.size(), 1, ());
+  auto const & geom = fData.m_tracksData[0].m_geometry;
+  TEST_EQUAL(geom.m_lines.size(), 1, ());
+  TEST_EQUAL(geom.m_lines[0].size(), 3, ());
+  TEST(!geom.HasTimestamps(), ("Non-monotonic timestamps should be dropped"));
+}
+
 // https://github.com/organicmaps/organicmaps/issues/9290
 UNIT_TEST(Kml_Import_OpenTracks)
 {

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -1028,6 +1028,18 @@ void KmlParser::Pop(std::string_view tag)
       lines.pop_back();
       m_geometry.m_timestamps.pop_back();
     }
+    else
+    {
+      // KML does not require <when> timestamps to be ordered, but downstream time
+      // metadata code assumes they are monotonic non-decreasing. Drop broken
+      // timestamps rather than the track -- geometry is preserved.
+      auto & timestamps = m_geometry.m_timestamps.back();
+      if (!std::is_sorted(timestamps.begin(), timestamps.end()))
+      {
+        LOG(LWARNING, ("Non-monotonic timestamps in track, dropping them"));
+        timestamps.clear();
+      }
+    }
   }
   else if (IsProcessTrackCoord())
   {
@@ -1071,10 +1083,7 @@ void KmlParser::CharData(std::string & value)
         auto const timestamp = base::StringToTimestamp(value);
         ASSERT(timestamp != base::INVALID_TIME_STAMP, (value));
 
-        auto & cont = timestamps.back();
-        if (!cont.empty())
-          ASSERT_LESS_OR_EQUAL(cont.back(), timestamp, ());
-        cont.emplace_back(timestamp);
+        timestamps.back().emplace_back(timestamp);
       }
       else if (IsCoord(currTag))
       {


### PR DESCRIPTION
The KML parser asserted that <when> timestamps inside a gx:Track arrive monotonic non-decreasing. The KML spec doesn't require that, and some files (notably Google Earth's shipped "Fells Loop" sample) carry intentionally unordered <when> tags. Debug builds crashed at serdes.cpp's ASSERT_LESS_OR_EQUAL on the first out-of-order sample; release builds kept the bogus timestamps and then tripped a downstream ASSERT in TrackStatistics::CalculateDuration for the same reason.

Move the check to end-of-track and mirror GpxParser's "too broken to be useful, give up on timestamps" policy: when std::is_sorted is false for a just-finished track, log a warning and clear the timestamp array. Track geometry is preserved; speed/duration metadata is forfeit for that track only.

Adds a regression test feeding an unordered gx:Track and asserting the geometry parses cleanly while HasTimestamps() returns false.