### PR TITLE
[map] Preserve selected transit route after closing unrelated place page

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
@@ -271,9 +271,12 @@ public class PlacePageController
     // fragments are gone so createPlacePageFragments() sees no existing tags.
     removePlacePageFragments();
     resetPlacePageHeightBounds();
+    boolean recovered = false;
     if (ChoosePositionMode.get() == ChoosePositionMode.None)
-      Framework.nativeDeactivatePopup();
-    Framework.nativeDeactivateMapSelectionCircle(false);
+      recovered = Framework.nativeDeactivatePopup();
+    // Skip circle deselect when recovery re-activated the transit PP — it just drew a new circle.
+    if (!recovered)
+      Framework.nativeDeactivateMapSelectionCircle(false);
     PlacePageUtils.updateMapViewport(mCoordinator, mDistanceToTop, mViewportMinHeight);
   }
 
@@ -650,7 +653,7 @@ public class PlacePageController
         transaction.remove(placePageButtonsFragment);
       if (placePageFragment != null)
         transaction.remove(placePageFragment);
-      transaction.commitNow();
+      transaction.commitNowAllowingStateLoss();
     }
     mViewModel.setMapObject(null);
   }

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
@@ -266,12 +266,15 @@ public class PlacePageController
 
   private void onHiddenInternal()
   {
+    // Must remove fragments before nativeDeactivatePopup() — the native call may
+    // restore a transit PP (re-creating fragments), and commitNow() ensures the old
+    // fragments are gone so createPlacePageFragments() sees no existing tags.
+    removePlacePageFragments();
+    resetPlacePageHeightBounds();
     if (ChoosePositionMode.get() == ChoosePositionMode.None)
       Framework.nativeDeactivatePopup();
     Framework.nativeDeactivateMapSelectionCircle(false);
     PlacePageUtils.updateMapViewport(mCoordinator, mDistanceToTop, mViewportMinHeight);
-    resetPlacePageHeightBounds();
-    removePlacePageFragments();
   }
 
   private void onTrackRecordingSelected()
@@ -642,12 +645,12 @@ public class PlacePageController
 
     if (placePageButtonsFragment != null || placePageFragment != null)
     {
-      final var transaction = fm.beginTransaction().setReorderingAllowed(true);
+      final var transaction = fm.beginTransaction();
       if (placePageButtonsFragment != null)
         transaction.remove(placePageButtonsFragment);
       if (placePageFragment != null)
         transaction.remove(placePageFragment);
-      transaction.commit();
+      transaction.commitNow();
     }
     mViewModel.setMapObject(null);
   }

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -156,11 +156,6 @@ public class PlacePageView extends Fragment
   private ImageView mIvRouteRef;
   @Nullable
   private RouteInfo[] mRoutes;
-  /// Ref of the route selected from the popup (and currently highlighted on the map).
-  /// Reset on each metadata refresh; bolded+underlined in the primary refs string.
-  /// Matched by ref (not by relId) since the primary string deduplicates by ref.
-  @Nullable
-  private String mSelectedRouteRef;
   private View mEditPlace;
   private View mAddOrganisation;
   private View mAddPlace;
@@ -760,8 +755,7 @@ public class PlacePageView extends Fragment
 
     // showTaxiOffer(mapObject);
     mRoutes = Framework.nativeGetActiveObjectRoutes();
-    mSelectedRouteRef = null;
-    refreshMetadataOrHide(formatRouteRefs(mRoutes, mSelectedRouteRef), mRouteRef, mTvRouteRef);
+    refreshMetadataOrHide(formatRouteRefs(mRoutes, Framework.nativeGetActiveTransitRouteRef()), mRouteRef, mTvRouteRef);
     if (mRouteRef.getVisibility() == VISIBLE)
     {
       if (mMapObject.isTramStop())
@@ -1013,8 +1007,7 @@ public class PlacePageView extends Fragment
     });
     popup.setOnItemClickListener((parent, view, position, id) -> {
       final RouteInfo r = mRoutes[position];
-      mSelectedRouteRef = r.getRef();
-      mTvRouteRef.setText(formatRouteRefs(mRoutes, mSelectedRouteRef));
+      mTvRouteRef.setText(formatRouteRefs(mRoutes, r.getRef()));
       Framework.nativeShowRouteTransit(r.getRelId());
       popup.dismiss();
     });

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -1640,6 +1640,12 @@ JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeShowRouteTransit(JNIEnv 
   frm()->ShowRouteTransit(static_cast<uint32_t>(relId));
 }
 
