### PR TITLE
[map] Find and build multiple track/relation track candidates in tap

### DIFF
--- a/libs/indexer/feature_decl.hpp
+++ b/libs/indexer/feature_decl.hpp
@@ -53,6 +53,10 @@ struct FeatureID
   uint32_t m_index = 0;
 };
 
+/// Reference to a Relation in a particular MWM. {m_mwmId, m_index} == {MwmId, in-MWM relIdx}.
+/// FeatureID's structure matches our needs exactly so we reuse it.
+using RelationID = FeatureID;
+
 std::string DebugPrint(FeatureID const & id);
 
 namespace std

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -836,7 +836,7 @@ std::string BookmarkManager::GetLocalizedRegionAddress(m2::PointD const & pt)
   return m_regionAddressGetter->GetLocalizedRegionAddress(pt);
 }
 
-void BookmarkManager::UpdateElevationMyPosition(kml::TrackId const & trackId)
+void BookmarkManager::UpdateElevationMyPosition(kml::TrackId const & trackId, bool ignoreLocationCache)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
 
@@ -845,14 +845,16 @@ void BookmarkManager::UpdateElevationMyPosition(kml::TrackId const & trackId)
   if (m_myPositionMark->HasPosition())
   {
     double const kEps = 1e-5;
-    if (m_lastElevationMyPosition.EqualDxDy(m_myPositionMark->GetPivot(), kEps))
+    if (!ignoreLocationCache && m_lastElevationMyPosition.EqualDxDy(m_myPositionMark->GetPivot(), kEps))
       return;
     m_lastElevationMyPosition = m_myPositionMark->GetPivot();
 
     auto const snapRect =
         mercator::RectByCenterXYAndSizeInMeters(m_myPositionMark->GetPivot(), kMyPositionTrackSnapInMeters);
-    auto const selectionInfo =
-        FindNearestTrack(snapRect, [trackId](Track const * track) { return track->GetId() == trackId; });
+    Track::TrackSelectionInfo selectionInfo;
+    selectionInfo.SetDistanceFilter(snapRect);
+    if (auto const * track = GetTrack(trackId))
+      track->UpdateSelectionInfo(m_myPositionMark->GetPivot(), selectionInfo);
     if (selectionInfo.m_trackId == trackId)
       myPositionDistance = selectionInfo.m_distFromBegM;
   }
@@ -862,7 +864,7 @@ void BookmarkManager::UpdateElevationMyPosition(kml::TrackId const & trackId)
   }
 
   auto const markId = GetTrackSelectionMarkId(trackId);
-  if (markId == kml::kInvalidTrackId)
+  if (markId == kml::kInvalidMarkId)
     return;
 
   auto es = GetEditSession();
