### PR TITLE
[drape] Limit viewport width to one world to prevent duplicates

### DIFF
--- a/libs/drape_frontend/drape_frontend_tests/screen_operations_tests.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/screen_operations_tests.cpp
@@ -194,14 +194,23 @@ UNIT_TEST(NormalizeScreenOriginX_WrapNegative)
 
 // -- CheckMinScale ------------------------------------------------------------
 
-UNIT_TEST(CheckMinScale_YOnly)
+UNIT_TEST(CheckMinScale_WithinBounds)
 {
-  // Viewport wider than world in X but within Y — should pass (X unconstrained).
+  ScreenBase screen;
+  screen.OnSize(0, 0, 800, 600);
+  screen.SetFromRect(m2::AnyRectD(m2::RectD(-50, -30, 50, 30)));
+
+  TEST(df::CheckMinScale(screen), ("Within world bounds should pass"));
+}
+
+UNIT_TEST(CheckMinScale_XExceeded)
+{
+  // Viewport wider than world in X — should fail (would show duplicate copies).
   ScreenBase screen;
   screen.OnSize(0, 0, 2000, 100);
   screen.SetFromRect(m2::AnyRectD(m2::RectD(-400, -50, 400, 50)));
 
-  TEST(df::CheckMinScale(screen), ("X wider than world should be OK"));
+  TEST(!df::CheckMinScale(screen), ("X wider than world should fail"));
 }
 
 UNIT_TEST(CheckMinScale_YExceeded)
@@ -286,6 +295,25 @@ UNIT_TEST(ScaleInto_ScalesForY)
   TEST_GREATER_OR_EQUAL(clip.minY(), worldR.minY() - 1e-5, ());
 }
 
+UNIT_TEST(ScaleInto_ClampsXWidth)
+{
+  df::VisualParams::Init(1.0, 1024);
+
+  ScreenBase screen;
+  screen.OnSize(0, 0, 2000, 100);
+  // Viewport wider than world; center off the canonical range to verify X
+  // position is preserved (no panning).
+  screen.SetFromRect(m2::AnyRectD(m2::RectD(-300, -10, 100, 10)));
+  double const orgXBefore = screen.GetOrg().x;
+
+  df::ScaleInto(screen, df::GetWorldRect());
+
+  m2::RectD const clip = screen.ClipRect();
+  m2::RectD const & worldR = df::GetWorldRect();
+  TEST_LESS_OR_EQUAL(clip.SizeX(), worldR.SizeX() + 1e-5, ());
+  TEST_ALMOST_EQUAL_ABS(screen.GetOrg().x, orgXBefore, 1e-5, ());
+}
+
 // -- ShrinkAndScaleInto -------------------------------------------------------
 
 UNIT_TEST(ShrinkAndScaleInto_ClampsXWidth)
@@ -340,6 +368,20 @@ UNIT_TEST(Navigator_DoDrag_HorizontalUnbounded)
 
   // Screen origin X should have moved past 180.
   TEST_GREATER(navigator.Screen().GetOrg().x, 170.0, ());
+}
+
+UNIT_TEST(Navigator_SetFromRect_ClampsWideX)
+{
+  df::VisualParams::Init(1.0, 1024);
+  df::Navigator navigator;
+  navigator.OnSize(800, 600);
+
+  // Programmatic SetFromRect with rect wider than the world.
+  navigator.SetFromRect(m2::AnyRectD(m2::RectD(-400, -100, 400, 100)));
+
+  m2::RectD const clip = navigator.Screen().ClipRect();
+  m2::RectD const & worldR = df::GetWorldRect();
+  TEST_LESS_OR_EQUAL(clip.SizeX(), worldR.SizeX() + 1e-5, ());
 }
 
 UNIT_TEST(Navigator_DoDrag_VerticalClamped)

