### PR TITLE
[android] [design] Increase corner radius for bottom sheets, buttons and drawables

### DIFF
--- a/android/app/src/main/res/drawable-night/bg_rounded_rect.xml
+++ b/android/app/src/main/res/drawable-night/bg_rounded_rect.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
   <solid android:color="@color/white_4"/>
-  <corners android:radius="@dimen/margin_quarter"/>
+  <corners android:radius="@dimen/corner_radius_small"/>
 </shape>

--- a/android/app/src/main/res/drawable/bg_donation_action_button.xml
+++ b/android/app/src/main/res/drawable/bg_donation_action_button.xml
@@ -3,14 +3,14 @@
 
   <item>
     <shape>
-      <corners android:radius="10dp" />
+      <corners android:radius="@dimen/corner_radius_medium" />
       <solid android:color="@color/donation_action_dark" />
     </shape>
   </item>
 
   <item>
     <shape>
-      <corners android:radius="10dp" />
+      <corners android:radius="@dimen/corner_radius_medium" />
       <gradient
           android:centerX="0.1"
           android:centerY="0.1"

--- a/android/app/src/main/res/drawable/bg_donation_action_button_ripple.xml
+++ b/android/app/src/main/res/drawable/bg_donation_action_button_ripple.xml
@@ -6,7 +6,7 @@
 
   <item android:id="@android:id/mask">
     <shape>
-      <corners android:radius="10dp" />
+      <corners android:radius="@dimen/corner_radius_medium" />
       <solid android:color="#FFFFFFFF" />
     </shape>
   </item>

--- a/android/app/src/main/res/drawable/bg_donation_gradient.xml
+++ b/android/app/src/main/res/drawable/bg_donation_gradient.xml
@@ -2,13 +2,13 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
   <item>
     <shape>
-      <corners android:radius="16dp" />
+      <corners android:radius="@dimen/corner_radius_large" />
       <solid android:color="@color/donation_bg_dark" />
     </shape>
   </item>
   <item>
     <shape>
-      <corners android:radius="16dp" />
+      <corners android:radius="@dimen/corner_radius_large" />
       <gradient
           android:centerX="0.15"
           android:centerY="0.85"

--- a/android/app/src/main/res/drawable/bg_nav_next_next_turn.xml
+++ b/android/app/src/main/res/drawable/bg_nav_next_next_turn.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
   <solid android:color="@color/bg_cards"/>
-  <corners android:radius="4dp"/>
+  <corners android:radius="@dimen/corner_radius_small"/>
 </shape>

--- a/android/app/src/main/res/drawable/bg_nav_next_turn.xml
+++ b/android/app/src/main/res/drawable/bg_nav_next_turn.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
   <solid android:color="@color/base_accent"/>
-  <corners android:radius="4dp"/>
+  <corners android:radius="@dimen/corner_radius_small"/>
 </shape>

--- a/android/app/src/main/res/drawable/bg_rounded_rect.xml
+++ b/android/app/src/main/res/drawable/bg_rounded_rect.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
   <solid android:color="@color/black_4"/>
-  <corners android:radius="@dimen/margin_quarter"/>
+  <corners android:radius="@dimen/corner_radius_small"/>
 </shape>

--- a/android/app/src/main/res/drawable/button.xml
+++ b/android/app/src/main/res/drawable/button.xml
@@ -4,7 +4,7 @@
   <item android:id="@android:id/mask">
     <shape android:shape="rectangle">
       <solid android:color="@android:color/white"/>
-      <corners android:radius="2dp"/>
+      <corners android:radius="@dimen/corner_radius_small"/>
     </shape>
   </item>
 </ripple>

--- a/android/app/src/main/res/drawable/button_accent_disabled.xml
+++ b/android/app/src/main/res/drawable/button_accent_disabled.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
   <solid android:color="@color/button_accent_disabled"/>
-  <corners android:radius="@dimen/button_small_corner_radius"/>
+  <corners android:radius="@dimen/corner_radius_small"/>
 </shape>

