### PR TITLE
[android] Improve place page bottom sheet: two-step dismiss and compact transit stops

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
@@ -54,6 +54,8 @@ public class PlacePageController
   private static final String TAG = PlacePageController.class.getSimpleName();
   private static final String PLACE_PAGE_BUTTONS_FRAGMENT_TAG = "PLACE_PAGE_BUTTONS";
   private static final String PLACE_PAGE_FRAGMENT_TAG = "PLACE_PAGE";
+  // Slide offset threshold below collapsed (0.0) at which the sheet is dismissed.
+  private static final float EASY_DISMISS_SLIDE_THRESHOLD = -0.15f;
 
   private BottomSheetBehavior<View> mPlacePageBehavior;
   private NestedScrollView mPlacePage;
@@ -74,6 +76,8 @@ public class PlacePageController
   private WindowInsetsCompat mCurrentWindowInsets;
 
   private boolean mShouldCollapse;
+  // Enabled after the sheet reaches COLLAPSED; prevents dismiss during initial open animation.
+  private boolean mEasyDismissEnabled;
   private int mDistanceToTop;
 
   private ValueAnimator mCustomPeekHeightAnimator;
@@ -142,8 +146,16 @@ public class PlacePageController
 
           PlacePageUtils.updateMapViewport(mCoordinator, mDistanceToTop, mViewportMinHeight);
 
+          if (PlacePageUtils.isExpandedState(newState))
+            mEasyDismissEnabled = false;
+          else if (PlacePageUtils.isCollapsedState(newState))
+            mEasyDismissEnabled = true;
+
           if (PlacePageUtils.isHiddenState(newState))
+          {
+            mEasyDismissEnabled = false;
             onHiddenInternal();
+          }
         }
 
         @Override
@@ -152,6 +164,8 @@ public class PlacePageController
           stopCustomPeekHeightAnimation();
           mDistanceToTop = bottomSheet.getTop();
           mViewModel.setPlacePageDistanceToTop(mDistanceToTop);
+          if (slideOffset < EASY_DISMISS_SLIDE_THRESHOLD && mEasyDismissEnabled)
+            mPlacePageBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
         }
       };
 
@@ -188,7 +202,7 @@ public class PlacePageController
     mPlacePageBehavior.setHideable(true);
     mPlacePageBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
     mPlacePageBehavior.setFitToContents(true);
-    mPlacePageBehavior.setSkipCollapsed(true);
+    mPlacePageBehavior.setSkipCollapsed(false);
 
     UiUtils.bringViewToFrontOf(view.findViewById(R.id.pp_buttons_fragment), mPlacePage);
 
@@ -440,7 +454,9 @@ public class PlacePageController
     final int bottomMargins = getResources().getDimensionPixelSize(R.dimen.margin_double);
     final View plusDetailsContainer = mPlacePage.findViewById(R.id.plus_details);
     int peekHeight = mPreviewHeight + mButtonsHeight + bottomMargins;
-    if (mMapObject != null && mMapObject.getOpeningMode() == MapObject.OPENING_MODE_PREVIEW_PLUS)
+    final View routeRef = mPlacePage.findViewById(R.id.ll__place_route_ref);
+    final boolean hasRouteRefs = routeRef != null && routeRef.getVisibility() == View.VISIBLE;
+    if (mMapObject != null && mMapObject.getOpeningMode() == MapObject.OPENING_MODE_PREVIEW_PLUS && !hasRouteRefs)
     {
       peekHeight += plusDetailsContainer.getHeight();
     }
@@ -465,6 +481,7 @@ public class PlacePageController
       setPeekHeight();
       if (mShouldCollapse && !PlacePageUtils.isCollapsedState(mPlacePageBehavior.getState()))
       {
+        mEasyDismissEnabled = false;
         mPlacePageBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
         // Make sure to reset the scroll position when opening the place page
         if (mPlacePage.getScrollY() != 0)
@@ -481,7 +498,7 @@ public class PlacePageController
     int state = mPlacePageBehavior.getState();
     stopCustomPeekHeightAnimation();
     if (PlacePageUtils.isExpandedState(state))
-      mPlacePageBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+      mPlacePageBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
     else
       mPlacePageBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
   }

--- a/android/app/src/main/res/layout/place_page_route_ref.xml
+++ b/android/app/src/main/res/layout/place_page_route_ref.xml
@@ -14,6 +14,7 @@
     android:id="@+id/ll__place_route_ref_content"
     style="@style/PlacePageItemFrame"
     android:tag="route_ref"
+      android:paddingEnd="@dimen/margin_half"
     android:visibility="visible"
     tools:background="#40FF00FF"
     tools:visibility="visible">
@@ -26,9 +27,20 @@
     <TextView
       android:id="@+id/tv__place_route_ref"
       android:textAlignment="viewStart"
-      android:layout_width="match_parent"
+        android:layout_width="0dp"
       android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:singleLine="true"
+        android:ellipsize="end"
       android:textAppearance="@style/MwmTextAppearance.PlacePage"
-      tools:text="Route references" />
+        tools:text="42 • 47 • M1 • 15 • 23" />
+
+      <ImageView
+          android:id="@+id/iv__place_route_ref_arrow"
+          android:layout_width="32dp"
+          android:layout_height="32dp"
+          android:rotation="-90"
+          app:srcCompat="@drawable/ic_down"
+          app:tint="?iconTint" />
   </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
 ## Summary                                                                                                 
  - Don't expand the place page to show Wikipedia when transit route refs (schedule) are already visible in the preview — keeps the card compact for transit stops                                                     
  - Enable two-step dismissal: swipe down from expanded → collapsed (peek), swipe down again → hidden        
  - Add easy dismiss from collapsed state (small drag threshold instead of default 50%)                      
  - Tap toggle: expanded → collapsed instead of hidden

<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/4796b407-4f92-41b3-a7ee-666f79c0d5a2" />
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/a8befb79-1385-4b16-90ad-d2ed9f51b9fe" />


Better to merge after update pp routes in master