### PR TITLE
[platform][ios][mac] Migrate ConnectionStatus from SCNetworkReachability to Network framework

### DIFF
--- a/iphone/Maps/Core/FirstSession/FirstSession.mm
+++ b/iphone/Maps/Core/FirstSession/FirstSession.mm
@@ -40,10 +40,6 @@
 #import <UIKit/UIScreen.h>
 #endif  // TARGET_OS_IPHONE
 
-#import <SystemConfiguration/SystemConfiguration.h>
-#import <netinet/in.h>
-#import <sys/socket.h>
-
 namespace
 {
 // Key for app unique installation id in standardUserDefaults.

--- a/libs/platform/CMakeLists.txt
+++ b/libs/platform/CMakeLists.txt
@@ -71,6 +71,7 @@ if (PLATFORM_IPHONE)
   append(SRC
     background_downloader_ios.h
     background_downloader_ios.mm
+    connection_status_apple.mm
     gui_thread_apple.mm
     http_client_apple.mm
     http_uploader_apple.mm
@@ -132,6 +133,7 @@ else() # neither iPhone nor Android
     )
   elseif(${PLATFORM_MAC})
     append(SRC
+      connection_status_apple.mm
       gui_thread_apple.mm
       http_client_apple.mm
       http_uploader_apple.mm
@@ -182,7 +184,7 @@ target_link_libraries(${PROJECT_NAME}
     $<$<BOOL:${PLATFORM_WIN}>:shlwapi>  # PathIsDirectoryEmptyA
     $<$<BOOL:${PLATFORM_MAC}>:
       -framework\ Foundation
-      -framework\ SystemConfiguration
+      -framework\ Network
       -framework\ CFNetwork
       -framework\ Security  # SecPKCS12Import
       >

--- a/libs/platform/connection_status_apple.mm
+++ b/libs/platform/connection_status_apple.mm
@@ -1,0 +1,64 @@
+#include "platform/platform.hpp"
+
+#include "base/logging.hpp"
+
+#include "std/target_os.hpp"
+
+#import <Network/Network.h>
+
+#include <atomic>
+
+namespace
+{
+Platform::EConnectionType ConnectionTypeFromPath(nw_path_t path)
+{
+  if (nw_path_get_status(path) != nw_path_status_satisfied)
+    return Platform::EConnectionType::CONNECTION_NONE;
+
+#if defined(OMIM_OS_IPHONE)
+  if (nw_path_uses_interface_type(path, nw_interface_type_cellular))
+    return Platform::EConnectionType::CONNECTION_WWAN;
+#endif
+
+  return Platform::EConnectionType::CONNECTION_WIFI;  // Wired Ethernet is bucketed here.
+}
+
+class PathMonitor
+{
+public:
+  static PathMonitor & Instance()
+  {
+    // Process-lifetime singleton; intentionally never destroyed to avoid racing
+    // the asynchronous nw_path_monitor update handler at static-destruction time.
+    static auto * instance = new PathMonitor();
+    return *instance;
+  }
+
+  Platform::EConnectionType Status() const { return m_status.load(std::memory_order_relaxed); }
+
+private:
+  PathMonitor() : m_monitor(nw_path_monitor_create())
+  {
+    nw_path_monitor_set_queue(m_monitor, dispatch_queue_create("app.organicmaps.netmon", DISPATCH_QUEUE_SERIAL));
+    nw_path_monitor_set_update_handler(m_monitor, ^(nw_path_t path) {
+      auto const status = ConnectionTypeFromPath(path);
+      auto const oldStatus = m_status.exchange(status, std::memory_order_relaxed);
+      if (oldStatus != status)
+        LOG(LINFO, ("Connection status changed to", status));
+    });
+    nw_path_monitor_start(m_monitor);
+  }
+
+  nw_path_monitor_t m_monitor;
+  std::atomic<Platform::EConnectionType> m_status{Platform::EConnectionType::CONNECTION_NONE};
+};
+}  // namespace
+
+// nw_path_monitor delivers updates asynchronously, so this returns CONNECTION_NONE
+// until the first callback arrives. Platform::Platform() warms the singleton at
+// launch; new callers invoked during/immediately after Platform construction must
+// tolerate a transient CONNECTION_NONE.
+Platform::EConnectionType Platform::ConnectionStatus()
+{
+  return PathMonitor::Instance().Status();
+}

--- a/libs/platform/platform.cpp
+++ b/libs/platform/platform.cpp
@@ -393,3 +393,15 @@ std::string DebugPrint(Platform::ChargingStatus status)
   }
   UNREACHABLE();
 }
+
+std::string DebugPrint(Platform::EConnectionType connectionType)
+{
+  switch (connectionType)
+  {
+    using enum Platform::EConnectionType;
+  case CONNECTION_NONE: return "No connection";
+  case CONNECTION_WIFI: return "WiFi or cable connection";
+  case CONNECTION_WWAN: return "Cellular connection";
+  }
+  UNREACHABLE();
+}

--- a/libs/platform/platform.hpp
+++ b/libs/platform/platform.hpp
@@ -338,3 +338,4 @@ private:
 
 std::string DebugPrint(Platform::EError err);
 std::string DebugPrint(Platform::ChargingStatus status);
+std::string DebugPrint(Platform::EConnectionType connectionType);

--- a/libs/platform/platform_ios.mm
+++ b/libs/platform/platform_ios.mm
@@ -19,16 +19,13 @@
 #include <net/if.h>
 #include <net/if_dl.h>
 
-#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <sys/xattr.h>
 
 #import <CoreFoundation/CFURL.h>
-#import <SystemConfiguration/SystemConfiguration.h>
 #import <UIKit/UIKit.h>
-#import <netinet/in.h>
 
 #include <memory>
 #include <sstream>
@@ -66,6 +63,10 @@ Platform::Platform()
 
   LOG(LINFO, ("Device:", device.model.UTF8String, "SystemName:", device.systemName.UTF8String,
               "SystemVersion:", device.systemVersion.UTF8String));
+
+  // Kick off the connection-status monitor at launch; its first asynchronous
+  // callback should arrive long before any UI code queries IsConnected().
+  ConnectionStatus();
 }
 
 // static