@@ -927,13 +929,6 @@ void BookmarkManager::SetElevationActivePointChangedCallback(ElevationActivePoin
   CHECK_THREAD_CHECKER(m_threadChecker, ());
 
   m_elevationActivePointChanged = cb;
-}
-
-Track::TrackSelectionInfo BookmarkManager::FindNearestTrack(m2::RectD const & touchRect,
-                                                            TracksFilter const & tracksFilter) const
-{
-  auto const tracks = FindTracksInRect(touchRect, tracksFilter);
-  return tracks.empty() ? Track::TrackSelectionInfo{} : tracks.front();
 }
 
 std::vector<Track::TrackSelectionInfo> BookmarkManager::FindTracksInRect(m2::RectD const & touchRect,
@@ -1270,7 +1265,6 @@ void BookmarkManager::ClearTempRelationTrack()
   if (!m_tempRelationTrack)
     return;
 
-  DeleteTrackSelectionMark(kml::kTempRelationTrackId);
   m_changesTracker.OnDeleteLine(kml::kTempRelationTrackId);
   m_tempRelationTrack.reset();
 

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -932,10 +932,16 @@ void BookmarkManager::SetElevationActivePointChangedCallback(ElevationActivePoin
 Track::TrackSelectionInfo BookmarkManager::FindNearestTrack(m2::RectD const & touchRect,
                                                             TracksFilter const & tracksFilter) const
 {
+  auto const tracks = FindTracksInRect(touchRect, tracksFilter);
+  return tracks.empty() ? Track::TrackSelectionInfo{} : tracks.front();
+}
+
+std::vector<Track::TrackSelectionInfo> BookmarkManager::FindTracksInRect(m2::RectD const & touchRect,
+                                                                         TracksFilter const & tracksFilter) const
+{
   CHECK_THREAD_CHECKER(m_threadChecker, ());
-  Track::TrackSelectionInfo selectionInfo;
+  std::vector<Track::TrackSelectionInfo> selectionInfos;
   auto const tapPoint = touchRect.Center();
-  selectionInfo.SetDistanceFilter(touchRect);
 
   for (auto const & pair : m_categories)
   {
@@ -949,11 +955,22 @@ Track::TrackSelectionInfo BookmarkManager::FindNearestTrack(m2::RectD const & to
       if (tracksFilter && !tracksFilter(track))
         continue;
 
+      Track::TrackSelectionInfo selectionInfo;
+      selectionInfo.SetDistanceFilter(touchRect);
       track->UpdateSelectionInfo(tapPoint, selectionInfo);
+      if (selectionInfo.IsValid())
+        selectionInfos.push_back(selectionInfo);
     }
   }
 
-  return selectionInfo;
+  std::sort(selectionInfos.begin(), selectionInfos.end(), [](auto const & lhs, auto const & rhs)
+  {
+    if (lhs.m_squareDist != rhs.m_squareDist)
+      return lhs.m_squareDist < rhs.m_squareDist;
+    return lhs.m_trackId < rhs.m_trackId;
+  });
+
+  return selectionInfos;
 }
 
 Track::TrackSelectionInfo BookmarkManager::GetTrackSelectionInfo(kml::TrackId const & trackId) const

--- a/libs/map/bookmark_manager.hpp
+++ b/libs/map/bookmark_manager.hpp
@@ -417,6 +417,8 @@ public:
   using TracksFilter = std::function<bool(Track const * track)>;
   Track::TrackSelectionInfo FindNearestTrack(m2::RectD const & touchRect,
                                              TracksFilter const & tracksFilter = nullptr) const;
+  std::vector<Track::TrackSelectionInfo> FindTracksInRect(m2::RectD const & touchRect,
+                                                          TracksFilter const & tracksFilter = nullptr) const;
   Track::TrackSelectionInfo GetTrackSelectionInfo(kml::TrackId const & trackId) const;
 
   void SetTrackSelectionInfo(Track::TrackSelectionInfo const & trackSelectionInfo, bool notifyListeners);

--- a/libs/map/bookmark_manager.hpp
+++ b/libs/map/bookmark_manager.hpp
@@ -406,7 +406,7 @@ public:
   // Returns distance from the start of the track to active point in meters.
   double GetElevationActivePoint(kml::TrackId const & trackId) const;
 
-  void UpdateElevationMyPosition(kml::TrackId const & trackId);
+  void UpdateElevationMyPosition(kml::TrackId const & trackId, bool ignoreLocationCache = false);
   // Returns distance from the start of the track to my position in meters.
   // Returns negative value if my position is not on the track.
   double GetElevationMyPosition(kml::TrackId const & trackId) const;
@@ -415,8 +415,6 @@ public:
   void SetElevationMyPositionChangedCallback(ElevationMyPositionChangedCallback const & cb);
 
   using TracksFilter = std::function<bool(Track const * track)>;
-  Track::TrackSelectionInfo FindNearestTrack(m2::RectD const & touchRect,
-                                             TracksFilter const & tracksFilter = nullptr) const;
   std::vector<Track::TrackSelectionInfo> FindTracksInRect(m2::RectD const & touchRect,
                                                           TracksFilter const & tracksFilter = nullptr) const;
   Track::TrackSelectionInfo GetTrackSelectionInfo(kml::TrackId const & trackId) const;

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -159,6 +159,13 @@ void UpdateTrackSelectionColor(dp::Color & color)
   if (hsl.AdjustLightness(isLightTheme))
     color = dp::HSL2Color(hsl);
 }
+
+bool HasHigherTrackSelectionPriority(Track::TrackSelectionInfo const & lhs, Track::TrackSelectionInfo const & rhs)
+{
+  if (lhs.IsRelation() != rhs.IsRelation())
+    return !lhs.IsRelation();  // non-relation tracks has higher priority
+  return lhs.m_squareDist < rhs.m_squareDist;
+}
 }  // namespace
 
 std::pair<MwmSet::MwmId, MwmSet::RegResult> Framework::RegisterMap(LocalCountryFile const & file)
@@ -686,14 +693,16 @@ void Framework::FillBookmarkInfo(Bookmark const & bmk, place_page::Info & info) 
   }
 }
 
-void Framework::FillTrackInfo(Track const & track, m2::PointD const & trackPoint, place_page::Info & info) const
+void Framework::FillTrackInfo(Track const & track, Track::TrackSelectionInfo const & trackSelectionInfo,
+                              place_page::Info & info) const
 {
   info.SetTrackId(track.GetId());
+  info.SetTrackRelationId(trackSelectionInfo.m_featureId);
   auto const groupId = track.GetGroupId();
   info.SetBookmarkCategoryId(groupId);
   if (groupId != kml::kInvalidMarkGroupId)
     info.SetBookmarkCategoryName(GetBookmarkManager().GetCategoryName(groupId));
-  info.SetMercator(trackPoint);
+  info.SetMercator(trackSelectionInfo.m_trackPoint);
   info.SetTitlesForTrack(track);
 }
 
@@ -705,18 +714,46 @@ search::ReverseGeocoder::Address Framework::GetAddressAtPoint(m2::PointD const &
   return addr;
 }
 
