### PR TITLE
[android] Align TTS test with navigation playback

### DIFF
--- a/android/app/src/main/java/app/organicmaps/settings/VoiceInstructionsSettingsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/VoiceInstructionsSettingsFragment.java
@@ -171,7 +171,7 @@ public class VoiceInstructionsSettingsFragment extends BaseXmlSettingsFragment
         return false;
 
       Utils.showSnackbar(view, getString(R.string.pref_tts_playing_test_voice));
-      TtsPlayer.INSTANCE.speak(mTtsTestStringArray.get(mTestStringIndex));
+      TtsPlayer.INSTANCE.playTurnNotifications(new String[] {mTtsTestStringArray.get(mTestStringIndex)});
       mTestStringIndex++;
       if (mTestStringIndex >= mTtsTestStringArray.size())
         mTestStringIndex = 0;


### PR DESCRIPTION
The button in the text-to-speech settings previously didn't bring in audio focus, and thus wasn't a valid test.

This is a follow-up to #12717