### PR TITLE
[desktop][build] Fix target_link_libraries signature conflict in drape_tests

### DIFF
--- a/libs/drape/drape_tests/CMakeLists.txt
+++ b/libs/drape/drape_tests/CMakeLists.txt
@@ -40,7 +40,7 @@ target_compile_definitions(${PROJECT_NAME}
 
 if (WITH_SYSTEM_PROVIDED_3PARTY)
   find_package(GTest REQUIRED)
-  target_link_libraries(${PROJECT_NAME} GTest::gtest)
+  target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest)
 else()
   add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../../../3party/googletest" "${CMAKE_CURRENT_BINARY_DIR}/googletest")
   # Same treatment as for libs under 3party/CMakeLists.txt: undo -ffinite-math-only


### PR DESCRIPTION
When I try to compile this program for the desktop, I encounter this CMake error:

```text
CMake Error at libs/drape/drape_tests/CMakeLists.txt:43 (target_link_libraries):
  The keyword signature for target_link_libraries has already been used with
  the target "drape_tests".  All uses of target_link_libraries with a target
  must be either all-keyword or all-plain.

  The uses of the keyword signature are here:

   * cmake/OmimHelpers.cmake:11 (target_link_libraries)
   * cmake/OmimTesting.cmake:64 (target_link_libraries)
   * cmake/OmimTesting.cmake:74 (target_link_libraries)



CMake Error at libs/drape/drape_tests/CMakeLists.txt:49 (target_link_libraries):
  The plain signature for target_link_libraries has already been used with
  the target "drape_tests".  All uses of target_link_libraries with a target
  must be either all-keyword or all-plain.

  The uses of the plain signature are here:

   * libs/drape/drape_tests/CMakeLists.txt:43 (target_link_libraries)
```

This appears to be related to #11690. Therefore, I added the `PRIVATE` keyword.

Furthermore, although I have successfully built this software without using the provided shell script, it appears that several patches are required (See [this PKGBUILD](https://github.com/archlinuxcn/repo/blob/23bca8fcec76aebdc0d91bc510af92835483a165/archlinuxcn/organicmaps/PKGBUILD)). Other patches may not be importable verbatim (for instance, where CMake overrides system compilation and linking parameters); however, I wonder if it might be possible to provide an option to skip the overriding of these compilation parameters.