### PR TITLE
[ios] Add a Track Recording button to the navigation panel and refine the navigation panel's style

### DIFF
--- a/iphone/Maps/Bridging-Header.h
+++ b/iphone/Maps/Bridging-Header.h
@@ -74,6 +74,7 @@
 #import "SearchOnMapState.h"
 #import "SearchResult.h"
 #import "SwizzleStyle.h"
+#import "TrackRecordingState.h"
 #import "UIButton+Orientation.h"
 #import "UIButton+RuntimeAttributes.h"
 #import "UIColor+Colors.h"

--- a/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
@@ -365,8 +365,8 @@ extension GlobalStyleSheet: IStyleSheet {
       }
     case .flatRedButton:
       return .add { s in
-        s.font = fonts.medium14
-        s.cornerRadius = .buttonDefault
+        s.font = fonts.semibold16
+        s.cornerRadius = .buttonDefaultBig
         s.fontColor = .whitePrimaryText
         s.backgroundColor = .buttonRed
         s.fontColorHighlighted = .buttonRedHighlighted

--- a/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
@@ -44,7 +44,7 @@ enum GlobalStyleSheet: String, CaseIterable {
   case flatPrimaryTransButton = "FlatPrimaryTransButton"
   case flatRedTransButton = "FlatRedTransButton"
   case flatRedTransButtonBig = "FlatRedTransButtonBig"
-  case flatRedButton = "FlatRedButton"
+  case flatRedButtonBig
   case moreButton = "MoreButton"
   case editButton = "EditButton"
   case rateAppButton = "RateAppButton"
@@ -363,7 +363,7 @@ extension GlobalStyleSheet: IStyleSheet {
         s.backgroundColor = .clear
         s.fontColorHighlighted = .redPrimary
       }
-    case .flatRedButton:
+    case .flatRedButtonBig:
       return .add { s in
         s.font = fonts.semibold16
         s.cornerRadius = .buttonDefaultBig

--- a/iphone/Maps/Core/TrackRecorder/TrackRecordingManager.swift
+++ b/iphone/Maps/Core/TrackRecorder/TrackRecordingManager.swift
@@ -1,9 +1,3 @@
-@objc
-enum TrackRecordingState: Int, Equatable {
-  case inactive
-  case active
-}
-
 enum TrackRecordingAction {
   case start
   case stopAndSave(name: String)
@@ -109,6 +103,10 @@ final class TrackRecordingManager: NSObject {
     recordingState == .active
   }
 
+  func start() {
+    start(completion: nil)
+  }
+
   func start(completion: ((StartTrackRecordingResult) -> Void)? = nil) {
     do {
       switch recordingState {
@@ -125,6 +123,8 @@ final class TrackRecordingManager: NSObject {
         }
       case .active:
         break
+      @unknown default:
+        fatalError()
       }
       completion?(.success)
     } catch {

--- a/iphone/Maps/Core/TrackRecorder/TrackRecordingManager.swift
+++ b/iphone/Maps/Core/TrackRecorder/TrackRecordingManager.swift
@@ -123,8 +123,6 @@ final class TrackRecordingManager: NSObject {
         }
       case .active:
         break
-      @unknown default:
-        fatalError()
       }
       completion?(.success)
     } catch {

--- a/iphone/Maps/Core/TrackRecorder/TrackRecordingState.h
+++ b/iphone/Maps/Core/TrackRecorder/TrackRecordingState.h
@@ -1,1 +1,4 @@
-typedef NS_ENUM(NSUInteger, TrackRecordingState) { TrackRecordingStateActive, TrackRecordingStateInactive };
+typedef NS_CLOSED_ENUM(NSUInteger, TrackRecordingState) {
+  TrackRecordingStateInactive,
+  TrackRecordingStateActive,
+};

--- a/iphone/Maps/Core/TrackRecorder/TrackRecordingState.h
+++ b/iphone/Maps/Core/TrackRecorder/TrackRecordingState.h
@@ -1,0 +1,1 @@
+typedef NS_ENUM(NSUInteger, TrackRecordingState) { TrackRecordingStateActive, TrackRecordingStateInactive };

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -1676,6 +1676,7 @@
 		EDBAB6F42E980421007962B5 /* GeoNavigationToOMURLConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoNavigationToOMURLConverterTests.swift; sourceTree = "<group>"; };
 		EDC4E3402C5D1BD3009286A2 /* MockRecentlyDeletedCategoriesManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockRecentlyDeletedCategoriesManager.swift; sourceTree = "<group>"; };
 		EDC4E3412C5D1BD3009286A2 /* RecentlyDeletedCategoriesViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentlyDeletedCategoriesViewModelTests.swift; sourceTree = "<group>"; };
+		EDCD96072F99476300B398FC /* TrackRecordingState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackRecordingState.h; sourceTree = "<group>"; };
 		EDF838AD2C00B9C7007E4E67 /* LocalDirectoryMonitorDelegateMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalDirectoryMonitorDelegateMock.swift; sourceTree = "<group>"; };
 		EDF838AE2C00B9C7007E4E67 /* DefaultLocalDirectoryMonitorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultLocalDirectoryMonitorTests.swift; sourceTree = "<group>"; };
 		EDF838AF2C00B9C7007E4E67 /* SynchronizationStateManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SynchronizationStateManagerTests.swift; sourceTree = "<group>"; };
@@ -3764,6 +3765,7 @@
 			children = (
 				ED82C72E2F90186300FA103D /* TrackRecordingActivityManager.swift */,
 				ED82C72F2F90186300FA103D /* TrackRecordingManager.swift */,
+				EDCD96072F99476300B398FC /* TrackRecordingState.h */,
 			);
 			path = TrackRecorder;
 			sourceTree = "<group>";

--- a/iphone/Maps/UI/Map/MapViewController.mm
+++ b/iphone/Maps/UI/Map/MapViewController.mm
@@ -14,6 +14,7 @@
 #import "MWMPlacePageProtocol.h"
 #import "MapsAppDelegate.h"
 #import "SwiftBridge.h"
+#import "TrackRecordingState.h"
 
 #import <CoreApi/Framework.h>
 #import <CoreApi/MWMFrameworkHelper.h>

--- a/iphone/Maps/UI/Map/MapViewControls/MWMMapViewControlsManager.mm
+++ b/iphone/Maps/UI/Map/MapViewControls/MWMMapViewControlsManager.mm
@@ -206,6 +206,8 @@ NSString * const kMapToCategorySelectorSegue = @"MapToCategorySelectorSegue";
   self.sideButtonsHidden = NO;
   self.disableStandbyOnRouteFollowing = YES;
   self.trafficButtonHidden = YES;
+  if (TrackRecordingManager.shared.isActive)
+    [self setTrackRecordingButtonState:TrackRecordingButtonStateHidden];
   [self.navigationManager onRouteStart];
   self.promoButton.hidden = YES;
 }
@@ -216,6 +218,8 @@ NSString * const kMapToCategorySelectorSegue = @"MapToCategorySelectorSegue";
   [self.navigationManager onRouteStop];
   self.disableStandbyOnRouteFollowing = NO;
   self.trafficButtonHidden = NO;
+  if (TrackRecordingManager.shared.isActive)
+    [self setTrackRecordingButtonState:TrackRecordingButtonStateVisible];
   self.promoButton.hidden = YES;
 }
 
@@ -298,6 +302,9 @@ NSString * const kMapToCategorySelectorSegue = @"MapToCategorySelectorSegue";
 
 - (void)setTrackRecordingButtonState:(TrackRecordingButtonState)state
 {
+  BOOL const isNavigation = self.navigationManager.state == MWMNavigationDashboardStateNavigation;
+  if (state == TrackRecordingButtonStateVisible && isNavigation)
+    state = TrackRecordingButtonStateHidden;
   if (!_trackRecordingButton)
     _trackRecordingButton = [[TrackRecordingButtonViewController alloc] init];
   [self.trackRecordingButton setState:state completion:^{ [MWMMapWidgetsHelper updateLayoutForAvailableArea]; }];

--- a/iphone/Maps/UI/Map/MapViewControls/MWMMapViewControlsManager.mm
+++ b/iphone/Maps/UI/Map/MapViewControls/MWMMapViewControlsManager.mm
@@ -218,7 +218,10 @@ NSString * const kMapToCategorySelectorSegue = @"MapToCategorySelectorSegue";
   [self.navigationManager onRouteStop];
   self.disableStandbyOnRouteFollowing = NO;
   self.trafficButtonHidden = NO;
-  if (TrackRecordingManager.shared.isActive)
+  // Must run after `onRouteStop` has flipped the dashboard state from Navigation to Closed,
+  // otherwise `setTrackRecordingButtonState:` would keep the widget hidden.
+  if (TrackRecordingManager.shared.isActive &&
+      ![TrackRecordingManager.shared contains:MapViewController.sharedController])
     [self setTrackRecordingButtonState:TrackRecordingButtonStateVisible];
   self.promoButton.hidden = YES;
 }
@@ -305,6 +308,8 @@ NSString * const kMapToCategorySelectorSegue = @"MapToCategorySelectorSegue";
   BOOL const isNavigation = self.navigationManager.state == MWMNavigationDashboardStateNavigation;
   if (state == TrackRecordingButtonStateVisible && isNavigation)
     state = TrackRecordingButtonStateHidden;
+  if ((state == TrackRecordingButtonStateHidden || state == TrackRecordingButtonStateClosed) && !_trackRecordingButton)
+    return;
   if (!_trackRecordingButton)
     _trackRecordingButton = [[TrackRecordingButtonViewController alloc] init];
   [self.trackRecordingButton setState:state completion:^{ [MWMMapWidgetsHelper updateLayoutForAvailableArea]; }];

--- a/iphone/Maps/UI/NavigationDashboard/MWMNavigationDashboardManager.mm
+++ b/iphone/Maps/UI/NavigationDashboard/MWMNavigationDashboardManager.mm
@@ -46,7 +46,9 @@
               __strong __typeof(weakSelf) self = weakSelf;
               if (!self)
                 return;
-              [self->_navigationDashboardView setTrackRecordingState:state];
+              id<NavigationDashboardView> view = self->_navigationDashboardView;
+              if (view)
+                [view setTrackRecordingState:state];
             }];
   }
   return self;
