### PR TITLE
[map] save the file name into the `LastEditedBookmarkCategory` setting

### DIFF
--- a/libs/base/base_tests/file_name_utils_tests.cpp
+++ b/libs/base/base_tests/file_name_utils_tests.cpp
@@ -7,32 +7,44 @@
 UNIT_TEST(FileName_Smoke)
 {
   std::string name = "/Users/xxx/Documents/test.test";
+  TEST_EQUAL(base::FileNameFromFullPath(name), "test.test", ());
   TEST_EQUAL(base::GetFileExtension(name), ".test", ());
   base::GetNameFromFullPath(name);
   TEST_EQUAL(name, "test.test", ());
   base::GetNameFromFullPath(name);
   TEST_EQUAL(name, "test.test", ());
+  TEST_EQUAL(base::FileNameFromFullPath(name), "test.test", ());
   base::GetNameWithoutExt(name);
   TEST_EQUAL(name, "test", ());
 
   name = "C:\\My Documents\\test.test";
+  TEST_EQUAL(base::FileNameFromFullPath(name), "test.test", ());
   TEST_EQUAL(base::GetFileExtension(name), ".test", ());
   base::GetNameFromFullPath(name);
   TEST_EQUAL(name, "test.test", ());
   base::GetNameWithoutExt(name);
   TEST_EQUAL(name, "test", ());
 
+  name = "";
+  TEST_EQUAL(base::FileNameFromFullPath(name), "", ());
+  TEST_EQUAL(base::GetFileExtension(name), std::string(), ());
+  base::GetNameFromFullPath(name);
+  TEST(name.empty(), ());
+
   name = "/";
+  TEST_EQUAL(base::FileNameFromFullPath(name), "", ());
   TEST_EQUAL(base::GetFileExtension(name), std::string(), ());
   base::GetNameFromFullPath(name);
   TEST(name.empty(), ());
 
   name = "C:\\";
+  TEST_EQUAL(base::FileNameFromFullPath(name), "", ());
   TEST_EQUAL(base::GetFileExtension(name), std::string(), ());
   base::GetNameFromFullPath(name);
   TEST(name.empty(), ());
 
   name = "../test";
+  TEST_EQUAL(base::FileNameFromFullPath(name), "test", ());
   TEST_EQUAL(base::GetFileExtension(name), std::string(), ());
   base::GetNameFromFullPath(name);
   TEST_EQUAL(name, "test", ());

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -86,6 +86,11 @@ std::string GetFileNameForExport(BookmarkManager::KMLDataCollectionPtr::element_
   return fileName;
 }
 
+std::string CategoryFileName(BookmarkCategory const & category)
+{
+  return base::FileNameFromFullPath(category.GetFileName());
+}
+
 BookmarkManager::SharingResult ExportSingleFileKml(
     BookmarkManager::KMLDataCollectionPtr::element_type::value_type const & kmlToShare)
 {
@@ -1961,13 +1966,22 @@ Track * BookmarkManager::AddTrack(std::unique_ptr<Track> && track)
 
 void BookmarkManager::SaveState() const
 {
-  settings::Set(kLastEditedBookmarkCategory, m_lastCategoryUrl);
+  settings::Set(kLastEditedBookmarkCategory, m_lastCategoryFileName);
   settings::Set(kLastEditedBookmarkColor, static_cast<uint32_t>(m_lastColor));
 }
 
 void BookmarkManager::LoadState()
 {
-  settings::TryGet(kLastEditedBookmarkCategory, m_lastCategoryUrl);
+  settings::TryGet(kLastEditedBookmarkCategory, m_lastCategoryFileName);
+
+  // One-shot migration from older versions that stored an absolute path here.
+  // On iOS the sandbox container UUID is regenerated on TestFlight installs, so
+  // any persisted absolute path is stale on the next launch.
+  if (auto migrated = base::FileNameFromFullPath(m_lastCategoryFileName); migrated != m_lastCategoryFileName)
+  {
+    m_lastCategoryFileName = std::move(migrated);
+    settings::Set(kLastEditedBookmarkCategory, m_lastCategoryFileName);
+  }
 
   uint32_t color;
   if (settings::Get(kLastEditedBookmarkColor, color) && color > static_cast<uint32_t>(kml::PredefinedColor::None) &&
@@ -2349,14 +2363,10 @@ kml::MarkGroupId BookmarkManager::LastEditedBMCategory()
   if (HasBmCategory(m_lastEditedGroupId))
     return m_lastEditedGroupId;
 
-  for (auto & cat : m_categories)
-  {
-    if (cat.second->GetFileName() == m_lastCategoryUrl)
-    {
-      m_lastEditedGroupId = cat.first;
-      return m_lastEditedGroupId;
-    }
-  }
+  for (auto const & [groupId, category] : m_categories)
+    if (CategoryFileName(*category) == m_lastCategoryFileName)
+      return m_lastEditedGroupId = groupId;
+
   m_lastEditedGroupId = CheckAndCreateDefaultCategory();
   return m_lastEditedGroupId;
 }
@@ -2370,7 +2380,7 @@ kml::PredefinedColor BookmarkManager::LastEditedBMColor() const
 void BookmarkManager::SetLastEditedBmCategory(kml::MarkGroupId groupId)
 {
   m_lastEditedGroupId = groupId;
-  m_lastCategoryUrl = GetBmCategory(groupId)->GetFileName();
+  m_lastCategoryFileName = CategoryFileName(*GetBmCategory(groupId));
   SaveState();
 }
 

--- a/libs/map/bookmark_manager.hpp
+++ b/libs/map/bookmark_manager.hpp
@@ -760,7 +760,7 @@ private:
   CategoriesCollection m_categories;
   kml::GroupIdCollection m_unsortedBmGroupsIdList;
 
-  std::string m_lastCategoryUrl;
+  std::string m_lastCategoryFileName;
   kml::MarkGroupId m_lastEditedGroupId = kml::kInvalidMarkGroupId;
   kml::PredefinedColor m_lastColor = kml::PredefinedColor::Red;
   UserMarkLayers m_userMarkLayers;


### PR DESCRIPTION
A proper version of #6890 that fixes resetting of bookmark category to a wrong one when switching between TestFlight/AppStore versions (it is very annoying, a newly added bookmark does not go into the last saved list, but to some specific other list)

iOS regenerates the sandbox container UUID on TestFlight installs, so the absolute path that was previously persisted in `LastBookmarkCategory` becomes stale after each upgrade and `LastEditedBMCategory()` silently falls back to the default category.

Persist only the file basename, which is unique by design: bookmark files live flat under SettingsDir()/bookmarks and `GenerateUniqueFileName` uniquifies their names at creation. Use a small `CategoryFileName` helper inside `bookmark_manager.cpp` for the comparison to keep the file-name derivation a `BookmarkManager` concern instead of a public method on `BookmarkCategory`.

Migrate stale absolute paths from older versions on first launch by reducing them to the basename and writing the canonical form back to settings, so the migration runs at most once per device and handles both '/' and '\\' path separators.