### PR TITLE
[drape_frontend] Add mid-frame polls to fix DetachSurface ANR

### DIFF
--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -1768,6 +1768,14 @@ void FrontendRenderer::RenderFrame()
   DrapeMeasurerGuard drapeMeasurerGuard;
 
   CHECK(m_context != nullptr, ());
+
+  // Early-exit polls bound the latency between SetRenderingDisabled() and the
+  // next CheckRenderingEnabled() call (which runs in IterateRenderLoopImpl
+  // immediately after RenderFrame() returns). Without them, a slow frame can
+  // block the UI thread in surfaceDestroyed() long enough to ANR.
+  if (!IsRenderingEnabled())
+    return;
+
   if (!m_context->Validate())
   {
     m_frameData.m_forceFullRedrawNextFrame = true;
@@ -1787,6 +1795,9 @@ void FrontendRenderer::RenderFrame()
   /// @todo Put ResolveZoomLevel under modelViewChanged after testing.
   ASSERT(!zoomChanged || modelViewChanged, ());
 
+  if (!IsRenderingEnabled())
+    return;
+
   if (!m_context->BeginRendering())
     return;
 
@@ -1795,6 +1806,13 @@ void FrontendRenderer::RenderFrame()
 
   if (isActiveFrame)
     PrepareScene(modelView);
+
+  // EndRendering() must balance the BeginRendering() above before returning.
+  if (!IsRenderingEnabled())
+  {
+    m_context->EndRendering();
+    return;
+  }
 
   bool const needUpdateDynamicTextures = m_texMng->UpdateDynamicTextures(m_context);
   isActiveFrame |= needUpdateDynamicTextures;
@@ -1821,6 +1839,9 @@ void FrontendRenderer::RenderFrame()
     m_renderInjectionHandler(m_context, m_texMng, make_ref(m_gpuProgramManager), false);
 
   m_context->EndRendering();
+
+  if (!IsRenderingEnabled())
+    return;
 
   bool const hasForceUpdate = m_forceUpdateScene || m_forceUpdateUserMarks;
   isActiveFrame |= hasForceUpdate;


### PR DESCRIPTION
The main thread can block indefinitely in BaseRenderer::SetRenderingEnabled when the surface is destroyed: it waits on a condition variable until the renderer acknowledges by reaching CheckRenderingEnabled(), which only runs once per frame after RenderFrame() returns. If a frame is slow (CPU starvation, vendor process throttling, memory pressure, GPU stalls), the acknowledgment latency can exceed Android's 5-second ANR threshold and manifests as an ANR in surfaceDestroyed -> nativeDetachSurface.

Poll IsRenderingEnabled() inside RenderFrame() at four safe boundaries: top of frame, before BeginRendering, between PrepareScene and the heavy GPU phase (with EndRendering cleanup to balance BeginRendering), and after EndRendering. The check is a single atomic load and bounds the worst-case acknowledgment latency to one segment between consecutive polls.