### PR TITLE
[ios] Drop dead IsBookmark() guards in PlacePageBookmarkData

### DIFF
--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageBookmarkData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageBookmarkData.h
@@ -9,8 +9,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) MWMMarkID bookmarkId;
 @property(nonatomic, readonly) MWMMarkGroupID bookmarkGroupId;
 @property(nonatomic, readonly, nullable) NSString * externalTitle;
-@property(nonatomic, readonly, nullable) NSString * bookmarkDescription;
-@property(nonatomic, readonly, nullable) NSString * bookmarkCategory;
+@property(nonatomic, readonly) NSString * bookmarkDescription;
+@property(nonatomic, readonly) NSString * bookmarkCategory;
 @property(nonatomic, readonly) BOOL isHtmlDescription;
 @property(nonatomic, readonly) MWMBookmarkColor color;
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageBookmarkData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageBookmarkData.h
@@ -9,8 +9,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) MWMMarkID bookmarkId;
 @property(nonatomic, readonly) MWMMarkGroupID bookmarkGroupId;
 @property(nonatomic, readonly, nullable) NSString * externalTitle;
-@property(nonatomic, readonly, nullable) NSString * bookmarkDescription;
-@property(nonatomic, readonly, nullable) NSString * bookmarkCategory;
+@property(nonatomic, readonly) NSString * bookmarkDescription;
+@property(nonatomic, readonly) NSString * bookmarkCategory;
 @property(nonatomic, readonly) BOOL isHtmlDescription;
 @property(nonatomic, readonly) UIColor * color;
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageBookmarkData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageBookmarkData.mm
@@ -15,9 +15,8 @@
     _bookmarkId = rawData.GetBookmarkId();
     _bookmarkGroupId = rawData.GetBookmarkCategoryId();
     _externalTitle = rawData.GetSecondaryTitle().empty() ? nil : @(rawData.GetSecondaryTitle().c_str());
-    _bookmarkDescription =
-        rawData.IsBookmark() ? @(GetPreferredBookmarkStr(rawData.GetBookmarkData().m_description).c_str()) : nil;
-    _bookmarkCategory = rawData.IsBookmark() ? @(rawData.GetBookmarkCategoryName().c_str()) : nil;
+    _bookmarkDescription = @(GetPreferredBookmarkStr(rawData.GetBookmarkData().m_description).c_str());
+    _bookmarkCategory = @(rawData.GetBookmarkCategoryName().c_str());
     _isHtmlDescription = strings::IsHTML(GetPreferredBookmarkStr(rawData.GetBookmarkData().m_description));
     _color = convertKmlColor(rawData.GetBookmarkData().m_color.m_predefinedColor);
   }

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageBookmarkData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageBookmarkData.mm
@@ -15,8 +15,8 @@
     _bookmarkGroupId = rawData.GetBookmarkCategoryId();
     _externalTitle = rawData.GetSecondaryTitle().empty() ? nil : @(rawData.GetSecondaryTitle().c_str());
     std::string const description = GetPreferredBookmarkStr(rawData.GetBookmarkData().m_description);
-    _bookmarkDescription = rawData.IsBookmark() ? @(description.c_str()) : nil;
-    _bookmarkCategory = rawData.IsBookmark() ? @(rawData.GetBookmarkCategoryName().c_str()) : nil;
+    _bookmarkDescription = @(description.c_str());
+    _bookmarkCategory = @(rawData.GetBookmarkCategoryName().c_str());
     _isHtmlDescription = strings::IsHTML(description);
     auto const color = kml::GetEffectiveColor(rawData.GetBookmarkData().m_color);
     _color = [UIColor colorWithRed:color.GetRedF() green:color.GetGreenF() blue:color.GetBlueF() alpha:1.f];


### PR DESCRIPTION
PlacePageBookmarkData is constructed only when rawData.IsBookmark() is true (see PlacePageData.mm), so the inline `rawData.IsBookmark() ? ... : nil` ternaries on _bookmarkDescription and _bookmarkCategory always evaluate the truthy branch. Remove the guards and tighten the two properties from `nullable NSString *` to non-null in the header to match what the producer actually returns: @() of an empty c_str() is @"", never nil.

The structural invariant (IsBookmark ⇒ Bookmark::Attach was called ⇒ GetGroupId is non-sentinel) lives a layer up and is what makes the flat shape correct here, in contrast to PlacePageTrackData where tracks without an owning category (e.g. OSM relation tracks) are a real domain state.

No consumer updates needed: the 6 readers either assign to a String? local (Swift implicit upcast from non-null String) or are Obj-C call sites where the change is invisible.