-bool Framework::TryBuildRelationTrack(FeatureID const & fid, m2::PointD const & mercator, place_page::Info & outInfo)
+std::vector<Track::TrackSelectionInfo> Framework::FindRelationTracksInTapPosition(
+    std::vector<std::pair<double, FeatureID>> const & lineCandidates, m2::PointD const & mercator)
 {
-  auto & bm = GetBookmarkManager();
-  bm.ClearTempRelationTrack();
+  std::vector<Track::TrackSelectionInfo> selectionCandidates;
+  selectionCandidates.reserve(lineCandidates.size());
+  std::unordered_set<RelationTrackBuilder::RelationID> processedRelations;
 
-  if (!fid.IsValid())
-    return false;
+  for (auto const & [dist, fid] : lineCandidates)
+  {
+    if (!fid.IsValid())
+      continue;
 
-  RelationTrackBuilder builder(m_featuresFetcher.GetDataSource(), fid, m_infoGetter.get());
-  auto trackData = builder.Build();
+    RelationTrackBuilder builder(m_featuresFetcher.GetDataSource(), fid, m_infoGetter.get());
+    auto const relationTracksMetadata = builder.BuildMetadata(&processedRelations);
+    for (auto const & metadata : relationTracksMetadata)
+    {
+      Track::TrackSelectionInfo trackSelInfo;
+      trackSelInfo.m_trackId = kml::kTempRelationTrackId;
+      trackSelInfo.m_trackPoint = mercator;
+      trackSelInfo.m_featureId = metadata.m_relationId;
+      trackSelInfo.m_title = metadata.m_name;
+      trackSelInfo.m_color = metadata.m_color;
+      UpdateTrackSelectionColor(trackSelInfo.m_color);
+      ASSERT(trackSelInfo.IsValid(), ());
+      selectionCandidates.push_back(std::move(trackSelInfo));
+    }
+  }
+
+  return selectionCandidates;
+}
+
+kml::TrackData Framework::BuildRelationTrack(Track::TrackSelectionInfo const & trackSelectionInfo)
+{
+  auto const relationId = trackSelectionInfo.m_featureId;
+  CHECK(trackSelectionInfo.IsRelation(), ());
+
+  RelationTrackBuilder builder(m_featuresFetcher.GetDataSource(), trackSelectionInfo.m_featureId, m_infoGetter.get());
+  auto trackData = builder.Build(relationId);
   if (!trackData)
-    return false;
+    return {};
 
   kml::TrackData kmlTrack;
   for (auto & line : trackData->m_lines)
@@ -730,20 +767,9 @@ bool Framework::TryBuildRelationTrack(FeatureID const & fid, m2::PointD const & 
   UpdateTrackSelectionColor(trackData->m_color);
   layer.m_color.m_rgba = trackData->m_color.GetRGBA();
   kmlTrack.m_layers.push_back(layer);
+  kmlTrack.m_id = kml::kTempRelationTrackId;
 
-  auto const trackId = bm.SetTempRelationTrack(std::move(kmlTrack));
-  auto const * track = bm.GetTrack(trackId);
-  CHECK(track, ());
-
-  // Snap to the nearest point on the track, same as BuildTrackPlacePage.
-  Track::TrackSelectionInfo trackSelInfo;
-  track->UpdateSelectionInfo(mercator, trackSelInfo);
-  ASSERT(trackSelInfo.IsValid(), ());
-
-  outInfo.SetSelectedObject(df::SelectionShape::OBJECT_TRACK);
-  FillTrackInfo(*track, trackSelInfo.m_trackPoint, outInfo);
-  bm.SetTrackSelectionInfo(trackSelInfo, true /* notifyListeners */);
-  return true;
+  return kmlTrack;
 }
 
 void Framework::FillApiMarkInfo(ApiMarkPoint const & api, place_page::Info & info) const
@@ -888,6 +914,25 @@ void Framework::ShowTrack(kml::TrackId trackId)
 
   ShowRect(rect, true /* isAnim */, true /* useVisibleViewport */);
 
+  ActivateMapSelection();
+}
+
+void Framework::SelectTrackCandidate(kml::TrackId trackId, FeatureID const & featureId)
+{
+  CHECK(m_currentPlacePageInfo, ());
+  auto const & candidates = m_currentPlacePageInfo->GetTrackCandidates();
+  auto const isRelationTrack = trackId == kml::kTempRelationTrackId;
+  auto const candidate =
+      std::find_if(candidates.begin(), candidates.end(), [&trackId, &featureId, isRelationTrack](auto const & candidate)
+  { return isRelationTrack ? candidate.m_featureId == featureId : candidate.m_trackId == trackId; });
+
+  CHECK(candidate != candidates.end(), ());
+  CHECK(candidate->IsValid(), ());
+
+  BuildTrackPlacePage(*candidate, m_currentPlacePageInfo.value());
+
+  if (!isRelationTrack)
+    GetBookmarkManager().UpdateElevationMyPosition(trackId);
   ActivateMapSelection();
 }
 
@@ -2282,9 +2327,28 @@ FeatureID Framework::FindBuildingAtPoint(m2::PointD const & mercator) const
 void Framework::BuildTrackPlacePage(Track::TrackSelectionInfo const & trackSelectionInfo, place_page::Info & info)
 {
   info.SetSelectedObject(df::SelectionShape::OBJECT_TRACK);
-  auto const & track = *GetBookmarkManager().GetTrack(trackSelectionInfo.m_trackId);
-  FillTrackInfo(track, trackSelectionInfo.m_trackPoint, info);
-  GetBookmarkManager().SetTrackSelectionInfo(trackSelectionInfo, true /* notifyListeners */);
+  auto & bm = GetBookmarkManager();
+  Track const * track = nullptr;
+  Track::TrackSelectionInfo selectedInfo = trackSelectionInfo;
+
+  if (trackSelectionInfo.IsRelation())
+  {
+    auto const tapPoint = selectedInfo.m_trackPoint;
+    auto trackData = BuildRelationTrack(selectedInfo);
+    if (trackData.m_id != kml::kInvalidTrackId)
+    {
+      bm.SetTempRelationTrack(std::move(trackData));
+      track = bm.GetTrack(kml::kTempRelationTrackId);
+      track->UpdateSelectionInfo(tapPoint, selectedInfo);
+    }
+  }
+  else
+    track = bm.GetTrack(selectedInfo.m_trackId);
+
+  CHECK(track, ("Failed to build track for selection info:", &trackSelectionInfo));
+
+  FillTrackInfo(*track, selectedInfo, info);
+  bm.SetTrackSelectionInfo(selectedInfo, true /* notifyListeners */);
 }
 
 place_page::Info Framework::BuildPlacePageInfo(place_page::BuildInfo const & buildInfo)
@@ -2352,23 +2416,43 @@ place_page::Info Framework::BuildPlacePageInfo(place_page::BuildInfo const & bui
     return outInfo;
   }
 
