### PR TITLE
[drape] Anchor Add-Place crosshair to visible viewport

### DIFF
--- a/libs/drape_frontend/drape_engine.cpp
+++ b/libs/drape_frontend/drape_engine.cpp
@@ -463,6 +463,12 @@ void DrapeEngine::UserPositionChanged(m2::PointD const & position, bool hasPosit
 void DrapeEngine::ResizeImpl(int w, int h)
 {
   gui::DrapeGui::Instance().SetSurfaceSize(m2::PointF(w, h));
+  // Seed the visible viewport so the GUI layer has a sensible default before the
+  // platform reports its safe area. Mirror UserEventStream's lazy init: only set
+  // it on the first resize, so a previously-reported safe area is preserved on
+  // subsequent resizes (the platform re-sends the safe area itself when needed).
+  if (!gui::DrapeGui::Instance().GetVisibleViewport().IsValid())
+    gui::DrapeGui::Instance().SetVisibleViewport(m2::RectD(0, 0, w, h));
   m_viewport.SetViewport(0, 0, w, h);
   PostUserEvent(make_unique_dp<ResizeEvent>(w, h));
 }

--- a/libs/drape_frontend/drape_engine.cpp
+++ b/libs/drape_frontend/drape_engine.cpp
@@ -463,12 +463,6 @@ void DrapeEngine::UserPositionChanged(m2::PointD const & position, bool hasPosit
 void DrapeEngine::ResizeImpl(int w, int h)
 {
   gui::DrapeGui::Instance().SetSurfaceSize(m2::PointF(w, h));
-  // Seed the visible viewport so the GUI layer has a sensible default before the
-  // platform reports its safe area. Mirror UserEventStream's lazy init: only set
-  // it on the first resize, so a previously-reported safe area is preserved on
-  // subsequent resizes (the platform re-sends the safe area itself when needed).
-  if (!gui::DrapeGui::Instance().GetVisibleViewport().IsValid())
-    gui::DrapeGui::Instance().SetVisibleViewport(m2::RectD(0, 0, w, h));
   m_viewport.SetViewport(0, 0, w, h);
   PostUserEvent(make_unique_dp<ResizeEvent>(w, h));
 }

--- a/libs/drape_frontend/drape_engine.cpp
+++ b/libs/drape_frontend/drape_engine.cpp
@@ -127,7 +127,6 @@ DrapeEngine::~DrapeEngine()
   m_frontend.reset();
   m_backend.reset();
 
-  gui::DrapeGui::Instance().Destroy();
   m_textureManager->Release();
 }
 

--- a/libs/drape_frontend/drape_frontend_tests/user_event_stream_tests.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/user_event_stream_tests.cpp
@@ -211,87 +211,35 @@ UNIT_TEST(SimpleScale)
   test.RunTest();
 }
 