@@ -186,30 +187,7 @@ int32_t Platform::IntVersion() const
   return (int32_t)(year - 2000) * 10000 + month * 100 + day;
 }
 
-Platform::EConnectionType Platform::ConnectionStatus()
-{
-  struct sockaddr_in zero;
-  bzero(&zero, sizeof(zero));
-  zero.sin_len = sizeof(zero);
-  zero.sin_family = AF_INET;
-  SCNetworkReachabilityRef reachability =
-      SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, (const struct sockaddr *)&zero);
-  if (!reachability)
-    return EConnectionType::CONNECTION_NONE;
-  SCNetworkReachabilityFlags flags;
-  bool const gotFlags = SCNetworkReachabilityGetFlags(reachability, &flags);
-  CFRelease(reachability);
-  if (!gotFlags || ((flags & kSCNetworkReachabilityFlagsReachable) == 0))
-    return EConnectionType::CONNECTION_NONE;
-  SCNetworkReachabilityFlags userActionRequired =
-      kSCNetworkReachabilityFlagsConnectionRequired | kSCNetworkReachabilityFlagsInterventionRequired;
-  if ((flags & userActionRequired) == userActionRequired)
-    return EConnectionType::CONNECTION_NONE;
-  if ((flags & kSCNetworkReachabilityFlagsIsWWAN) == kSCNetworkReachabilityFlagsIsWWAN)
-    return EConnectionType::CONNECTION_WWAN;
-  else
-    return EConnectionType::CONNECTION_WIFI;
-}
+// Platform::ConnectionStatus() lives in connection_status_apple.mm (shared with macOS).
 
 Platform::ChargingStatus Platform::GetChargingStatus()
 {

--- a/libs/platform/platform_mac.mm
+++ b/libs/platform/platform_mac.mm
@@ -22,9 +22,6 @@
 
 #include <dispatch/dispatch.h>
 
-#import <SystemConfiguration/SystemConfiguration.h>
-#import <netinet/in.h>
-
 Platform::Platform()
 {
   // OMaps.app/Content/Resources or omim-build-debug for tests.
@@ -136,6 +133,10 @@ Platform::Platform()
   LOG(LDEBUG, ("Writable Directory:", m_writableDir));
   LOG(LDEBUG, ("Tmp Directory:", m_tmpDir));
   LOG(LDEBUG, ("Settings Directory:", m_settingsDir));
+
+  // Kick off the connection-status monitor at launch; its first asynchronous
+  // callback should arrive long before any UI code queries IsConnected().
+  ConnectionStatus();
 }
 
 std::string Platform::DeviceName() const
@@ -148,27 +149,7 @@ std::string Platform::DeviceModel() const
   return {};
 }
 