@@ -259,14 +261,13 @@
   [self.searchManager close];
 }
 
-- (void)trackRecordingButonDidTap
+- (void)trackRecordingButtonDidTap
 {
   TrackRecordingManager * manager = TrackRecordingManager.shared;
   switch (manager.recordingState)
   {
   case TrackRecordingStateInactive: [manager start]; break;
   case TrackRecordingStateActive: [[MapViewController sharedController] showTrackRecordingPlacePage]; break;
-  default: NSAssert(false, @"Unexpected track recording state.");
   }
 }
 

--- a/iphone/Maps/UI/NavigationDashboard/MWMNavigationDashboardManager.mm
+++ b/iphone/Maps/UI/NavigationDashboard/MWMNavigationDashboardManager.mm
@@ -37,8 +37,24 @@
 {
   self = [super init];
   if (self)
+  {
+    __weak __typeof(self) weakSelf = self;
     _parentViewController = viewController;
+    [TrackRecordingManager.shared addObserver:self
+            recordingIsActiveDidChangeHandler:^(TrackRecordingState state, TrackInfo * _Nonnull,
+                                                ElevationProfileData * _Nonnull (^_Nullable)()) {
+              __strong __typeof(weakSelf) self = weakSelf;
+              if (!self)
+                return;
+              [self->_navigationDashboardView setTrackRecordingState:state];
+            }];
+  }
   return self;
+}
+
+- (void)dealloc
+{
+  [TrackRecordingManager.shared removeObserver:self];
 }
 
 - (id<NavigationDashboardView>)navigationDashboardView
@@ -241,6 +257,17 @@
   [MWMSearch clear];
   [MWMRouter stopRouting];
   [self.searchManager close];
+}
+
+- (void)trackRecordingButonDidTap
+{
+  TrackRecordingManager * manager = TrackRecordingManager.shared;
+  switch (manager.recordingState)
+  {
+  case TrackRecordingStateInactive: [manager start]; break;
+  case TrackRecordingStateActive: [[MapViewController sharedController] showTrackRecordingPlacePage]; break;
+  default: NSAssert(false, @"Unexpected track recording state.");
+  }
 }
 
 #pragma mark - SearchOnMapManagerObserver

