### PR TITLE
[strings] Update Australian regional descriptions

### DIFF
--- a/data/countries-strings/ar.json/localize.json
+++ b/data/countries-strings/ar.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "سيدني, كانبرا",

--- a/data/countries-strings/az.json/localize.json
+++ b/data/countries-strings/az.json/localize.json
@@ -1369,7 +1369,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"Sydney, Canberra, Newcastle",

--- a/data/countries-strings/be.json/localize.json
+++ b/data/countries-strings/be.json/localize.json
@@ -1369,7 +1369,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Сідней, Канбера, Ньюкасл",

--- a/data/countries-strings/ca.json/localize.json
+++ b/data/countries-strings/ca.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Sydney, Canberra, Newcastle",

--- a/data/countries-strings/cs.json/localize.json
+++ b/data/countries-strings/cs.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Sydney, Canberra, Newcastle",

--- a/data/countries-strings/da.json/localize.json
+++ b/data/countries-strings/da.json/localize.json
@@ -1374,7 +1374,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"Sydney, Canberra, Newcastle",

--- a/data/countries-strings/de.json/localize.json
+++ b/data/countries-strings/de.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane",
 "Australia_Melbourne Description": "Melbourne",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide",
 "Australia_Sydney Description": "Sydney, Canberra",

--- a/data/countries-strings/el.json/localize.json
+++ b/data/countries-strings/el.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Μπρίσμπεϊν, Ρέντκλιφ, Χρυσή Ακτή",
 "Australia_Melbourne Description": "Μελβούρνη, Τζίλονγκ, Γιερίγκ",
 "Australia_New South Wales Description": "Μπαρχάμ, Τουνκούρι Τοκουμβάλ",
-"Australia_Northern Territory Description": "Ντάργουιν, Τέναντ Κρικ, Μουτιτζούλου",
+"Australia_Northern Territory Description": "Ντάργουιν, Άλις Σπρινγκς, Γιουλάρα",
 "Australia_Queensland Description": "Σάρλβιλ, Γουίντον, Τάουνσβιλ",
 "Australia_South Australia Description": "Αδελαΐδα, Πορτ Λίνκολν, Μάρει Μπριτζ",
 "Australia_Sydney Description": "Σίδνεϊ, Καμπέρα, Νιούκαστλ",

--- a/data/countries-strings/en.json/localize.json
+++ b/data/countries-strings/en.json/localize.json
@@ -1380,7 +1380,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"Sydney, Canberra, Newcastle",

--- a/data/countries-strings/es.json/localize.json
+++ b/data/countries-strings/es.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Sídney, Camberra, Newcastle",

--- a/data/countries-strings/et.json/localize.json
+++ b/data/countries-strings/et.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Sydney, Canberra, Newcastle",

--- a/data/countries-strings/eu.json/localize.json
+++ b/data/countries-strings/eu.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"Sydney, Canberra, Newcastle",

--- a/data/countries-strings/fi.json/localize.json
+++ b/data/countries-strings/fi.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"Sydney, Canberra, Newcastle",

--- a/data/countries-strings/fr.json/localize.json
+++ b/data/countries-strings/fr.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane",
 "Australia_Melbourne Description": "Melbourne",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adélaïde",
 "Australia_Sydney Description": "Sydney, Canberra",

--- a/data/countries-strings/gl.json/localize.json
+++ b/data/countries-strings/gl.json/localize.json
@@ -1377,7 +1377,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaida, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Sydney, Canberra, Newcastle",

--- a/data/countries-strings/he.json/localize.json
+++ b/data/countries-strings/he.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description":"בריסביין",
 "Australia_Melbourne Description":"מלבורן",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"אדלייד",
 "Australia_Sydney Description":"סידני, קנברה",

--- a/data/countries-strings/hu.json/localize.json
+++ b/data/countries-strings/hu.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Sydney, Canberra, Newcastle",

--- a/data/countries-strings/id.json/localize.json
+++ b/data/countries-strings/id.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Sydney, Canberra, Newcastle",

--- a/data/countries-strings/it.json/localize.json
+++ b/data/countries-strings/it.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"Sydney, Canberra, Newcastle",

--- a/data/countries-strings/ja.json/localize.json
+++ b/data/countries-strings/ja.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description":"ブリスベン, レッドクリフ, ゴールドコースト",
 "Australia_Melbourne Description":"メルボルン, ジーロング",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"ダーウィン",
+"Australia_Northern Territory Description":"ダーウィン、アリススプリングス、ユララ",
 "Australia_Queensland Description":"チャールビル, ウィントン, タウンズビル",
 "Australia_South Australia Description":"アデレード, ポートリンカーン, マレーブリッジ",
 "Australia_Sydney Description":"シドニー, キャンベラ, ニューカッスル",

--- a/data/countries-strings/ko.json/localize.json
+++ b/data/countries-strings/ko.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"캔버라",

--- a/data/countries-strings/mr.json/localize.json
+++ b/data/countries-strings/mr.json/localize.json
@@ -1369,7 +1369,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"Sydney, Canberra, Newcastle",

--- a/data/countries-strings/nb.json/localize.json
+++ b/data/countries-strings/nb.json/localize.json
@@ -1374,7 +1374,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"Sydney, Canberra, Newcastle",