-UNIT_TEST(SetCenter_TrackVisibleViewport_False_UsesGeometricScreenCenter)
+UNIT_TEST(SetCenter_AlignsToVisibleViewportCenter)
 {
-  // Simulates "Add Place" triggered from a search result with an explicit coordinate.
-  UserEventStreamTest test(false);
-
+  // With an asymmetric visible viewport (e.g. host UI panel covering bottom 30%),
+  // SetCenter must place the geographic target at the visible-viewport center
+  // regardless of trackVisibleViewport. The flag only controls whether the engine
+  // continues to follow the viewport when it changes later.
   uint32_t const kW = 1000, kH = 1000;
   m2::RectD const kVisibleViewport(0.0, 0.0, static_cast<double>(kW), 700.0);
-
-  test.AddResizeEvent(kW, kH);
-  test.AddSetVisibleViewport(kVisibleViewport);
-  test.SetRect(m2::RectD(-100.0, -100.0, 100.0, 100.0));
-  test.RunTest();
-
   m2::PointD const kTarget(0.0, 0.0);
-  test.AddSetCenter(kTarget, df::kDoNotChangeZoom, false /* trackVisibleViewport */);
-  test.RunTest();
-
-  ScreenBase const & screen = test.GetScreen();
-  m2::PointD const pixelPos = screen.GtoP(kTarget);
-
-  double const kEps = 1.0;  // 1 pixel tolerance
-  double const expectedX = kW * 0.5;
-  double const expectedY = kH * 0.5;
-  TEST(std::fabs(pixelPos.x - expectedX) < kEps, (pixelPos.x, "expected", expectedX));
-  TEST(std::fabs(pixelPos.y - expectedY) < kEps, (pixelPos.y, "expected", expectedY));
-}
-
-UNIT_TEST(SetCenter_TrackVisibleViewport_True_UsesVisibleViewportCenter)
-{
-  // Normal navigation (no explicit position): trackVisibleViewport=true
-  UserEventStreamTest test(false);
-
-  uint32_t const kW = 1000, kH = 1000;
-  m2::RectD const kVisibleViewport(0.0, 0.0, static_cast<double>(kW), 700.0);
-
-  test.AddResizeEvent(kW, kH);
-  test.AddSetVisibleViewport(kVisibleViewport);
-  test.SetRect(m2::RectD(-100.0, -100.0, 100.0, 100.0));
-  test.RunTest();
-
-  m2::PointD const kTarget(0.0, 0.0);
-  test.AddSetCenter(kTarget, df::kDoNotChangeZoom, true /* trackVisibleViewport */);
-  test.RunTest();
-
-  ScreenBase const & screen = test.GetScreen();
-  m2::PointD const pixelPos = screen.GtoP(kTarget);
-
   double const kEps = 1.0;
   m2::PointD const viewportCenter = kVisibleViewport.Center();
-  TEST(std::fabs(pixelPos.x - viewportCenter.x) < kEps, (pixelPos.x, "expected", viewportCenter.x));
-  TEST(std::fabs(pixelPos.y - viewportCenter.y) < kEps, (pixelPos.y, "expected", viewportCenter.y));
-}
 
-UNIT_TEST(SetCenter_TrackVisibleViewport_DifferentResults_WithAsymmetricViewport)
-{
-  // Regression guard: with an asymmetric visible viewport (UI panel present),
-  // trackVisibleViewport=false and trackVisibleViewport=true
-  uint32_t const kW = 1000, kH = 1000;
-  m2::RectD const kVisibleViewport(0.0, 0.0, static_cast<double>(kW), 700.0);
-  m2::PointD const kTarget(0.0, 0.0);
+  for (bool trackVisibleViewport : {false, true})
+  {
+    UserEventStreamTest test(false);
+    test.AddResizeEvent(kW, kH);
+    test.AddSetVisibleViewport(kVisibleViewport);
+    test.SetRect(m2::RectD(-100.0, -100.0, 100.0, 100.0));
+    test.RunTest();
 
-  UserEventStreamTest testFalse(false);
-  testFalse.AddResizeEvent(kW, kH);
-  testFalse.AddSetVisibleViewport(kVisibleViewport);
-  testFalse.SetRect(m2::RectD(-100.0, -100.0, 100.0, 100.0));
-  testFalse.RunTest();
-  testFalse.AddSetCenter(kTarget, df::kDoNotChangeZoom, false);
-  testFalse.RunTest();
-  m2::PointD const pixelFalse = testFalse.GetScreen().GtoP(kTarget);
+    test.AddSetCenter(kTarget, df::kDoNotChangeZoom, trackVisibleViewport);
+    test.RunTest();
 
-  UserEventStreamTest testTrue(false);
-  testTrue.AddResizeEvent(kW, kH);
-  testTrue.AddSetVisibleViewport(kVisibleViewport);
-  testTrue.SetRect(m2::RectD(-100.0, -100.0, 100.0, 100.0));
-  testTrue.RunTest();
-  testTrue.AddSetCenter(kTarget, df::kDoNotChangeZoom, true);
-  testTrue.RunTest();
-  m2::PointD const pixelTrue = testTrue.GetScreen().GtoP(kTarget);
-
-  double const yDiff = std::fabs(pixelFalse.y - pixelTrue.y);
-  TEST(yDiff > 100.0, (yDiff, "Expected ~150px difference in Y due to 300px bottom panel"));
+    m2::PointD const pixelPos = test.GetScreen().GtoP(kTarget);
+    TEST(std::fabs(pixelPos.x - viewportCenter.x) < kEps,
+         (pixelPos.x, "expected", viewportCenter.x, "trackVisibleViewport", trackVisibleViewport));
+    TEST(std::fabs(pixelPos.y - viewportCenter.y) < kEps,
+         (pixelPos.y, "expected", viewportCenter.y, "trackVisibleViewport", trackVisibleViewport));
+  }
 }
 
 #endif

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -785,7 +785,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
           zoom = scales::GetAddNewPlaceScale();
         AddUserEvent(make_unique_dp<SetCenterEvent>(
             pt ? *pt : m_userEventStream.GetCurrentScreen().GlobalRect().Center(), zoom, true /* isAnim */,
-            !pt /* trackVisibleViewport */, nullptr /* parallelAnimCreator */));
+            true /* trackVisibleViewport */, nullptr /* parallelAnimCreator */));
       }
       else
       {
@@ -801,6 +801,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
     AddUserEvent(make_unique_dp<SetVisibleViewportEvent>(msg->GetRect()));
     m_myPositionController->SetVisibleViewport(msg->GetRect());
     m_myPositionController->UpdatePosition();
+    gui::DrapeGui::Instance().SetVisibleViewport(msg->GetRect());
     // PullToBoundArea(false /* randomPlace */, false /* applyZoom */);
     break;
   }