+JNIEXPORT jstring Java_app_organicmaps_sdk_Framework_nativeGetActiveTransitRouteRef(JNIEnv * env, jclass)
+{
+  auto const ref = frm()->GetActiveTransitRouteRef();
+  return ref.empty() ? nullptr : jni::ToJavaString(env, ref);
+}
+
 JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeSetVisibleRect(JNIEnv * env, jclass, jint left, jint top,
                                                                        jint right, jint bottom)
 {

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -610,9 +610,9 @@ void Framework::ExecuteMapApiRequest()
   return m_work.ExecuteMapApiRequest();
 }
 
-void Framework::DeactivatePopup()
+bool Framework::DeactivatePopup()
 {
-  m_work.DeactivateMapSelection();
+  return m_work.DeactivateMapSelection();
 }
 
 void Framework::DeactivateMapSelectionCircle(bool restoreViewport)
@@ -1353,9 +1353,9 @@ JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeSetRoutingLoadPointsList
     g_loadRouteHandler = nullptr;
 }
 
-JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeDeactivatePopup(JNIEnv * env, jclass)
+JNIEXPORT jboolean Java_app_organicmaps_sdk_Framework_nativeDeactivatePopup(JNIEnv * env, jclass)
 {
-  return g_framework->DeactivatePopup();
+  return static_cast<jboolean>(g_framework->DeactivatePopup());
 }
 
 JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeDeactivateMapSelectionCircle(JNIEnv * env, jclass,

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.hpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.hpp
@@ -158,7 +158,7 @@ public:
 
   void ExecuteMapApiRequest();
 
-  void DeactivatePopup();
+  bool DeactivatePopup();
   void DeactivateMapSelectionCircle(bool restoreViewport);
 
   //    std::string GetOutdatedCountriesString();

--- a/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
@@ -147,7 +147,8 @@ public class Framework
   public static native double[] nativeGetParsedCenterLatLon();
   public static native @Nullable String nativeGetParsedBackUrl();
 
-  public static native void nativeDeactivatePopup();
+  /// @return true if a transit route selection was recovered.
+  public static native boolean nativeDeactivatePopup();
   public static native void nativeDeactivateMapSelectionCircle(boolean restoreViewport);
 
   public static native String nativeGetDataFileExt();

--- a/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
@@ -318,6 +318,9 @@ public class Framework
 
   public static native void nativeShowRouteTransit(int relId);
 
+  @Nullable
+  public static native String nativeGetActiveTransitRouteRef();
+
   public static native void nativeSetVisibleRect(int left, int top, int right, int bottom);
 
   // Navigation.

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1382,15 +1382,15 @@ void Framework::ShowRouteTransit(uint32_t relID)
   if (!info)
     return;
 
-  if (!m_routeTransitSelectionSession || m_routeTransitSelectionSession->m_featureId != fid)
+  if (!m_routeTransitSelection || m_routeTransitSelection->m_featureId != fid)
   {
-    auto modelView = m_currentModelView;
-    if (modelView.isPerspective())
-      modelView.ResetPerspective();
-    m_routeTransitSelectionSession = RouteTransitSelectionSession(m_currentPlacePageInfo->GetBuildInfo(), fid, relID);
+    if (m_currentModelView.isPerspective())
+      m_currentModelView.ResetPerspective();
+
+    m_routeTransitSelection.emplace(fid, relID);
   }
   else
-    m_routeTransitSelectionSession->m_relID = relID;
+    m_routeTransitSelection->m_relID = relID;
 
   // Fit the viewport to the route before pushing data — same UX as the old selection-line path.
   m2::RectD bbox;
@@ -1413,9 +1413,9 @@ void Framework::ShowRouteTransit(uint32_t relID)
 
 std::string Framework::GetActiveTransitRouteRef() const
 {
-  if (!m_routeTransitSelectionSession || !HasPlacePageInfo())
+  if (!m_routeTransitSelection || !HasPlacePageInfo())
     return {};
-  uint32_t const relID = m_routeTransitSelectionSession->m_relID;
+  uint32_t const relID = m_routeTransitSelection->m_relID;
   for (auto const & r : GetCurrentPlacePageInfo().GetRoutes())
     if (r.m_relID == relID)
       return r.m_ref;
@@ -1424,9 +1424,9 @@ std::string Framework::GetActiveTransitRouteRef() const
 
 void Framework::HideRouteTransitIfNeeded()
 {
-  if (!m_routeTransitSelectionSession)
+  if (!m_routeTransitSelection)
     return;
-  m_routeTransitSelectionSession = {};
+  m_routeTransitSelection = {};
 
   if (!m_drapeEngine)
     return;
@@ -2087,9 +2087,8 @@ void Framework::DeactivateMapSelection()
   if (m_routingManager.IsRoutingActive())
     HideRouteTransitIfNeeded();
 
-  bool const recoverRouteTransitSession =
-      m_currentPlacePageInfo && m_routeTransitSelectionSession &&
-      m_currentPlacePageInfo->GetID() != m_routeTransitSelectionSession->m_featureId;
+  bool const recoverRouteTransitSession = m_currentPlacePageInfo && m_routeTransitSelection &&
+                                          m_currentPlacePageInfo->GetID() != m_routeTransitSelection->m_featureId;
   if (recoverRouteTransitSession)
   {
     DeactivateHotelSearchMark();
@@ -2099,7 +2098,10 @@ void Framework::DeactivateMapSelection()
     bm.ClearTempRelationTrack();
     bm.ResetRecentlyDeletedBookmark();
 
-    m_currentPlacePageInfo = BuildPlacePageInfo(m_routeTransitSelectionSession->m_buildInfo);
+    place_page::BuildInfo info;
+    info.m_featureId = m_routeTransitSelection->m_featureId;
+    info.m_match = place_page::BuildInfo::Match::FeatureOnly;
+    m_currentPlacePageInfo = BuildPlacePageInfo(info);
     ActivateMapSelection();
     return;
   }

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -2082,7 +2082,7 @@ void Framework::ActivateMapSelection()
     m_onPlacePageOpen();
 }
 
-void Framework::DeactivateMapSelection()
+bool Framework::DeactivateMapSelection()
 {
   if (m_routingManager.IsRoutingActive())
     HideRouteTransitIfNeeded();
@@ -2103,7 +2103,7 @@ void Framework::DeactivateMapSelection()
     info.m_match = place_page::BuildInfo::Match::FeatureOnly;
     m_currentPlacePageInfo = BuildPlacePageInfo(info);
     ActivateMapSelection();
-    return;
+    return true;
   }
 
   if (m_onPlacePageClose)
@@ -2125,6 +2125,8 @@ void Framework::DeactivateMapSelection()
     if (m_drapeEngine != nullptr)
       m_drapeEngine->DeselectObject(false /* restoreViewport */);
   }
+
+  return false;
 }
 
 void Framework::DeactivateMapSelectionCircle(bool restoreViewport)

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -2084,7 +2084,7 @@ void Framework::ActivateMapSelection()
 
 bool Framework::DeactivateMapSelection()
 {
-  if (m_routingManager.IsRoutingActive())
+  if (m_routingManager.IsRoutingActive() || m_routingManager.GetRoutePointsCount() > 0)
     HideRouteTransitIfNeeded();
 
   bool const recoverRouteTransitSession = m_currentPlacePageInfo && m_routeTransitSelection &&

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1382,6 +1382,16 @@ void Framework::ShowRouteTransit(uint32_t relID)
   if (!info)
     return;
 
+  if (!m_routeTransitSelectionSession || m_routeTransitSelectionSession->m_featureId != fid)
+  {
+    auto modelView = m_currentModelView;
+    if (modelView.isPerspective())
+      modelView.ResetPerspective();
+    m_routeTransitSelectionSession = RouteTransitSelectionSession(m_currentPlacePageInfo->GetBuildInfo(), fid, relID);
+  }
+  else
+    m_routeTransitSelectionSession->m_relID = relID;
+
   // Fit the viewport to the route before pushing data — same UX as the old selection-line path.
   m2::RectD bbox;
   for (auto const & route : info->m_routes)
@@ -1396,7 +1406,6 @@ void Framework::ShowRouteTransit(uint32_t relID)
   }
 
   UpdateTrackSelectionColor(info->m_color);
