### PR TITLE
[drape] Skip ApplyAnimations cascade when screen unchanged

### DIFF
--- a/libs/drape_frontend/user_event_stream.cpp
+++ b/libs/drape_frontend/user_event_stream.cpp
@@ -310,11 +310,13 @@ void UserEventStream::ApplyAnimations()
 {
   if (m_animationSystem.AnimationExists(Animation::Object::MapPlane))
   {
+    ScreenBase const & current = GetCurrentScreen();
     ScreenBase screen;
-    if (m_animationSystem.GetScreen(GetCurrentScreen(), screen))
+    if (m_animationSystem.GetScreen(current, screen) && screen != current)
+    {
       m_navigator.SetFromScreen(screen);
-
-    m_modelViewChanged = true;
+      m_modelViewChanged = true;
+    }
   }
 
   /// @todo (By VNG): NormalizeScreenOriginX is disabled — it causes full tile invalidation because


### PR DESCRIPTION
## Summary                                                                                                                                               
   
  `UserEventStream::ApplyAnimations` previously set `m_modelViewChanged = true`                                                                            
  unconditionally whenever any `MapPlane` animation existed in `AnimationSystem`.                                                                        
  Finished animations linger in the system until `AnimationSystem::Advance()`                                                                              
  removes them on the next render tick. During that window the unconditional flag                                                                          
  re-triggered `UpdateScene` and a `BackendRenderer` tile-update message every
  frame, even though the visible scene did not change.                                                                                                     
                                                                                                                                                           
  Now the flag is set only when `AnimationSystem::GetScreen` produces a screen
  that actually differs from the current navigator screen.                                                                                                 
                                                                                                                                                         
  `GetCurrentScreen()` is cached as a `const &` once — `AnimationSystem::GetScreen`                                                                        
  does not mutate the navigator, so the comparison and the input are guaranteed
  to look at the same snapshot.                                                                                                                            
                                                                                                                                                         
  ## Effect                                                                                                                                                
                                                                                                                                                         
  Measured on a Pixel 6 (Tensor G1) with smooth-motion fake-location navigation:                                                                           
   
  - Foreground CPU during follow-mode navigation drops measurably; the                                                                                     
    cascade-skip rate from `ApplyAnimations` is ~13 % under typical load                                                                                 
    (instrumented and measured locally).                                                                                                                   
  - `BackendRenderer` per-thread CPU drops significantly when stale animations                                                                           
    stop triggering tile-update messages each frame.                                                                                                       
                                                                                                                                                           
  ## Background
                                                                                                                                                           
  Split out from #12789 per review (different subsystem, independently                                                                                     
  mergeable). Review suggestion to cache `GetCurrentScreen()` is included.