--- a/android/app/src/main/res/drawable/button_accent_flat.xml
+++ b/android/app/src/main/res/drawable/button_accent_flat.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:color="?attr/colorBtnHighlight">
+  <item>
+    <selector>
+      <item android:drawable="@color/button_accent_pressed"
+            android:state_pressed="true"/>
+        <item
+            android:drawable="@color/button_accent_normal"
+            android:state_enabled="true"/>
+      <item android:drawable="@color/button_accent_disabled"/>
+    </selector>
+  </item>
+</ripple>

--- a/android/app/src/main/res/drawable/button_accent_normal.xml
+++ b/android/app/src/main/res/drawable/button_accent_normal.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
   <solid android:color="@color/button_accent"/>
-  <corners android:radius="@dimen/button_small_corner_radius"/>
+  <corners android:radius="@dimen/corner_radius_small"/>
 </shape>

--- a/android/app/src/main/res/drawable/button_accent_pressed.xml
+++ b/android/app/src/main/res/drawable/button_accent_pressed.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
   <solid android:color="@color/button_accent_pressed"/>
-  <corners android:radius="@dimen/button_small_corner_radius"/>
+  <corners android:radius="@dimen/corner_radius_small"/>
 </shape>

--- a/android/app/src/main/res/drawable/button_editor_light.xml
+++ b/android/app/src/main/res/drawable/button_editor_light.xml
@@ -5,7 +5,7 @@
   <item>
     <shape android:shape="rectangle">
       <solid android:color="@color/bg_editor_light"/>
-      <corners android:radius="2dp"/>
+      <corners android:radius="@dimen/corner_radius_small"/>
     </shape>
   </item>
 </ripple>

--- a/android/app/src/main/res/drawable/button_red.xml
+++ b/android/app/src/main/res/drawable/button_red.xml
@@ -4,7 +4,7 @@
   <item>
     <shape android:shape="rectangle">
       <solid android:color="@color/button_red"/>
-      <corners android:radius="2dp"/>
+      <corners android:radius="@dimen/corner_radius_small"/>
     </shape>
   </item>
 </ripple>

--- a/android/app/src/main/res/drawable/button_red_disabled.xml
+++ b/android/app/src/main/res/drawable/button_red_disabled.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
   <solid android:color="@color/button_red_disabled"/>
-  <corners android:radius="2dp"/>
+  <corners android:radius="@dimen/corner_radius_small"/>
 </shape>

--- a/android/app/src/main/res/drawable/button_red_normal.xml
+++ b/android/app/src/main/res/drawable/button_red_normal.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
   <solid android:color="@color/button_red"/>
-  <corners android:radius="2dp"/>
+  <corners android:radius="@dimen/corner_radius_small"/>
 </shape>

--- a/android/app/src/main/res/drawable/button_red_pressed.xml
+++ b/android/app/src/main/res/drawable/button_red_pressed.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
   <solid android:color="@color/button_red_pressed"/>
-  <corners android:radius="2dp"/>
+  <corners android:radius="@dimen/corner_radius_small"/>
 </shape>

--- a/android/app/src/main/res/drawable/ic_layers_outline_selector.xml
+++ b/android/app/src/main/res/drawable/ic_layers_outline_selector.xml
@@ -2,7 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_activated="true">
     <shape android:shape="rectangle">
-      <corners android:radius="8dp" />
+      <corners android:radius="@dimen/corner_radius_small" />
       <solid android:color="@android:color/transparent" />
       <stroke android:width="2dp" android:color="#249CF2" />
     </shape>

--- a/android/app/src/main/res/drawable/onmap_downloader_background.xml
+++ b/android/app/src/main/res/drawable/onmap_downloader_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="?attr/menuBackground"/>
-    <corners android:radius="10dp"/>
+    <corners android:radius="@dimen/corner_radius_medium"/>
     <padding android:left="0dp" android:top="0dp" android:right="0dp" android:bottom="0dp" />
 </shape>

--- a/android/app/src/main/res/drawable/ripple_mask.xml
+++ b/android/app/src/main/res/drawable/ripple_mask.xml
@@ -3,5 +3,5 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:shape="rectangle">
   <solid android:color="@android:color/white"/>
-  <corners android:radius="@dimen/button_small_corner_radius"/>
+  <corners android:radius="@dimen/corner_radius_small"/>
 </shape>

