### PR TITLE
[android] Fixed track look

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -175,6 +175,7 @@ public class PlacePageView extends Fragment
   private View mAddOrganisation;
   private View mAddPlace;
   private View mEditTopSpace;
+  private View mDetailsTopSpace;
   private ImageView mColorIcon;
   private TextView mTvCategory;
   private ImageView mEditBookmark;
@@ -369,6 +370,7 @@ public class PlacePageView extends Fragment
     mAddPlace = mFrame.findViewById(R.id.ll__place_add);
     mAddPlace.setOnClickListener(this);
     mEditTopSpace = mFrame.findViewById(R.id.edit_top_space);
+    mDetailsTopSpace = mFrame.findViewById(R.id.details_top_space);
     latlon.setOnLongClickListener(this);
     address.setOnLongClickListener(this);
     mOperator.setOnLongClickListener(this);
@@ -808,8 +810,9 @@ public class PlacePageView extends Fragment
           UiUtils.isVisible(mEditPlace) || UiUtils.isVisible(mAddOrganisation) || UiUtils.isVisible(mAddPlace),
           mEditTopSpace);
     }
-    UiUtils.hideIf(mMapObject.isTrackRecording(), mShareButton, mFrame.findViewById(R.id.ll__place_open_in));
-    UiUtils.hideIf(mMapObject.isTrack(), mFrame.findViewById(R.id.ll__place_open_in));
+    final boolean isTrackOrRecording = mMapObject.isTrack() || mMapObject.isTrackRecording();
+    UiUtils.hideIf(mMapObject.isTrackRecording(), mShareButton);
+    UiUtils.hideIf(isTrackOrRecording, mFrame.findViewById(R.id.ll__place_open_in), mDetailsTopSpace);
     updateLinksView();
     updateOpeningHoursView();
     updateProductsView();

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageTrackFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageTrackFragment.java
@@ -26,7 +26,6 @@ public class PlacePageTrackFragment extends Fragment
   @Nullable
   private Track mTrack;
   private ElevationProfileViewRenderer mElevationProfileViewRenderer;
-  private View mElevationProfileView;
 
   @Nullable
   @Override
@@ -42,8 +41,7 @@ public class PlacePageTrackFragment extends Fragment
   {
     super.onViewCreated(view, savedInstanceState);
 
-    mElevationProfileView = view.findViewById(R.id.elevation_profile);
-    mElevationProfileViewRenderer = new ElevationProfileViewRenderer(mElevationProfileView);
+    mElevationProfileViewRenderer = new ElevationProfileViewRenderer(view.findViewById(R.id.elevation_profile));
   }
 
   @Override
@@ -65,12 +63,6 @@ public class PlacePageTrackFragment extends Fragment
   }
 
   @Override
-  public void onDestroy()
-  {
-    super.onDestroy();
-  }
-
-  @Override
   public void onChanged(@Nullable MapObject mapObject)
   {
     // MapObject could be something else than a Track if the user already has the place page
@@ -79,6 +71,7 @@ public class PlacePageTrackFragment extends Fragment
     if (mapObject == null || !mapObject.isTrack())
     {
       mTrack = null;
+      UiUtils.hide(requireView());
       return;
     }
 
@@ -86,13 +79,11 @@ public class PlacePageTrackFragment extends Fragment
     if (track.getElevationInfo() != null)
     {
       if (mTrack == null || mTrack.getTrackId() != track.getTrackId() || track.isTempRelationTrack())
-      {
         mElevationProfileViewRenderer.render(track, track.getElevationInfo(), track.getTrackStatistics());
-        UiUtils.show(mElevationProfileView);
-      }
+      UiUtils.show(requireView());
     }
     else
-      UiUtils.hide(mElevationProfileView);
+      UiUtils.hide(requireView());
     mTrack = track;
   }
 

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageTrackRecordingFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageTrackRecordingFragment.java
@@ -16,6 +16,7 @@ import app.organicmaps.sdk.bookmarks.data.TrackRecording;
 import app.organicmaps.sdk.bookmarks.data.TrackStatistics;
 import app.organicmaps.sdk.location.TrackRecorder;
 import app.organicmaps.sdk.util.StringUtils;
+import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
 import app.organicmaps.widget.placepage.ElevationProfileViewRenderer;
 import app.organicmaps.widget.placepage.PlacePageStateListener;
@@ -76,10 +77,13 @@ public class PlacePageTrackRecordingFragment
             StringUtils.nativeFormatDistance(trackStatistics.getLength()).toString(getContext()) + " • "
             + Utils.formatRoutingTime(getContext(), (int) trackStatistics.getDuration(), R.dimen.text_size_body_3));
     ElevationInfo elevationInfo = TrackRecorder.nativeGetElevationInfo();
-    // This check is needed because the elevationInfo can be null in case there are no elevation data.
-    // When Track Recording has just started
-    if (elevationInfo == null)
-      return;
-    mElevationProfileViewRenderer.render(/* track */ null, elevationInfo, trackStatistics);
+    // elevationInfo can be null when Track Recording has just started and no elevation data exists yet.
+    if (elevationInfo != null)
+    {
+      mElevationProfileViewRenderer.render(/* track */ null, elevationInfo, trackStatistics);
+      UiUtils.show(requireView());
+    }
+    else
+      UiUtils.hide(requireView());
   }
 }

--- a/android/app/src/main/res/layout/place_page_details.xml
+++ b/android/app/src/main/res/layout/place_page_details.xml
@@ -8,7 +8,9 @@
   android:orientation="vertical">
 
 
-  <include layout="@layout/place_page_fat_shadow"/>
+  <include
+    android:id="@+id/details_top_space"
+    layout="@layout/place_page_fat_shadow" />
 
   <LinearLayout
     android:layout_width="match_parent"


### PR DESCRIPTION
Summary                                                                                                    
                                                                                                             
  - Hide the entire track elevation fragment (including its shadow divider) when there is no elevation data, 
  instead of hiding only the chart view
  - Hide the details section top shadow for tracks and track recordings, since all detail items (lat/lon,    
  open in, metadata) are hidden for these type

UI bug:
<img width="266" height="397" alt="parking_divider_line" src="https://github.com/user-attachments/assets/59f66c59-adce-4898-a753-5069f67567d6" />
<img width="380" height="206" alt="image" src="https://github.com/user-attachments/assets/f296c99f-9a2c-4145-973c-f7b626804a4c" />

Now: 
<img width="344" height="405" alt="image" src="https://github.com/user-attachments/assets/e1f5029f-31b1-426e-9161-9aa589734a83" />
<img width="360" height="260" alt="image" src="https://github.com/user-attachments/assets/c40d129b-f03d-4e1f-9bb8-f4387663b8d6" />
<img width="370" height="295" alt="image" src="https://github.com/user-attachments/assets/3f7ab5e5-0f4e-4725-9752-3c8b963662cb" />
