### PR TITLE
[platform] Retry HTTP/2 streams rejected by GOAWAY over HTTP/1.1

### DIFF
--- a/libs/platform/http_client_qt.cpp
+++ b/libs/platform/http_client_qt.cpp
@@ -59,6 +59,22 @@ std::string CollectServerCookies(QNetworkReply * reply)
   }
   return rawCookies.empty() ? std::string{} : platform::HttpClient::NormalizeServerCookies(std::move(rawCookies));
 }
+
+// sendCustomRequest supports body for any method, including DELETE.
+// QNetworkAccessManager::deleteResource() silently drops the body.
+QNetworkReply * IssueRequest(QNetworkAccessManager & manager, std::string const & method,
+                             QNetworkRequest const & request, QByteArray const & body)
+{
+  if (method == "GET")
+    return manager.get(request);
+  if (method == "POST")
+    return manager.post(request, body);
+  if (method == "PUT")
+    return manager.put(request, body);
+  if (method == "HEAD")
+    return manager.head(request);
+  return manager.sendCustomRequest(request, QByteArray::fromStdString(method), body);
+}
 }  // namespace
 
 namespace platform
@@ -67,9 +83,9 @@ HttpClientReply::HttpClientReply(QNetworkReply * reply, HttpClient::CompletionHa
                                  HttpClient::ProgressHandler progressHandler, HttpClient::DataHandler dataHandler,
                                  CancelChecker cancelChecker, bool loadHeaders, bool followRedirects,
                                  std::string urlRequested, std::string cookies, std::string outputFile,
-                                 std::optional<HttpClient::ReceivedFileSegment> segment)
-  : m_reply(reply)
-  , m_handler(std::move(handler))
+                                 std::optional<HttpClient::ReceivedFileSegment> segment, QNetworkRequest request,
+                                 std::string httpMethod, QByteArray bodyBytes, RebindCancel rebindCancel)
+  : m_handler(std::move(handler))
   , m_progressHandler(std::move(progressHandler))
   , m_dataHandler(std::move(dataHandler))
   , m_cancelChecker(std::move(cancelChecker))
