### PR TITLE
[map][ios] Fix sharing button bug

### DIFF
--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageTrackData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageTrackData.h
@@ -10,7 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PlacePageTrackData : NSObject
 
 @property(nonatomic, readonly) MWMTrackID trackId;
-@property(nonatomic, readonly) BOOL isTempRelationTrack;
 @property(nonatomic, readonly) MWMMarkGroupID groupId;
 @property(nonatomic, readonly, nullable) NSString * trackCategory;
 // TODO: The track description is not fully implemented in the core yet.

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageTrackData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageTrackData.mm
@@ -46,7 +46,6 @@
     auto const & bm = GetFramework().GetBookmarkManager();
 
     _trackId = track.GetData().m_id;
-    _isTempRelationTrack = (_trackId == kml::kTempRelationTrackId);
 
     auto const & groupId = track.GetGroupId();
     if (groupId && bm.HasBmCategory(groupId))

--- a/iphone/CoreApi/CoreApi/PlacePageData/PlacePageData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/PlacePageData.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(NSInteger, PlacePageObjectType) {
   PlacePageObjectTypePOI,
   PlacePageObjectTypeBookmark,
   PlacePageObjectTypeTrack,
+  PlacePageObjectTypeRelationTrack,
   PlacePageObjectTypeTrackRecording
 };
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/PlacePageData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/PlacePageData.mm
@@ -157,7 +157,7 @@ static PlacePageRoadType convertRoadType(RoadWarningMarkType roadType)
   if (rawData().IsBookmark())
     return PlacePageObjectTypeBookmark;
   else if (rawData().IsTrack())
-    return PlacePageObjectTypeTrack;
+    return rawData().IsRelationTrack() ? PlacePageObjectTypeRelationTrack : PlacePageObjectTypeTrack;
   else if (self.trackData)
     return PlacePageObjectTypeTrackRecording;
   else

