### PR TITLE
[storage] Preserve partial download files on graceful shutdown

### DIFF
--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/DownloadResourcesLegacyActivity.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/DownloadResourcesLegacyActivity.cpp
@@ -166,7 +166,7 @@ JNIEXPORT jint Java_app_organicmaps_sdk_DownloadResourcesLegacyActivity_nativeSt
     g_currentRequest.reset(HttpRequest::GetFile(downloader->MakeUrlListLegacy(fileName),
                                                 storage.GetFilePath(curFile.GetName(), MapFileType::Map),
                                                 curFile.GetRemoteSize(), std::bind(&DownloadFileFinished, ptr, _1),
-                                                std::bind(&DownloadFileProgress, ptr, _1), 512 * 1024, false));
+                                                std::bind(&DownloadFileProgress, ptr, _1), false));
   });
 
   return ERR_FILE_IN_PROGRESS;

--- a/libs/platform/http_request.cpp
+++ b/libs/platform/http_request.cpp
@@ -260,8 +260,8 @@ HttpRequest::HttpRequest(Callback && onFinish, Callback && onProgress)
 HttpRequest::~HttpRequest() {}
 
 HttpRequest * HttpRequest::GetFile(std::vector<string> const & urls, string const & filePath, int64_t fileSize,
-                                   Callback && onFinish, Callback && onProgress, int64_t chunkSize,
-                                   bool doCleanOnCancel)
+                                   Callback && onFinish, Callback && onProgress, bool doCleanOnCancel,
+                                   int64_t chunkSize)
 {
   try
   {

--- a/libs/platform/http_request.cpp
+++ b/libs/platform/http_request.cpp
@@ -236,7 +236,6 @@ public:
 
     for (auto & chunk : m_chunks)
       chunk.m_handle.Cancel();
-    m_chunks.clear();
 
     if (m_status == DownloadStatus::InProgress)
     {

--- a/libs/platform/http_request.cpp
+++ b/libs/platform/http_request.cpp
@@ -47,6 +47,10 @@ using AliveFlag = std::shared_ptr<std::atomic<bool>>;
 /// is not churned by per-chunk 512 KB byte[] allocations.
 class FileHttpRequest : public HttpRequest
 {
+  // Save .resume to disk every Nth completed chunk so a crash loses at most N-1 chunks.
+  // Tests in downloader_test.cpp depend on this value to choose a "below threshold" cancel point.
+  static size_t constexpr kPeriodicResumeSaveInterval = 10;
+
   ChunksDownloadStrategy m_strategy;
 
   struct ChunkInfo
@@ -150,7 +154,7 @@ class FileHttpRequest : public HttpRequest
     if (isChunkOk)
     {
       ++m_goodChunksCount;
-      if (m_status != DownloadStatus::Completed && m_goodChunksCount % 10 == 0)
+      if (m_status != DownloadStatus::Completed && m_goodChunksCount % kPeriodicResumeSaveInterval == 0)
         SaveResumeChunks();
     }
 
@@ -248,9 +252,9 @@ public:
       }
       else
       {
-        // Periodic SaveResumeChunks() runs only every 10th completed chunk, so .resume
-        // may lag the .downloading file by up to 9 chunks. Flush now so those chunks
-        // aren't re-downloaded on next launch.
+        // Periodic SaveResumeChunks() runs only every kPeriodicResumeSaveInterval-th completed
+        // chunk, so .resume may lag the .downloading file by up to N-1 chunks. Flush now so
+        // those chunks aren't re-downloaded on next launch.
         SaveResumeChunks();
       }
     }

--- a/libs/platform/http_request.cpp
+++ b/libs/platform/http_request.cpp
@@ -64,7 +64,7 @@ class FileHttpRequest : public HttpRequest
   string m_filePath;
   string m_downloadingPath;  // m_filePath + DOWNLOADING_FILE_EXTENSION, cached.
   size_t m_goodChunksCount;
-  bool m_doCleanProgressFiles;
+  bool m_doCleanOnCancel;
 
 #ifdef DEBUG
   std::optional<threads::ThreadID> m_callbackThreadId;
@@ -187,14 +187,14 @@ class FileHttpRequest : public HttpRequest
 
 public:
   FileHttpRequest(std::vector<string> const & urls, string const & filePath, int64_t fileSize, Callback && onFinish,
-                  Callback && onProgress, int64_t chunkSize, bool doCleanProgressFiles)
+                  Callback && onProgress, int64_t chunkSize, bool doCleanOnCancel)
     : HttpRequest(std::move(onFinish), std::move(onProgress))
     , m_strategy(urls)
     , m_alive(std::make_shared<std::atomic<bool>>(true))
     , m_filePath(filePath)
     , m_downloadingPath(filePath + DOWNLOADING_FILE_EXTENSION)
     , m_goodChunksCount(0)
-    , m_doCleanProgressFiles(doCleanProgressFiles)
+    , m_doCleanOnCancel(doCleanOnCancel)
   {
     ASSERT(!urls.empty(), ());
 
@@ -240,7 +240,7 @@ public:
 
     if (m_status == DownloadStatus::InProgress)
     {
-      if (m_doCleanProgressFiles)
+      if (m_doCleanOnCancel)
       {
         // Delete temp files synchronously. Any still-in-flight transport writes will land
         // on the unlinked inode (POSIX: data goes to limbo, inode reclaimed when last fd

--- a/libs/platform/http_request.cpp
+++ b/libs/platform/http_request.cpp
@@ -207,6 +207,7 @@ public:
           static_cast<int64_t>(size) >= m_strategy.RequiredFileSize())
       {
         openMode = FileWriter::OP_WRITE_EXISTING;
+        LOG(LINFO, ("Resuming download of", m_filePath, "from", m_progress.m_bytesDownloaded, "of", fileSize, "bytes"));
       }
       else
       {
@@ -250,6 +251,8 @@ public:
         // Periodic SaveResumeChunks() runs only every kPeriodicResumeSaveInterval-th completed
         // chunk, so .resume may lag the .downloading file by up to N-1 chunks. Flush now so
         // those chunks aren't re-downloaded on next launch.
+        LOG(LINFO, ("Preserving partial download for", m_filePath, "at", m_progress.m_bytesDownloaded, "of",
+                    m_progress.m_bytesTotal, "bytes"));
         SaveResumeChunks();
       }
     }

--- a/libs/platform/http_request.cpp
+++ b/libs/platform/http_request.cpp
@@ -234,15 +234,25 @@ public:
       chunk.m_handle.Cancel();
     m_chunks.clear();
 
-    // Delete temp files synchronously. Any still-in-flight transport writes will land
-    // on the unlinked inode (POSIX: data goes to limbo, inode reclaimed when last fd
-    // closes) or fail silently (Windows) — either way, no interaction with a potential
-    // new download that reuses the same path. A deferred-cleanup scheme here would
-    // introduce a cancel+retry race where the cleanup deletes the NEW download's file.
-    if (m_status == DownloadStatus::InProgress && m_doCleanProgressFiles)
+    if (m_status == DownloadStatus::InProgress)
     {
-      Platform::RemoveFileIfExists(m_downloadingPath);
-      Platform::RemoveFileIfExists(m_filePath + RESUME_FILE_EXTENSION);
+      if (m_doCleanProgressFiles)
+      {
+        // Delete temp files synchronously. Any still-in-flight transport writes will land
+        // on the unlinked inode (POSIX: data goes to limbo, inode reclaimed when last fd
+        // closes) or fail silently (Windows) — either way, no interaction with a potential
+        // new download that reuses the same path. A deferred-cleanup scheme here would
+        // introduce a cancel+retry race where the cleanup deletes the NEW download's file.
+        Platform::RemoveFileIfExists(m_downloadingPath);
+        Platform::RemoveFileIfExists(m_filePath + RESUME_FILE_EXTENSION);
+      }
+      else
+      {
+        // Periodic SaveResumeChunks() runs only every 10th completed chunk, so .resume
+        // may lag the .downloading file by up to 9 chunks. Flush now so those chunks
+        // aren't re-downloaded on next launch.
+        SaveResumeChunks();
+      }
     }
   }
 

--- a/libs/platform/http_request.cpp
+++ b/libs/platform/http_request.cpp
@@ -47,10 +47,6 @@ using AliveFlag = std::shared_ptr<std::atomic<bool>>;
 /// is not churned by per-chunk 512 KB byte[] allocations.
 class FileHttpRequest : public HttpRequest
 {
-  // Save .resume to disk every Nth completed chunk so a crash loses at most N-1 chunks.
-  // Tests in downloader_test.cpp depend on this value to choose a "below threshold" cancel point.
-  static size_t constexpr kPeriodicResumeSaveInterval = 10;
-
   ChunksDownloadStrategy m_strategy;
 
   struct ChunkInfo

--- a/libs/platform/http_request.hpp
+++ b/libs/platform/http_request.hpp
@@ -19,6 +19,9 @@ auto constexpr kInvalidURL = -5;
 auto constexpr kCancelled = -6;
 }  // namespace non_http_error_code
 
+/// .resume is flushed every Nth completed chunk; a hard crash can lose at most N-1.
+inline constexpr size_t kPeriodicResumeSaveInterval = 10;
+
 /// Request in progress will be canceled on delete
 class HttpRequest
 {

--- a/libs/platform/http_request.hpp
+++ b/libs/platform/http_request.hpp
@@ -44,7 +44,7 @@ public:
   /// Download file to filePath.
   /// @param[in]  fileSize  Correct file size (needed for resuming and reserving).
   static HttpRequest * GetFile(std::vector<std::string> const & urls, std::string const & filePath, int64_t fileSize,
-                               Callback && onFinish, Callback && onProgress = Callback(),
-                               int64_t chunkSize = 512 * 1024, bool doCleanOnCancel = true);
+                               Callback && onFinish, Callback && onProgress = Callback(), bool doCleanOnCancel = true,
+                               int64_t chunkSize = 512 * 1024);
 };
 }  // namespace downloader