@@ -79,6 +95,10 @@ HttpClientReply::HttpClientReply(QNetworkReply * reply, HttpClient::CompletionHa
   , m_cookies(std::move(cookies))
   , m_outputFile(std::move(outputFile))
   , m_segment(std::move(segment))
+  , m_request(std::move(request))
+  , m_httpMethod(std::move(httpMethod))
+  , m_bodyBytes(std::move(bodyBytes))
+  , m_rebindCancel(std::move(rebindCancel))
 {
   // Segment mode takes precedence over plain output file and defers file open
   // until 206 + Content-Range are validated in ValidateSegmentIfNeeded().
@@ -93,17 +113,85 @@ HttpClientReply::HttpClientReply(QNetworkReply * reply, HttpClient::CompletionHa
       m_writeError = true;
     }
   }
-  connect(m_reply, &QNetworkReply::readyRead, this, &HttpClientReply::OnReadyRead);
-  connect(m_reply, &QNetworkReply::downloadProgress, this, &HttpClientReply::OnDownloadProgress);
-  connect(m_reply, &QNetworkReply::finished, this, &HttpClientReply::OnFinished);
+  AttachReply(reply);
 
   // Abort immediately so we don't waste bandwidth on a doomed download.
-  // Must be after signal connections so OnFinished() still fires.
+  // Must be after AttachReply so OnFinished() still fires.
   // Note: abort() triggers OnFinished() synchronously via direct connection,
   // but all members are already initialized at this point and OnFinished()
   // uses only deleteLater() for cleanup, so this is safe.
   if (m_writeError)
     m_reply->abort();
+}
+
+void HttpClientReply::AttachReply(QNetworkReply * reply)
+{
+  m_reply = reply;
+  connect(reply, &QNetworkReply::readyRead, this, &HttpClientReply::OnReadyRead);
+  connect(reply, &QNetworkReply::downloadProgress, this, &HttpClientReply::OnDownloadProgress);
+  connect(reply, &QNetworkReply::finished, this, &HttpClientReply::OnFinished);
+
+  // Re-point the platform cancel hook at the new reply. Cancel() called between
+  // the old hook firing (no-op against a destroyed reply) and the rebind would
+  // have set m_cancelled, so check the cancel-checker afterwards and abort now.
+  m_rebindCancel(reply);
+  if (m_cancelChecker && m_cancelChecker())
+    reply->abort();
+}
+
+// static
+bool HttpClientReply::ShouldRetry(QNetworkReply::NetworkError error, QString const & errorString, int httpCode,
+                                  bool anyBytesReceived, bool writeError, int retriesRemaining)
+{
+  if (writeError || anyBytesReceived || retriesRemaining <= 0)
+    return false;
+  // Any HTTP status means the server processed (at least the headers of) this request.
+  if (httpCode != 0)
+    return false;
+
+  switch (error)
+  {
+  case QNetworkReply::ContentReSendError: return true;
+
+  case QNetworkReply::ProtocolFailure:
+    // Defensive secondary signal: Qt 6.x's HTTP/2 layer logs these phrases when a
+    // stream is rejected after GOAWAY or with REFUSED_STREAM (see Qt sources
+    // qhttp2connection.cpp / qhttpnetworkconnectionchannel.cpp — not public API,
+    // re-verify on Qt upgrade). RFC 9113 §6.8 permits retrying these on a new
+    // connection.
+    return errorString.contains("stopped accepting", Qt::CaseInsensitive) ||
+           errorString.contains("REFUSED_STREAM", Qt::CaseInsensitive) ||
+           errorString.contains("GOAWAY", Qt::CaseInsensitive);
+
+  default: return false;
+  }
+}
+
+bool HttpClientReply::TryRetryOnGoAway()
+{
+  if (m_cancelChecker && m_cancelChecker())
+    return false;
+
+  int const httpCode = m_reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+  if (!ShouldRetry(m_reply->error(), m_reply->errorString(), httpCode, m_anyBytesReceived, m_writeError,
+                   m_retriesRemaining))
+    return false;
+
+  --m_retriesRemaining;
+  LOG(LWARNING, ("HTTP/2 stream rejected, retrying once over HTTP/1.1:", m_urlRequested,
+                 "Qt error:", static_cast<int>(m_reply->error()), m_reply->errorString().toStdString()));
+
+  m_reply->disconnect(this);
+  m_reply->deleteLater();
+
+  // Force HTTP/1.1 for the retry so we cannot multiplex onto another HTTP/2
+  // connection from the same poisoned pool. The GOAWAY'd HTTP/2 connection is
+  // already closed by the server; Qt will open a fresh TCP/TLS leg naturally.
+  m_request.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
+
+  auto & manager = GetNetworkThread().worker->m_manager;
+  AttachReply(IssueRequest(manager, m_httpMethod, m_request, m_bodyBytes));
+  return true;
 }
 
 bool HttpClientReply::ValidateSegmentIfNeeded()
@@ -169,6 +257,9 @@ void HttpClientReply::OnReadyRead()
   QByteArray const data = m_reply->readAll();
   if (data.isEmpty())
     return;
+
+  // Past this point the caller will observe body bytes; retry would double-deliver.
+  m_anyBytesReceived = true;
 
   if (m_dataHandler)
   {
@@ -236,6 +327,11 @@ void HttpClientReply::OnFinished()
     deleteLater();
     return;
   }
+
+  // Transparent retry for HTTP/2 GOAWAY-rejected streams (RFC 9113 §6.8).
+  // On success a new reply is in flight and will fire OnFinished again.
+  if (TryRetryOnGoAway())
+    return;
 
   int const httpCode = m_reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
   bool const noError = (m_reply->error() == QNetworkReply::NoError);
