### PR TITLE
[cmake] Add PkgConfig fallback for jansson detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,16 @@ if (WITH_SYSTEM_PROVIDED_3PARTY)
   find_package(gflags REQUIRED)
 
   find_package(expat CONFIG REQUIRED)
-  find_package(jansson CONFIG REQUIRED)
+
+  find_package(jansson CONFIG QUIET)
+  if (NOT jansson_FOUND)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(PKG_JANSSON REQUIRED IMPORTED_TARGET jansson)
+    if (NOT TARGET jansson::jansson)
+      add_library(jansson::jansson ALIAS PkgConfig::PKG_JANSSON)
+    endif()
+  endif()
+
   find_package(pugixml REQUIRED)
   find_package(utf8cpp REQUIRED)
   find_package(Boost REQUIRED)


### PR DESCRIPTION
When `WITH_SYSTEM_PROVIDED_3PARTY` is enabled, `jansson` might not be found via CMake CONFIG mode on some Linux distributions (e.g. Arch Linux). This adds a `PkgConfig` fallback to ensure the system library is correctly identified and the required `jansson::jansson` imported target is defined.