--- a/iphone/Maps/UI/PlacePage/Components/ActionBarViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ActionBarViewController.swift
@@ -70,7 +70,7 @@ final class ActionBarViewController: UIViewController {
       if canRouteToAndFrom {
         buttons.append(.routeTo)
       }
-    case .track:
+    case .track, .relationTrack:
       if canRouteToAndFrom {
         buttons.append(.routeFrom)
       }
@@ -81,7 +81,7 @@ final class ActionBarViewController: UIViewController {
       if canRouteToAndFrom {
         buttons.append(.routeTo)
       }
-      if !(placePageData.trackData?.isTempRelationTrack ?? false) {
+      if placePageData.objectType == .track {
         buttons.append(.track)
       }
     case .trackRecording:

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderBuilder.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderBuilder.swift
@@ -7,7 +7,6 @@ class PlacePageHeaderBuilder {
     let presenter = PlacePageHeaderPresenter(view: viewController,
                                              placePagePreviewData: data.previewData,
                                              objectType: data.objectType,
-                                             isTempRelationTrack: data.trackData?.isTempRelationTrack ?? false,
                                              delegate: delegate,
                                              headerType: headerType)
 

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderPresenter.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderPresenter.swift
@@ -30,28 +30,25 @@ class PlacePageHeaderPresenter {
   private weak var view: PlacePageHeaderViewProtocol?
   private let placePagePreviewData: PlacePagePreviewData
   let objectType: PlacePageObjectType
-  private let isTempRelationTrack: Bool
   private weak var delegate: PlacePageHeaderViewControllerDelegate?
   private let headerType: HeaderType
 
   init(view: PlacePageHeaderViewProtocol,
        placePagePreviewData: PlacePagePreviewData,
        objectType: PlacePageObjectType,
-       isTempRelationTrack: Bool,
        delegate: PlacePageHeaderViewControllerDelegate?,
        headerType: HeaderType) {
     self.view = view
     self.delegate = delegate
     self.placePagePreviewData = placePagePreviewData
     self.objectType = objectType
-    self.isTempRelationTrack = isTempRelationTrack
     self.headerType = headerType
   }
 }
 
 extension PlacePageHeaderPresenter: PlacePageHeaderPresenterProtocol {
-  var canEditTitle: Bool { objectType == .bookmark || (objectType == .track && !isTempRelationTrack) }
-  var canShare: Bool { canEditTitle }
+  var canEditTitle: Bool { objectType == .bookmark || objectType == .track }
+  var canShare: Bool { objectType == .POI || objectType == .bookmark || objectType == .track }
 
   func configure() {
     view?.setTitle(placePagePreviewData.title, secondaryTitle: placePagePreviewData.secondaryTitle)

--- a/iphone/Maps/UI/PlacePage/PlacePageBuilder.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageBuilder.swift
@@ -10,7 +10,7 @@
     switch data.objectType {
     case .POI, .bookmark:
       layout = PlacePageCommonLayout(interactor: interactor, storyboard: storyboard, data: data)
-    case .track:
+    case .track, .relationTrack:
       let trackLayout = PlacePageTrackLayout(interactor: interactor, storyboard: storyboard, data: data)
       interactor.trackActivePointPresenter = trackLayout.elevationMapViewController?.presenter
       layout = trackLayout
@@ -37,7 +37,7 @@
     switch data.objectType {
     case .POI, .bookmark:
       layout = PlacePageCommonLayout(interactor: interactor, storyboard: storyboard, data: data)
-    case .track:
+    case .track, .relationTrack:
       let trackLayout = PlacePageTrackLayout(interactor: interactor, storyboard: storyboard, data: data)
       interactor.trackActivePointPresenter = trackLayout.elevationMapViewController?.presenter
       layout = trackLayout

--- a/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
@@ -38,7 +38,7 @@ class PlacePageInteractor: NSObject {
         return
       }
       updatePlacePage()
-    case .track:
+    case .track, .relationTrack:
       guard let trackData = placePageData.trackData, bookmarksManager.hasTrack(trackData.trackId) else {
         if let trackDeletionConfirmationDialog {
           trackDeletionConfirmationDialog.dismiss(animated: true)
@@ -54,7 +54,10 @@ class PlacePageInteractor: NSObject {
 
   private func subscribeOnTrackActivePointUpdatesIfNeeded() {
     unsubscribeFromTrackActivePointUpdates()
-    guard placePageData.objectType == .track, let trackData = placePageData.trackData else { return }
+    let isActivePointTrackingEnabled = placePageData.objectType == .track || placePageData.objectType == .relationTrack
+    guard isActivePointTrackingEnabled, let trackData = placePageData.trackData else {
+      return
+    }
     bookmarksManager.setElevationActivePointChanged(trackData.trackId) { [weak self] distance in
       self?.trackActivePointPresenter?.updateActivePointDistance(distance)
       trackData.updateActivePointDistance(distance)

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageTrackLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageTrackLayout.swift
@@ -70,7 +70,7 @@ class PlacePageTrackLayout: IPlacePageLayout {
   private func configureViewControllers() -> [UIViewController] {
     var viewControllers = [UIViewController]()
 
-    if !trackData.isTempRelationTrack {
+    if placePageData.objectType == .track {
       viewControllers.append(editTrackViewController)
       editTrackViewController.view.isHidden = false
       editTrackInteractor?.data = .track(trackData)

--- a/libs/map/place_page_info.hpp
+++ b/libs/map/place_page_info.hpp
@@ -97,6 +97,7 @@ public:
   bool IsFeature() const { return m_featureID.IsValid(); }
   bool IsBookmark() const;
   bool IsTrack() const { return m_trackId != kml::kInvalidTrackId; }
+  bool IsRelationTrack() const { return m_trackId == kml::kTempRelationTrackId; }
   bool IsMyPosition() const { return m_selectedObject == df::SelectionShape::ESelectedObject::OBJECT_MY_POSITION; }
   bool IsRoutePoint() const { return m_isRoutePoint; }
   bool IsRoadType() const { return m_roadType != RoadWarningMarkType::Count; }

--- a/qt/place_page_dialog_developer.cpp
+++ b/qt/place_page_dialog_developer.cpp
@@ -62,7 +62,7 @@ PlacePageDialogDeveloper::PlacePageDialogDeveloper(QWidget * parent, place_page:
     grid->addWidget(new QLabel("Bookmark"), row, 0);
     grid->addWidget(new QLabel("Yes"), row++, 1);
   }
-  else if (info.IsTrack() && info.GetTrackId() == kml::kTempRelationTrackId)
+  else if (info.IsRelationTrack())
   {
     grid->addWidget(new QLabel("Track from Relation"), row, 0);
     grid->addWidget(new QLabel("Yes"), row++, 1);


### PR DESCRIPTION
This PR:
1. Introduces the new object type to the iOS Place Page. Date: `PlacePageObjectTypeRelationTrack`. This allows the property `isTempRelationTrack` to be safely removed. It will help explicitly configure the Place Page screens for the track and related track.
2. The bug fix itself: the share button should be displayed for the POI, bookmarks and track and should not for track recording and relation track.