@@ -432,12 +528,26 @@ HttpClient::RequestHandle HttpClient::RunHttpRequestAsync(CompletionHandler hand
   auto impl = handle.m_impl;
   auto cancelChecker = handle.MakeCancelChecker();
 
+  // reply->abort() must be invoked on the reply's thread, so the inner cancel
+  // dispatches via QueuedConnection regardless of which thread Cancel() runs on.
+  auto const rebindCancel = [impl](QNetworkReply * reply)
+  {
+    QPointer<QNetworkReply> guardedReply(reply);
+    std::lock_guard lock(impl->m_mu);
+    impl->m_platformCancel = [guardedReply]
+    {
+      if (guardedReply)
+        QMetaObject::invokeMethod(guardedReply.data(), "abort", Qt::QueuedConnection);
+    };
+  };
+
   // Post to the network worker thread. The lambda runs on that thread
   // where QNetworkAccessManager lives, so QNetworkReply is created with
   // correct affinity and signals fire on the worker's event loop.
   auto & nt = GetNetworkThread();
   QMetaObject::invokeMethod(nt.worker,
-                            [=, handler = std::move(handler), cancelChecker = std::move(cancelChecker)]() mutable
+                            [=, handler = std::move(handler), cancelChecker = std::move(cancelChecker),
+                             rebindCancel = std::move(rebindCancel)]() mutable
   {
     // Check cancellation BEFORE creating the request — fixes the race where
     // Cancel() is called between RunHttpRequestAsync() returning and this
@@ -452,45 +562,13 @@ HttpClient::RequestHandle HttpClient::RunHttpRequestAsync(CompletionHandler hand
     }
 
     auto & manager = GetNetworkThread().worker->m_manager;
-    QNetworkReply * reply = nullptr;
-
-    if (httpMethod == "GET")
-      reply = manager.get(request);
-    else if (httpMethod == "POST")
-      reply = manager.post(request, bodyBytes);
-    else if (httpMethod == "PUT")
-      reply = manager.put(request, bodyBytes);
-    else if (httpMethod == "HEAD")
-      reply = manager.head(request);
-    else
-      // sendCustomRequest supports body for any method, including DELETE.
-      // QNetworkAccessManager::deleteResource() silently drops the body.
-      reply = manager.sendCustomRequest(request, QByteArray::fromStdString(httpMethod), bodyBytes);
+    QNetworkReply * reply = IssueRequest(manager, httpMethod, request, bodyBytes);
 
     new HttpClientReply(reply, std::move(handler), progressHandler, dataHandler, std::move(cancelChecker), loadHeaders,
-                        followRedirects, urlRequested, cookies, outputFile, segment);
-
-    // Install platform cancel hook. reply->abort() must be called on the
-    // reply's thread; use QMetaObject::invokeMethod with QueuedConnection.
-    QPointer<QNetworkReply> guardedReply(reply);
-    {
-      std::lock_guard lock(impl->m_mu);
-      impl->m_platformCancel = [guardedReply]
-      {
-        if (guardedReply)
-          QMetaObject::invokeMethod(guardedReply.data(), "abort", Qt::QueuedConnection);
-      };
-    }
-
-    // Double-check: if Cancel() ran between creating the reply and installing the hook,
-    // m_cancelled is set but m_platformCancel was not called. Abort now.
-    // We're on the worker thread (same as the reply), so direct abort is safe.
-    if (impl->m_cancelled.load(std::memory_order_acquire))
-    {
-      if (guardedReply)
-        guardedReply->abort();
-    }
-  }, Qt::QueuedConnection);
+                        followRedirects, urlRequested, cookies, outputFile, segment, request, httpMethod, bodyBytes,
+                        std::move(rebindCancel));
+  },
+                            Qt::QueuedConnection);
 
   return handle;
 }

--- a/libs/platform/http_client_qt.hpp
+++ b/libs/platform/http_client_qt.hpp
@@ -21,10 +21,22 @@ class HttpClientReply : public QObject
   Q_OBJECT
 
 public:
+  // Installs the platform cancel hook against the given reply. Owns a captured
+  // shared_ptr to the request handle's Impl, so it can be re-bound to a fresh
+  // reply across a transparent retry without exposing Impl outside HttpClient.
+  using RebindCancel = std::function<void(QNetworkReply *)>;
+
   HttpClientReply(QNetworkReply * reply, HttpClient::CompletionHandler handler,
                   HttpClient::ProgressHandler progressHandler, HttpClient::DataHandler dataHandler,
                   CancelChecker cancelChecker, bool loadHeaders, bool followRedirects, std::string urlRequested,
-                  std::string cookies, std::string outputFile, std::optional<HttpClient::ReceivedFileSegment> segment);
+                  std::string cookies, std::string outputFile, std::optional<HttpClient::ReceivedFileSegment> segment,
+                  QNetworkRequest request, std::string httpMethod, QByteArray bodyBytes, RebindCancel rebindCancel);
+
+  // Pure decision predicate for the GOAWAY/REFUSED_STREAM retry. Exposed for
+  // unit testing — cancellation is intentionally not part of this, it's an
+  // orthogonal concern handled by the caller.
+  static bool ShouldRetry(QNetworkReply::NetworkError error, QString const & errorString, int httpCode,
+                          bool anyBytesReceived, bool writeError, int retriesRemaining);
 
 private slots:
   void OnReadyRead();