--- a/android/app/src/main/res/layout/fragment_downloader.xml
+++ b/android/app/src/main/res/layout/fragment_downloader.xml
@@ -14,6 +14,7 @@
     android:layout_width="match_parent"
     android:layout_height="@dimen/height_block_base"
     android:layout_alignParentBottom="true"
+    android:background="@drawable/button_accent_flat"
     style="@style/MwmWidget.Button.Primary"
     tools:text="@string/downloader_update_all_button"/>
 

--- a/android/app/src/main/res/layout/view_donation.xml
+++ b/android/app/src/main/res/layout/view_donation.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     app:cardBackgroundColor="@android:color/transparent"
-    app:cardCornerRadius="16dp"
+    app:cardCornerRadius="@dimen/corner_radius_large"
     app:cardElevation="6dp"
     app:cardUseCompatPadding="false">
 
@@ -16,8 +16,7 @@
       android:background="@drawable/bg_donation_gradient"
       android:clipToOutline="true"
       android:clickable="false"
-      android:outlineProvider="background"
-      app:cardCornerRadius="16dp">
+      android:outlineProvider="background">
 
     <View
         android:id="@+id/donation_backgroundPattern"

--- a/android/app/src/main/res/values-night/themes-base.xml
+++ b/android/app/src/main/res/values-night/themes-base.xml
@@ -22,6 +22,9 @@
     <item name="android:windowTranslucentNavigation">false</item>
 
     <item name="alertDialogTheme">@style/MwmTheme.AlertDialog</item>
+    <item name="shapeAppearanceSmallComponent">@style/ShapeAppearance.App.SmallComponent</item>
+    <item name="shapeAppearanceMediumComponent">@style/ShapeAppearance.App.MediumComponent</item>
+    <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.App.LargeComponent</item>
     <item name="windowBackgroundForced">@color/bg_window</item>
     <item name="cardBackground">@color/bg_cards</item>
     <item name="titleDialogTheme">@color/white_primary</item>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -72,8 +72,12 @@
   <dimen name="margin_direction_mid">24dp</dimen>
   <dimen name="margin_direction_around_center">40dp</dimen>
 
+  <!-- corner radii -->
+  <dimen name="corner_radius_small">8dp</dimen>
+  <dimen name="corner_radius_medium">14dp</dimen>
+  <dimen name="corner_radius_large">20dp</dimen>
+
   <!-- map widgets -->
-  <dimen name="button_small_corner_radius">2dp</dimen>
   <dimen name="viewport_min_height">100dp</dimen>
   <dimen name="viewport_min_width">300dp</dimen>
   <dimen name="elevation_profile_peek_height">260dp</dimen>
@@ -93,9 +97,9 @@
   <dimen name="map_button_arrow_icon_size">34dp</dimen>
 
   <!-- routing layout -->
+    <dimen name="routing_transit_step_corner_radius">4dp</dimen>
   <dimen name="routing_selector_wheel_size">40dp</dimen>
   <dimen name="routing_selector_wheel_margin">4dp</dimen>
-  <dimen name="routing_transit_step_corner_radius">4dp</dimen>
   <dimen name="routing_transit_step_min_height">20dp</dimen>
   <dimen name="routing_transit_setp_min_acceptable_with">104dp</dimen>
   <dimen name="track_recorder_status_top_margin">64dp</dimen>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -38,7 +38,7 @@
   <style name="MwmWidget.MapButton.Square">
     <item name="android:backgroundTint">?menuBackground</item>
     <item name="cornerFamily">rounded</item>
-    <item name="cornerSize">10dp</item>
+    <item name="cornerSize">@dimen/corner_radius_medium</item>
   </style>
 
   <style name="MwmWidget.Button">
@@ -115,6 +115,18 @@
   <style name="ShapeAppearanceOverlay.Button.Round" parent="">
     <item name="cornerFamily">rounded</item>
     <item name="cornerSize">50%</item>