--- a/libs/drape_frontend/navigator.cpp
+++ b/libs/drape_frontend/navigator.cpp
@@ -20,7 +20,7 @@ void Navigator::SetFromScreen(ScreenBase const & screen)
 void Navigator::SetFromScreen(ScreenBase const & screen, uint32_t tileSize, double visualScale)
 {
   ScreenBase tmp = screen;
-  if (!CheckBorders(tmp))
+  if (!CheckMinScale(tmp) || !CheckBorders(tmp))
     ScaleInto(tmp, df::GetWorldRect());
 
   if (!CheckMaxScale(tmp, tileSize, visualScale))

--- a/libs/drape_frontend/screen_operations.cpp
+++ b/libs/drape_frontend/screen_operations.cpp
@@ -51,9 +51,8 @@ bool CheckMinScale(ScreenBase const & screen)
   m2::RectD const & r = screen.ClipRect();
   m2::RectD const & worldR = df::GetWorldRect();
 
-  // Y must not exceed pole boundaries (no scrolling past poles).
-  // X is unconstrained — the world wraps horizontally at the antimeridian.
-  return r.SizeY() <= worldR.SizeY();
+  // X must fit one world copy (no duplicates across the antimeridian); Y must fit between the poles.
+  return r.SizeX() <= worldR.SizeX() && r.SizeY() <= worldR.SizeY();
 }
 
 bool CheckMaxScale(ScreenBase const & screen)
@@ -72,15 +71,14 @@ bool CheckBorders(ScreenBase const & screen)
   m2::RectD const & r = screen.ClipRect();
   m2::RectD const & worldR = df::GetWorldRect();
 
-  // Viewport Y must fit inside world Y (no scrolling past poles).
+  // Y must stay between the poles. X is intentionally unchecked — the world wraps at the antimeridian.
   return r.minY() >= worldR.minY() && r.maxY() <= worldR.maxY();
 }
 
 bool CanShrinkInto(ScreenBase const & screen, m2::RectD const & boundRect)
 {
   m2::RectD const & clipRect = screen.ClipRect();
-  // Only check Y — X is unconstrained (world wraps horizontally).
-  return boundRect.SizeY() >= clipRect.SizeY();
+  return boundRect.SizeX() >= clipRect.SizeX() && boundRect.SizeY() >= clipRect.SizeY();
 }
 
 void ShrinkInto(ScreenBase & screen, m2::RectD const & boundRect)
@@ -124,6 +122,9 @@ void ScaleInto(ScreenBase & screen, m2::RectD const & boundRect)
       LOG(LERROR, ("Bad scale factor =", k, "Bound rect =", boundRect, "Clip rect =", clipRect));
     }
   };
+
+  if (clipRect.SizeX() > boundRect.SizeX())
+    DoScale(boundRect.SizeX() / clipRect.SizeX());
 
   if (clipRect.minY() < boundRect.minY())
     DoScale((boundRect.minY() - clipRect.Center().y) / (clipRect.minY() - clipRect.Center().y));


### PR DESCRIPTION
When antimeridian wrapping was enabled in the master branch, X-axis viewport enforcement was removed from every constraint function except ShrinkAndScaleInto. That function is only called on screen resize, not on the zoom path, so a user pinching out in landscape orientation could grow the viewport past 360deg mercator and see two or more world copies side-by-side with duplicated continents, bookmarks, tracks, and labels.

Re-add the X-width constraint without re-introducing X-panning bounds:

- CheckMinScale: gate both axes against world rect (was Y only). This blocks interactive zoom-out via ApplyScale and Navigator::ScaleImpl once SizeX would exceed 360deg.
- CanShrinkInto: gate both axes for consistency with CheckMinScale.
- ScaleInto: add an X-width branch at the top (scale-around-center, no offset, so the antimeridian X position is preserved). Mirrors the existing branch in ShrinkAndScaleInto.
- Navigator::SetFromScreen: trigger the ScaleInto recovery on !CheckMinScale too, so a programmatic restore or animation endpoint with a too-wide rect is clamped on entry instead of persisting until the next OnSize.

The X-panning constraints (X offsets in ShrinkInto, X min/max in CheckBorders) stay removed: continuous horizontal panning across the antimeridian remains free.

Tests: replace CheckMinScale_YOnly (which asserted the buggy behavior) with CheckMinScale_WithinBounds + CheckMinScale_XExceeded; add ScaleInto_ClampsXWidth (verifies X origin is preserved while width is clamped); add Navigator_SetFromRect_ClampsWideX integration test for the SetFromScreen guard path.