--- a/iphone/Maps/UI/NavigationDashboard/MWMNavigationDashboardView.h
+++ b/iphone/Maps/UI/NavigationDashboard/MWMNavigationDashboardView.h
@@ -1,5 +1,6 @@
 #import "RoutePreviewView.h"
 #import "SearchOnMapState.h"
+#import "TrackRecordingState.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)onNavigationInfoUpdated:(MWMNavigationDashboardEntity *)entity;
 - (void)setDrivingOptionState:(MWMDrivingOptionsState)state;
+- (void)setTrackRecordingState:(TrackRecordingState)state;
 - (void)searchManagerWithDidChangeState:(SearchOnMapState)state;
 - (void)updateNavigationInfoAvailableArea:(CGRect)frame;
 - (void)setRouteBuilderProgress:(MWMRouterType)router progress:(CGFloat)progress;

--- a/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.swift
@@ -84,7 +84,18 @@ final class NavigationControlView: SolidTouchView {
 
     updateLegendSize()
 
+    configureButton(settingsButton)
+    configureButton(ttsButton)
+    configureButton(trackRecordingButton)
+
     MWMTextToSpeech.add(self)
+  }
+
+  private func configureButton(_ button: UIButton) {
+    button.imageView?.contentMode = .scaleAspectFit
+    button.contentHorizontalAlignment = .fill
+    button.contentVerticalAlignment = .fill
+    button.contentEdgeInsets = UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15)
   }
 
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.swift
@@ -18,14 +18,18 @@ final class NavigationControlView: SolidTouchView {
     }
   }
 
+  @IBOutlet var settingsButton: UIButton!
+
   @IBOutlet private var ttsButton: UIButton! {
     didSet {
-      ttsButton.setImage(UIImage(resource: .icVoiceOff), for: .normal)
-      ttsButton.setImage(UIImage(resource: .icVoiceOn), for: .selected)
-      ttsButton.setImage(UIImage(resource: .icVoiceOn), for: [.selected, .highlighted])
+      ttsButton.setImage(UIImage.icVoiceOff, for: .normal)
+      ttsButton.setImage(UIImage.icVoiceOn, for: .selected)
+      ttsButton.setImage(UIImage.icVoiceOn, for: [.selected, .highlighted])
       onTTSStatusUpdated()
     }
   }