-  m_wasPTRoute = true;
 
   m_drapeEngine->EnableTransitScheme(true);
   m_drapeEngine->ShowRouteTransit(std::move(*info));
@@ -1404,9 +1413,9 @@ void Framework::ShowRouteTransit(uint32_t relID)
 
 void Framework::HideRouteTransitIfNeeded()
 {
-  if (!m_wasPTRoute)
+  if (!m_routeTransitSelectionSession)
     return;
-  m_wasPTRoute = false;
+  m_routeTransitSelectionSession = {};
 
   if (!m_drapeEngine)
     return;
@@ -2064,6 +2073,26 @@ void Framework::ActivateMapSelection()
 
 void Framework::DeactivateMapSelection()
 {
+  if (m_routingManager.IsRoutingActive())
+    HideRouteTransitIfNeeded();
+
+  bool const recoverRouteTransitSession =
+      m_currentPlacePageInfo && m_routeTransitSelectionSession &&
+      m_currentPlacePageInfo->GetID() != m_routeTransitSelectionSession->m_featureId;
+  if (recoverRouteTransitSession)
+  {
+    DeactivateHotelSearchMark();
+
+    auto & bm = GetBookmarkManager();
+    bm.OnTrackDeselected();
+    bm.ClearTempRelationTrack();
+    bm.ResetRecentlyDeletedBookmark();
+
+    m_currentPlacePageInfo = BuildPlacePageInfo(m_routeTransitSelectionSession->m_buildInfo);
+    ActivateMapSelection();
+    return;
+  }
+
   if (m_onPlacePageClose)
     m_onPlacePageClose();
 

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1411,6 +1411,17 @@ void Framework::ShowRouteTransit(uint32_t relID)
   m_drapeEngine->ShowRouteTransit(std::move(*info));
 }
 
+std::string Framework::GetActiveTransitRouteRef() const
+{
+  if (!m_routeTransitSelectionSession || !HasPlacePageInfo())
+    return {};
+  uint32_t const relID = m_routeTransitSelectionSession->m_relID;
+  for (auto const & r : GetCurrentPlacePageInfo().GetRoutes())
+    if (r.m_relID == relID)
+      return r.m_ref;
+  return {};
+}
+
 void Framework::HideRouteTransitIfNeeded()
 {
   if (!m_routeTransitSelectionSession)

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -61,6 +61,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -465,7 +466,20 @@ private:
   std::unique_ptr<descriptions::Loader> m_descriptionsLoader;
   SelectionProcessor m_selectionProcessor;
 
-  bool m_wasPTRoute = false;
+  struct RouteTransitSelectionSession
+  {
+    RouteTransitSelectionSession(place_page::BuildInfo const & buildInfo, FeatureID const & featureId, uint32_t relID)
+      : m_buildInfo(buildInfo)
+      , m_featureId(featureId)
+      , m_relID(relID)
+    {}
+
+    place_page::BuildInfo m_buildInfo;
+    FeatureID m_featureId;
+    uint32_t m_relID = 0;
+  };
+
+  std::optional<RouteTransitSelectionSession> m_routeTransitSelectionSession;
 
 public:
   // Moves viewport to the search result and taps on it.
@@ -478,7 +492,7 @@ public:
   // Builds a TransitInfo (lines + stops) for @p relID relative to the current place page's feature
   // and shows it on the transit scheme layer (with the usual map dim).
   void ShowRouteTransit(uint32_t relID);
-  // Is called on PP close. Clears drape's transit scheme if ShowRouteTransit above was called before.
+  // Is called on PT PP close. Clears drape's transit scheme if ShowRouteTransit above was called before.
   void HideRouteTransitIfNeeded();
 
   // Cancels all searches, stops location follow and then selects

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -308,7 +308,8 @@ private:
   void DeactivateHotelSearchMark();
 
 public:
-  void DeactivateMapSelection();
+  /// @return true if a transit route selection was recovered (PP re-activated).
+  bool DeactivateMapSelection();
   void DeactivateMapSelectionCircle(bool restoreViewport);
   void SwitchFullScreen();
   /// Used to "refresh" UI in some cases (e.g. feature editing).

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -492,6 +492,8 @@ public:
   // Builds a TransitInfo (lines + stops) for @p relID relative to the current place page's feature
   // and shows it on the transit scheme layer (with the usual map dim).
   void ShowRouteTransit(uint32_t relID);
+  // Returns the ref string of the currently selected transit route, or empty if none.
+  std::string GetActiveTransitRouteRef() const;
   // Is called on PT PP close. Clears drape's transit scheme if ShowRouteTransit above was called before.
   void HideRouteTransitIfNeeded();
 

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -466,20 +466,13 @@ private:
   std::unique_ptr<descriptions::Loader> m_descriptionsLoader;
   SelectionProcessor m_selectionProcessor;
 
-  struct RouteTransitSelectionSession
+  struct RouteTransitSelection
   {
-    RouteTransitSelectionSession(place_page::BuildInfo const & buildInfo, FeatureID const & featureId, uint32_t relID)
-      : m_buildInfo(buildInfo)
-      , m_featureId(featureId)
-      , m_relID(relID)
-    {}
-
-    place_page::BuildInfo m_buildInfo;
     FeatureID m_featureId;
     uint32_t m_relID = 0;
   };
 
-  std::optional<RouteTransitSelectionSession> m_routeTransitSelectionSession;
+  std::optional<RouteTransitSelection> m_routeTransitSelection;
 
 public:
   // Moves viewport to the search result and taps on it.


### PR DESCRIPTION
This PR:
1. Keep the current public transport route selection as an active session when another map object is selected and its place page is closed.
2. When the route building for navigation is active (routeTo / routeFrom is selected)  and the place page dismissed, the transit selection will be cancelled.