-  // 4. User Tracks. Using VisualParams inside FindTrackInTapPosition/GetDefaultTapRect requires drapeEngine.
+  // 4. User Tracks. Using VisualParams inside FindTracksInTapPosition/GetDefaultTapRect requires drapeEngine.
   if (m_drapeEngine != nullptr && buildInfo.IsTrackMatchingEnabled())
   {
-    Track::TrackSelectionInfo trackSelInfo;
+    Track::TrackSelectionInfo trackToSelect;
+    std::vector<Track::TrackSelectionInfo> trackSelectionCandidates;
+
     if (buildInfo.m_trackId != kml::kInvalidTrackId)
     {
       // Known track: find the closest point to the track's bounding-rect center, no distance limit.
       auto const * track = GetBookmarkManager().GetTrack(buildInfo.m_trackId);
-      track->UpdateSelectionInfo(track->GetLimitRect().Center(), trackSelInfo);
-      ASSERT(trackSelInfo.IsValid(), ());
+      if (track == nullptr)
+        return outInfo;
+      track->UpdateSelectionInfo(track->GetLimitRect().Center(), trackToSelect);
+      ASSERT(trackToSelect.IsValid(), ());
+      trackSelectionCandidates.push_back(trackToSelect);
     }
     else
-      trackSelInfo = FindTrackInTapPosition(buildInfo);
-
-    if (trackSelInfo.IsValid())
     {
-      BuildTrackPlacePage(trackSelInfo, outInfo);
+      trackSelectionCandidates = FindTracksInTapPosition(buildInfo);
+      if (!trackSelectionCandidates.empty() && isFeatureMatchingEnabled)
+      {
+        auto const searchRect =
+            df::TapInfo::GetDefaultTapRect(buildInfo.m_mercator, m_currentModelView).GetGlobalRect();
+        auto relationTrackCandidates = FindRelationTracksInTapPosition(
+            sp.FindFeaturesInRect(buildInfo.m_mercator, searchRect).m_lineCandidates, buildInfo.m_mercator);
+        trackSelectionCandidates.insert(trackSelectionCandidates.end(), relationTrackCandidates.begin(),
+                                        relationTrackCandidates.end());
+        std::sort(trackSelectionCandidates.begin(), trackSelectionCandidates.end(), HasHigherTrackSelectionPriority);
+      }
+      if (!trackSelectionCandidates.empty())
+        trackToSelect = trackSelectionCandidates.front();
+    }
+
+    if (trackToSelect.IsValid())
+    {
+      BuildTrackPlacePage(trackToSelect, outInfo);
+      outInfo.SetTrackCandidates(std::move(trackSelectionCandidates));
       return outInfo;
     }
   }