+
+  @IBOutlet var trackRecordingButton: UIButton!
 
   private lazy var dimBackground: DimBackground = .init(mainView: self, tapAction: { [weak self] in
     self?.diminish()
@@ -35,6 +39,7 @@ final class NavigationControlView: SolidTouchView {
   weak var delegate: RouteNavigationControlsDelegate!
 
   private weak var navigationInfo: MWMNavigationDashboardEntity?
+  private var trackRecordingState = TrackRecordingState.inactive
   private var extendedConstraint: NSLayoutConstraint!
   private var notExtendedConstraint: NSLayoutConstraint!
   private let diminishSelector = #selector(diminish)
@@ -133,8 +138,10 @@ final class NavigationControlView: SolidTouchView {
     timePageControl.transform = CGAffineTransform(scaleX: pgScale, y: pgScale)
   }
 
-  func onNavigationInfoUpdated(_ info: MWMNavigationDashboardEntity) {
+  func render(navigationInfo info: MWMNavigationDashboardEntity, trackRecordingState: TrackRecordingState) {
     navigationInfo = info
+    self.trackRecordingState = trackRecordingState
+    trackRecordingButton.tintColor = trackRecordingState == .active ? .redPrimary : .blackSecondaryText
     guard isVisible else { return }
     let routingNumberAttributes: [NSAttributedString.Key: Any] =
       [
@@ -207,7 +214,7 @@ final class NavigationControlView: SolidTouchView {
   private func toggleInfoAction() {
     if let navigationInfo = navigationInfo {
       timePageControl.currentPage = (timePageControl.currentPage + 1) % timePageControl.numberOfPages
-      onNavigationInfoUpdated(navigationInfo)
+      render(navigationInfo: navigationInfo, trackRecordingState: trackRecordingState)
     }
     refreshDiminishTimer()
   }
@@ -231,6 +238,11 @@ final class NavigationControlView: SolidTouchView {
   @IBAction
   private func stopRoutingButtonAction(_: Any) {
     delegate.stopRoutingButtonDidTap()
+  }
+
+  @IBAction
+  private func trackRecordingButonAction(_: Any) {
+    delegate.trackRecordingButonDidTap()
   }
 
   private func morphExtendButton() {

--- a/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.swift
@@ -1,4 +1,8 @@
 final class NavigationControlView: SolidTouchView {
+  private enum Constants {
+    static let buttonContentInset: CGFloat = 15
+  }
+
   @IBOutlet private var distanceLabel: UILabel!
   @IBOutlet private var distanceLegendLabel: UILabel!
   @IBOutlet private var distanceWithLegendLabel: UILabel!
@@ -18,9 +22,9 @@ final class NavigationControlView: SolidTouchView {
     }
   }
 
-  @IBOutlet var settingsButton: UIButton!
+  @IBOutlet private var settingsButton: MWMButton!
 
-  @IBOutlet private var ttsButton: UIButton! {
+  @IBOutlet private var ttsButton: MWMButton! {
     didSet {
       ttsButton.setImage(UIImage.icVoiceOff, for: .normal)
       ttsButton.setImage(UIImage.icVoiceOn, for: .selected)
@@ -29,7 +33,7 @@ final class NavigationControlView: SolidTouchView {
     }
   }
 
-  @IBOutlet var trackRecordingButton: UIButton!
+  @IBOutlet private var trackRecordingButton: MWMButton!
 
   private lazy var dimBackground: DimBackground = .init(mainView: self, tapAction: { [weak self] in
     self?.diminish()
@@ -39,7 +43,6 @@ final class NavigationControlView: SolidTouchView {
   weak var delegate: RouteNavigationControlsDelegate!
 
   private weak var navigationInfo: MWMNavigationDashboardEntity?
-  private var trackRecordingState = TrackRecordingState.inactive
   private var extendedConstraint: NSLayoutConstraint!
   private var notExtendedConstraint: NSLayoutConstraint!
   private let diminishSelector = #selector(diminish)
@@ -95,7 +98,10 @@ final class NavigationControlView: SolidTouchView {
     button.imageView?.contentMode = .scaleAspectFit
     button.contentHorizontalAlignment = .fill
     button.contentVerticalAlignment = .fill
-    button.contentEdgeInsets = UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15)
+    button.contentEdgeInsets = UIEdgeInsets(top: Constants.buttonContentInset,
+                                            left: Constants.buttonContentInset,
+                                            bottom: Constants.buttonContentInset,
+                                            right: Constants.buttonContentInset)
   }
 
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -149,10 +155,12 @@ final class NavigationControlView: SolidTouchView {
     timePageControl.transform = CGAffineTransform(scaleX: pgScale, y: pgScale)
   }
 
-  func render(navigationInfo info: MWMNavigationDashboardEntity, trackRecordingState: TrackRecordingState) {
+  func setTrackRecordingState(_ state: TrackRecordingState) {
+    trackRecordingButton.coloring = state == .active ? .red : .black
+  }
+
+  func onNavigationInfoUpdated(_ info: MWMNavigationDashboardEntity) {
     navigationInfo = info
-    self.trackRecordingState = trackRecordingState
-    trackRecordingButton.tintColor = trackRecordingState == .active ? .redPrimary : .blackSecondaryText
     guard isVisible else { return }
     let routingNumberAttributes: [NSAttributedString.Key: Any] =
       [
@@ -225,7 +233,7 @@ final class NavigationControlView: SolidTouchView {
   private func toggleInfoAction() {
     if let navigationInfo = navigationInfo {
       timePageControl.currentPage = (timePageControl.currentPage + 1) % timePageControl.numberOfPages
-      render(navigationInfo: navigationInfo, trackRecordingState: trackRecordingState)
+      onNavigationInfoUpdated(navigationInfo)
     }
     refreshDiminishTimer()
   }
@@ -252,8 +260,8 @@ final class NavigationControlView: SolidTouchView {
   }
 
   @IBAction
-  private func trackRecordingButonAction(_: Any) {
-    delegate.trackRecordingButonDidTap()
+  private func trackRecordingButtonAction(_: Any) {
+    delegate.trackRecordingButtonDidTap()
   }
 
   private func morphExtendButton() {
@@ -301,6 +309,7 @@ final class NavigationControlView: SolidTouchView {
   override func applyTheme() {
     super.applyTheme()
     onTTSStatusUpdated()
+    setTrackRecordingState(TrackRecordingManager.shared.recordingState)
   }
 
   override var sideButtonsAreaAffectDirections: MWMAvailableAreaAffectDirections {

--- a/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.xib
+++ b/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.xib
@@ -231,7 +231,7 @@
                                 <button opaque="NO" contentMode="center" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="skM-Xx-3En" userLabel="Settings" customClass="MWMButton">
                                     <rect key="frame" x="0.0" y="0.0" width="64" height="64"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" secondItem="skM-Xx-3En" secondAttribute="height" multiplier="1:1" id="L4Y-X5-7oP"/>
+                                        <constraint firstAttribute="width" secondItem="skM-Xx-3En" secondAttribute="height" priority="999" multiplier="1:1" id="L4Y-X5-7oP"/>
                                     </constraints>
                                     <state key="normal" image="ic_menu_settings"/>
                                     <userDefinedRuntimeAttributes>
@@ -244,7 +244,7 @@
                                 <button opaque="NO" contentMode="center" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bfb-5v-iWA" customClass="MWMButton">
                                     <rect key="frame" x="64" y="0.0" width="64" height="64"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" secondItem="Bfb-5v-iWA" secondAttribute="height" multiplier="1:1" id="Iku-MW-9C2"/>
+                                        <constraint firstAttribute="width" secondItem="Bfb-5v-iWA" secondAttribute="height" priority="999" multiplier="1:1" id="Iku-MW-9C2"/>
                                     </constraints>
                                     <state key="normal" image="ic_voice_on"/>
                                     <state key="selected" image="ic_voice_off"/>
@@ -258,31 +258,31 @@
                                 <button opaque="NO" contentMode="center" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f6v-NB-AKJ" userLabel="Track Recording Button" customClass="MWMButton">
                                     <rect key="frame" x="128" y="0.0" width="64" height="64"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" secondItem="f6v-NB-AKJ" secondAttribute="height" multiplier="1:1" id="ERa-wJ-0YC"/>
+                                        <constraint firstAttribute="width" secondItem="f6v-NB-AKJ" secondAttribute="height" priority="999" multiplier="1:1" id="ERa-wJ-0YC"/>
                                     </constraints>
-                                    <state key="normal" image="ic_menu_track_recording">
-                                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="40"/>
-                                    </state>
-                                    <state key="selected" image="ic_voice_off"/>
+                                    <state key="normal" image="ic_menu_track_recording"/>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="MWMBlack"/>
+                                    </userDefinedRuntimeAttributes>
                                     <connections>
-                                        <action selector="trackRecordingButonAction:" destination="9fq-65-qd9" eventType="touchUpInside" id="DKF-qL-sRq"/>
+                                        <action selector="trackRecordingButtonAction:" destination="9fq-65-qd9" eventType="touchUpInside" id="DKF-qL-sRq"/>
                                     </connections>
                                 </button>
                             </subviews>
                         </stackView>
                         <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mtt-q0-SUx" customClass="MWMStopButton">
-                            <rect key="frame" x="255" y="10" width="120" height="44"/>
+                            <rect key="frame" x="279" y="10" width="96" height="44"/>
                             <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="lessThanOrEqual" constant="200" id="4E4-UU-lhc"/>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="N0o-f3-nuw"/>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="96" id="N0o-f3-nuw"/>
                                 <constraint firstAttribute="height" priority="750" constant="44" id="Pfs-0w-XX9"/>
                             </constraints>
                             <state key="normal" title="STOP">
                                 <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="FlatRedButton"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="flatRedButtonBig"/>
                                 <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="navigation_stop_button"/>
                             </userDefinedRuntimeAttributes>
                             <connections>
@@ -295,7 +295,7 @@
                         <constraint firstItem="mtt-q0-SUx" firstAttribute="top" secondItem="CMT-MI-d8X" secondAttribute="top" priority="750" constant="10" id="L5z-8y-Duk"/>
                         <constraint firstAttribute="height" constant="64" id="LaX-SD-Kzr"/>
                         <constraint firstItem="udk-ZC-Gz0" firstAttribute="leading" secondItem="CMT-MI-d8X" secondAttribute="leading" id="QXO-Hi-2pN"/>
-                        <constraint firstItem="mtt-q0-SUx" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="udk-ZC-Gz0" secondAttribute="trailing" constant="20" id="R5p-Eg-3S4"/>
+                        <constraint firstItem="mtt-q0-SUx" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="udk-ZC-Gz0" secondAttribute="trailing" priority="250" constant="20" id="R5p-Eg-3S4"/>
                         <constraint firstItem="udk-ZC-Gz0" firstAttribute="top" secondItem="CMT-MI-d8X" secondAttribute="top" id="W8O-lT-eqz"/>
                         <constraint firstAttribute="bottom" secondItem="udk-ZC-Gz0" secondAttribute="bottom" id="bMN-ct-cOQ"/>
                         <constraint firstAttribute="trailing" secondItem="mtt-q0-SUx" secondAttribute="trailing" constant="12" id="huM-XX-MM9"/>

--- a/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.xib
+++ b/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,29 +11,29 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MWMNavigationDashboardManager"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9fq-65-qd9" customClass="NavigationControlView" customModule="Organic_Maps" customModuleProvider="target" propertyAccessControl="none">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="116"/>
+            <rect key="frame" x="0.0" y="0.0" width="387" height="116"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jBZ-WO-Nz7">
-                    <rect key="frame" x="-100" y="59" width="520" height="123"/>
+                    <rect key="frame" x="-100" y="118" width="587" height="64"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
                     </userDefinedRuntimeAttributes>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="u7O-n6-ZXy">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="52"/>
+                    <rect key="frame" x="0.0" y="0.0" width="387" height="52"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QLk-JN-wfO">
-                            <rect key="frame" x="0.0" y="0.0" width="66" height="48"/>
+                            <rect key="frame" x="0.0" y="0.0" width="88" height="48"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LY7-dx-CtV">
-                                    <rect key="frame" x="33" y="4" width="0.0" height="0.0"/>
+                                    <rect key="frame" x="44" y="4" width="0.0" height="0.0"/>
                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b3M-75-5HW">
-                                    <rect key="frame" x="33" y="4" width="0.0" height="0.0"/>
+                                    <rect key="frame" x="44" y="4" width="0.0" height="0.0"/>
                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
@@ -42,7 +42,7 @@
                                     </userDefinedRuntimeAttributes>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wgS-eK-vfD">
-                                    <rect key="frame" x="33" y="10.666666666666666" width="0.0" height="0.0"/>
+                                    <rect key="frame" x="44" y="10.666666666666666" width="0.0" height="0.0"/>
                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
@@ -68,7 +68,7 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HNY-h1-A95">
-                            <rect key="frame" x="66" y="0.0" width="128" height="48"/>
+                            <rect key="frame" x="111" y="0.0" width="128" height="48"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wEc-R2-1Tv">
                                     <rect key="frame" x="64" y="4" width="0.0" height="0.0"/>
@@ -80,7 +80,7 @@
                                     </userDefinedRuntimeAttributes>
                                 </label>
                                 <pageControl opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="100" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="2" translatesAutoresizingMaskIntoConstraints="NO" id="ppd-rW-dYo">
-                                    <rect key="frame" x="36.333333333333329" y="4" width="55.333333333333329" height="13"/>
+                                    <rect key="frame" x="36.333333333333343" y="4" width="55.333333333333343" height="13"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="13" id="BmO-Rd-DKp"/>
@@ -101,16 +101,16 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sUB-KS-dnn">
-                            <rect key="frame" x="194" y="0.0" width="66" height="48"/>
+                            <rect key="frame" x="239" y="0.0" width="88" height="48"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fxK-Ae-ebd">
-                                    <rect key="frame" x="33" y="4" width="0.0" height="0.0"/>
+                                    <rect key="frame" x="44" y="4" width="0.0" height="0.0"/>
                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbY-p5-3bX">
-                                    <rect key="frame" x="33" y="4" width="0.0" height="0.0"/>
+                                    <rect key="frame" x="44" y="4" width="0.0" height="0.0"/>
                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
@@ -119,7 +119,7 @@
                                     </userDefinedRuntimeAttributes>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7dx-1W-LWs">
-                                    <rect key="frame" x="33" y="10.666666666666666" width="0.0" height="0.0"/>
+                                    <rect key="frame" x="44" y="10.666666666666666" width="0.0" height="0.0"/>
                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
@@ -140,7 +140,7 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q0w-Me-x4p">
-                            <rect key="frame" x="0.0" y="48" width="320" height="4"/>
+                            <rect key="frame" x="0.0" y="48" width="387" height="4"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JiD-R1-DnS">
                                     <rect key="frame" x="0.0" y="0.0" width="0.0" height="4"/>
@@ -162,14 +162,14 @@
                             </constraints>
                         </view>
                         <button contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UPO-sh-VhS" userLabel="ToggleInfo">
-                            <rect key="frame" x="0.0" y="0.0" width="260" height="48"/>
+                            <rect key="frame" x="0.0" y="0.0" width="327" height="48"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <connections>
                                 <action selector="toggleInfoAction" destination="9fq-65-qd9" eventType="touchUpInside" id="h7P-d8-FJM"/>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="center" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XwA-oz-M3Q" customClass="MWMButton">
-                            <rect key="frame" x="260" y="0.0" width="60" height="52"/>
+                            <rect key="frame" x="327" y="0.0" width="60" height="52"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <accessibility key="accessibilityConfiguration" identifier="menuButton"/>
                             <constraints>
@@ -223,13 +223,29 @@
                     </constraints>
                 </view>
                 <view hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CMT-MI-d8X">
-                    <rect key="frame" x="0.0" y="52" width="320" height="64"/>
+                    <rect key="frame" x="0.0" y="52" width="387" height="64"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="right" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="udk-ZC-Gz0">
-                            <rect key="frame" x="103" y="0.0" width="93" height="64"/>
+                        <stackView opaque="NO" contentMode="right" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="udk-ZC-Gz0">
+                            <rect key="frame" x="20" y="0.0" width="192" height="64"/>
                             <subviews>
+                                <button opaque="NO" contentMode="center" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="skM-Xx-3En" userLabel="Settings" customClass="MWMButton">
+                                    <rect key="frame" x="0.0" y="0.0" width="64" height="64"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" secondItem="skM-Xx-3En" secondAttribute="height" multiplier="1:1" id="L4Y-X5-7oP"/>
+                                    </constraints>
+                                    <state key="normal" image="ic_menu_settings"/>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="MWMBlack"/>
+                                    </userDefinedRuntimeAttributes>
+                                    <connections>
+                                        <action selector="settingsButtonAction:" destination="9fq-65-qd9" eventType="touchUpInside" id="MfK-7T-hSL"/>
+                                    </connections>
+                                </button>
                                 <button opaque="NO" contentMode="center" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bfb-5v-iWA" customClass="MWMButton">
-                                    <rect key="frame" x="0.0" y="0.0" width="57" height="64"/>
+                                    <rect key="frame" x="64" y="0.0" width="64" height="64"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" secondItem="Bfb-5v-iWA" secondAttribute="height" multiplier="1:1" id="Iku-MW-9C2"/>
+                                    </constraints>
                                     <state key="normal" image="ic_voice_on"/>
                                     <state key="selected" image="ic_voice_off"/>
                                     <userDefinedRuntimeAttributes>
@@ -239,34 +255,39 @@
                                         <action selector="ttsButtonAction:" destination="9fq-65-qd9" eventType="touchUpInside" id="FpY-RW-zow"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="center" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="skM-Xx-3En" userLabel="Settings" customClass="MWMButton">
-                                    <rect key="frame" x="65" y="0.0" width="28" height="64"/>
-                                    <state key="normal" image="ic_menu_settings"/>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="MWMBlack"/>
-                                    </userDefinedRuntimeAttributes>
+                                <button opaque="NO" contentMode="center" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f6v-NB-AKJ" userLabel="Track Recording Button" customClass="MWMButton">
+                                    <rect key="frame" x="128" y="0.0" width="64" height="64"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" secondItem="f6v-NB-AKJ" secondAttribute="height" multiplier="1:1" id="ERa-wJ-0YC"/>
+                                    </constraints>
+                                    <state key="normal" image="ic_menu_track_recording">
+                                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="40"/>
+                                    </state>
+                                    <state key="selected" image="ic_voice_off"/>
                                     <connections>
-                                        <action selector="settingsButtonAction:" destination="9fq-65-qd9" eventType="touchUpInside" id="MfK-7T-hSL"/>
+                                        <action selector="trackRecordingButonAction:" destination="9fq-65-qd9" eventType="touchUpInside" id="DKF-qL-sRq"/>
                                     </connections>
                                 </button>
                             </subviews>
                             <constraints>
-                                <constraint firstItem="Bfb-5v-iWA" firstAttribute="width" secondItem="udk-ZC-Gz0" secondAttribute="height" multiplier="57:64" id="Pvi-bX-9ME"/>
+                                <constraint firstItem="f6v-NB-AKJ" firstAttribute="height" secondItem="udk-ZC-Gz0" secondAttribute="height" id="E4I-Sd-Kjc"/>
+                                <constraint firstItem="skM-Xx-3En" firstAttribute="height" secondItem="udk-ZC-Gz0" secondAttribute="height" id="f1r-Sv-yvW"/>
+                                <constraint firstItem="Bfb-5v-iWA" firstAttribute="height" secondItem="udk-ZC-Gz0" secondAttribute="height" id="o24-7E-XnA"/>
                             </constraints>
                         </stackView>
                         <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mtt-q0-SUx" customClass="MWMStopButton">
-                            <rect key="frame" x="204" y="14" width="96" height="36"/>
+                            <rect key="frame" x="247" y="12" width="120" height="38"/>
                             <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
-                                <constraint firstAttribute="width" relation="lessThanOrEqual" constant="140" id="4E4-UU-lhc"/>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="96" id="N0o-f3-nuw"/>
-                                <constraint firstAttribute="height" priority="750" constant="36" id="Pfs-0w-XX9"/>
+                                <constraint firstAttribute="width" relation="lessThanOrEqual" constant="200" id="4E4-UU-lhc"/>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="N0o-f3-nuw"/>
+                                <constraint firstAttribute="height" priority="750" constant="38" id="Pfs-0w-XX9"/>
                             </constraints>
                             <state key="normal" title="STOP">
                                 <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="FlatRedButton:regular17"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="FlatRedButton"/>
                                 <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="navigation_stop_button"/>
                             </userDefinedRuntimeAttributes>
                             <connections>
@@ -276,10 +297,9 @@
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstItem="mtt-q0-SUx" firstAttribute="top" secondItem="CMT-MI-d8X" secondAttribute="top" priority="750" constant="14" id="L5z-8y-Duk"/>
+                        <constraint firstItem="mtt-q0-SUx" firstAttribute="top" secondItem="CMT-MI-d8X" secondAttribute="top" priority="750" constant="12" id="L5z-8y-Duk"/>
                         <constraint firstAttribute="height" constant="64" id="LaX-SD-Kzr"/>
-                        <constraint firstItem="mtt-q0-SUx" firstAttribute="leading" secondItem="udk-ZC-Gz0" secondAttribute="trailing" constant="8" id="QSr-OG-Imw"/>
-                        <constraint firstItem="udk-ZC-Gz0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="CMT-MI-d8X" secondAttribute="leading" priority="250" constant="8" id="V36-Jb-U8R"/>
+                        <constraint firstItem="udk-ZC-Gz0" firstAttribute="leading" secondItem="CMT-MI-d8X" secondAttribute="leading" constant="20" id="QXO-Hi-2pN"/>
                         <constraint firstItem="udk-ZC-Gz0" firstAttribute="top" secondItem="CMT-MI-d8X" secondAttribute="top" id="W8O-lT-eqz"/>
                         <constraint firstAttribute="bottom" secondItem="udk-ZC-Gz0" secondAttribute="bottom" id="bMN-ct-cOQ"/>
                         <constraint firstAttribute="trailing" secondItem="mtt-q0-SUx" secondAttribute="trailing" constant="20" id="huM-XX-MM9"/>
@@ -313,20 +333,23 @@
                 <outlet property="extendedView" destination="CMT-MI-d8X" id="1OK-Ps-fL4"/>
                 <outlet property="progressView" destination="Q0w-Me-x4p" id="efq-ve-QAZ"/>
                 <outlet property="routingProgress" destination="vxl-iA-p8N" id="gw7-Pn-5m7"/>
+                <outlet property="settingsButton" destination="skM-Xx-3En" id="ZkN-Yp-ydR"/>
                 <outlet property="speedBackground" destination="QLk-JN-wfO" id="aYN-db-Xaa"/>
                 <outlet property="speedLabel" destination="b3M-75-5HW" id="bLg-uX-05a"/>
                 <outlet property="speedLegendLabel" destination="wgS-eK-vfD" id="ZOP-Ro-KbD"/>
                 <outlet property="speedWithLegendLabel" destination="LY7-dx-CtV" id="tK9-Em-ztB"/>
                 <outlet property="timeLabel" destination="wEc-R2-1Tv" id="cfd-vS-d1G"/>
                 <outlet property="timePageControl" destination="ppd-rW-dYo" id="U1U-6U-JjR"/>
+                <outlet property="trackRecordingButton" destination="f6v-NB-AKJ" id="IIf-SL-tjO"/>
                 <outlet property="ttsButton" destination="Bfb-5v-iWA" id="GMb-ft-G6X"/>
             </connections>
-            <point key="canvasLocation" x="33.600000000000001" y="53.073463268365821"/>
+            <point key="canvasLocation" x="84.732824427480907" y="52.816901408450704"/>
         </view>
     </objects>
     <resources>
-        <image name="ic_menu" width="48" height="48"/>
-        <image name="ic_menu_settings" width="28" height="28"/>
+        <image name="ic_menu" width="24" height="24"/>
+        <image name="ic_menu_settings" width="24" height="24"/>
+        <image name="ic_menu_track_recording" width="24" height="24"/>
         <image name="ic_voice_off" width="28" height="28"/>
         <image name="ic_voice_on" width="28" height="28"/>
     </resources>

--- a/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.xib
+++ b/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.xib
@@ -24,7 +24,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="387" height="52"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QLk-JN-wfO">
-                            <rect key="frame" x="0.0" y="0.0" width="88" height="48"/>
+                            <rect key="frame" x="12" y="0.0" width="88" height="48"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LY7-dx-CtV">
                                     <rect key="frame" x="44" y="4" width="0.0" height="0.0"/>
@@ -187,7 +187,7 @@
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="bottom" secondItem="QLk-JN-wfO" secondAttribute="bottom" constant="4" id="0AT-pb-GFy"/>
-                        <constraint firstItem="QLk-JN-wfO" firstAttribute="leading" secondItem="u7O-n6-ZXy" secondAttribute="leading" id="0hr-A3-h7F">
+                        <constraint firstItem="QLk-JN-wfO" firstAttribute="leading" secondItem="u7O-n6-ZXy" secondAttribute="leading" constant="12" id="0hr-A3-h7F">
                             <variation key="heightClass=compact" constant="16"/>
                             <variation key="heightClass=regular-widthClass=regular" constant="16"/>
                         </constraint>
@@ -225,8 +225,8 @@
                 <view hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CMT-MI-d8X">
                     <rect key="frame" x="0.0" y="52" width="387" height="64"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="right" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="udk-ZC-Gz0">
-                            <rect key="frame" x="20" y="0.0" width="192" height="64"/>
+                        <stackView opaque="NO" contentMode="right" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="udk-ZC-Gz0">
+                            <rect key="frame" x="0.0" y="0.0" width="192" height="64"/>
                             <subviews>
                                 <button opaque="NO" contentMode="center" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="skM-Xx-3En" userLabel="Settings" customClass="MWMButton">
                                     <rect key="frame" x="0.0" y="0.0" width="64" height="64"/>
@@ -269,19 +269,14 @@
                                     </connections>
                                 </button>
                             </subviews>
-                            <constraints>
-                                <constraint firstItem="f6v-NB-AKJ" firstAttribute="height" secondItem="udk-ZC-Gz0" secondAttribute="height" id="E4I-Sd-Kjc"/>
-                                <constraint firstItem="skM-Xx-3En" firstAttribute="height" secondItem="udk-ZC-Gz0" secondAttribute="height" id="f1r-Sv-yvW"/>
-                                <constraint firstItem="Bfb-5v-iWA" firstAttribute="height" secondItem="udk-ZC-Gz0" secondAttribute="height" id="o24-7E-XnA"/>
-                            </constraints>
                         </stackView>
                         <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mtt-q0-SUx" customClass="MWMStopButton">
-                            <rect key="frame" x="247" y="12" width="120" height="38"/>
+                            <rect key="frame" x="255" y="10" width="120" height="44"/>
                             <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="lessThanOrEqual" constant="200" id="4E4-UU-lhc"/>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="N0o-f3-nuw"/>
-                                <constraint firstAttribute="height" priority="750" constant="38" id="Pfs-0w-XX9"/>
+                                <constraint firstAttribute="height" priority="750" constant="44" id="Pfs-0w-XX9"/>
                             </constraints>
                             <state key="normal" title="STOP">
                                 <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -297,12 +292,13 @@
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstItem="mtt-q0-SUx" firstAttribute="top" secondItem="CMT-MI-d8X" secondAttribute="top" priority="750" constant="12" id="L5z-8y-Duk"/>
+                        <constraint firstItem="mtt-q0-SUx" firstAttribute="top" secondItem="CMT-MI-d8X" secondAttribute="top" priority="750" constant="10" id="L5z-8y-Duk"/>
                         <constraint firstAttribute="height" constant="64" id="LaX-SD-Kzr"/>
-                        <constraint firstItem="udk-ZC-Gz0" firstAttribute="leading" secondItem="CMT-MI-d8X" secondAttribute="leading" constant="20" id="QXO-Hi-2pN"/>
+                        <constraint firstItem="udk-ZC-Gz0" firstAttribute="leading" secondItem="CMT-MI-d8X" secondAttribute="leading" id="QXO-Hi-2pN"/>
+                        <constraint firstItem="mtt-q0-SUx" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="udk-ZC-Gz0" secondAttribute="trailing" constant="20" id="R5p-Eg-3S4"/>
                         <constraint firstItem="udk-ZC-Gz0" firstAttribute="top" secondItem="CMT-MI-d8X" secondAttribute="top" id="W8O-lT-eqz"/>
                         <constraint firstAttribute="bottom" secondItem="udk-ZC-Gz0" secondAttribute="bottom" id="bMN-ct-cOQ"/>
-                        <constraint firstAttribute="trailing" secondItem="mtt-q0-SUx" secondAttribute="trailing" constant="20" id="huM-XX-MM9"/>
+                        <constraint firstAttribute="trailing" secondItem="mtt-q0-SUx" secondAttribute="trailing" constant="12" id="huM-XX-MM9"/>
                     </constraints>
                 </view>
             </subviews>

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardInteractor.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardInteractor.swift
@@ -89,6 +89,9 @@ extension NavigationDashboard {
       case .updateNavigationInfo(let entity):
         return .updateNavigationInfo(entity)
 
+      case .updateTrackRecordingState(let state):
+        return .updateTrackRecordingState(state)
+
       case .updateElevationInfo(let elevationInfo):
         return .updateElevationInfo(elevationInfo)
 
@@ -141,6 +144,10 @@ extension NavigationDashboard.Interactor: NavigationDashboardView {
 
   func onNavigationInfoUpdated(_ entity: MWMNavigationDashboardEntity) {
     process(.updateNavigationInfo(entity))
+  }
+
+  func setTrackRecordingState(_ state: TrackRecordingState) {
+    process(.updateTrackRecordingState(state))
   }
 
   func setDrivingOptionState(_ state: MWMDrivingOptionsState) {

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardPresenter.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardPresenter.swift
@@ -74,6 +74,9 @@ extension NavigationDashboard {
         viewModel.entity = entity
         viewModel.estimates = estimates
 
+      case .updateTrackRecordingState(let state):
+        viewModel.trackRecordingState = state
+
       case .updateElevationInfo(let elevationInfo):
         viewModel.routeElevationPreviewData = elevationInfo
 

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardRequest.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardRequest.swift
@@ -22,6 +22,7 @@ extension NavigationDashboard {
     case updateRouteBuildingProgress(CGFloat, routerType: MWMRouterType)
     case updateNavigationInfo(MWMNavigationDashboardEntity)
     case updateElevationInfo(RouteElevationPreviewData?)
+    case updateTrackRecordingState(TrackRecordingState)
     case updateVisibleAreaInsets(UIEdgeInsets)
     case updateNavigationInfoAvailableArea(CGRect)
     case updateSearchState(SearchOnMapState)

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardResponse.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardResponse.swift
@@ -7,6 +7,7 @@ extension NavigationDashboard {
     case updateRouteBuildingProgress(CGFloat, routerType: MWMRouterType)
     case updateNavigationInfo(MWMNavigationDashboardEntity)
     case updateElevationInfo(RouteElevationPreviewData?)
+    case updateTrackRecordingState(TrackRecordingState)
     case updatePresentationStep(NavigationDashboardModalPresentationStep)
     case updateNavigationInfoAvailableArea(CGRect)
     case updateSearchState(SearchOnMapState)

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardViewController.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardViewController.swift
@@ -517,7 +517,8 @@ extension NavigationDashboardViewController {
         navigationInfoView.setSearchState(navigationSearchState, animated: true)
       }
       navigationControlView.isVisible = true
-      navigationControlView.onNavigationInfoUpdated(viewModel.entity)
+      navigationControlView.render(navigationInfo: viewModel.entity,
+                                   trackRecordingState: viewModel.trackRecordingState)
 
     case .error:
       estimatesView.setState(viewModel.estimatesState)

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardViewController.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardViewController.swift
@@ -517,8 +517,8 @@ extension NavigationDashboardViewController {
         navigationInfoView.setSearchState(navigationSearchState, animated: true)
       }
       navigationControlView.isVisible = true
-      navigationControlView.render(navigationInfo: viewModel.entity,
-                                   trackRecordingState: viewModel.trackRecordingState)
+      navigationControlView.onNavigationInfoUpdated(viewModel.entity)
+      navigationControlView.setTrackRecordingState(viewModel.trackRecordingState)
 
     case .error:
       estimatesView.setState(viewModel.estimatesState)

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardViewModel.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardViewModel.swift
@@ -4,6 +4,7 @@ enum NavigationDashboard {
     var routePoints: RoutePoints
     var routerType: MWMRouterType
     var entity: MWMNavigationDashboardEntity
+    var trackRecordingState: TrackRecordingState
     var routingOptions: RoutingOptions
     var routeElevationPreviewData: RouteElevationPreviewData?
     var navigationInfo: NavigationInfo
@@ -37,6 +38,7 @@ extension NavigationDashboard.ViewModel {
       routePoints: .empty,
       routerType: MWMRouter.type(),
       entity: MWMNavigationDashboardEntity(),
+      trackRecordingState: TrackRecordingManager.shared.recordingState,
       routingOptions: RoutingOptions(),
       routeElevationPreviewData: nil,
       navigationInfo: .hidden,

--- a/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePreviewView.h
+++ b/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePreviewView.h
@@ -32,6 +32,7 @@ typedef NS_ENUM(NSInteger, MWMDrivingOptionsState) {
 - (void)ttsButtonDidTap;
 - (void)settingsButtonDidTap;
 - (void)stopRoutingButtonDidTap;
+- (void)trackRecordingButonDidTap;
 
 @end
 

--- a/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePreviewView.h
+++ b/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePreviewView.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSInteger, MWMDrivingOptionsState) {
 - (void)ttsButtonDidTap;
 - (void)settingsButtonDidTap;
 - (void)stopRoutingButtonDidTap;
-- (void)trackRecordingButonDidTap;
+- (void)trackRecordingButtonDidTap;
 
 @end
 


### PR DESCRIPTION
1. Add a track recording button to the navigation panel. The TR blinking button will be hidden when navigation is active.
2. Increase the size of navigation panel buttons (including the tappable zone) and reposition them to the left.

| Before | After |
| ------ | ----- |
| <img width="350" height="759" alt="image" src="https://github.com/user-attachments/assets/8b08d72f-095d-46ae-8b54-c5a4cea270a6" /> | <img width="350" height="759" alt="image" src="https://github.com/user-attachments/assets/b585284f-2a9f-4787-b7ee-bd3ccae9d16e" /> |
