### PR TITLE
[map][android] Hide share button for OSM relation tracks

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
@@ -730,7 +730,7 @@ public class PlacePageController
       {
         buttons.add(mapObject.isBookmark() ? PlacePageButtons.ButtonType.BOOKMARK_DELETE
                                            : PlacePageButtons.ButtonType.BOOKMARK_SAVE);
-        if (mapObject.isTrack() && !((Track) mapObject).isTempRelationTrack())
+        if (mapObject.isTrack() && !((Track) mapObject).isRelationTrack())
           buttons.add(PlacePageButtons.ButtonType.TRACK_DELETE);
       }
 

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -574,7 +574,7 @@ public class PlacePageView extends Fragment
       Drawable circle = Graphics.drawCircle(track.getColor(), R.dimen.place_page_icon_background_size,
                                             requireContext().getResources());
       mColorIcon.setImageDrawable(circle);
-      showCategory = !track.isTempRelationTrack();
+      showCategory = !track.isRelationTrack();
       if (showCategory)
         mTvCategory.setText(BookmarkManager.INSTANCE.getCategoryById(track.getCategoryId()).getName());
     }
@@ -811,7 +811,8 @@ public class PlacePageView extends Fragment
           mEditTopSpace);
     }
     final boolean isTrackOrRecording = mMapObject.isTrack() || mMapObject.isTrackRecording();
-    UiUtils.hideIf(mMapObject.isTrackRecording(), mShareButton);
+    final boolean isRelationTrack = mMapObject.isTrack() && ((Track) mMapObject).isRelationTrack();
+    UiUtils.hideIf(mMapObject.isTrackRecording() || isRelationTrack, mShareButton);
     UiUtils.hideIf(isTrackOrRecording, mFrame.findViewById(R.id.ll__place_open_in), mDetailsTopSpace);
     updateLinksView();
     updateOpeningHoursView();

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageTrackFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageTrackFragment.java
@@ -78,7 +78,7 @@ public class PlacePageTrackFragment extends Fragment
     Track track = (Track) mapObject;
     if (track.getElevationInfo() != null)
     {
-      if (mTrack == null || mTrack.getTrackId() != track.getTrackId() || track.isTempRelationTrack())
+      if (mTrack == null || mTrack.getTrackId() != track.getTrackId() || track.isRelationTrack())
         mElevationProfileViewRenderer.render(track, track.getElevationInfo(), track.getTrackStatistics());
       UiUtils.show(requireView());
     }

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/BookmarkManager.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/BookmarkManager.cpp
@@ -5,6 +5,8 @@
 #include "app/organicmaps/sdk/core/jni_helper.hpp"
 #include "app/organicmaps/sdk/util/Distance.hpp"
 
+#include "kml/type_utils.hpp"
+
 #include "map/bookmark_helpers.hpp"
 #include "map/place_page_info.hpp"
 