@@ -38,7 +50,16 @@ private:
   // to receive data, false if validation failed.
   bool ValidateSegmentIfNeeded();
 
-  QNetworkReply * m_reply;
+  // Reused on initial attach and after a retry installs a fresh reply.
+  void AttachReply(QNetworkReply * reply);
+
+  // RFC 9113 §6.8: a stream above the GOAWAY's last-stream-id was provably not
+  // processed by the server and is safe to retry. Re-issues once over HTTP/1.1
+  // on a fresh connection. Returns true if a retry was scheduled (caller must
+  // not touch m_reply afterwards — a new one is in flight).
+  bool TryRetryOnGoAway();
+
+  QNetworkReply * m_reply = nullptr;
   HttpClient::CompletionHandler m_handler;
   HttpClient::ProgressHandler m_progressHandler;
   HttpClient::DataHandler m_dataHandler;
@@ -59,6 +80,16 @@ private:
   bool m_segmentValidated = false;
   int64_t m_segmentBytesWritten = 0;
   int m_segmentErrorCode = HttpClient::kNoError;  // Overrides result error code when set.
+
+  // Retry state: kept so a single GOAWAY-rejected stream can be re-issued
+  // transparently. Flipped permanently when any body byte is observed by the
+  // caller, so a retry can never silently double-deliver.
+  QNetworkRequest m_request;
+  std::string m_httpMethod;
+  QByteArray m_bodyBytes;
+  RebindCancel m_rebindCancel;
+  int m_retriesRemaining = 1;
+  bool m_anyBytesReceived = false;
 };
 
 // QObject worker living on a dedicated QThread. Owns the QNetworkAccessManager

--- a/libs/platform/platform_tests/CMakeLists.txt
+++ b/libs/platform/platform_tests/CMakeLists.txt
@@ -21,6 +21,12 @@ set(SRC
   utm_mgrs_utils_tests.cpp
 )
 
