### PR TITLE
[android] Added dividers for Multi geometry

### DIFF
--- a/android/app/src/main/java/app/organicmaps/ChartController.java
+++ b/android/app/src/main/java/app/organicmaps/ChartController.java
@@ -71,6 +71,8 @@ public class ChartController implements OnChartValueSelectedListener
     for (ElevationInfo.Point point : info.getPoints())
       values.add(new Entry((float) point.getDistance(), point.getAltitude()));
 
+    ElevationChartUtils.configureYAxisBounds(mChart, stats.getMinElevation(), stats.getMaxElevation());
+    ElevationChartUtils.addSegmentSeparators(mChart, info.getSegmentDistances(), mContext);
     ElevationChartUtils.setChartData(mChart, values, mContext);
 
     mMinAltitude.setText(Framework.nativeFormatAltitude(stats.getMinElevation()));

--- a/android/app/src/main/java/app/organicmaps/routing/RouteElevationChartController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RouteElevationChartController.java
@@ -99,6 +99,7 @@ public class RouteElevationChartController
     for (int i = 0; i < data.getSize(); i++)
       values.add(new Entry((float) data.getDistance(i), data.getAltitude(i), i));
 
+    ElevationChartUtils.configureYAxisBounds(mChart, data.getMinAltitude(), data.getMaxAltitude());
     ElevationChartUtils.setChartData(mChart, values, mContext);
 
     if (mMinAltitude != null)

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/ElevationChartUtils.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/ElevationChartUtils.java
@@ -5,8 +5,10 @@ import android.graphics.Color;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import app.organicmaps.R;
+import app.organicmaps.sdk.settings.UnitLocale;
 import app.organicmaps.util.ThemeUtils;
 import com.github.mikephil.charting.charts.LineChart;
+import com.github.mikephil.charting.components.LimitLine;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.data.Entry;
@@ -21,6 +23,7 @@ public final class ElevationChartUtils
   private static final int ROUTE_X_LABEL_COUNT = 3;
 
   private static final int CHART_Y_LABEL_COUNT = 3;
+  private static final int CHART_Y_MAX_STEP_COUNT = 6;
   private static final int CHART_FILL_ALPHA = (int) (0.12 * 255);
   private static final int CHART_AXIS_GRANULARITY = 100;
 
@@ -68,16 +71,18 @@ public final class ElevationChartUtils
     x.setGranularityEnabled(true);
     x.setTextColor(ThemeUtils.getColor(context, R.attr.elevationProfileAxisLabelColor));
     x.setPosition(XAxis.XAxisPosition.BOTTOM);
-    x.setAxisLineColor(ThemeUtils.getColor(context, androidx.appcompat.R.attr.dividerHorizontal));
+    int dividerColor = ThemeUtils.getColor(context, androidx.appcompat.R.attr.dividerHorizontal);
+    x.setAxisLineColor(dividerColor);
     x.setAxisLineWidth(context.getResources().getDimensionPixelSize(R.dimen.divider_height));
     ValueFormatter xAxisFormatter = new AxisValueFormatter(chart);
     x.setValueFormatter(xAxisFormatter);
+    x.setDrawLimitLinesBehindData(false);
 
     YAxis y = chart.getAxisLeft();
     y.setLabelCount(CHART_Y_LABEL_COUNT, false);
     y.setPosition(YAxis.YAxisLabelPosition.INSIDE_CHART);
     y.setDrawGridLines(true);
-    y.setGridColor(ContextCompat.getColor(context, R.color.black_12));
+    y.setGridColor(dividerColor);
     y.setEnabled(true);
     y.setTextColor(Color.TRANSPARENT);
     y.setAxisLineColor(Color.TRANSPARENT);
@@ -114,6 +119,79 @@ public final class ElevationChartUtils
     chart.animateX(0);
     // Reset zoom after layout to handle viewport size changes on rotation.
     chart.post(chart::fitScreen);