+  </style>
+
+    <style name="ShapeAppearance.App.SmallComponent" parent="ShapeAppearance.Material3.SmallComponent">
+    <item name="cornerSize">@dimen/corner_radius_small</item>
+  </style>
+
+    <style name="ShapeAppearance.App.MediumComponent" parent="ShapeAppearance.Material3.MediumComponent">
+    <item name="cornerSize">@dimen/corner_radius_medium</item>
+  </style>
+
+  <style name="ShapeAppearance.App.LargeComponent" parent="ShapeAppearance.Material3.LargeComponent">
+    <item name="cornerSize">@dimen/corner_radius_large</item>
   </style>
 
   <style name="MwmWidget.ToolbarStyle" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar">
@@ -335,7 +347,7 @@
   <style name="MwmWidget.BottomSheetDialog" parent="Widget.Material3.BottomSheet.Modal">
     <item name="backgroundTint">?cardBackground</item>
     <item name="elevationOverlayEnabled">false</item>
-    <item name="shapeAppearance">@style/ShapeAppearance.Material3.LargeComponent</item>
+    <item name="shapeAppearance">?attr/shapeAppearanceLargeComponent</item>
   </style>
 
   <style name="MwmWidget.BottomSheet" parent="MwmWidget.BottomSheetDialog">
@@ -345,7 +357,7 @@
 
   <style name="MwmWidget.BottomSheet.Rounded" parent="">
     <item name="backgroundTint">?cardBackground</item>
-    <item name="shapeAppearance">@style/ShapeAppearance.Material3.LargeComponent</item>
+    <item name="shapeAppearance">?attr/shapeAppearanceLargeComponent</item>
   </style>
 
   <style name="FAB" parent="Widget.MaterialComponents.ExtendedFloatingActionButton">

--- a/android/app/src/main/res/values/themes-base.xml
+++ b/android/app/src/main/res/values/themes-base.xml
@@ -21,6 +21,9 @@
     <item name="android:statusBarColor">?colorPrimary</item>
     <item name="android:windowTranslucentNavigation">false</item>
     <item name="alertDialogTheme">@style/MwmTheme.AlertDialog</item>
+    <item name="shapeAppearanceSmallComponent">@style/ShapeAppearance.App.SmallComponent</item>
+    <item name="shapeAppearanceMediumComponent">@style/ShapeAppearance.App.MediumComponent</item>
+    <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.App.LargeComponent</item>
     <item name="windowBackgroundForced">@color/bg_window</item>
     <item name="cardBackground">@color/bg_cards</item>
     <item name="titleDialogTheme">@color/black_primary</item>


### PR DESCRIPTION
 ## Summary                                                                                               
  - Define centralized corner radius constants (`corner_radius_small/medium/large`) in `dimens.xml`
  - Add `ShapeAppearance.App.*` styles (Small/Medium/Large) and register them in both light and night base themes                                                                                                     
  - Update bottom sheets to use `?attr/shapeAppearanceLargeComponent`                                        
  - Replace all hardcoded corner radii in ~20 drawables with `@dimen/corner_radius_*` references             
  - Use flat background for the full-width downloader Cancel button 

 ## Global impact
  Setting `shapeAppearanceSmallComponent/MediumComponent/LargeComponent` at the theme level propagates to **all** Material components that read them, not just bottom sheets:
  - All `MaterialButton` instances pick up `corner_radius_small` (4dp → 8dp)
  - All `MaterialCardView` without an explicit `cardCornerRadius` pick up `corner_radius_medium` (4dp → 14dp) — currently none affected, donation card has explicit radius
  - Bottom sheets pick up `corner_radius_large` (20dp)

Before:
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/0080c388-8fb1-4507-93e7-d496ed052a78" />
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/449f5fc9-db82-41e5-bc51-a1823df8e823" />
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/3f7010a1-22ea-42f3-95e6-7c708e9809bf" />
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/0f7bc32c-af8b-4d91-a856-f7d67d6d614c" />

After:
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/4b23ee17-5539-453f-858c-395e36fae9d2" /> 
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/a71e9bb4-ee41-40fc-bbae-651e099f7493" />
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/d4c4a09a-0ac8-4c2f-9300-91c8349ababd" />
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/a5462aad-f724-4570-9bfd-ada95785aa41" />