--- a/data/countries-strings/nl.json/localize.json
+++ b/data/countries-strings/nl.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Sydney, Canberra, Newcastle",

--- a/data/countries-strings/pl.json/localize.json
+++ b/data/countries-strings/pl.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Sydney, Canberra",

--- a/data/countries-strings/pt.json/localize.json
+++ b/data/countries-strings/pt.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Camberra",

--- a/data/countries-strings/ro.json/localize.json
+++ b/data/countries-strings/ro.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"Sydney, Canberra, Newcastle",

--- a/data/countries-strings/ru.json/localize.json
+++ b/data/countries-strings/ru.json/localize.json
@@ -1372,7 +1372,7 @@
 "Armenia Description": "Ереван, Аштарак, Гюмри",
 "Australia_Brisbane Description": "Брисбен, Голд-Кост",
 "Australia_Melbourne Description": "Мельбурн, Джелонг",
-"Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
+"Australia_New South Wales Description": "Бархам, Танкурри, Токумвал",
 "Australia_Northern Territory Description": "Дарвин, Алис-Спрингс, Юлара",
 "Australia_Queensland Description": "Чарлвилл, Уинтон, Таунсвилл",
 "Australia_South Australia Description": "Аделаида, Порт-Линкольн",

--- a/data/countries-strings/ru.json/localize.json
+++ b/data/countries-strings/ru.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Брисбен, Голд-Кост",
 "Australia_Melbourne Description": "Мельбурн, Джелонг",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Дарвин, Теннант-Крик",
+"Australia_Northern Territory Description": "Дарвин, Алис-Спрингс, Юлара",
 "Australia_Queensland Description": "Чарлвилл, Уинтон, Таунсвилл",
 "Australia_South Australia Description": "Аделаида, Порт-Линкольн",
 "Australia_Sydney Description": "Сидней, Канберра, Ньюкасл",

--- a/data/countries-strings/sk.json/localize.json
+++ b/data/countries-strings/sk.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"Sydney, Canberra, Newcastle",

--- a/data/countries-strings/sv.json/localize.json
+++ b/data/countries-strings/sv.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description":"Brisbane",
 "Australia_Melbourne Description":"Melbourne",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide",
 "Australia_Sydney Description":"Sydney, Canberra",

--- a/data/countries-strings/th.json/localize.json
+++ b/data/countries-strings/th.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"แคนเบอร์รา",

--- a/data/countries-strings/tr.json/localize.json
+++ b/data/countries-strings/tr.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Sydney, Canberra, Newcastle",

--- a/data/countries-strings/uk.json/localize.json
+++ b/data/countries-strings/uk.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Брісбен, Голд-Кост",
 "Australia_Melbourne Description": "Мельбурн, Джелонг",
 "Australia_New South Wales Description": "Бархам, Танкуррі, Токумвал",
-"Australia_Northern Territory Description": "Дарвін, Теннант-Крік",
+"Australia_Northern Territory Description": "Дарвін, Аліс-Спрінгс, Юлара",
 "Australia_Queensland Description": "Шарлевіль, Вінтон, Таунсвілль",
 "Australia_South Australia Description": "Аделаїда, Порт-Лінкольн",
 "Australia_Sydney Description": "Сідней, Канберра, Ньюкасл",

--- a/data/countries-strings/vi.json/localize.json
+++ b/data/countries-strings/vi.json/localize.json
@@ -1374,7 +1374,7 @@
 "Australia_Brisbane Description":"Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description":"Melbourne, Geelong, Yering",
 "Australia_New South Wales Description":"Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description":"Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description":"Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description":"Charleville, Winton, Townsville",
 "Australia_South Australia Description":"Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description":"Sydney, Canberra, Newcastle",

--- a/data/countries-strings/zh-Hans.json/localize.json
+++ b/data/countries-strings/zh-Hans.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Sydney, Canberra, Newcastle",

--- a/data/countries-strings/zh-Hant.json/localize.json
+++ b/data/countries-strings/zh-Hant.json/localize.json
@@ -1373,7 +1373,7 @@
 "Australia_Brisbane Description": "Brisbane, Redcliffe, Gold Coast",
 "Australia_Melbourne Description": "Melbourne, Geelong, Yering",
 "Australia_New South Wales Description": "Barham, Tuncurry, Tocumwal",
-"Australia_Northern Territory Description": "Darwin, Tennant Creek, Mutitjulu",
+"Australia_Northern Territory Description": "Darwin, Alice Springs, Yulara",
 "Australia_Queensland Description": "Charleville, Winton, Townsville",
 "Australia_South Australia Description": "Adelaide, Port Lincoln, Murray Bridge",
 "Australia_Sydney Description": "Sydney, Canberra, Newcastle",


### PR DESCRIPTION
Replaced Tennant Creek (fifth largest town) with Alice Springs (second largest town).
Replaced Mutitjulu (aboriginal Australian community near Uluṟu) with Yulara (tourist town near Uluru where almost all visitors stay in).
https://en.wikipedia.org/wiki/List_of_places_in_the_Northern_Territory_by_population

Translated New South Wales description in Russian.