### PR TITLE
[ios] Fix CarPlay deprecation warnings

### DIFF
--- a/iphone/Maps/Core/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayService.swift
@@ -99,16 +99,17 @@ final class CarPlayService: NSObject {
       title: L("car_continue_in_the_car"),
       style: .default,
       handler: { [weak self] _ in
-        self?.savedInterfaceController?.dismissTemplate(animated: false)
-        self?.showOnCarplay()
+        guard let self else { return }
+        savedInterfaceController?.dismissTemplate(animated: false, completion: templateCompletion)
+        showOnCarplay()
       }
     )
     let alert = CPAlertTemplate(
       titleVariants: [L("car_used_on_the_phone_screen")],
       actions: [switchToCarAction]
     )
-    savedInterfaceController?.dismissTemplate(animated: false)
-    savedInterfaceController?.presentTemplate(alert, animated: false)
+    savedInterfaceController?.dismissTemplate(animated: false, completion: templateCompletion)
+    savedInterfaceController?.presentTemplate(alert, animated: false, completion: templateCompletion)
   }
 
   private func switchScreenToPhone() {
@@ -190,14 +191,14 @@ final class CarPlayService: NSObject {
     let mapTemplate = MapTemplateBuilder.buildBaseTemplate(positionMode: currentPositionMode)
     mapTemplate.mapDelegate = self
     mapTemplate.tripEstimateStyle = rootTemplateStyle
-    interfaceController?.setRootTemplate(mapTemplate, animated: true)
+    interfaceController?.setRootTemplate(mapTemplate, animated: true, completion: templateCompletion)
     FrameworkHelper.rotateMap(0.0, animated: false)
   }
 
   private func applyNavigationRootTemplate(trip: CPTrip, routeInfo: RouteInfo) {
     let mapTemplate = MapTemplateBuilder.buildNavigationTemplate()
     mapTemplate.mapDelegate = self
-    interfaceController?.setRootTemplate(mapTemplate, animated: true)
+    interfaceController?.setRootTemplate(mapTemplate, animated: true, completion: templateCompletion)
     router?.startNavigationSession(forTrip: trip, template: mapTemplate)
     if let estimates = createEstimates(routeInfo: routeInfo) {
       mapTemplate.tripEstimateStyle = rootTemplateStyle
@@ -213,8 +214,6 @@ final class CarPlayService: NSObject {
   func pushTemplate(_ templateToPush: CPTemplate, animated: Bool) {
     if let interfaceController = interfaceController {
       switch templateToPush {
-      case let list as CPListTemplate:
-        list.delegate = self
       case let search as CPSearchTemplate:
         search.delegate = self
       case let map as CPMapTemplate:
@@ -222,17 +221,17 @@ final class CarPlayService: NSObject {
       default:
         break
       }
-      interfaceController.pushTemplate(templateToPush, animated: animated)
+      interfaceController.pushTemplate(templateToPush, animated: animated, completion: templateCompletion)
     }
   }
 
   func popTemplate(animated: Bool) {
-    interfaceController?.popTemplate(animated: animated)
+    interfaceController?.popTemplate(animated: animated, completion: templateCompletion)
   }
 
   func presentAlert(_ template: CPAlertTemplate, animated: Bool) {
-    interfaceController?.dismissTemplate(animated: false)
-    interfaceController?.presentTemplate(template, animated: animated)
+    interfaceController?.dismissTemplate(animated: false, completion: templateCompletion)
+    interfaceController?.presentTemplate(template, animated: animated, completion: templateCompletion)
   }
 
   func cancelCurrentTrip() {
@@ -286,7 +285,7 @@ final class CarPlayService: NSObject {
 
     let alert = CPNavigationAlert(titleVariants: [L("trip_finished")],
                                   subtitleVariants: [subtitle],
-                                  imageSet: nil,
+                                  image: nil,
                                   primaryAction: doneAction,
                                   secondaryAction: nil,
                                   duration: 0)
@@ -321,8 +320,13 @@ final class CarPlayService: NSObject {
        let info = presentedTemplate.userInfo as? [String: String],
        let alertType = info[CPConstants.TemplateKey.alert],
        alertType == CPConstants.TemplateType.downloadMap {
-      interfaceController?.dismissTemplate(animated: true)
+      interfaceController?.dismissTemplate(animated: true, completion: templateCompletion)
     }
+  }
+
+  private func templateCompletion(_: Bool, _ error: Error?) {
+    guard let error else { return }
+    LOG(.warning, "CarPlay template operation failed with error: \(error.localizedDescription)")
   }
 }
 
@@ -465,7 +469,7 @@ extension CarPlayService: CPMapTemplateDelegate {
     MapTemplateBuilder.configureNavigationUI(mapTemplate: rootMapTemplate)
 
     if interfaceController.templates.count > 1 {
-      interfaceController.popToRootTemplate(animated: false)
+      interfaceController.popToRootTemplate(animated: false, completion: templateCompletion)
     }
     router.startNavigationSession(forTrip: trip, template: rootMapTemplate)
     router.startRoute()
@@ -506,45 +510,6 @@ extension CarPlayService: CPMapTemplateDelegate {
     mapTemplate.updateEstimates(estimates, for: trip)
     routeChoice.userInfo = nil
     router?.rebuildRoute()
-  }
-}
-
-// MARK: - CPListTemplateDelegate implementation
-
-extension CarPlayService: CPListTemplateDelegate {
-  func listTemplate(_: CPListTemplate, didSelect item: CPListItem, completionHandler: @escaping () -> Void) {
-    if let userInfo = item.userInfo as? ListItemInfo {
-      switch userInfo.type {
-      case CPConstants.ListItemType.history:
-        let locale = window?.textInputMode?.primaryLanguage ?? "en"
-        guard let searchService = searchService else {
-          completionHandler()
-          return
-        }
-        searchService.searchText(item.text ?? "", forInputLocale: locale, completionHandler: { [weak self] results in
-          guard let self = self else { return }
-          let template = ListTemplateBuilder.buildListTemplate(for: .searchResults(results: results))
-          completionHandler()
-          self.pushTemplate(template, animated: true)
-        })
-      case CPConstants.ListItemType.bookmarkLists where userInfo.metadata is CategoryInfo:
-        let metadata = userInfo.metadata as! CategoryInfo
-        let template = ListTemplateBuilder.buildListTemplate(for: .bookmarks(category: metadata.category))
-        completionHandler()
-        pushTemplate(template, animated: true)
-      case CPConstants.ListItemType.bookmarks where userInfo.metadata is BookmarkInfo:
-        let metadata = userInfo.metadata as! BookmarkInfo
-        let bookmark = MWMCarPlayBookmarkObject(bookmarkId: metadata.bookmarkId)
-        preparePreview(forBookmark: bookmark)
-        completionHandler()
-      case CPConstants.ListItemType.searchResults where userInfo.metadata is SearchResultInfo:
-        let metadata = userInfo.metadata as! SearchResultInfo
-        preparePreviewForSearchResults(selectedRow: metadata.originalRow)
-        completionHandler()
-      default:
-        completionHandler()
-      }
-    }
   }
 }
 
@@ -717,9 +682,9 @@ extension CarPlayService {
       mapTemplate.mapDelegate = self
 
       if interfaceController.templates.count > 1 {
-        interfaceController.popToRootTemplate(animated: false)
+        interfaceController.popToRootTemplate(animated: false, completion: templateCompletion)
       }
-      interfaceController.pushTemplate(mapTemplate, animated: false)
+      interfaceController.pushTemplate(mapTemplate, animated: false, completion: templateCompletion)
     }
   }
 
@@ -728,6 +693,48 @@ extension CarPlayService {
                                                         additionalRoutesButtonTitle: nil,
                                                         overviewButtonTitle: nil)
     mapTemplate.showTripPreviews(trips, textConfiguration: tripTextConfig)
+  }
+
+  func handleListItemSelection(_ selectableItem: CPSelectableListItem, completionHandler: @escaping () -> Void) {
+    guard let item = selectableItem as? CPListItem,
+          let userInfo = item.userInfo as? ListItemInfo else {
+      completionHandler()
+      return
+    }
+
+    switch userInfo.type {
+    case CPConstants.ListItemType.history:
+      let locale = window?.textInputMode?.primaryLanguage ?? "en"
+      guard let searchService = searchService else {
+        completionHandler()
+        return
+      }
+      searchService.searchText(item.text ?? "", forInputLocale: locale, completionHandler: { [weak self] results in
+        guard let self else {
+          completionHandler()
+          return
+        }
+        let template = ListTemplateBuilder.buildListTemplate(for: .searchResults(results: results))
+        completionHandler()
+        self.pushTemplate(template, animated: true)
+      })
+    case CPConstants.ListItemType.bookmarkLists where userInfo.metadata is CategoryInfo:
+      let metadata = userInfo.metadata as! CategoryInfo
+      let template = ListTemplateBuilder.buildListTemplate(for: .bookmarks(category: metadata.category))
+      completionHandler()
+      pushTemplate(template, animated: true)
+    case CPConstants.ListItemType.bookmarks where userInfo.metadata is BookmarkInfo:
+      let metadata = userInfo.metadata as! BookmarkInfo
+      let bookmark = MWMCarPlayBookmarkObject(bookmarkId: metadata.bookmarkId)
+      preparePreview(forBookmark: bookmark)
+      completionHandler()
+    case CPConstants.ListItemType.searchResults where userInfo.metadata is SearchResultInfo:
+      let metadata = userInfo.metadata as! SearchResultInfo
+      preparePreviewForSearchResults(selectedRow: metadata.originalRow)
+      completionHandler()
+    default:
+      completionHandler()
+    }
   }
 
   func createEstimates(routeInfo: RouteInfo) -> CPTravelEstimates? {
@@ -748,10 +755,10 @@ extension CarPlayService {
       router?.cancelTrip()
       updateMapTemplateUIToBase()
       preparedToPreviewTrips = trips
-      interfaceController?.dismissTemplate(animated: true)
+      interfaceController?.dismissTemplate(animated: true, completion: templateCompletion)
     })
     let noAction = CPAlertAction(title: L("no"), style: .cancel, handler: { [unowned self] _ in
-      interfaceController?.dismissTemplate(animated: true)
+      interfaceController?.dismissTemplate(animated: true, completion: templateCompletion)
     })
     let alert = CPAlertTemplate(titleVariants: [L("redirect_route_alert")], actions: [noAction, yesAction])
     alert.userInfo = [CPConstants.TemplateKey.alert: CPConstants.TemplateType.redirectRoute]
@@ -760,7 +767,7 @@ extension CarPlayService {
 
   func showKeyboardAlert() {
     let okAction = CPAlertAction(title: L("ok"), style: .default, handler: { [unowned self] _ in
-      interfaceController?.dismissTemplate(animated: true)
+      interfaceController?.dismissTemplate(animated: true, completion: templateCompletion)
     })
     let alert = CPAlertTemplate(titleVariants: [L("keyboard_availability_alert")], actions: [okAction])
     presentAlert(alert, animated: true)
@@ -796,7 +803,7 @@ extension CarPlayService {
     }
 
     let okAction = CPAlertAction(title: L("ok"), style: .cancel, handler: { [unowned self] _ in
-      interfaceController?.dismissTemplate(animated: true)
+      interfaceController?.dismissTemplate(animated: true, completion: templateCompletion)
     })
     let alert = CPAlertTemplate(titleVariants: titleVariants, actions: [okAction])
     presentAlert(alert, animated: true)
@@ -813,12 +820,12 @@ extension CarPlayService {
       trip.userInfo = info
       preparedToPreviewTrips = [trip]
       router?.updateStartPointAndRebuild(trip: trip)
-      interfaceController?.dismissTemplate(animated: true)
+      interfaceController?.dismissTemplate(animated: true, completion: templateCompletion)
     })
     let noAction = CPAlertAction(title: L("cancel"), style: .cancel, handler: { [unowned self] _ in
       FrameworkHelper.rotateMap(0.0, animated: false)
       router?.completeRouteAndRemovePoints()
-      interfaceController?.dismissTemplate(animated: true)
+      interfaceController?.dismissTemplate(animated: true, completion: templateCompletion)
     })
     let title = isTypeCorrect ? L("dialog_routing_rebuild_from_current_location_carplay") : L("dialog_routing_rebuild_for_vehicle_carplay")
     let alert = CPAlertTemplate(titleVariants: [title], actions: [noAction, yesAction])

--- a/iphone/Maps/Core/CarPlay/Template Builders/ListTemplateBuilder.swift
+++ b/iphone/Maps/Core/CarPlay/Template Builders/ListTemplateBuilder.swift
@@ -13,6 +13,10 @@ final class ListTemplateBuilder {
     case search
   }
 
+  private static let itemHandler: (CPSelectableListItem, @escaping () -> Void) -> Void = { selectableItem, completionHandler in
+    CarPlayService.shared.handleListItemSelection(selectableItem, completionHandler: completionHandler)
+  }
+
   // MARK: - CPListTemplate bilder
 
   class func buildListTemplate(for type: ListTemplateType) -> CPListTemplate {
@@ -66,6 +70,7 @@ final class ListTemplateBuilder {
       let item = CPListItem(text: text, detailText: nil, image: UIImage(named: "ic_carplay_recent"))
       item.userInfo = ListItemInfo(type: CPConstants.ListItemType.history,
                                    metadata: nil)
+      item.handler = Self.itemHandler
       return item
     }
     let section = CPListSection(items: items)
@@ -81,6 +86,7 @@ final class ListTemplateBuilder {
       let item = CPListItem(text: category.title, detailText: placesString)
       item.userInfo = ListItemInfo(type: CPConstants.ListItemType.bookmarkLists,
                                    metadata: CategoryInfo(category: category))
+      item.handler = Self.itemHandler
       return item
     }
     let section = CPListSection(items: items)
@@ -94,6 +100,7 @@ final class ListTemplateBuilder {
       let item = CPListItem(text: bookmark.prefferedName, detailText: bookmark.address)
       item.userInfo = ListItemInfo(type: CPConstants.ListItemType.bookmarks,
                                    metadata: BookmarkInfo(bookmarkId: bookmark.bookmarkId))
+      item.handler = Self.itemHandler
       return item
     }
     if #available(iOS 15.0, *) {
@@ -115,6 +122,7 @@ final class ListTemplateBuilder {
       let item = CPListItem(text: object.title, detailText: object.address)
       item.userInfo = ListItemInfo(type: CPConstants.ListItemType.searchResults,
                                    metadata: SearchResultInfo(originalRow: object.originalRow))
+      item.handler = Self.itemHandler
       items.append(item)
     }
     let section = CPListSection(items: items)


### PR DESCRIPTION
Migrate deprecated CarPlay APIs to their iOS 14+ replacements:
- CPInterfaceController template methods (set/push/pop/popToRoot/present/ dismiss) now use the :completion: variant
- CPNavigationAlert switched from imageSet: to image:
- CPListTemplateDelegate replaced with per-item CPListItem.handler

The handler closure uses the framework-provided selectableItem parameter instead of capturing the outer item to avoid a retain cycle through CPListItem.handler.

Also fixes a latent bug in list-item selection: the previous delegate implementation never invoked the completion handler when the item's userInfo was not a ListItemInfo, or when [weak self] resolved to nil inside the history-search closure. Either path could leave CarPlay's selection spinner hung indefinitely. The new handleListItemSelection calls completionHandler() on both paths.