### PR TITLE
[drape] Select RouteTransit overlay elements.

### DIFF
--- a/libs/drape/overlay_tree.cpp
+++ b/libs/drape/overlay_tree.cpp
@@ -487,9 +487,8 @@ void OverlayTree::Select(m2::RectD const & rect, TOverlayContainer & result) con
   ScreenBase const & screen = GetModelView();
   ForEachInRect(rect, [&](ref_ptr<OverlayHandle> const & h)
   {
-    // RouteTransit elements with empty FeatureID. Probably, can assign valid IDs.
-    if (!h->GetOverlayID().IsValid())
-      return;
+    // BuildFromRouteTransit elements with _possible_ empty FeatureID. Text shapes have valid FeatureID.
+    // ASSERT(h->GetOverlayID().IsValid(), ());
 
     if (!h->HasLinearFeatureShape() && h->IsVisible())
     {

--- a/libs/drape_frontend/selection_info.hpp
+++ b/libs/drape_frontend/selection_info.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "indexer/feature_decl.hpp"
+
 #include "drape/color.hpp"
 
 #include "geometry/point2d.hpp"
@@ -35,8 +37,10 @@ struct TransitInfo
 
   struct Stop
   {
+    FeatureID m_featureId;  // for the OverlayTree::Select routine
     m2::PointD m_pos;
     std::string m_name;
+
     /// true for the PP's feature (the user-selected stop) and for the first/last stop
     /// members of the relation (terminals). Rendered in red with a lower zoom threshold.
     bool m_highlight = false;

--- a/libs/drape_frontend/transit_scheme_builder.cpp
+++ b/libs/drape_frontend/transit_scheme_builder.cpp
@@ -1119,6 +1119,7 @@ void TransitSchemeBuilder::BuildFromRouteTransit(ref_ptr<dp::GraphicsContext> co
       if (stop.m_name.empty())
         continue;
 
+      textParams.m_featureId = stop.m_featureId;
       textParams.m_titleDecl.m_primaryTextFont = stop.m_highlight ? highlightedFont : regularFont;
       textParams.m_titleDecl.m_primaryText = stop.m_name;
       textParams.m_specialPriority = stop.m_highlight ? highlightedPrio : regularPrio;

--- a/libs/map/relation_track.cpp
+++ b/libs/map/relation_track.cpp
@@ -217,6 +217,7 @@ std::optional<df::TransitInfo> RelationTrackBuilder::BuildTransitInfo(uint32_t r
       continue;
 
     df::TransitInfo::Stop stop;
+    stop.m_featureId = stopFt->GetID();
     stop.m_pos = stopFt->GetCenter();
     stop.m_name = std::string(stopFt->GetReadableName());
     stop.m_highlight = (ftIdx == m_fid.m_index);  // Current (PP's) stop.


### PR DESCRIPTION
TODO: Bookmarks/Tracks select priority should be lower (to the Overlay) when Transit mode.