+  }
+
+  public static void configureYAxisBounds(@NonNull LineChart chart, float minAltitude, float maxAltitude)
+  {
+    // Step size in meters: 50m for metric, 100ft (30.48m) for imperial.
+    boolean isImperial = UnitLocale.getUnits() == UnitLocale.UNITS_FOOT;
+    float altitudeStep = isImperial ? 30.48f : 50f;
+
+    float range = maxAltitude - minAltitude;
+    float lower;
+    float upper;
+    if (range < 1f)
+    {
+      // Flat track: expand to at least one step on each side.
+      lower = minAltitude - altitudeStep;
+      upper = maxAltitude + altitudeStep;
+    }
+    else
+    {
+      float padding = Math.round(range / 10f);
+      lower = minAltitude - padding;
+      upper = maxAltitude + padding;
+    }
+
+    // Round to step boundaries.
+    lower = (float) (Math.floor(lower / altitudeStep) * altitudeStep);
+    upper = (float) (Math.ceil(upper / altitudeStep) * altitudeStep);
+
+    // Guard against degenerate range after rounding.
+    if (upper <= lower)
+      upper = lower + altitudeStep;
+
+    // Determine label count: double step size while more than CHART_Y_MAX_STEP_COUNT labels.
+    float effectiveStep = altitudeStep;
+    int stepCount = (int) Math.ceil((upper - lower) / effectiveStep);
+    while (stepCount > CHART_Y_MAX_STEP_COUNT && effectiveStep < upper - lower)
+    {
+      effectiveStep *= 2;
+      stepCount = (int) Math.ceil((upper - lower) / effectiveStep);
+    }
+    // Ensure range is an exact multiple of effectiveStep so labels land on step boundaries.
+    upper = lower + stepCount * effectiveStep;
+
+    YAxis y = chart.getAxisLeft();
+    y.setAxisMinimum(lower);
+    y.setAxisMaximum(upper);
+    y.setLabelCount(stepCount + 1, true);
+  }
+
+  public static void addSegmentSeparators(@NonNull LineChart chart, @NonNull double[] segmentDistances,
+                                          @NonNull Context context)
+  {
+    XAxis xAxis = chart.getXAxis();
+    xAxis.removeAllLimitLines();
+
+    if (segmentDistances.length == 0)
+      return;
+
+    int lineColor = ThemeUtils.getColor(context, androidx.appcompat.R.attr.dividerHorizontal);
+    // setLineWidth() takes dp (auto-converts internally), enableDashedLine() takes raw pixels.
+    float lineWidth = 2f;
+    int dashOn = context.getResources().getDimensionPixelSize(R.dimen.elevation_profile_separator_dash);
+    int dashOff = context.getResources().getDimensionPixelSize(R.dimen.elevation_profile_separator_gap);
+
+    for (double distance : segmentDistances)
+    {
+      LimitLine line = new LimitLine((float) distance);
+      line.setLineColor(lineColor);
+      line.setLineWidth(lineWidth);
+      line.enableDashedLine(dashOn, dashOff, 0f);
+      line.setLabel("");
+      xAxis.addLimitLine(line);
+    }
   }
 
   public static float interpolateY(@NonNull List<Entry> entries, float xVal)

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -85,6 +85,8 @@
   <dimen name="elevation_profile_height">80dp</dimen>
   <dimen name="elevation_profile_half_height">40dp</dimen>
   <dimen name="elevation_profile_dot_levels_margin">3dp</dimen>
+  <dimen name="elevation_profile_separator_dash">8dp</dimen>
+  <dimen name="elevation_profile_separator_gap">4dp</dimen>
   <dimen name="elevation_profile_marker_width">25dp</dimen>
   <dimen name="map_button_size">48dp</dimen>
   <dimen name="map_button_icon_size">32dp</dimen>

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/ElevationInfo.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/ElevationInfo.cpp
@@ -29,14 +29,40 @@ jobjectArray ToElevationPointArray(JNIEnv * env, ElevationInfo const & info)
                           [](JNIEnv * env, std::pair<double, int> const & item)
   { return CreateElevationPoint(env, item.first, item.second); });
 }