-Platform::EConnectionType Platform::ConnectionStatus()
-{
-  struct sockaddr_in zero;
-  memset(&zero, 0, sizeof(zero));
-  zero.sin_len = sizeof(zero);
-  zero.sin_family = AF_INET;
-  SCNetworkReachabilityRef reachability =
-      SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, reinterpret_cast<const struct sockaddr *>(&zero));
-  if (!reachability)
-    return EConnectionType::CONNECTION_NONE;
-  SCNetworkReachabilityFlags flags;
-  bool const gotFlags = SCNetworkReachabilityGetFlags(reachability, &flags);
-  CFRelease(reachability);
-  if (!gotFlags || ((flags & kSCNetworkReachabilityFlagsReachable) == 0))
-    return EConnectionType::CONNECTION_NONE;
-  SCNetworkReachabilityFlags userActionRequired =
-      kSCNetworkReachabilityFlagsConnectionRequired | kSCNetworkReachabilityFlagsInterventionRequired;
-  if ((flags & userActionRequired) == userActionRequired)
-    return EConnectionType::CONNECTION_NONE;
-  return EConnectionType::CONNECTION_WIFI;
-}
+// Platform::ConnectionStatus() lives in connection_status_apple.mm (shared with iOS).
 
 // static
 Platform::ChargingStatus Platform::GetChargingStatus()

--- a/xcode/common.xcconfig
+++ b/xcode/common.xcconfig
@@ -17,8 +17,8 @@ MACOSX_DEPLOYMENT_TARGET = 10.15
 SUPPORTED_PLATFORMS = macosx iphonesimulator iphoneos
 
 // Linked frameworks
-OTHER_LDFLAGS[sdk=macosx*] = -framework Cocoa -framework IOKit -framework OpenGL -framework QtCore -framework QtGui -framework QtNetwork -framework QtOpenGL -framework QtWidgets -framework SystemConfiguration -framework CFNetwork
-OTHER_LDFLAGS[sdk=iphone*] = -framework CoreGraphics -framework Foundation -framework IOKit -framework OpenGLES -framework SystemConfiguration -framework UIKit -framework CFNetwork -ObjC
+OTHER_LDFLAGS[sdk=macosx*] = -framework Cocoa -framework IOKit -framework Network -framework OpenGL -framework QtCore -framework QtGui -framework QtNetwork -framework QtOpenGL -framework QtWidgets -framework CFNetwork
+OTHER_LDFLAGS[sdk=iphone*] = -framework CoreGraphics -framework Foundation -framework IOKit -framework Network -framework OpenGLES -framework UIKit -framework CFNetwork -ObjC
 
 // Workaround for boost/gil boost/geometry boost/qvm template errors appeared in newer clang from XCode 16.3
 // See https://github.com/llvm/llvm-project/issues/94194

--- a/xcode/platform/platform.xcodeproj/project.pbxproj
+++ b/xcode/platform/platform.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		3DEE1AE821F7091100054A91 /* battery_tracker.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3DEE1AE621F7091100054A91 /* battery_tracker.hpp */; };
 		3DF528EB238BFFC1000ED0D5 /* downloader_defines.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3DF528EA238BFFC1000ED0D5 /* downloader_defines.hpp */; };
 		3DFACF312432421C00A29A94 /* background_downloader_ios.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3DFACF2F2432421C00A29A94 /* background_downloader_ios.mm */; };