--- a/libs/drape_frontend/gui/choose_position_mark.cpp
+++ b/libs/drape_frontend/gui/choose_position_mark.cpp
@@ -39,7 +39,10 @@ public:
 
   bool Update(ScreenBase const & screen) override
   {
-    SetPivot(glsl::ToVec2(m2::PointF(screen.PixelRectIn3d().Center())));
+    // Pivot at the visible-viewport center so the crosshair coincides with the
+    // pixel that UserEventStream::OnSetCenter aligns the geographic target to.
+    // DrapeGui's visible viewport is seeded on first resize, so it is always valid here.
+    SetPivot(glsl::ToVec2(m2::PointF(DrapeGui::Instance().GetVisibleViewport().Center())));
     return TBase::Update(screen);
   }
 };

--- a/libs/drape_frontend/gui/drape_gui.cpp
+++ b/libs/drape_frontend/gui/drape_gui.cpp
@@ -54,6 +54,18 @@ m2::PointF DrapeGui::GetSurfaceSize() const
   return m_surfaceSize;
 }
 
+void DrapeGui::SetVisibleViewport(m2::RectD const & rect)
+{
+  std::lock_guard<std::mutex> lock(m_visibleViewportMutex);
+  m_visibleViewport = rect;
+}
+
+m2::RectD DrapeGui::GetVisibleViewport() const
+{
+  std::lock_guard<std::mutex> lock(m_visibleViewportMutex);
+  return m_visibleViewport;
+}
+
 RulerHelper & DrapeGui::GetRulerHelperImpl()
 {
   ASSERT(m_impl != nullptr, ());

--- a/libs/drape_frontend/gui/drape_gui.cpp
+++ b/libs/drape_frontend/gui/drape_gui.cpp
@@ -1,45 +1,25 @@
 #include "drape_gui.hpp"
-#include "ruler_helper.hpp"
 
 #include "drape_frontend/color_constants.hpp"
-#include "drape_frontend/visual_params.hpp"
-
-#include "base/assert.hpp"
 
 namespace gui
 {
 df::ColorConstant const kGuiTextColor = "GuiText";
 
-struct DrapeGui::Impl
-{
-  RulerHelper m_rulerHelper;
-};
-
-DrapeGui::DrapeGui() : m_impl(new Impl()) {}
-
 DrapeGui & DrapeGui::Instance()
 {
   static DrapeGui s_gui;
-  if (!s_gui.m_impl)
-    s_gui.m_impl.reset(new Impl());
-
   return s_gui;
 }
 
 RulerHelper & DrapeGui::GetRulerHelper()
 {
-  return Instance().GetRulerHelperImpl();
+  return Instance().m_rulerHelper;
 }
 
 dp::FontDecl DrapeGui::GetGuiTextFont()
 {
   return {df::GetColorConstant(kGuiTextColor), 14};
-}
-
-void DrapeGui::Destroy()
-{
-  ASSERT(m_impl != nullptr, ());
-  m_impl.reset();
 }
 
 void DrapeGui::SetSurfaceSize(m2::PointF const & size)
@@ -71,12 +51,6 @@ m2::RectD DrapeGui::GetVisibleViewport() const
     // Better than assign in SetSurfaceSize.
     return {0, 0, m_surfaceSize.x, m_surfaceSize.y};
   }
-}
-
-RulerHelper & DrapeGui::GetRulerHelperImpl()
-{
-  ASSERT(m_impl != nullptr, ());
-  return m_impl->m_rulerHelper;
 }
 
 void DrapeGui::ConnectOnCompassTappedHandler(Shape::TTapHandler const & handler)