+
+jdoubleArray ToSegmentDistancesArray(JNIEnv * env, ElevationInfo const & info)
+{
+  auto const & lines = info.GetLines();
+  if (lines.empty())
+    return env->NewDoubleArray(0);
+
+  std::vector<double> breaks;
+  breaks.reserve(lines.size() - 1);
+  double const totalLength = info.GetLength();
+  double cumulativeOffset = 0;
+  for (size_t i = 0; i < lines.size(); ++i)
+  {
+    if (i > 0 && cumulativeOffset > 0 && cumulativeOffset < totalLength)
+      breaks.emplace_back(cumulativeOffset);
+    if (!lines[i].empty())
+      cumulativeOffset += lines[i].back().m_distance;
+  }
+
+  jdoubleArray result = env->NewDoubleArray(static_cast<jsize>(breaks.size()));
+  if (!breaks.empty())
+    env->SetDoubleArrayRegion(result, 0, static_cast<jsize>(breaks.size()), breaks.data());
+  return result;
+}
 }  // namespace
 
 jobject ToJavaElevationInfo(JNIEnv * env, ElevationInfo const & info)
 {
-  // public ElevationInfo(@NonNull Point[] points, int difficulty);
-  static jmethodID const ctorId =
-      jni::GetConstructorID(env, g_elevationInfoClazz, "([Lapp/organicmaps/sdk/bookmarks/data/ElevationInfo$Point;I)V");
+  // public ElevationInfo(@NonNull Point[] points, int difficulty, @NonNull double[] segmentDistances)
+  static jmethodID const ctorId = jni::GetConstructorID(
+      env, g_elevationInfoClazz, "([Lapp/organicmaps/sdk/bookmarks/data/ElevationInfo$Point;I[D)V");
 
   jni::TScopedLocalObjectArrayRef jPoints(env, ToElevationPointArray(env, info));
-  return env->NewObject(g_elevationInfoClazz, ctorId, jPoints.get(), static_cast<jint>(info.GetDifficulty()));
+  jni::TScopedLocalRef jSegDist(env, ToSegmentDistancesArray(env, info));
+  return env->NewObject(g_elevationInfoClazz, ctorId, jPoints.get(), static_cast<jint>(info.GetDifficulty()),
+                        jSegDist.get());
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/ElevationInfo.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/ElevationInfo.java
@@ -18,16 +18,21 @@ public class ElevationInfo implements PlacePageData
   @NonNull
   private final List<Point> mPoints;
   private final int mDifficulty;
+  @NonNull
+  private final double[] mSegmentDistances;
 
-  public ElevationInfo(@NonNull Point[] points, int difficulty)
+  public ElevationInfo(@NonNull Point[] points, int difficulty, @NonNull double[] segmentDistances)
   {
     mPoints = Arrays.asList(points);
     mDifficulty = difficulty;
+    mSegmentDistances = segmentDistances;
   }
 
   protected ElevationInfo(Parcel in)
   {
     mDifficulty = in.readInt();
+    double[] arr = in.createDoubleArray();
+    mSegmentDistances = arr != null ? arr : new double[0];
     mPoints = readPoints(in);
   }
 
@@ -50,6 +55,12 @@ public class ElevationInfo implements PlacePageData
     return mDifficulty;
   }
 
+  @NonNull
+  public double[] getSegmentDistances()
+  {
+    return mSegmentDistances;
+  }
+
   @Override
   public int describeContents()
   {
@@ -60,6 +71,7 @@ public class ElevationInfo implements PlacePageData
   public void writeToParcel(Parcel dest, int flags)
   {
     dest.writeInt(mDifficulty);
+    dest.writeDoubleArray(mSegmentDistances);
     // All collections are deserialized AFTER non-collection and primitive type objects,
     // so collections must be always serialized at the end.
     dest.writeTypedList(mPoints);


### PR DESCRIPTION
Summary                                                                                                            

  - Add step-based Y-axis scaling matching iOS behavior: 50m steps (metric) / 100ft steps (imperial) with 10% padding, 
  preventing small elevation deltas from filling the entire chart height
  - Add vertical dashed separator lines at multi-geometry track segment boundaries, matching iOS ChartSegmentLinesView 
  - Fix Y-axis grid lines invisible in dark mode by using theme-aware dividerHorizontal color                          
                                                                                                                       
  Changes                                                                                                              
                                                                                                                       
  - JNI bridge (ElevationInfo.cpp): pass double[] segmentDistances from C++ ElevationInfo::GetLines() to Java,         
  mirroring iOS ElevationProfileData.mm logic
  - ElevationInfo.java: add mSegmentDistances field with Parcelable support                                            
  - ElevationChartUtils.java: add configureYAxisBounds() (step-based rounding) and addSegmentSeparators() (LimitLine on
   XAxis)                                                                                                              
  - ChartController / RouteElevationChartController: integrate new methods in setData()                                
  - dimens.xml: add elevation_profile_separator_dash (8dp) and elevation_profile_separator_gap (4dp)

<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/7211c285-f280-40d1-92db-1f5580c0b5aa" />

<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/0230d077-7690-4c89-974f-3ea50984af5c" />