@@ -2402,14 +2486,21 @@ place_page::Info Framework::BuildPlacePageInfo(place_page::BuildInfo const & bui
     }
     else
     {
-      // Try building a route relation track from line candidates (closest first).
-      for (auto const & [dist, fid] : tap.m_lineCandidates)
+      Track::TrackSelectionInfo trackToSelect;
+      auto trackSelectionCandidates = FindRelationTracksInTapPosition(tap.m_lineCandidates, buildInfo.m_mercator);
+      std::sort(trackSelectionCandidates.begin(), trackSelectionCandidates.end(), HasHigherTrackSelectionPriority);
+
+      if (!trackSelectionCandidates.empty())
+        trackToSelect = trackSelectionCandidates.front();
+
+      // Set first track as selected to display.
+      if (trackToSelect.IsValid())
       {
-        if (TryBuildRelationTrack(fid, buildInfo.m_mercator, outInfo))
-        {
-          sp.SetPlacePageLocation(outInfo);
-          return outInfo;
-        }
+        outInfo.SetSelectedObject(df::SelectionShape::OBJECT_TRACK);
+        sp.SetPlacePageLocation(outInfo);
+        BuildTrackPlacePage(trackToSelect, outInfo);
+        outInfo.SetTrackCandidates(std::move(trackSelectionCandidates));
+        return outInfo;
       }
 
       auto const bestFeature = tap.m_line.IsValid() ? tap.m_line : tap.m_area;
@@ -2447,7 +2538,7 @@ void Framework::UpdatePlacePageInfoForCurrentSelection(std::optional<place_page:
     m_onPlacePageUpdate();
 }
 
-Track::TrackSelectionInfo Framework::FindTrackInTapPosition(place_page::BuildInfo const & buildInfo) const
+std::vector<Track::TrackSelectionInfo> Framework::FindTracksInTapPosition(place_page::BuildInfo const & buildInfo) const
 {
   auto const & bm = GetBookmarkManager();
   if (buildInfo.m_trackId != kml::kInvalidTrackId)
@@ -2455,11 +2546,11 @@ Track::TrackSelectionInfo Framework::FindTrackInTapPosition(place_page::BuildInf
     if (bm.GetTrack(buildInfo.m_trackId) == nullptr)
       return {};
     auto const selection = bm.GetTrackSelectionInfo(buildInfo.m_trackId);
-    CHECK_NOT_EQUAL(selection.m_trackId, kml::kInvalidTrackId, ());
-    return selection;
+    CHECK(selection.IsValid(), ());
+    return {selection};
   }
   auto const touchRect = df::TapInfo::GetDefaultTapRect(buildInfo.m_mercator, m_currentModelView).GetGlobalRect();
-  return bm.FindNearestTrack(touchRect);
+  return bm.FindTracksInRect(touchRect);
 }
 
 UserMark const * Framework::FindUserMarkInTapPosition(place_page::BuildInfo const & buildInfo) const

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -697,7 +697,7 @@ void Framework::FillTrackInfo(Track const & track, Track::TrackSelectionInfo con
                               place_page::Info & info) const
 {
   info.SetTrackId(track.GetId());
-  info.SetTrackRelationId(trackSelectionInfo.m_featureId);
+  info.SetTrackRelationId(trackSelectionInfo.m_relationId);
   auto const groupId = track.GetGroupId();
   info.SetBookmarkCategoryId(groupId);
   if (groupId != kml::kInvalidMarkGroupId)
@@ -719,7 +719,6 @@ std::vector<Track::TrackSelectionInfo> Framework::FindRelationTracksInTapPositio
 {
   std::vector<Track::TrackSelectionInfo> selectionCandidates;
   selectionCandidates.reserve(lineCandidates.size());
-  std::unordered_set<RelationTrackBuilder::RelationID> processedRelations;
 
   for (auto const & [dist, fid] : lineCandidates)
   {
@@ -727,13 +726,13 @@ std::vector<Track::TrackSelectionInfo> Framework::FindRelationTracksInTapPositio
       continue;
 
     RelationTrackBuilder builder(m_featuresFetcher.GetDataSource(), fid, m_infoGetter.get());
-    auto const relationTracksMetadata = builder.BuildMetadata(&processedRelations);
+    auto const relationTracksMetadata = builder.BuildMetadata();
     for (auto const & metadata : relationTracksMetadata)
     {
       Track::TrackSelectionInfo trackSelInfo;
       trackSelInfo.m_trackId = kml::kTempRelationTrackId;
       trackSelInfo.m_trackPoint = mercator;
-      trackSelInfo.m_featureId = metadata.m_relationId;
+      trackSelInfo.m_relationId = metadata.m_relationId;
       trackSelInfo.m_title = metadata.m_name;
       trackSelInfo.m_color = metadata.m_color;
       UpdateTrackSelectionColor(trackSelInfo.m_color);
@@ -747,10 +746,10 @@ std::vector<Track::TrackSelectionInfo> Framework::FindRelationTracksInTapPositio
 
 kml::TrackData Framework::BuildRelationTrack(Track::TrackSelectionInfo const & trackSelectionInfo)
 {
-  auto const relationId = trackSelectionInfo.m_featureId;
+  auto const relationId = trackSelectionInfo.m_relationId;
   CHECK(trackSelectionInfo.IsRelation(), ());
 
-  RelationTrackBuilder builder(m_featuresFetcher.GetDataSource(), trackSelectionInfo.m_featureId, m_infoGetter.get());
+  RelationTrackBuilder builder(m_featuresFetcher.GetDataSource(), trackSelectionInfo.m_relationId, m_infoGetter.get());
   auto trackData = builder.Build(relationId);
   if (!trackData)
     return {};
@@ -917,14 +916,14 @@ void Framework::ShowTrack(kml::TrackId trackId)
   ActivateMapSelection();
 }
 
-void Framework::SelectTrackCandidate(kml::TrackId trackId, FeatureID const & featureId)
+void Framework::SelectTrackCandidate(kml::TrackId trackId, RelationID const & relationId)
 {
   CHECK(m_currentPlacePageInfo, ());
   auto const & candidates = m_currentPlacePageInfo->GetTrackCandidates();
   auto const isRelationTrack = trackId == kml::kTempRelationTrackId;
-  auto const candidate =
-      std::find_if(candidates.begin(), candidates.end(), [&trackId, &featureId, isRelationTrack](auto const & candidate)
-  { return isRelationTrack ? candidate.m_featureId == featureId : candidate.m_trackId == trackId; });
+  auto const candidate = std::find_if(candidates.begin(), candidates.end(),
+                                      [&trackId, &relationId, isRelationTrack](auto const & candidate)
+  { return isRelationTrack ? candidate.m_relationId == relationId : candidate.m_trackId == trackId; });
 
   CHECK(candidate != candidates.end(), ());
   CHECK(candidate->IsValid(), ());

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -931,8 +931,7 @@ void Framework::SelectTrackCandidate(kml::TrackId trackId, FeatureID const & fea
 
   BuildTrackPlacePage(*candidate, m_currentPlacePageInfo.value());
 
-  if (!isRelationTrack)
-    GetBookmarkManager().UpdateElevationMyPosition(trackId);
+  GetBookmarkManager().UpdateElevationMyPosition(trackId, true /* ignoreLocationCache */);
   ActivateMapSelection();
 }
 
@@ -2283,7 +2282,7 @@ void Framework::OnTapEvent(place_page::BuildInfo const & buildInfo)
         }
         return;
       }
-      GetBookmarkManager().UpdateElevationMyPosition(newTrackId);
+      GetBookmarkManager().UpdateElevationMyPosition(newTrackId, true /* ignoreLocationCache */);
     }
 
     ActivateMapSelection();
@@ -2343,7 +2342,10 @@ void Framework::BuildTrackPlacePage(Track::TrackSelectionInfo const & trackSelec
     }
   }
   else
+  {
+    bm.ClearTempRelationTrack();
     track = bm.GetTrack(selectedInfo.m_trackId);
+  }
 
   CHECK(track, ("Failed to build track for selection info:", &trackSelectionInfo));
 

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -275,6 +275,8 @@ public:
   void ShowFeature(FeatureID const & featureId);
   void ShowBookmarkCategory(kml::MarkGroupId categoryId, bool animation = true);
 
+  void SelectTrackCandidate(kml::TrackId trackId, FeatureID const & featureId);
+
   void AddBookmarksFile(std::string const & filePath, bool isTemporaryFile);
 
   BookmarkManager & GetBookmarkManager();
@@ -352,8 +354,12 @@ private:
 
   void OnTapEvent(place_page::BuildInfo const & buildInfo);
   place_page::Info BuildPlacePageInfo(place_page::BuildInfo const & buildInfo);
+  kml::TrackData BuildRelationTrack(Track::TrackSelectionInfo const & candidateInfo);
   void BuildTrackPlacePage(Track::TrackSelectionInfo const & trackSelectionInfo, place_page::Info & info);
-  Track::TrackSelectionInfo FindTrackInTapPosition(place_page::BuildInfo const & buildInfo) const;
+  std::vector<Track::TrackSelectionInfo> FindTracksInTapPosition(place_page::BuildInfo const & buildInfo) const;
+  /// Builds temporary track candidates for route relations associated with tapped line features.
+  std::vector<Track::TrackSelectionInfo> FindRelationTracksInTapPosition(
+      std::vector<std::pair<double, FeatureID>> const & lineCandidates, m2::PointD const & mercator);
   UserMark const * FindUserMarkInTapPosition(place_page::BuildInfo const & buildInfo) const;
   FeatureID FindBuildingAtPoint(m2::PointD const & mercator) const;
 
@@ -611,9 +617,6 @@ private:
 
   static bool ParseAllTypesDebugCommand(search::SearchParams const & params);
 
-  /// Tries to build a temporary track from a route relation associated with the feature.
-  /// If successful, fills outInfo as a track selection and returns true.
-  bool TryBuildRelationTrack(FeatureID const & fid, m2::PointD const & mercator, place_page::Info & outInfo);
   void FillUserMarkInfo(UserMark const * mark, place_page::Info & outInfo);
   void FillApiMarkInfo(ApiMarkPoint const & api, place_page::Info & info) const;
   void FillSearchResultInfo(SearchMarkPoint const & smp, place_page::Info & info) const;
@@ -624,7 +627,8 @@ private:
   void FillRoadTypeMarkInfo(RoadWarningMark const & roadTypeMark, place_page::Info & info) const;
   void FillPointInfoForBookmark(Bookmark const & bmk, place_page::Info & info) const;
   void FillBookmarkInfo(Bookmark const & bmk, place_page::Info & info) const;
-  void FillTrackInfo(Track const & track, m2::PointD const & trackPoint, place_page::Info & info) const;
+  void FillTrackInfo(Track const & track, Track::TrackSelectionInfo const & trackSelectionInfo,
+                     place_page::Info & info) const;
 
   SelectionProcessor const & GetSelectionProcessor() const { return m_selectionProcessor; }
 

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -275,7 +275,7 @@ public:
   void ShowFeature(FeatureID const & featureId);
   void ShowBookmarkCategory(kml::MarkGroupId categoryId, bool animation = true);
 
-  void SelectTrackCandidate(kml::TrackId trackId, FeatureID const & featureId);
+  void SelectTrackCandidate(kml::TrackId trackId, RelationID const & relationId);
 
   void AddBookmarksFile(std::string const & filePath, bool isTemporaryFile);
 

--- a/libs/map/place_page_info.cpp
+++ b/libs/map/place_page_info.cpp
@@ -158,6 +158,14 @@ void Info::SetMercator(m2::PointD const & mercator)
   m_buildInfo.m_mercator = mercator;
 }
 
+void Info::SetTrackCandidates(std::vector<Track::TrackSelectionInfo> candidates)
+{
+  if (candidates.size() > 1)
+    m_trackSelectionCandidates = std::move(candidates);
+  else
+    m_trackSelectionCandidates.clear();
+}
+
 std::string Info::FormatSubtitle(bool withTypes, bool withMainType) const
 {
   std::string result;

--- a/libs/map/place_page_info.hpp
+++ b/libs/map/place_page_info.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "map/routing_mark.hpp"
+#include "map/track.hpp"
 
 #include "storage/storage_defines.hpp"
 
@@ -159,6 +160,12 @@ public:
   /// Track
   void SetTrackId(kml::TrackId trackId) { m_trackId = trackId; }
   kml::TrackId GetTrackId() const { return m_trackId; }
+  void SetTrackRelationId(FeatureID const & relationId) { m_trackRelationId = relationId; }
+  FeatureID const & GetTrackRelationId() const { return m_trackRelationId; }
+
+  void SetTrackCandidates(std::vector<Track::TrackSelectionInfo> candidates);
+  // Returns only actionable candidates: empty when there is no real choice, otherwise 2 or more tracks.
+  std::vector<Track::TrackSelectionInfo> const & GetTrackCandidates() const { return m_trackSelectionCandidates; }
 
   /// Api
   void SetApiId(std::string const & apiId) { m_apiId = apiId; }
@@ -267,6 +274,9 @@ private:
   kml::BookmarkData m_bookmarkData;
   /// If not invalid, track is bound to this place page.
   kml::TrackId m_trackId = kml::kInvalidTrackId;
+  /// If valid, relation track is bound to this place page.
+  FeatureID m_trackRelationId;
+  std::vector<Track::TrackSelectionInfo> m_trackSelectionCandidates;
   /// Whether to treat it as plain feature.
   bool m_hasMetadata = false;
 

--- a/libs/map/place_page_info.hpp
+++ b/libs/map/place_page_info.hpp
@@ -160,8 +160,8 @@ public:
   /// Track
   void SetTrackId(kml::TrackId trackId) { m_trackId = trackId; }
   kml::TrackId GetTrackId() const { return m_trackId; }
-  void SetTrackRelationId(FeatureID const & relationId) { m_trackRelationId = relationId; }
-  FeatureID const & GetTrackRelationId() const { return m_trackRelationId; }
+  void SetTrackRelationId(RelationID const & relationId) { m_trackRelationId = relationId; }
+  RelationID const & GetTrackRelationId() const { return m_trackRelationId; }
 
   void SetTrackCandidates(std::vector<Track::TrackSelectionInfo> candidates);
   // Returns only actionable candidates: empty when there is no real choice, otherwise 2 or more tracks.
@@ -275,7 +275,7 @@ private:
   /// If not invalid, track is bound to this place page.
   kml::TrackId m_trackId = kml::kInvalidTrackId;
   /// If valid, relation track is bound to this place page.
-  FeatureID m_trackRelationId;
+  RelationID m_trackRelationId;
   std::vector<Track::TrackSelectionInfo> m_trackSelectionCandidates;
   /// Whether to treat it as plain feature.
   bool m_hasMetadata = false;

--- a/libs/map/relation_track.cpp
+++ b/libs/map/relation_track.cpp
@@ -239,41 +239,64 @@ RelationTrackBuilder::RelationTrackBuilder(DataSource const & dataSource, Featur
   , m_infoGetter(infoGetter)
 {}
 
-std::optional<RelationTrackBuilder::Data> RelationTrackBuilder::Build()
+std::vector<RelationTrackBuilder::Metadata> RelationTrackBuilder::BuildMetadata(
+    std::unordered_set<RelationID> * processedRelations)
 {
   df::RelationsDrawSettings sett;
   sett.Load();
   if (sett.IsEmpty())
-    return std::nullopt;
+    return {};
 
   FeaturesLoaderGuard guard(m_dataSource, m_fid.m_mwmId);
   auto ft = guard.GetFeatureByIndex(m_fid.m_index);
   ASSERT(ft, ());
 
-  for (uint32_t const relID : ft->GetRelations())
+  auto const & relIDs = ft->GetRelations();
+  std::vector<Metadata> result;
+  result.reserve(relIDs.size());
+
+  for (uint32_t const relID : relIDs)
   {
     if (!sett.MatchHikingOrCycling(ft->ReadRelationType(relID)))
       continue;
 
-    auto const rel = ft->ReadRelation<feature::RouteRelation>(relID);
-    auto members = LoadMemberGeometries(rel, guard, RelationID(m_fid.m_mwmId, relID));
-    if (members.empty())
+    RelationID const relationId(m_fid.m_mwmId, relID);
+    if (processedRelations != nullptr && !processedRelations->insert(relationId).second)
       continue;
 
-    // Cross-MWM merging.
-    AppendNeighbourMembers(guard, relID, members);
+    auto const rel = ft->ReadRelation<feature::RouteRelationBase>(relID);
 
-    auto lines = MergeAllMembers(members);
-    if (lines.empty())
-      continue;
-
-    Data data;
-    data.m_lines = std::move(lines);
-    data.m_name = std::string(rel.GetDefaultName());
-    data.m_color = rel.GetColor();
-    return data;
+    Metadata info;
+    info.m_relationId = relationId;
+    info.m_name = std::string(rel.GetDefaultName());
+    info.m_color = rel.GetColor();
+    result.emplace_back(info);
   }
-  return std::nullopt;
+  return result;
+}
+
+std::optional<RelationTrackBuilder::Data> RelationTrackBuilder::Build(RelationID const & relationId)
+{
+  if (!relationId.IsValid())
+    return std::nullopt;
+
+  FeaturesLoaderGuard guard(m_dataSource, relationId.m_mwmId);
+  auto const rel = guard.GetRelation(relationId.m_index);
+  auto members = LoadMemberGeometries(rel, guard, relationId);
+  if (members.empty())
+    return std::nullopt;
+
+  AppendNeighbourMembers(guard, relationId.m_index, members);
+
+  auto lines = MergeAllMembers(members);
+  if (lines.empty())
+    return std::nullopt;
+
+  Data data;
+  data.m_lines = std::move(lines);
+  data.m_name = std::string(rel.GetDefaultName());
+  data.m_color = rel.GetColor();
+  return data;
 }
 
 void RelationTrackBuilder::AppendNeighbourMembers(FeaturesLoaderGuard const & guard, uint32_t relIdx,

--- a/libs/map/relation_track.cpp
+++ b/libs/map/relation_track.cpp
@@ -27,7 +27,6 @@ namespace relation_track_merger  // Unity build protect
 namespace  // Avoid exposing symbols
 {
 using Geometry = RelationTrackBuilder::Geometry;
-using RelationID = RelationTrackBuilder::RelationID;
 
 bool IsEqual(m2::PointD const & lhs, m2::PointD const & rhs)
 {
@@ -239,8 +238,7 @@ RelationTrackBuilder::RelationTrackBuilder(DataSource const & dataSource, Featur
   , m_infoGetter(infoGetter)
 {}
 
-std::vector<RelationTrackBuilder::Metadata> RelationTrackBuilder::BuildMetadata(
-    std::unordered_set<RelationID> * processedRelations)
+std::vector<RelationTrackBuilder::Metadata> RelationTrackBuilder::BuildMetadata()
 {
   df::RelationsDrawSettings sett;
   sett.Load();
@@ -260,14 +258,10 @@ std::vector<RelationTrackBuilder::Metadata> RelationTrackBuilder::BuildMetadata(
     if (!sett.MatchHikingOrCycling(ft->ReadRelationType(relID)))
       continue;
 
-    RelationID const relationId(m_fid.m_mwmId, relID);
-    if (processedRelations != nullptr && !processedRelations->insert(relationId).second)
-      continue;
-
     auto const rel = ft->ReadRelation<feature::RouteRelationBase>(relID);
 
     Metadata info;
-    info.m_relationId = relationId;
+    info.m_relationId = {m_fid.m_mwmId, relID};
     info.m_name = std::string(rel.GetDefaultName());
     info.m_color = rel.GetColor();
     result.emplace_back(info);

--- a/libs/map/relation_track.hpp
+++ b/libs/map/relation_track.hpp
@@ -23,10 +23,6 @@ class CountryInfoGetter;
 class RelationTrackBuilder
 {
 public:
-  /// Reference to a Relation in a particular MWM. {m_mwmId, m_index} == {MwmId, in-MWM relIdx}.
-  /// FeatureID's structure matches our needs exactly so we reuse it.
-  using RelationID = FeatureID;
-
   /// Geometry of a (possibly chained) line, plus the ordered list of source Relations
   /// that contributed runs of points to it. Way-orientation inside a Relation is
   /// arbitrary, so we record only *which* Relation each run came from — never a
@@ -86,7 +82,7 @@ public:
                        storage::CountryInfoGetter const * infoGetter = nullptr);
 
   /// Builds relation track candidates metadata.
-  std::vector<Metadata> BuildMetadata(std::unordered_set<RelationID> * processedRelations = nullptr);
+  std::vector<Metadata> BuildMetadata();
   /// Builds full relation track geometry.
   std::optional<Data> Build(RelationID const & relationId);
 

--- a/libs/map/relation_track.hpp
+++ b/libs/map/relation_track.hpp
@@ -67,6 +67,13 @@ public:
     void Reverse();
   };
 
+  struct Metadata
+  {
+    RelationID m_relationId;
+    std::string m_name;
+    dp::Color m_color;
+  };
+
   struct Data
   {
     std::vector<Geometry> m_lines;
@@ -78,8 +85,10 @@ public:
   RelationTrackBuilder(DataSource const & dataSource, FeatureID const & fid,
                        storage::CountryInfoGetter const * infoGetter = nullptr);
 
-  /// @return nullopt if no suitable relation found or geometry can't be built.
-  std::optional<Data> Build();
+  /// Builds relation track candidates metadata.
+  std::vector<Metadata> BuildMetadata(std::unordered_set<RelationID> * processedRelations = nullptr);
+  /// Builds full relation track geometry.
+  std::optional<Data> Build(RelationID const & relationId);
 
   /// Builds a SelectionInfo (ordered polylines + color) for a specific relation (by @p relID),
   /// using MergeOrdered — suitable for public-transport routes where way ordering is meaningful.

--- a/libs/map/track.cpp
+++ b/libs/map/track.cpp
@@ -143,6 +143,8 @@ void Track::UpdateSelectionInfo(m2::PointD const & tapPoint, TrackSelectionInfo 
       if (squaredDist >= info.m_squareDist)
         continue;
 
+      info.m_title = GetName();
+      info.m_color = GetColor(0);
       info.m_squareDist = squaredDist;
       info.m_trackId = m_data.m_id;
       info.m_trackPoint = closestPoint;

--- a/libs/map/track.hpp
+++ b/libs/map/track.hpp
@@ -65,9 +65,14 @@ public:
     /// @return true  Data is initialized and correct (after UpdateSelectionInfo call).
     /// Can be false if input m_squareDist filtered all track's segments.
     bool IsValid() const { return m_trackId != kml::kInvalidTrackId; }
+    bool IsRelation() const { return m_trackId == kml::kTempRelationTrackId && m_featureId.IsValid(); }
 
     kml::TrackId m_trackId = kml::kInvalidTrackId;
     m2::PointD m_trackPoint;
+    FeatureID m_featureId;  // Relation only.
+    std::string m_title;
+    dp::Color m_color = dp::Color::Transparent();
+
     // Distance in meters from the beginning to m_trackPoint.
     double m_distFromBegM;
     // Mercator square distance, used to select nearest track.

--- a/libs/map/track.hpp
+++ b/libs/map/track.hpp
@@ -65,11 +65,11 @@ public:
     /// @return true  Data is initialized and correct (after UpdateSelectionInfo call).
     /// Can be false if input m_squareDist filtered all track's segments.
     bool IsValid() const { return m_trackId != kml::kInvalidTrackId; }
-    bool IsRelation() const { return m_trackId == kml::kTempRelationTrackId && m_featureId.IsValid(); }
+    bool IsRelation() const { return m_trackId == kml::kTempRelationTrackId && m_relationId.IsValid(); }
 
     kml::TrackId m_trackId = kml::kInvalidTrackId;
     m2::PointD m_trackPoint;
-    FeatureID m_featureId;  // Relation only.
+    RelationID m_relationId;  // Relation only.
     std::string m_title;
     dp::Color m_color = dp::Color::Transparent();
 


### PR DESCRIPTION
### This PR implements tracks selector when there are multiple tracks in the tap area:
- [x] Multiple bm tracks selection
- [x] Multiple mixed bm/rel tracks selection
- [x] Multiple rel (osm) tracks selection. 
   - [x] Relation track storage and selection when relation tracks are not multiline (when the user taps on the segment that does not have >1 tracks)
   - [x] Relation tracks building is not working when the rel line is a `multiline` - the `RelationTrackBuilder build` always returns false for all non first candidates 
- [x] `My position point` support for relation tracks. This feature is important for clear selection flow between tracks from one single PP.

### Also this PR fixes the issue (important for the `my position point`):
BookmarkManager::UpdateElevationMyPosition() skips recalculation when the current GPS point has not changed. This works for location updates, but not for track switching: the user can select another track while staying at the same position.
As a result, the previous track’s myPositionDistance can be reused for the newly selected track.
**Solution:** The last-location cache is ignored on track switching allowing to rebuild the point for new track ID. 

How it will look on the platform - see the https://github.com/organicmaps/organicmaps/pull/12690 

<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-06-02 at 20 21 41" src="https://github.com/user-attachments/assets/4e5915d6-13d0-4365-9b5b-99209e0fa573" />