--- a/libs/drape_frontend/gui/drape_gui.cpp
+++ b/libs/drape_frontend/gui/drape_gui.cpp
@@ -44,26 +44,33 @@ void DrapeGui::Destroy()
 
 void DrapeGui::SetSurfaceSize(m2::PointF const & size)
 {
-  std::lock_guard<std::mutex> lock(m_surfaceSizeMutex);
+  std::lock_guard lock(m_paramsMutex);
   m_surfaceSize = size;
 }
 
 m2::PointF DrapeGui::GetSurfaceSize() const
 {
-  std::lock_guard<std::mutex> lock(m_surfaceSizeMutex);
+  std::lock_guard lock(m_paramsMutex);
   return m_surfaceSize;
 }
 
 void DrapeGui::SetVisibleViewport(m2::RectD const & rect)
 {
-  std::lock_guard<std::mutex> lock(m_visibleViewportMutex);
+  std::lock_guard lock(m_paramsMutex);
   m_visibleViewport = rect;
 }
 
 m2::RectD DrapeGui::GetVisibleViewport() const
 {
-  std::lock_guard<std::mutex> lock(m_visibleViewportMutex);
-  return m_visibleViewport;
+  std::lock_guard lock(m_paramsMutex);
+
+  if (m_visibleViewport.IsValid())
+    return m_visibleViewport;
+  else
+  {
+    // Better than assign in SetSurfaceSize.
+    return {0, 0, m_surfaceSize.x, m_surfaceSize.y};
+  }
 }
 
 RulerHelper & DrapeGui::GetRulerHelperImpl()

--- a/libs/drape_frontend/gui/drape_gui.hpp
+++ b/libs/drape_frontend/gui/drape_gui.hpp
@@ -1,34 +1,27 @@
 #pragma once
 
-#include "drape_frontend/gui/compass.hpp"
+#include "drape_frontend/gui/ruler_helper.hpp"
 #include "drape_frontend/gui/scale_fps_helper.hpp"
-#include "drape_frontend/gui/skin.hpp"
+#include "drape_frontend/gui/shape.hpp"
 
-#include "storage/storage_defines.hpp"
-
-#include "drape/pointers.hpp"
+#include "drape/drape_global.hpp"
 
 #include "geometry/rect2d.hpp"
 
-#include <functional>
-#include <memory>
 #include <mutex>
 
 class ScreenBase;
 
 namespace gui
 {
-class RulerHelper;
 
 class DrapeGui
 {
 public:
   static DrapeGui & Instance();
   static RulerHelper & GetRulerHelper();
-
   static dp::FontDecl GetGuiTextFont();
 
-  void Destroy();
   void SetSurfaceSize(m2::PointF const & size);
   m2::PointF GetSurfaceSize() const;
   void SetVisibleViewport(m2::RectD const & rect);
@@ -47,11 +40,8 @@ public:
   ScaleFpsHelper const & GetScaleFpsHelper() const { return m_scaleFpsHelper; }
 
 private:
-  DrapeGui();
-  RulerHelper & GetRulerHelperImpl();
+  RulerHelper m_rulerHelper;
 
-  struct Impl;
-  std::unique_ptr<Impl> m_impl;
   bool m_isCopyrightActive = true;
 
   Shape::TTapHandler m_onCompassTappedHandler;

--- a/libs/drape_frontend/gui/drape_gui.hpp
+++ b/libs/drape_frontend/gui/drape_gui.hpp
@@ -8,6 +8,8 @@
 
 #include "drape/pointers.hpp"
 
+#include "geometry/rect2d.hpp"
+
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -29,6 +31,8 @@ public:
   void Destroy();
   void SetSurfaceSize(m2::PointF const & size);
   m2::PointF GetSurfaceSize() const;
+  void SetVisibleViewport(m2::RectD const & rect);
+  m2::RectD GetVisibleViewport() const;
 
   bool IsInUserAction() const { return m_inUserAction; }
   void SetInUserAction(bool isInUserAction) { m_inUserAction = isInUserAction; }
@@ -53,6 +57,8 @@ private:
   Shape::TTapHandler m_onCompassTappedHandler;
   m2::PointF m_surfaceSize;
   mutable std::mutex m_surfaceSizeMutex;
+  m2::RectD m_visibleViewport;
+  mutable std::mutex m_visibleViewportMutex;
   bool m_inUserAction = false;
   ScaleFpsHelper m_scaleFpsHelper;
 };

--- a/libs/drape_frontend/gui/drape_gui.hpp
+++ b/libs/drape_frontend/gui/drape_gui.hpp
@@ -55,10 +55,11 @@ private:
   bool m_isCopyrightActive = true;
 
   Shape::TTapHandler m_onCompassTappedHandler;
-  m2::PointF m_surfaceSize;
-  mutable std::mutex m_surfaceSizeMutex;
+
+  mutable std::mutex m_paramsMutex;
   m2::RectD m_visibleViewport;
-  mutable std::mutex m_visibleViewportMutex;
+  m2::PointF m_surfaceSize;
+
   bool m_inUserAction = false;
   ScaleFpsHelper m_scaleFpsHelper;
 };