+# Qt HTTP backend tests are only valid where http_client_qt.cpp is compiled
+# (macOS uses http_client_apple.mm instead).
+if (PLATFORM_DESKTOP AND NOT PLATFORM_MAC)
+  list(APPEND SRC http_client_qt_retry_test.cpp)
+endif()
+
 omim_add_test(${PROJECT_NAME} ${SRC} REQUIRE_QT REQUIRE_SERVER)
 
 target_link_libraries(${PROJECT_NAME}

--- a/libs/platform/platform_tests/http_client_qt_retry_test.cpp
+++ b/libs/platform/platform_tests/http_client_qt_retry_test.cpp
@@ -1,0 +1,89 @@
+#include "testing/testing.hpp"
+
+#include "platform/http_client_qt.hpp"
+
+namespace http_client_qt_retry_test
+{
+using platform::HttpClientReply;
+
+UNIT_TEST(HttpClientQt_ShouldRetry_ContentReSendError)
+{
+  TEST(HttpClientReply::ShouldRetry(QNetworkReply::ContentReSendError, "", 0,
+                                    /*anyBytesReceived*/ false, /*writeError*/ false,
+                                    /*retriesRemaining*/ 1),
+       ());
+}
+
+UNIT_TEST(HttpClientQt_ShouldRetry_ProtocolFailureWithGoAwayString)
+{
+  TEST(HttpClientReply::ShouldRetry(QNetworkReply::ProtocolFailure,
+                                    "stream 9 finished with error: Server stopped accepting new streams "
+                                    "before this stream was established",
+                                    0, false, false, 1),
+       ());
+  TEST(HttpClientReply::ShouldRetry(QNetworkReply::ProtocolFailure, "received REFUSED_STREAM", 0, false, false, 1), ());
+  TEST(HttpClientReply::ShouldRetry(QNetworkReply::ProtocolFailure, "GOAWAY received", 0, false, false, 1), ());
+  // Case-insensitive match.
+  TEST(HttpClientReply::ShouldRetry(QNetworkReply::ProtocolFailure, "refused_stream", 0, false, false, 1), ());
+}
+
+UNIT_TEST(HttpClientQt_ShouldRetry_ProtocolFailureWithoutGoAwayString)
+{
+  // Generic protocol failure without GOAWAY/REFUSED_STREAM markers — don't retry blindly.
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::ProtocolFailure, "malformed HTTP response", 0, false, false, 1),
+       ());
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::ProtocolFailure, "", 0, false, false, 1), ());
+}
+
+UNIT_TEST(HttpClientQt_ShouldRetry_NoErrorMeansSuccess)
+{
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::NoError, "", 200, false, false, 1), ());
+}
+
+UNIT_TEST(HttpClientQt_ShouldRetry_AnyHttpStatusMeansServerProcessedRequest)
+{
+  // Server returned an HTTP response of any kind — request was processed, don't retry transparently.
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::ContentReSendError, "", 503, false, false, 1), ());
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::ProtocolFailure, "GOAWAY", 200, false, false, 1), ());
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::ProtocolFailure, "GOAWAY", 404, false, false, 1), ());
+}
+
+UNIT_TEST(HttpClientQt_ShouldRetry_NotAfterBytesReceived)
+{
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::ContentReSendError, "", 0,
+                                     /*anyBytesReceived*/ true, false, 1),
+       ());
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::ProtocolFailure, "GOAWAY", 0,
+                                     /*anyBytesReceived*/ true, false, 1),
+       ());
+}
+
+UNIT_TEST(HttpClientQt_ShouldRetry_NotOnLocalWriteError)
+{
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::ContentReSendError, "", 0, false,
+                                     /*writeError*/ true, 1),
+       ());
+}
+
+UNIT_TEST(HttpClientQt_ShouldRetry_NotWhenBudgetExhausted)
+{
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::ContentReSendError, "", 0, false, false,
+                                     /*retriesRemaining*/ 0),
+       ());
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::ContentReSendError, "", 0, false, false, -1), ());
+}
+
+UNIT_TEST(HttpClientQt_ShouldRetry_UnrelatedErrorsDoNotRetry)
+{
+  // Errors that don't match the GOAWAY/REFUSED_STREAM pattern must not retry —
+  // they cover cases where the server may have processed the request (timeout
+  // during response, connection reset mid-stream, etc.).
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::TimeoutError, "", 0, false, false, 1), ());
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::HostNotFoundError, "", 0, false, false, 1), ());
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::ConnectionRefusedError, "", 0, false, false, 1), ());
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::OperationCanceledError, "", 0, false, false, 1), ());
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::RemoteHostClosedError, "", 0, false, false, 1), ());
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::SslHandshakeFailedError, "", 0, false, false, 1), ());
+  TEST(!HttpClientReply::ShouldRetry(QNetworkReply::TemporaryNetworkFailureError, "", 0, false, false, 1), ());
+}
+}  // namespace http_client_qt_retry_test


### PR DESCRIPTION
Qt 6's HTTP/2 implementation surfaces a server-sent GOAWAY as a fatal network error when a stream is allocated above the GOAWAY's last-stream-id, even though RFC 9113 §6.8 explicitly states such streams were not processed and are safe to retry on a fresh connection.

Observed in CI on osm_auth_tests/OSM_Auth_Login against master.apis.dev.openstreetmap.org: a pooled HTTP/2 connection goes idle between tests, the server sends GOAWAY, and Qt fails the next request with "Server stopped accepting new streams before this stream was established".

HttpClientReply::TryRetryOnGoAway() re-issues the request once over HTTP/1.1 on a fresh TCP/TLS leg when:

  - No HTTP status was received (server processed nothing)
  - No body bytes were observed (caller has no partial state to roll back)
  - The Qt error is ContentReSendError or a ProtocolFailure whose error string matches Qt's HTTP/2 GOAWAY/REFUSED_STREAM logging phrases
  - The write target is healthy and a retry budget remains

The retry forces Http2AllowedAttribute=false so it cannot multiplex onto another poisoned HTTP/2 connection from the same pool, and clears the manager's idle connections to guarantee a fresh handshake.

The decision predicate is extracted as a pure static method HttpClientReply::ShouldRetry, with a unit test covering all branches in libs/platform/platform_tests/http_client_qt_retry_test.cpp (Linux/Windows only, since http_client_qt.cpp is not compiled on macOS).

Also moves the platform cancel-hook installation into HttpClientReply via a RebindCancel callable, so cancellation correctly tracks the new reply across a transparent retry.