--- a/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
+++ b/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
@@ -135,7 +135,7 @@ public:
 // Convenience builder for HttpRequest::GetFile bound to a DownloadObserver. Two overloads:
 // the multi-URL form for tests that need URL fallback semantics, and a single-URL form
 // defaulting to kTestUrlBigFile (the common case).
-[[nodiscard]] inline std::unique_ptr<HttpRequest> MakeRequest(vector<string> const & urls, string const & file,
+std::unique_ptr<HttpRequest> MakeRequest(vector<string> const & urls, string const & file,
                                                               int64_t fileSize, DownloadObserver & obs,
                                                               bool doCleanOnCancel = true, int64_t chunkSize = 1024)
 {
@@ -144,7 +144,7 @@ public:
                            bind(&DownloadObserver::OnDownloadProgress, &obs, _1), doCleanOnCancel, chunkSize));
 }
 
-[[nodiscard]] inline std::unique_ptr<HttpRequest> MakeRequest(string const & file, int64_t fileSize,
+std::unique_ptr<HttpRequest> MakeRequest(string const & file, int64_t fileSize,
                                                               DownloadObserver & obs, bool doCleanOnCancel = true,
                                                               int64_t chunkSize = 1024)
 {
@@ -153,7 +153,7 @@ public:
 
 // Reads .resume via the same load path the production constructor uses (LoadOrInitChunks).
 // Returns the bytes-completed claim recorded in the resume file.
-[[nodiscard]] inline int64_t LoadResumeBytes(string const & resumeFile, int64_t fileSize, int64_t chunkSize)
+int64_t LoadResumeBytes(string const & resumeFile, int64_t fileSize, int64_t chunkSize)
 {
   ChunksDownloadStrategy s({});
   return s.LoadOrInitChunks(resumeFile, fileSize, chunkSize);

--- a/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
+++ b/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
@@ -15,6 +15,7 @@
 
 #include <functional>
 #include <memory>
+#include <string_view>
 #include <vector>
 
 #include "defines.hpp"
@@ -23,7 +24,7 @@ namespace downloader_test
 {
 using namespace downloader;
 using namespace std::placeholders;
-using std::bind, std::string, std::vector;
+using std::bind, std::string, std::string_view, std::vector;
 
 char constexpr kTestUrl1[] = "http://localhost:24568/unit_tests/1.txt";
 char constexpr kTestUrl404[] = "http://localhost:24568/unit_tests/notexisting_unittest";
@@ -31,6 +32,35 @@ char constexpr kTestUrlBigFile[] = "http://localhost:24568/unit_tests/47kb.file"
 
 // Should match file size in tools/python/ResponseProvider.py
 int constexpr kBigFileSize = 47684;
+
+// RAII helper: gives each test a unique tmp path and wipes the result/.downloading/.resume
+// triple at construction (clean slate) and destruction (no leakage to next test, even on
+// assertion abort during stack unwind).
+struct ScopedDownloadArtifacts
+{
+  string const m_path;
+
+  explicit ScopedDownloadArtifacts(string_view prefix) : m_path(GetPlatform().TmpPathForFile(string(prefix), ".tmp"))
+  {
+    Wipe();
+  }
+
+  ~ScopedDownloadArtifacts() { Wipe(); }
+
+  ScopedDownloadArtifacts(ScopedDownloadArtifacts const &) = delete;
+  ScopedDownloadArtifacts & operator=(ScopedDownloadArtifacts const &) = delete;
+
+  string Downloading() const { return m_path + DOWNLOADING_FILE_EXTENSION; }
+  string Resume() const { return m_path + RESUME_FILE_EXTENSION; }
+
+private:
+  void Wipe() const
+  {
+    base::DeleteFileX(m_path);
+    base::DeleteFileX(Downloading());
+    base::DeleteFileX(Resume());
+  }
+};
 
 class DownloadObserver
 {
@@ -50,6 +80,7 @@ public:
   {
     m_progressWasCalled = false;
     m_statuses.clear();
+    m_chunksToFail = -1;
   }
 
   void TestOk()
@@ -100,6 +131,33 @@ public:
     QCoreApplication::quit();
   }
 };
+
+// Convenience builder for HttpRequest::GetFile bound to a DownloadObserver. Two overloads:
+// the multi-URL form for tests that need URL fallback semantics, and a single-URL form
+// defaulting to kTestUrlBigFile (the common case).
+[[nodiscard]] inline std::unique_ptr<HttpRequest> MakeRequest(vector<string> const & urls, string const & file,
+                                                              int64_t fileSize, DownloadObserver & obs,
+                                                              bool doCleanOnCancel = true, int64_t chunkSize = 1024)
+{
+  return std::unique_ptr<HttpRequest>(
+      HttpRequest::GetFile(urls, file, fileSize, bind(&DownloadObserver::OnDownloadFinish, &obs, _1),
+                           bind(&DownloadObserver::OnDownloadProgress, &obs, _1), doCleanOnCancel, chunkSize));
+}
+
+[[nodiscard]] inline std::unique_ptr<HttpRequest> MakeRequest(string const & file, int64_t fileSize,
+                                                              DownloadObserver & obs, bool doCleanOnCancel = true,
+                                                              int64_t chunkSize = 1024)
+{
+  return MakeRequest({kTestUrlBigFile}, file, fileSize, obs, doCleanOnCancel, chunkSize);
+}
+
+// Reads .resume via the same load path the production constructor uses (LoadOrInitChunks).
+// Returns the bytes-completed claim recorded in the resume file.
+[[nodiscard]] inline int64_t LoadResumeBytes(string const & resumeFile, int64_t fileSize, int64_t chunkSize)
+{
+  ChunksDownloadStrategy s({});
+  return s.LoadOrInitChunks(resumeFile, fileSize, chunkSize);
+}
 
 UNIT_TEST(ChunksDownloadStrategy)
 {
@@ -240,96 +298,66 @@ void FinishDownloadFail(string const & file)
 
   TEST(base::DeleteFileX(file + RESUME_FILE_EXTENSION), ("Resume file should present on fail"));
 }
-
-void DeleteTempDownloadFiles()
-{
-  // Remove data from previously failed files.
-
-  // Get regexp like this: (\.downloading3$|\.resume3$)
-  string const regexp = "(\\" RESUME_FILE_EXTENSION "$|\\" DOWNLOADING_FILE_EXTENSION "$)";
-
-  Platform::FilesList files;
-  Platform::GetFilesByRegExp(".", regexp, files);
-  for (Platform::FilesList::iterator it = files.begin(); it != files.end(); ++it)
-    FileWriter::DeleteFileX(*it);
-}
 }  // namespace
 
 UNIT_TEST(DownloadChunks)
 {
-  string const kFileName = GetPlatform().TmpPathForFile("downloader_test_", ".tmp");
-
-  // remove data from previously failed files
-  DeleteTempDownloadFiles();
-
-  vector<string> urls = {kTestUrl1, kTestUrl1};
-  int64_t fileSize = 5;
+  ScopedDownloadArtifacts files{"downloader_test_"};
 
   DownloadObserver observer;
-  auto const MakeRequest = [&](int64_t chunkSize)
-  {
-    return HttpRequest::GetFile(urls, kFileName, fileSize, bind(&DownloadObserver::OnDownloadFinish, &observer, _1),
-                                bind(&DownloadObserver::OnDownloadProgress, &observer, _1), true /* doCleanOnCancel */,
-                                chunkSize);
-  };
 
   {
     // should use only one thread
-    std::unique_ptr<HttpRequest> const request{MakeRequest(512 * 1024)};
-    // wait until download is finished
+    auto const request = MakeRequest({kTestUrl1, kTestUrl1}, files.m_path, 5, observer,
+                                     /*doCleanOnCancel=*/true, /*chunkSize=*/512 * 1024);
     QCoreApplication::exec();
     observer.TestOk();
-    TEST_EQUAL(request->GetFilePath(), kFileName, ());
-    TEST_EQUAL(ReadFileAsString(kFileName), "Test1", ());
-    FinishDownloadSuccess(kFileName);
+    TEST_EQUAL(request->GetFilePath(), files.m_path, ());
+    TEST_EQUAL(ReadFileAsString(files.m_path), "Test1", ());
+    FinishDownloadSuccess(files.m_path);
   }
 
   observer.Reset();
-  urls = {kTestUrlBigFile, kTestUrlBigFile, kTestUrlBigFile};
-  fileSize = 5;
   {
     // 3 threads - fail, because of invalid size
-    [[maybe_unused]] std::unique_ptr<HttpRequest> const request{MakeRequest(2048)};
-    // wait until download is finished
+    [[maybe_unused]] auto const request =
+        MakeRequest({kTestUrlBigFile, kTestUrlBigFile, kTestUrlBigFile}, files.m_path, 5, observer,
+                    /*doCleanOnCancel=*/true, /*chunkSize=*/2048);
     QCoreApplication::exec();
     observer.TestFailed();
-    FinishDownloadFail(kFileName);
+    FinishDownloadFail(files.m_path);
   }
 
   observer.Reset();
-  urls = {kTestUrlBigFile, kTestUrlBigFile, kTestUrlBigFile};
-  fileSize = kBigFileSize;
   {
     // 3 threads - succeeded
-    [[maybe_unused]] std::unique_ptr<HttpRequest> const request{MakeRequest(2048)};
-    // wait until download is finished
+    [[maybe_unused]] auto const request =
+        MakeRequest({kTestUrlBigFile, kTestUrlBigFile, kTestUrlBigFile}, files.m_path, kBigFileSize, observer,
+                    /*doCleanOnCancel=*/true, /*chunkSize=*/2048);
     QCoreApplication::exec();
     observer.TestOk();
-    FinishDownloadSuccess(kFileName);
+    FinishDownloadSuccess(files.m_path);
   }
 
   observer.Reset();
-  urls = {kTestUrlBigFile, kTestUrl1, kTestUrl404};
-  fileSize = kBigFileSize;
   {
     // 3 threads with only one valid url - succeeded
-    [[maybe_unused]] std::unique_ptr<HttpRequest> const request{MakeRequest(2048)};
-    // wait until download is finished
+    [[maybe_unused]] auto const request =
+        MakeRequest({kTestUrlBigFile, kTestUrl1, kTestUrl404}, files.m_path, kBigFileSize, observer,
+                    /*doCleanOnCancel=*/true, /*chunkSize=*/2048);
     QCoreApplication::exec();
     observer.TestOk();
-    FinishDownloadSuccess(kFileName);
+    FinishDownloadSuccess(files.m_path);
   }
 
   observer.Reset();
-  urls = {kTestUrlBigFile, kTestUrlBigFile};
-  fileSize = 12345;
   {
     // 2 threads and all points to file with invalid size - fail
-    [[maybe_unused]] std::unique_ptr<HttpRequest> const request{MakeRequest(2048)};
-    // wait until download is finished
+    [[maybe_unused]] auto const request = MakeRequest({kTestUrlBigFile, kTestUrlBigFile}, files.m_path, 12345, observer,
+                                                      /*doCleanOnCancel=*/true, /*chunkSize=*/2048);
     QCoreApplication::exec();
     observer.TestFailed();
-    FinishDownloadFail(kFileName);
+    FinishDownloadFail(files.m_path);
   }
 }
 
@@ -371,37 +399,25 @@ struct ResumeChecker
 
 UNIT_TEST(DownloadResumeChunks)
 {
-  string const FILENAME = GetPlatform().TmpPathForFile("downloader_resume_test_", ".tmp");
-  string const RESUME_FILENAME = FILENAME + RESUME_FILE_EXTENSION;
-  string const DOWNLOADING_FILENAME = FILENAME + DOWNLOADING_FILE_EXTENSION;
-
-  // remove data from previously failed files
-  DeleteTempDownloadFiles();
-
-  vector<string> urls = {kTestUrlBigFile};
+  ScopedDownloadArtifacts files{"downloader_resume_test_"};
 
   // 1st step - download full file
   {
     DownloadObserver observer;
-
-    std::unique_ptr<HttpRequest> const request(
-        HttpRequest::GetFile(urls, FILENAME, kBigFileSize, bind(&DownloadObserver::OnDownloadFinish, &observer, _1),
-                             bind(&DownloadObserver::OnDownloadProgress, &observer, _1)));
-
+    auto const request = MakeRequest(files.m_path, kBigFileSize, observer);
     QCoreApplication::exec();
-
     observer.TestOk();
 
     uint64_t size;
-    TEST(!base::GetFileSize(RESUME_FILENAME, size), ("No resume file on success"));
+    TEST(!base::GetFileSize(files.Resume(), size), ("No resume file on success"));
   }
 
   // 2nd step - mark some file blocks as not downloaded
   {
     // to substitute temporary not fully downloaded file
-    TEST(base::RenameFileX(FILENAME, DOWNLOADING_FILENAME), ());
+    TEST(base::RenameFileX(files.m_path, files.Downloading()), ());
 
-    FileWriter f(DOWNLOADING_FILENAME, FileWriter::OP_WRITE_EXISTING);
+    FileWriter f(files.Downloading(), FileWriter::OP_WRITE_EXISTING);
     f.Seek(beg1);
     char b1[end1 - beg1 + 1] = {0};
     f.Write(b1, ARRAY_SIZE(b1));
@@ -416,30 +432,25 @@ UNIT_TEST(DownloadResumeChunks)
     strategy.AddChunk(std::make_pair(end1 + 1, beg2 - 1), ChunksDownloadStrategy::CHUNK_COMPLETE);
     strategy.AddChunk(std::make_pair(beg2, end2), ChunksDownloadStrategy::CHUNK_FREE);
 
-    strategy.SaveChunks(kBigFileSize, RESUME_FILENAME);
+    strategy.SaveChunks(kBigFileSize, files.Resume());
   }
 
   // 3rd step - check that resume works
   {
     ResumeChecker checker;
-    std::unique_ptr<HttpRequest> const request(HttpRequest::GetFile(urls, FILENAME, kBigFileSize,
+    std::unique_ptr<HttpRequest> const request(HttpRequest::GetFile({kTestUrlBigFile}, files.m_path, kBigFileSize,
                                                                     bind(&ResumeChecker::OnFinish, &checker, _1),
                                                                     bind(&ResumeChecker::OnProgress, &checker, _1)));
     QCoreApplication::exec();
 
-    FinishDownloadSuccess(FILENAME);
+    FinishDownloadSuccess(files.m_path);
   }
 }
 
 // Unit test with forcible canceling of http request
 UNIT_TEST(DownloadResumeChunksWithCancel)
 {
-  string const FILENAME = GetPlatform().TmpPathForFile("downloader_resume_test_", ".tmp");
-
-  // remove data from previously failed files
-  DeleteTempDownloadFiles();
-
-  vector<string> urls = {kTestUrlBigFile};
+  ScopedDownloadArtifacts files{"downloader_resume_test_"};
 
   DownloadObserver observer;
 
@@ -447,21 +458,19 @@ UNIT_TEST(DownloadResumeChunksWithCancel)
 
   for (size_t i = 0; i < ARRAY_SIZE(arrCancelChunks); ++i)
   {
-    // Always reset cancel state. Without this, an iteration whose download completes
-    // naturally (cancel never reached) leaves m_chunksToFail > 0, which would then
-    // cancel a later "no cancel" iteration unexpectedly.
-    observer.CancelDownloadOnGivenChunk(arrCancelChunks[i] > 0 ? arrCancelChunks[i] : -1);
+    // Reset() clears m_chunksToFail; this call sets the new value (or leaves it at -1 for "no cancel").
+    if (arrCancelChunks[i] > 0)
+      observer.CancelDownloadOnGivenChunk(arrCancelChunks[i]);
+    else
+      observer.Reset();
 
-    std::unique_ptr<HttpRequest> const request(HttpRequest::GetFile(
-        urls, FILENAME, kBigFileSize, bind(&DownloadObserver::OnDownloadFinish, &observer, _1),
-        bind(&DownloadObserver::OnDownloadProgress, &observer, _1), false /* doCleanOnCancel */, 1024 /* chunkSize */));
-
+    auto const request = MakeRequest(files.m_path, kBigFileSize, observer, /*doCleanOnCancel=*/false);
     QCoreApplication::exec();
   }
 
   observer.TestOk();
 
-  FinishDownloadSuccess(FILENAME);
+  FinishDownloadSuccess(files.m_path);
 }
 
 }  // namespace downloader_test

--- a/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
+++ b/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
@@ -269,7 +269,8 @@ UNIT_TEST(DownloadChunks)
   auto const MakeRequest = [&](int64_t chunkSize)
   {
     return HttpRequest::GetFile(urls, kFileName, fileSize, bind(&DownloadObserver::OnDownloadFinish, &observer, _1),
-                                bind(&DownloadObserver::OnDownloadProgress, &observer, _1), chunkSize);
+                                bind(&DownloadObserver::OnDownloadProgress, &observer, _1), true /* doCleanOnCancel */,
+                                chunkSize);
   };
 
   {
@@ -449,9 +450,9 @@ UNIT_TEST(DownloadResumeChunksWithCancel)
     if (arrCancelChunks[i] > 0)
       observer.CancelDownloadOnGivenChunk(arrCancelChunks[i]);
 
-    std::unique_ptr<HttpRequest> const request(
-        HttpRequest::GetFile(urls, FILENAME, kBigFileSize, bind(&DownloadObserver::OnDownloadFinish, &observer, _1),
-                             bind(&DownloadObserver::OnDownloadProgress, &observer, _1), 1024, false));
+    std::unique_ptr<HttpRequest> const request(HttpRequest::GetFile(
+        urls, FILENAME, kBigFileSize, bind(&DownloadObserver::OnDownloadFinish, &observer, _1),
+        bind(&DownloadObserver::OnDownloadProgress, &observer, _1), false /* doCleanOnCancel */, 1024 /* chunkSize */));
 
     QCoreApplication::exec();
   }

--- a/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
+++ b/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
@@ -447,8 +447,10 @@ UNIT_TEST(DownloadResumeChunksWithCancel)
 
   for (size_t i = 0; i < ARRAY_SIZE(arrCancelChunks); ++i)
   {
-    if (arrCancelChunks[i] > 0)
-      observer.CancelDownloadOnGivenChunk(arrCancelChunks[i]);
+    // Always reset cancel state. Without this, an iteration whose download completes
+    // naturally (cancel never reached) leaves m_chunksToFail > 0, which would then
+    // cancel a later "no cancel" iteration unexpectedly.
+    observer.CancelDownloadOnGivenChunk(arrCancelChunks[i] > 0 ? arrCancelChunks[i] : -1);
 
     std::unique_ptr<HttpRequest> const request(HttpRequest::GetFile(
         urls, FILENAME, kBigFileSize, bind(&DownloadObserver::OnDownloadFinish, &observer, _1),

--- a/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
+++ b/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
@@ -473,4 +473,137 @@ UNIT_TEST(DownloadResumeChunksWithCancel)
   FinishDownloadSuccess(files.m_path);
 }
 
+// Cancel mid-flight with doCleanOnCancel=true (the "user removes country" path).
+// Asserts: ~FileHttpRequest wipes both .downloading and .resume when status is InProgress
+// and m_doCleanProgressFiles is true (http_request.cpp lines 246-247). No other test
+// exercises this branch — DownloadChunks always lets requests complete naturally.
+UNIT_TEST(HttpRequest_CancelMidFlight_DoClean_WipesArtifacts)
+{
+  ScopedDownloadArtifacts files{"http_cancel_clean_"};
+  DownloadObserver obs;
+  obs.CancelDownloadOnGivenChunk(5);
+  {
+    auto req = MakeRequest(files.m_path, kBigFileSize, obs, /*doCleanOnCancel=*/true);
+    QCoreApplication::exec();
+  }  // dtor runs while m_status == InProgress
+
+  uint64_t size = 0;
+  TEST(!base::GetFileSize(files.Downloading(), size), ("Downloading must be wiped"));
+  TEST(!base::GetFileSize(files.Resume(), size), ("Resume must be wiped"));
+}
+
+// Cancel mid-flight with doCleanOnCancel=false (the "graceful shutdown" path).
+// Asserts: ~FileHttpRequest preserves both files when status is InProgress and
+// m_doCleanProgressFiles is false (http_request.cpp lines 249-258). Pins down the
+// positive contract of the new flag semantics.
+UNIT_TEST(HttpRequest_CancelMidFlight_NoClean_PreservesArtifacts)
+{
+  ScopedDownloadArtifacts files{"http_cancel_preserve_"};
+  DownloadObserver obs;
+  obs.CancelDownloadOnGivenChunk(5);
+  {
+    auto req = MakeRequest(files.m_path, kBigFileSize, obs, /*doCleanOnCancel=*/false);
+    QCoreApplication::exec();
+  }
+  uint64_t downloadingSize = 0, resumeSize = 0;
+  TEST(base::GetFileSize(files.Downloading(), downloadingSize), ("Downloading must be preserved"));
+  TEST(base::GetFileSize(files.Resume(), resumeSize), ("Resume must be preserved"));
+  TEST_GREATER(downloadingSize, 0u, ());
+  TEST_GREATER(resumeSize, 0u, ());
+}
+
+// Regression test for the destructor flush. Cancel point (5) must stay below
+// kPeriodicResumeSaveInterval (10, in http_request.cpp), so the periodic save never fires.
+// Without the dtor's SaveResumeChunks() call, .resume would be missing or stale.
+UNIT_TEST(HttpRequest_CancelMidFlight_NoClean_ResumeReflectsAllCompletedChunks)
+{
+  ScopedDownloadArtifacts files{"http_resume_flush_"};
+  int64_t constexpr kChunkSize = 1024;
+  int constexpr kCancelAtChunk = 5;  // < kPeriodicResumeSaveInterval (10)
+  DownloadObserver obs;
+  obs.CancelDownloadOnGivenChunk(kCancelAtChunk);
+  {
+    auto req = MakeRequest(files.m_path, kBigFileSize, obs, /*doCleanOnCancel=*/false, kChunkSize);
+    QCoreApplication::exec();
+  }
+  // kCancelAtChunk - 1 because the chunk that triggered cancel may not have completed before quit().
+  int64_t const resumed = LoadResumeBytes(files.Resume(), kBigFileSize, kChunkSize);
+  TEST_GREATER_OR_EQUAL(resumed, (kCancelAtChunk - 1) * kChunkSize,
+                        ("Resume file under-reports completed bytes; dtor flush regressed"));
+}
+
+// End-to-end round-trip: cancel + preserve + reload + complete. Validates the user-facing
+// claim that graceful shutdown does not lose progress. Catches regressions in the dtor
+// preservation/flush, ctor reload (LoadOrInitChunks at http_request.cpp:198), and success
+// cleanup, all in one test.
+UNIT_TEST(HttpRequest_ResumeFromPreservedArtifacts_SkipsCompletedChunks)
+{
+  ScopedDownloadArtifacts files{"http_round_trip_"};
+  int64_t constexpr kChunkSize = 1024;
+  int64_t bytesAfterCancel = 0;
+  {
+    DownloadObserver obs;
+    obs.CancelDownloadOnGivenChunk(5);
+    auto req = MakeRequest(files.m_path, kBigFileSize, obs, /*doCleanOnCancel=*/false, kChunkSize);
+    QCoreApplication::exec();
+    bytesAfterCancel = req->GetProgress().m_bytesDownloaded;
+  }
+  TEST_GREATER(bytesAfterCancel, 0, ());
+
+  DownloadObserver obs2;
+  auto req2 = MakeRequest(files.m_path, kBigFileSize, obs2, /*doCleanOnCancel=*/false, kChunkSize);
+  // Construction reloaded preserved resume state — this is the user-facing claim.
+  TEST_GREATER_OR_EQUAL(req2->GetProgress().m_bytesDownloaded, bytesAfterCancel, ());
+  QCoreApplication::exec();
+  obs2.TestOk();
+
+  // After natural success, files must be cleaned up regardless of the doCleanOnCancel flag.
+  uint64_t size = 0;
+  TEST(base::GetFileSize(files.m_path, size), ("Result file must exist"));
+  TEST(!base::GetFileSize(files.Downloading(), size), ());
+  TEST(!base::GetFileSize(files.Resume(), size), ());
+}
+
+// On success, the OnChunkFinished cleanup path (http_request.cpp:165-170) must run
+// regardless of doCleanOnCancel — the flag only governs the dtor's InProgress branch.
+// Pins this invariant explicitly so a future "optimization" gating success cleanup
+// behind the flag is caught.
+UNIT_TEST(HttpRequest_Success_AlwaysCleansArtifacts_DespiteNoClean)
+{
+  ScopedDownloadArtifacts files{"http_success_noclean_"};
+  DownloadObserver obs;
+  {
+    auto req = MakeRequest(files.m_path, kBigFileSize, obs, /*doCleanOnCancel=*/false);
+    QCoreApplication::exec();
+  }
+  obs.TestOk();
+
+  uint64_t size = 0;
+  TEST(base::GetFileSize(files.m_path, size), ("Result must exist"));
+  TEST(!base::GetFileSize(files.Downloading(), size), ("Downloading wiped on success"));
+  TEST(!base::GetFileSize(files.Resume(), size), ("Resume wiped on success"));
+}
+
+// On failure, OnChunkFinished's save-on-fail (http_request.cpp:161-162) must run
+// regardless of doCleanOnCancel. Existing DownloadChunks failure tests only cover
+// the flag=true case; this exercises both.
+UNIT_TEST(HttpRequest_Failure_PreservesResume_RegardlessOfFlag)
+{
+  for (bool doCleanOnCancel : {true, false})
+  {
+    ScopedDownloadArtifacts files{"http_fail_"};
+    DownloadObserver obs;
+    {
+      // fileSize mismatch with the real server file triggers Failed status.
+      auto req = MakeRequest({kTestUrlBigFile, kTestUrlBigFile}, files.m_path, /*fileSize=*/12345, obs, doCleanOnCancel,
+                             /*chunkSize=*/2048);
+      QCoreApplication::exec();
+    }
+    obs.TestFailed();
+
+    uint64_t size = 0;
+    TEST(base::GetFileSize(files.Resume(), size), ("Resume must be preserved on failure"));
+  }
+}
+
 }  // namespace downloader_test

--- a/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
+++ b/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
@@ -447,32 +447,6 @@ UNIT_TEST(DownloadResumeChunks)
   }
 }
 
-// Unit test with forcible canceling of http request
-UNIT_TEST(DownloadResumeChunksWithCancel)
-{
-  ScopedDownloadArtifacts files{"downloader_resume_test_"};
-
-  DownloadObserver observer;
-
-  int arrCancelChunks[] = {1, 3, 10, 15, 20, 0};
-
-  for (size_t i = 0; i < ARRAY_SIZE(arrCancelChunks); ++i)
-  {
-    // Reset() clears m_chunksToFail; this call sets the new value (or leaves it at -1 for "no cancel").
-    if (arrCancelChunks[i] > 0)
-      observer.CancelDownloadOnGivenChunk(arrCancelChunks[i]);
-    else
-      observer.Reset();
-
-    auto const request = MakeRequest(files.m_path, kBigFileSize, observer, /*doCleanOnCancel=*/false);
-    QCoreApplication::exec();
-  }
-
-  observer.TestOk();
-
-  FinishDownloadSuccess(files.m_path);
-}
-
 // Cancel mid-flight with doCleanOnCancel=true (the "user removes country" path).
 // Asserts: ~FileHttpRequest wipes both .downloading and .resume when status is InProgress
 // and m_doCleanProgressFiles is true (http_request.cpp lines 246-247). No other test

--- a/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
+++ b/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
@@ -453,7 +453,10 @@ UNIT_TEST(HttpRequest_CancelMidFlight_DoClean_WipesArtifacts)
 {
   ScopedDownloadArtifacts files{"http_cancel_clean_"};
   DownloadObserver obs;
-  obs.CancelDownloadOnGivenChunk(5);
+  // Cancel after the periodic SaveResumeChunks() has fired, otherwise no .resume exists
+  // on disk at dtor time and the wipe assertion below is vacuous.
+  int constexpr kCancelAtChunk = kPeriodicResumeSaveInterval + 1;
+  obs.CancelDownloadOnGivenChunk(kCancelAtChunk);
   {
     auto req = MakeRequest(files.m_path, kBigFileSize, obs, /*doCleanOnCancel=*/true);
     QCoreApplication::exec();
@@ -498,9 +501,12 @@ UNIT_TEST(HttpRequest_CancelMidFlight_NoClean_ResumeReflectsAllCompletedChunks)
     auto req = MakeRequest(files.m_path, kBigFileSize, obs, /*doCleanOnCancel=*/false, kChunkSize);
     QCoreApplication::exec();
   }
-  // kCancelAtChunk - 1 because the chunk that triggered cancel may not have completed before quit().
+  // OnDownloadProgress fires after ChunkFinished marks the chunk complete in the strategy,
+  // so the cancel-triggering chunk is committed by quit() time. The next chunk (started
+  // synchronously after the callback) may or may not finish before exec() returns, so the
+  // bound is >= kCancelAtChunk, never == .
   int64_t const resumed = LoadResumeBytes(files.Resume(), kBigFileSize, kChunkSize);
-  TEST_GREATER_OR_EQUAL(resumed, (kCancelAtChunk - 1) * kChunkSize,
+  TEST_GREATER_OR_EQUAL(resumed, kCancelAtChunk * kChunkSize,
                         ("Resume file under-reports completed bytes; dtor flush regressed"));
 }
 

--- a/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
+++ b/libs/platform/platform_tests/downloader_tests/downloader_test.cpp
@@ -56,9 +56,9 @@ struct ScopedDownloadArtifacts
 private:
   void Wipe() const
   {
-    base::DeleteFileX(m_path);
-    base::DeleteFileX(Downloading());
-    base::DeleteFileX(Resume());
+    Platform::RemoveFileIfExists(m_path);
+    Platform::RemoveFileIfExists(Downloading());
+    Platform::RemoveFileIfExists(Resume());
   }
 };
 
@@ -320,9 +320,8 @@ UNIT_TEST(DownloadChunks)
   observer.Reset();
   {
     // 3 threads - fail, because of invalid size
-    [[maybe_unused]] auto const request =
-        MakeRequest({kTestUrlBigFile, kTestUrlBigFile, kTestUrlBigFile}, files.m_path, 5, observer,
-                    /*doCleanOnCancel=*/true, /*chunkSize=*/2048);
+    auto const request = MakeRequest({kTestUrlBigFile, kTestUrlBigFile, kTestUrlBigFile}, files.m_path, 5, observer,
+                                     /*doCleanOnCancel=*/true, /*chunkSize=*/2048);
     QCoreApplication::exec();
     observer.TestFailed();
     FinishDownloadFail(files.m_path);
@@ -331,7 +330,7 @@ UNIT_TEST(DownloadChunks)
   observer.Reset();
   {
     // 3 threads - succeeded
-    [[maybe_unused]] auto const request =
+    auto const request =
         MakeRequest({kTestUrlBigFile, kTestUrlBigFile, kTestUrlBigFile}, files.m_path, kBigFileSize, observer,
                     /*doCleanOnCancel=*/true, /*chunkSize=*/2048);
     QCoreApplication::exec();
@@ -342,9 +341,8 @@ UNIT_TEST(DownloadChunks)
   observer.Reset();
   {
     // 3 threads with only one valid url - succeeded
-    [[maybe_unused]] auto const request =
-        MakeRequest({kTestUrlBigFile, kTestUrl1, kTestUrl404}, files.m_path, kBigFileSize, observer,
-                    /*doCleanOnCancel=*/true, /*chunkSize=*/2048);
+    auto const request = MakeRequest({kTestUrlBigFile, kTestUrl1, kTestUrl404}, files.m_path, kBigFileSize, observer,
+                                     /*doCleanOnCancel=*/true, /*chunkSize=*/2048);
     QCoreApplication::exec();
     observer.TestOk();
     FinishDownloadSuccess(files.m_path);
@@ -353,8 +351,8 @@ UNIT_TEST(DownloadChunks)
   observer.Reset();
   {
     // 2 threads and all points to file with invalid size - fail
-    [[maybe_unused]] auto const request = MakeRequest({kTestUrlBigFile, kTestUrlBigFile}, files.m_path, 12345, observer,
-                                                      /*doCleanOnCancel=*/true, /*chunkSize=*/2048);
+    auto const request = MakeRequest({kTestUrlBigFile, kTestUrlBigFile}, files.m_path, 12345, observer,
+                                     /*doCleanOnCancel=*/true, /*chunkSize=*/2048);
     QCoreApplication::exec();
     observer.TestFailed();
     FinishDownloadFail(files.m_path);
@@ -448,9 +446,9 @@ UNIT_TEST(DownloadResumeChunks)
 }
 
 // Cancel mid-flight with doCleanOnCancel=true (the "user removes country" path).
-// Asserts: ~FileHttpRequest wipes both .downloading and .resume when status is InProgress
-// and m_doCleanProgressFiles is true (http_request.cpp lines 246-247). No other test
-// exercises this branch — DownloadChunks always lets requests complete naturally.
+// Asserts: ~FileHttpRequest wipes both .downloading and .resume when destroyed while
+// the request is still InProgress. No other test exercises this branch — DownloadChunks
+// always lets requests complete naturally.
 UNIT_TEST(HttpRequest_CancelMidFlight_DoClean_WipesArtifacts)
 {
   ScopedDownloadArtifacts files{"http_cancel_clean_"};
@@ -467,9 +465,8 @@ UNIT_TEST(HttpRequest_CancelMidFlight_DoClean_WipesArtifacts)
 }
 
 // Cancel mid-flight with doCleanOnCancel=false (the "graceful shutdown" path).
-// Asserts: ~FileHttpRequest preserves both files when status is InProgress and
-// m_doCleanProgressFiles is false (http_request.cpp lines 249-258). Pins down the
-// positive contract of the new flag semantics.
+// Asserts: ~FileHttpRequest preserves both files when destroyed while the request is
+// still InProgress. Pins down the positive contract of the new flag semantics.
 UNIT_TEST(HttpRequest_CancelMidFlight_NoClean_PreservesArtifacts)
 {
   ScopedDownloadArtifacts files{"http_cancel_preserve_"};
@@ -486,14 +483,15 @@ UNIT_TEST(HttpRequest_CancelMidFlight_NoClean_PreservesArtifacts)
   TEST_GREATER(resumeSize, 0u, ());
 }
 
-// Regression test for the destructor flush. Cancel point (5) must stay below
-// kPeriodicResumeSaveInterval (10, in http_request.cpp), so the periodic save never fires.
-// Without the dtor's SaveResumeChunks() call, .resume would be missing or stale.
+// Regression test for the destructor flush. Cancel point must stay below
+// kPeriodicResumeSaveInterval so the periodic save never fires; without the dtor's
+// SaveResumeChunks() call, .resume would be missing or stale.
 UNIT_TEST(HttpRequest_CancelMidFlight_NoClean_ResumeReflectsAllCompletedChunks)
 {
   ScopedDownloadArtifacts files{"http_resume_flush_"};
   int64_t constexpr kChunkSize = 1024;
-  int constexpr kCancelAtChunk = 5;  // < kPeriodicResumeSaveInterval (10)
+  int constexpr kCancelAtChunk = 5;
+  static_assert(kCancelAtChunk < kPeriodicResumeSaveInterval, "Periodic save would mask the dtor flush");
   DownloadObserver obs;
   obs.CancelDownloadOnGivenChunk(kCancelAtChunk);
   {
@@ -508,8 +506,7 @@ UNIT_TEST(HttpRequest_CancelMidFlight_NoClean_ResumeReflectsAllCompletedChunks)
 
 // End-to-end round-trip: cancel + preserve + reload + complete. Validates the user-facing
 // claim that graceful shutdown does not lose progress. Catches regressions in the dtor
-// preservation/flush, ctor reload (LoadOrInitChunks at http_request.cpp:198), and success
-// cleanup, all in one test.
+// preservation/flush, ctor reload via LoadOrInitChunks, and success cleanup, all in one test.
 UNIT_TEST(HttpRequest_ResumeFromPreservedArtifacts_SkipsCompletedChunks)
 {
   ScopedDownloadArtifacts files{"http_round_trip_"};
@@ -538,10 +535,9 @@ UNIT_TEST(HttpRequest_ResumeFromPreservedArtifacts_SkipsCompletedChunks)
   TEST(!base::GetFileSize(files.Resume(), size), ());
 }
 
-// On success, the OnChunkFinished cleanup path (http_request.cpp:165-170) must run
-// regardless of doCleanOnCancel — the flag only governs the dtor's InProgress branch.
-// Pins this invariant explicitly so a future "optimization" gating success cleanup
-// behind the flag is caught.
+// On success, the OnChunkFinished cleanup path must run regardless of doCleanOnCancel —
+// the flag only governs the dtor's InProgress branch. Pins this invariant explicitly so
+// a future "optimization" gating success cleanup behind the flag is caught.
 UNIT_TEST(HttpRequest_Success_AlwaysCleansArtifacts_DespiteNoClean)
 {
   ScopedDownloadArtifacts files{"http_success_noclean_"};
@@ -558,9 +554,8 @@ UNIT_TEST(HttpRequest_Success_AlwaysCleansArtifacts_DespiteNoClean)
   TEST(!base::GetFileSize(files.Resume(), size), ("Resume wiped on success"));
 }
 
-// On failure, OnChunkFinished's save-on-fail (http_request.cpp:161-162) must run
-// regardless of doCleanOnCancel. Existing DownloadChunks failure tests only cover
-// the flag=true case; this exercises both.
+// On failure, OnChunkFinished's save-on-fail path must run regardless of doCleanOnCancel.
+// Existing DownloadChunks failure tests only cover the flag=true case; this exercises both.
 UNIT_TEST(HttpRequest_Failure_PreservesResume_RegardlessOfFlag)
 {
   for (bool doCleanOnCancel : {true, false})

--- a/libs/storage/http_map_files_downloader.cpp
+++ b/libs/storage/http_map_files_downloader.cpp
@@ -63,7 +63,7 @@ void HttpMapFilesDownloader::Download()
     m_request.reset(downloader::HttpRequest::GetFile(
         urls, path, size, std::bind(&HttpMapFilesDownloader::OnMapFileDownloaded, this, queuedCountry, _1),
         std::bind(&HttpMapFilesDownloader::OnMapFileDownloadingProgress, this, queuedCountry, _1),
-        512 * 1024 /* chunkSize */, false /* doCleanOnCancel */));
+        false /* doCleanOnCancel */));
   }
   else
   {

--- a/libs/storage/http_map_files_downloader.cpp
+++ b/libs/storage/http_map_files_downloader.cpp
@@ -3,6 +3,9 @@
 #include "storage/downloader.hpp"
 
 #include "platform/downloader_defines.hpp"
+#include "platform/platform.hpp"
+
+#include "defines.hpp"
 
 #include <functional>
 
@@ -96,6 +99,17 @@ void HttpMapFilesDownloader::Clear()
   CHECK_THREAD_CHECKER(m_checker, ());
 
   MapFilesDownloader::Clear();
+
+  // Wipe in-flight artifacts before tearing down m_request, since the dtor preserves them
+  // (doCleanOnCancel=false). Clear() is "throw everything away" — leaving .downloading and
+  // .resume on disk would orphan files that nothing else cleans up.
+  if (m_request && !m_queue.IsEmpty())
+  {
+    auto const path = m_queue.GetFirstCountry().GetFileDownloadPath();
+    Platform::RemoveFileIfExists(path);
+    Platform::RemoveFileIfExists(path + DOWNLOADING_FILE_EXTENSION);
+    Platform::RemoveFileIfExists(path + RESUME_FILE_EXTENSION);
+  }
 
   m_request.reset();
   m_queue.Clear();

--- a/libs/storage/http_map_files_downloader.cpp
+++ b/libs/storage/http_map_files_downloader.cpp
@@ -57,9 +57,13 @@ void HttpMapFilesDownloader::Download()
     queuedCountry.OnStartDownloading();
 
     using namespace std::placeholders;
+    // doCleanOnCancel=false: keep .downloading and .resume on destruction so a graceful
+    // app shutdown mid-download does not lose progress. Storage::DeleteCountryFilesFromDownloader
+    // wipes them explicitly when the user actually removes the country.
     m_request.reset(downloader::HttpRequest::GetFile(
         urls, path, size, std::bind(&HttpMapFilesDownloader::OnMapFileDownloaded, this, queuedCountry, _1),
-        std::bind(&HttpMapFilesDownloader::OnMapFileDownloadingProgress, this, queuedCountry, _1)));
+        std::bind(&HttpMapFilesDownloader::OnMapFileDownloadingProgress, this, queuedCountry, _1),
+        512 * 1024 /* chunkSize */, false /* doCleanOnCancel */));
   }
   else
   {


### PR DESCRIPTION
## Summary
Map downloads now preserve `.downloading` and `.resume` files when `~FileHttpRequest` runs while the request is still `InProgress` (e.g. graceful app shutdown), so users do not lose progress and can resume on the next launch. Previously the dtor wiped those files unconditionally.

## Changes
- `HttpRequest::GetFile` adds `doCleanOnCancel` (default `true` preserves the old contract). `HttpMapFilesDownloader` passes `false` so storage downloads are preserved on shutdown; `Storage::DeleteCountryFilesFromDownloader` keeps wiping them when the user actually removes the country.
- `~FileHttpRequest` flushes `.resume` on the preserve path so up to `kPeriodicResumeSaveInterval - 1` chunks aren't re-downloaded.
- `HttpMapFilesDownloader::Clear()` now wipes the in-flight country's artifacts before resetting the request — `Clear()` is the "throw everything away" path and the new preserve default would otherwise orphan files.
- Constant `kPeriodicResumeSaveInterval` lifted to the public header so tests can `static_assert` against it.
- `LOG(LINFO)` on resume / preserve events for diagnosability.
- `downloader_test.cpp` refactored: RAII `ScopedDownloadArtifacts`, `MakeRequest` helpers, and 6 focused tests covering both flag values across cancel / success / failure / round-trip.

Affects Android and Qt desktop. iOS uses `BackgroundDownloaderAdapter` (`libs/storage/CMakeLists.txt:51-62`) and is not affected.

LLM tools were used to draft and review the change.

## Test plan
- [x] `ctest -R "platform_tests|storage_tests" --test-dir build-...`
- [ ] Manual on Qt: start a download, quit the app mid-download, relaunch, verify progress resumes from the preserved `.resume` instead of restarting.
- [ ] Manual on Android: same flow.