--- a/libs/drape_frontend/user_event_stream.cpp
+++ b/libs/drape_frontend/user_event_stream.cpp
@@ -427,12 +427,7 @@ bool UserEventStream::OnSetCenter(ref_ptr<SetCenterEvent> centerEvent)
 
   center.x = mercator::NearestWrapX(center.x, GetCurrentScreen().GetOrg().x);
 
-  bool const trackViewport = centerEvent->TrackVisibleViewport();
-
-  m2::PointD const pixelTarget =
-      trackViewport ? m_visibleViewport.Center() : GetCurrentScreen().PixelRectIn3d().Center();
-
-  if (trackViewport)
+  if (centerEvent->TrackVisibleViewport())
   {
     m_needTrackCenter = true;
     m_trackedCenter = center;
@@ -443,17 +438,17 @@ bool UserEventStream::OnSetCenter(ref_ptr<SetCenterEvent> centerEvent)
   if (zoom != kDoNotChangeZoom)
   {
     screen.SetFromParams(center, screen.GetAngle(), GetScreenScale(zoom));
-    screen.MatchGandP3d(center, pixelTarget);
+    screen.MatchGandP3d(center, m_visibleViewport.Center());
   }
   else if (scaleFactor > 0.0)
   {
     screen.SetOrg(center);
-    ApplyScale(pixelTarget, scaleFactor, screen);
+    ApplyScale(m_visibleViewport.Center(), scaleFactor, screen);
   }
   else
   {
     GetTargetScreen(screen);
-    screen.MatchGandP3d(center, pixelTarget);
+    screen.MatchGandP3d(center, m_visibleViewport.Center());
   }
 
   return SetScreen(screen, centerEvent->IsAnim(), centerEvent->GetParallelAnimCreator());


### PR DESCRIPTION
The crosshair was drawn at PixelRectIn3d().Center() while UserEventStream::OnSetCenter aligned the geographic anchor at m_visibleViewport.Center(); when those points differ (iOS bottom sheet, Android Auto / CarPlay safe area, etc.) the crosshair pointed at the wrong coordinate.

Plumb the visible viewport through DrapeGui (the existing GUI / engine bridge that already carries SurfaceSize) and pivot the crosshair at the visible-viewport center, so it coincides with the pixel that OnSetCenter targets. This preserves the invariant "visible viewport center is the anchor for SetCenter" instead of changing the semantics of trackVisibleViewport, and therefore does not regress Follow mode (MyPositionController::UpdateViewport), the nativeSetViewportCenter intent path used by Android Auto search, PullToBoundArea, or the first-launch animation - all of which dispatch SetCenterEvent with trackVisibleViewport=false and rely on viewport-center alignment.

Replace the three regression-codifying tests added alongside the original fix attempt with a single parameterized test that asserts both trackVisibleViewport=true and trackVisibleViewport=false align the target to the visible-viewport center.

Closes: #12237

Follow-up fix for https://github.com/organicmaps/organicmaps/pull/12396