@@ -383,14 +385,16 @@ JNIEXPORT jobject Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_native
                                                                                          jlong trackId,
                                                                                          jclass trackClazz)
 {
-  // Track(long trackId, long categoryId, String name, String lengthString, int color)
+  // Track(long trackId, long categoryId, boolean isRelationTrack, String name, String lengthString, int color)
   static jmethodID const cId =
-      jni::GetConstructorID(env, trackClazz, "(JJLjava/lang/String;Lapp/organicmaps/sdk/util/Distance;I)V");
-  auto const * nTrack = frm()->GetBookmarkManager().GetTrack(static_cast<kml::TrackId>(trackId));
+      jni::GetConstructorID(env, trackClazz, "(JJZLjava/lang/String;Lapp/organicmaps/sdk/util/Distance;I)V");
+  auto const kmlTrackId = static_cast<kml::TrackId>(trackId);
+  auto const * nTrack = frm()->GetBookmarkManager().GetTrack(kmlTrackId);
 
   ASSERT(nTrack, ("Track must not be null with id:)", trackId));
 
-  return env->NewObject(trackClazz, cId, trackId, static_cast<jlong>(nTrack->GetGroupId()),
+  auto const isRelationTrack = static_cast<jboolean>(kmlTrackId == kml::kTempRelationTrackId);
+  return env->NewObject(trackClazz, cId, trackId, static_cast<jlong>(nTrack->GetGroupId()), isRelationTrack,
                         jni::ToJavaString(env, nTrack->GetName()),
                         ToJavaDistance(env, platform::Distance::CreateFormatted(nTrack->GetLengthMeters())),
                         nTrack->GetColor(0).GetARGB());

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/Track.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/Track.cpp
@@ -14,6 +14,7 @@ jobject CreateTrack(JNIEnv * env, place_page::Info const & info, jni::TScopedLoc
     "("
     "J"                                               // categoryId
     "J"                                               // trackId
+    "Z"                                               // isRelationTrack
     "Ljava/lang/String;"                              // title
     "Ljava/lang/String;"                              // secondaryTitle
     "Ljava/lang/String;"                              // subtitle
@@ -38,6 +39,7 @@ jobject CreateTrack(JNIEnv * env, place_page::Info const & info, jni::TScopedLoc
   jobject mapObject = env->NewObject(g_trackClazz, ctorId,
     static_cast<jlong>(track->GetGroupId()),
     static_cast<jlong>(trackId),
+    static_cast<jboolean>(info.IsRelationTrack()),
     jni::ToJavaStringWithSupplementalCharsFix(env, info.GetTitle()),
     jni::ToJavaStringWithSupplementalCharsFix(env, info.GetSecondaryTitle()),
     jni::ToJavaStringWithSupplementalCharsFix(env, info.GetSubtitle()),

--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/Track.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/Track.java
@@ -10,6 +10,7 @@ import app.organicmaps.sdk.util.Distance;
 public final class Track extends MapObject
 {
   private final long mId;
+  private final boolean mIsRelationTrack;
   private String mName;
   private final Distance mLength;
   private long mCategoryId;
@@ -23,11 +24,12 @@ public final class Track extends MapObject
   // Called from JNI.
   @Keep
   @SuppressWarnings("unused")
-  private Track(long id, long categoryId, String name, Distance length, int color)
+  private Track(long id, long categoryId, boolean isRelationTrack, String name, Distance length, int color)
   {
     super(TRACK, name, "", "", "", 0, 0, "", null, OPENING_MODE_PREVIEW_PLUS, "", "",
           RoadWarningMarkType.UNKNOWN.ordinal(), null);
     mId = id;
+    mIsRelationTrack = isRelationTrack;
     mCategoryId = categoryId;
     mName = name;
     mLength = length;
@@ -37,31 +39,29 @@ public final class Track extends MapObject
   // Called from JNI.
   @Keep
   @SuppressWarnings("unused")
-  private Track(long categoryId, long id, String title, @Nullable String secondaryTitle, @Nullable String subtitle,
-                @Nullable String address, @Nullable RoutePointInfo routePointInfo, @OpeningMode int openingMode,
-                @NonNull String wikiArticle, @NonNull String osmDescription, @Nullable String[] rawTypes,
-                @ColorInt int color, Distance length, double lat, double lon)
+  private Track(long categoryId, long id, boolean isRelationTrack, String title, @Nullable String secondaryTitle,
+                @Nullable String subtitle, @Nullable String address, @Nullable RoutePointInfo routePointInfo,
+                @OpeningMode int openingMode, @NonNull String wikiArticle, @NonNull String osmDescription,
+                @Nullable String[] rawTypes, @ColorInt int color, Distance length, double lat, double lon)
   {
     super(TRACK, title, secondaryTitle, subtitle, address, lat, lon, "", routePointInfo, openingMode, wikiArticle,
           osmDescription, RoadWarningMarkType.UNKNOWN.ordinal(), rawTypes);
     mId = id;
+    mIsRelationTrack = isRelationTrack;
     mCategoryId = categoryId;
     mColor = color;
     mName = title;
     mLength = length;
   }
 
-  /// Temp relation track ID matches kml::kTempRelationTrackId (kInvalidTrackId - 1).
-  private static final long TEMP_RELATION_TRACK_ID = -2L;
-
   public long getTrackId()
   {
     return mId;
   }
 
-  public boolean isTempRelationTrack()
+  public boolean isRelationTrack()
   {
-    return mId == TEMP_RELATION_TRACK_ID;
+    return mIsRelationTrack;
   }
 
   public void setCategoryId(long categoryId)


### PR DESCRIPTION
Match the iOS behavior introduced in 31dad0c65b ([ios] Hide share                                          
  button for OSM tracks): the share button should not be displayed for
  tracks that are temporarily built from an OSM Relation (route, hiking                                      
  trail, cycle network, etc.), since they are not user-owned content.                                      
                                                                                                             
  While here, plumb the relation-track flag from C++ to Java via the
  Info::IsRelationTrack() helper added in #12763, so Java no longer                                          
  duplicates kml::kTempRelationTrackId as a hardcoded -2L constant.                                          
  The detection now lives entirely in C++; Java just stores the boolean
  passed from JNI.