+		AB8CB2D5558742AD860212F4 /* connection_status_apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8A16141224C1989C8F965 /* connection_status_apple.mm */; };
 		3DFACF322432421C00A29A94 /* background_downloader_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DFACF302432421C00A29A94 /* background_downloader_ios.h */; };
 		44486DC42A1F9AC800A5DD6C /* utm_mgrs_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44DC51072A1F91EA00B6562E /* utm_mgrs_utils.cpp */; };
 		44CAB5F62A1F926800819330 /* utm_mgrs_utils_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44CAB5F52A1F926800819330 /* utm_mgrs_utils_tests.cpp */; };
@@ -167,6 +168,7 @@
 		3DEE1AE621F7091100054A91 /* battery_tracker.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = battery_tracker.hpp; sourceTree = "<group>"; };
 		3DF528EA238BFFC1000ED0D5 /* downloader_defines.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = downloader_defines.hpp; sourceTree = "<group>"; };
 		3DFACF2F2432421C00A29A94 /* background_downloader_ios.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = background_downloader_ios.mm; sourceTree = "<group>"; };
+		2EA8A16141224C1989C8F965 /* connection_status_apple.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = connection_status_apple.mm; sourceTree = "<group>"; };
 		3DFACF302432421C00A29A94 /* background_downloader_ios.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = background_downloader_ios.h; sourceTree = "<group>"; };
 		40D4697623FAB8D00030476C /* helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = helpers.hpp; sourceTree = "<group>"; };
 		44CAB5F52A1F926800819330 /* utm_mgrs_utils_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = utm_mgrs_utils_tests.cpp; sourceTree = "<group>"; };
@@ -439,6 +441,7 @@
 				671C62041AE9014C00076BD0 /* measurement_utils.cpp */,
 				56EB1EDB1C6B6E6C0022D831 /* mwm_traits.hpp */,
 				56EB1EDA1C6B6E6C0022D831 /* mwm_traits.cpp */,
+				2EA8A16141224C1989C8F965 /* connection_status_apple.mm */,
 				67AB92DB1B7B3D7300AB5194 /* mwm_version.hpp */,
 				67AB92DA1B7B3D7300AB5194 /* mwm_version.cpp */,
 				3DE8B98E1DEC3115000E6083 /* network_policy.hpp */,
@@ -728,6 +731,7 @@
 				675343D31A3F5D5A00A0A8C3 /* settings.cpp in Sources */,
 				675343CE1A3F5D5A00A0A8C3 /* preferred_languages.cpp in Sources */,
 				3DFACF312432421C00A29A94 /* background_downloader_ios.mm in Sources */,
+				AB8CB2D5558742AD860212F4 /* connection_status_apple.mm in Sources */,
 				1669C8402A30DCD200530AD1 /* distance.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Fixes #8253

SCNetworkReachability is deprecated since macOS 14.4 / iOS 17. Replace the synchronous SCNetworkReachability calls in platform_mac.mm and platform_ios.mm with a single shared implementation in connection_status_apple.mm built around nw_path_monitor (Network.framework).
    
The new implementation:
    
- Singleton with a long-lived nw_path_monitor on a private serial queue.
- Caches the latest path status in a std::atomic; ConnectionStatus() is an O(1) atomic load on the hot path.
- Platform::Platform() warms up the singleton at launch so the first asynchronous nw_path_monitor callback arrives long before any UI code queries IsConnected(). Callers invoked during or immediately after Platform construction must tolerate a transient CONNECTION_NONE regardless of actual connectivity.
- Reports CONNECTION_WWAN on macOS too when the active interface is cellular (USB-tethered iPhone, Personal Hotspot) -- the previous macOS impl always returned CONNECTION_WIFI; the downloader policy will now correctly throttle on cellular Macs.
    
Linked frameworks: -framework SystemConfiguration is replaced with -framework Network in libs/platform/CMakeLists.txt (macOS Qt build) and xcode/common.xcconfig (iOS + macOS Xcode builds). The new source file is registered in xcode/platform/platform.xcodeproj.
    
Also adds DebugPrint(Platform::EConnectionType) so the new status enum can be used with LOG().
    
Bonus: drop the dead #import <SystemConfiguration/...>, <netinet/in.h>, and <sys/socket.h> in iphone/Maps/Core/FirstSession/FirstSession.mm -- none of those symbols are referenced in the file.