### PR TITLE
[generator] Drop StageDownloadDescriptions and orphan wiki options

### DIFF
--- a/tools/python/airmaps/dags/build_maps.py
+++ b/tools/python/airmaps/dags/build_maps.py
@@ -68,7 +68,6 @@ class MapsGenerationDAG(DAG):
                 sd.StageCoastline(),
                 sd.StagePreprocess(),
                 sd.StageFeatures(),
-                sd.StageDownloadDescriptions(),
             ),
         )
 

--- a/tools/python/maps_generator/generator/env.py
+++ b/tools/python/maps_generator/generator/env.py
@@ -274,10 +274,6 @@ class PathProvider:
         return os.path.join(self.intermediate_data_path, "id_to_wikidata.csv")
 
     @property
-    def wiki_url_path(self) -> AnyStr:
-        return os.path.join(self.intermediate_data_path, "wiki_urls.txt")
-
-    @property
     def ugc_path(self) -> AnyStr:
         return os.path.join(self.intermediate_data_path, "ugc_db.sqlite3")
 

--- a/tools/python/maps_generator/generator/gen_tool.py
+++ b/tools/python/maps_generator/generator/gen_tool.py
@@ -52,7 +52,6 @@ class GenTool:
         "cache_path": str,
         "cities_boundaries_data": str,
         "data_path": str,
-        "dump_wikipedia_urls": str,
         "geo_objects_features": str,
         "geo_objects_key_value": str,
         "ids_without_addresses": str,

--- a/tools/python/maps_generator/generator/stages_declaration.py
+++ b/tools/python/maps_generator/generator/stages_declaration.py
@@ -18,9 +18,6 @@ from typing import Type
 
 import maps_generator.generator.diffs as diffs
 import maps_generator.generator.stages_tests as st
-from descriptions.descriptions_downloader import check_and_get_checker
-from descriptions.descriptions_downloader import download_from_wikidata_tags
-from descriptions.descriptions_downloader import download_from_wikipedia_tags
 from maps_generator.generator import coastline
 from maps_generator.generator import settings
 from maps_generator.generator import steps
@@ -137,34 +134,6 @@ class StageFeatures(Stage):
         steps.step_features(env, **extra)
         if os.path.exists(env.paths.packed_polygons_path):
             shutil.copy2(env.paths.packed_polygons_path, env.paths.mwm_path)
-
-
-@outer_stage
-@production_only
-@helper_stage_for("StageDescriptions")
-class StageDownloadDescriptions(Stage):
-    def apply(self, env: Env):
-        run_gen_tool(
-            env.gen_tool,
-            out=env.get_subprocess_out(),
-            err=env.get_subprocess_out(),
-            data_path=env.paths.data_path,
-            intermediate_data_path=env.paths.intermediate_data_path,
-            cache_path=env.paths.cache_path,
-            user_resource_path=env.paths.user_resource_path,
-            dump_wikipedia_urls=env.paths.wiki_url_path,
-            idToWikidata=env.paths.id_to_wikidata_path,
-            threads_count=settings.THREADS_COUNT,
-        )
-
-        langs = ("en", "ru", "es", "fr", "de")
-        checker = check_and_get_checker(env.paths.popularity_path)
-        download_from_wikipedia_tags(
-            env.paths.wiki_url_path, env.paths.descriptions_path, langs, checker
-        )
-        download_from_wikidata_tags(
-            env.paths.id_to_wikidata_path, env.paths.descriptions_path, langs, checker
-        )
 
 
 @outer_stage

--- a/tools/python/maps_generator/maps_generator.py
+++ b/tools/python/maps_generator/maps_generator.py
@@ -32,7 +32,6 @@ def generate_maps(env: Env, from_stage: Optional[AnyStr] = None):
         sd.StageCoastline(),
         sd.StagePreprocess(),
         sd.StageFeatures(),
-        sd.StageDownloadDescriptions(),
         sd.StageMwm(),
         sd.StageCountriesTxt(),
         sd.StageLocalAds(),

--- a/tools/python/maps_generator/requirements.txt
+++ b/tools/python/maps_generator/requirements.txt
@@ -1,4 +1,3 @@
 filelock==3.20.3
-beautifulsoup4==4.9.1
 requests>=2.31.0
 requests_file==1.5.1

--- a/tools/python/maps_generator/requirements_dev.txt
+++ b/tools/python/maps_generator/requirements_dev.txt
@@ -1,5 +1,4 @@
 -r ../post_generation/requirements_dev.txt
 filelock==3.20.3
-beautifulsoup4==4.9.1
 requests>=2.31.0
 requests_file==1.5.1


### PR DESCRIPTION
The descriptions_downloader Python module was removed, leaving its sole caller (StageDownloadDescriptions) and the wiki_url_path / dump_wikipedia_urls plumbing it owned with no consumers. Remove the broken imports, the stage, its references in the maps_generator and airmaps build pipelines, and the now-unused PathProvider / GenTool options.

Fixes https://github.com/organicmaps/organicmaps/issues/12655

@dvdmrtnz sorry, I forgot to clean up also this unused code, please test if this commit fixes your issue.