### PR TITLE
[android] Log WebView load errors in WebContainerDelegate

### DIFF
--- a/android/app/src/main/java/app/organicmaps/WebContainerDelegate.java
+++ b/android/app/src/main/java/app/organicmaps/WebContainerDelegate.java
@@ -9,10 +9,13 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
 import app.organicmaps.base.OnBackPressListener;
+import app.organicmaps.sdk.util.log.Logger;
 import app.organicmaps.util.UiUtils;
 
 public abstract class WebContainerDelegate implements OnBackPressListener
 {
+  private static final String TAG = WebContainerDelegate.class.getSimpleName();
+
   private final WebView mWebView;
   private final View mProgress;
 
@@ -25,6 +28,13 @@ public abstract class WebContainerDelegate implements OnBackPressListener
       {
         UiUtils.show(mWebView);
         UiUtils.hide(mProgress);
+      }
+
+      @Override
+      public void onReceivedError(WebView view, int errorCode, String description, String failingUrl)
+      {
+        Logger.w(TAG,
+                 "WebView load error: code=" + errorCode + ", description=" + description + ", url=" + failingUrl);
       }
 
       @Override


### PR DESCRIPTION
Fixes #12819

### What this does

Adds an `onReceivedError(view, errorCode, description, failingUrl)` override to the anonymous `WebViewClient` in `android/app/src/main/java/app/organicmaps/WebContainerDelegate.java`. The override logs the error code, description and failing URL through `Logger.w(...)`. A small `private static final String TAG = WebContainerDelegate.class.getSimpleName()` is introduced for the tag.

No behavior change in the happy path. No new dependencies, no manifest changes.

### Why

`onPageFinished` fires regardless of load success, after which the delegate hides the progress indicator and shows the WebView. A failed load currently lands the user on a blank or partly-rendered page with nothing in logcat, so triaging "the about page is empty" type reports has nothing to go on.

### Note on the signature

I used the deprecated 4-arg `onReceivedError(WebView, int, String, String)` form rather than the API 23+ `(WebView, WebResourceRequest, WebResourceError)` overload. The Android `minSdk` is 21 and the framework dispatches the deprecated form on every supported API level when nothing else is overridden, so this single override fires for every user. Happy to switch to the new signature gated on `Build.VERSION.SDK_INT >= M` if you prefer that style.