### PR TITLE
[drape] Thread label language to HarfBuzz for correct locl shaping

### DIFF
--- a/libs/drape/drape_global.hpp
+++ b/libs/drape/drape_global.hpp
@@ -3,6 +3,8 @@
 #include "drape/color.hpp"
 #include "drape/pointers.hpp"
 
+#include "coding/string_utf8_multilang.hpp"
+
 #include "geometry/point2d.hpp"
 
 #include "base/assert.hpp"
@@ -96,6 +98,11 @@ struct TitleDecl
   m2::PointF m_secondaryOffset = m2::PointF(0.0f, 0.0f);
   bool m_primaryOptional = false;
   bool m_secondaryOptional = false;
+  // StringUtf8Multilang code of the language of each rendered string. Drives HarfBuzz `locl`
+  // glyph substitutions (Serbian Cyrillic, Turkish dotted-i, CJK regional forms).
+  // kUnsupportedLanguageCode means "no language hint" -- HarfBuzz applies no locl.
+  int8_t m_primaryLang = StringUtf8Multilang::kUnsupportedLanguageCode;
+  int8_t m_secondaryLang = StringUtf8Multilang::kUnsupportedLanguageCode;
 };
 
 class BaseFramebuffer

--- a/libs/drape/drape_tests/glyph_mng_tests.cpp
+++ b/libs/drape/drape_tests/glyph_mng_tests.cpp
@@ -6,6 +6,8 @@
 #include "drape/glyph_manager.hpp"
 #include "drape/harfbuzz_shaping.hpp"
 
+#include "coding/string_utf8_multilang.hpp"
+
 #include "base/file_name_utils.hpp"
 
 #include "qt_tstfrm/test_main_loop.hpp"
@@ -591,6 +593,38 @@ UNIT_TEST(GlyphManager_GlyphReadinessTracking)
   mng.MarkGlyphReady(k1);
   mng.MarkGlyphReady(k2);
   TEST(mng.AreGlyphsReady(both), ("repeated marks are idempotent"));
+}
+
+// Pins the int8_t lang plumbing end-to-end: kUnsupportedLanguageCode must shape without
+// crashing (the lang<0 short-circuit in ToHarfbuzzLanguage), and the lang argument must
+// actually reach the OpenType `locl` lookup. The latter is verified against bundled Roboto,
+// which suppresses the "fi" ligature under Turkish to preserve the dotted-i: English/default
+// shapes "fi" as a single ligature glyph, Turkish shapes it as two glyphs (f + i). A regression
+// that dropped the lang argument would yield the same glyph stream for both inputs.
+UNIT_TEST(ShapeText_LangParameterPlumbing)
+{
+  auto mng = MakeGlyphManager();
+
+  auto const tr = StringUtf8Multilang::GetLangIndex("tr");
+  TEST_NOT_EQUAL(tr, StringUtf8Multilang::kUnsupportedLanguageCode, ());
+
+  // kUnsupportedLanguageCode must not crash and must produce the same glyph stream as a
+  // valid lang for plain ASCII without locl-sensitive sequences.
+  auto const noLang = mng.ShapeText("Hello", StringUtf8Multilang::kUnsupportedLanguageCode);
+  auto const en = mng.ShapeText("Hello", "en");
+  TEST(!noLang.m_glyphs.empty(), ());
+  TEST_EQUAL(noLang.m_glyphs.size(), en.m_glyphs.size(), ());
+  for (size_t i = 0; i < noLang.m_glyphs.size(); ++i)
+  {
+    TEST_EQUAL(noLang.m_glyphs[i].m_key.m_fontIndex, en.m_glyphs[i].m_key.m_fontIndex, (i));
+    TEST_EQUAL(noLang.m_glyphs[i].m_key.m_glyphId, en.m_glyphs[i].m_key.m_glyphId, (i));
+  }
+
+  // Turkish `locl` in Roboto blocks the fi ligature. English/default keeps it.
+  auto const fiEn = mng.ShapeText("fi", "en");
+  auto const fiTr = mng.ShapeText("fi", tr);
+  TEST_EQUAL(fiEn.m_glyphs.size(), 1, ("English keeps the fi ligature"));
+  TEST_EQUAL(fiTr.m_glyphs.size(), 2, ("Turkish must suppress the fi ligature"));
 }
 
 }  // namespace glyph_mng_tests

--- a/libs/drape/glyph_manager.cpp
+++ b/libs/drape/glyph_manager.cpp
@@ -646,24 +646,26 @@ struct GlyphManager::Impl
   // hb_language_from_string (a string-keyed lookup in HB's global language table) on the
   // common path. HB language pointers are stable singletons so a value cached today is valid
   // forever. ShapeText is the only caller and is single-threaded by contract.
+  //
+  // Negative codes (e.g. kUnsupportedLanguageCode == -1) mean "no language hint" -- return
+  // HB_LANGUAGE_INVALID. We deliberately avoid hb_language_get_default() because it calls
+  // setlocale(LC_CTYPE, nullptr) on first use, which is not thread-safe and would pick up
+  // the OS locale (unrelated to map data).
   hb_language_t ToHarfbuzzLanguage(int8_t lang)
   {
-    auto const resolve = [](int8_t code) -> hb_language_t
-    {
-      auto const svLang = StringUtf8Multilang::GetLangByCode(code);
-      auto const hb = hb_language_from_string(svLang.data(), static_cast<int>(svLang.size()));
-      return hb == HB_LANGUAGE_INVALID ? hb_language_get_default() : hb;
-    };
-
-    // Out-of-range codes (e.g. kUnsupportedLanguageCode == -1) bypass the cache.
     if (lang < 0 || static_cast<size_t>(lang) >= m_languageCache.size())
-      return resolve(lang);
+      return HB_LANGUAGE_INVALID;
 
     auto const idx = static_cast<size_t>(lang);
     if (auto const cached = m_languageCache[idx]; cached != HB_LANGUAGE_INVALID)
       return cached;
 
-    auto const hb = resolve(lang);
+    auto const svLang = StringUtf8Multilang::GetLangByCode(lang);
+    auto const hb = hb_language_from_string(svLang.data(), static_cast<int>(svLang.size()));
+    // Reserved-slot codes return an empty svLang and hb_language_from_string yields
+    // HB_LANGUAGE_INVALID for them. The cache uses HB_LANGUAGE_INVALID as the "unset" sentinel
+    // (see the hit check above), so those rare codes re-resolve on every call -- acceptable
+    // because reserved slots are never produced by the name selectors that drive this path.
     m_languageCache[idx] = hb;
     return hb;
   }

--- a/libs/drape/texture_manager.cpp
+++ b/libs/drape/texture_manager.cpp
@@ -541,7 +541,9 @@ void TextureManager::Init(ref_ptr<dp::GraphicsContext> context, Params const & p
   m_maxGlypsCount = static_cast<uint32_t>(ceil(kGlyphAreaCoverage * textureSquare / averageGlyphSquare));
 
   std::string_view constexpr kSpace{" "};
-  m_spaceGlyph = m_glyphManager->ShapeText(kSpace, "en").m_glyphs.front().m_key;
+  // The space glyph has no `locl` variants; the language tag is irrelevant here.
+  m_spaceGlyph =
+      m_glyphManager->ShapeText(kSpace, StringUtf8Multilang::kUnsupportedLanguageCode).m_glyphs.front().m_key;
 
   LOG(LDEBUG, ("Glyphs texture size =", kGlyphsTextureSize, "with max glyphs count =", m_maxGlypsCount));
 
@@ -701,7 +703,7 @@ std::optional<TextureManager::RainbowRegion> TextureManager::GetRainbowRegion(Ra
   return result;
 }
 
-text::TextMetrics TextureManager::ShapeSingleTextLine(std::string_view utf8,
+text::TextMetrics TextureManager::ShapeSingleTextLine(std::string_view utf8, int8_t lang,
                                                       TGlyphsBuffer * glyphRegions)  // TODO(AB): Better name?
 {
   ASSERT(!utf8.empty(), ());
@@ -710,8 +712,7 @@ text::TextMetrics TextureManager::ShapeSingleTextLine(std::string_view utf8,
   // TODO(AB): Is this mutex too slow?
   std::lock_guard lock(m_calcGlyphsMutex);
 
-  // TODO(AB): Fix hard-coded lang.
-  auto textMetrics = m_glyphManager->ShapeText(utf8, "en");
+  auto textMetrics = m_glyphManager->ShapeText(utf8, lang);
 
   auto const & glyphs = textMetrics.m_glyphs;
 
@@ -744,6 +745,7 @@ text::TextMetrics TextureManager::ShapeSingleTextLine(std::string_view utf8,
 }
 
 TextureManager::TShapedTextLines TextureManager::ShapeMultilineText(std::string_view utf8, char const * delimiters,
+                                                                    int8_t lang,
                                                                     TMultilineGlyphsBuffer & multilineGlyphRegions)
 {
   TShapedTextLines textLines;
@@ -754,7 +756,7 @@ TextureManager::TShapedTextLines TextureManager::ShapeMultilineText(std::string_
 
     multilineGlyphRegions.emplace_back();
 
-    textLines.emplace_back(ShapeSingleTextLine(line, &multilineGlyphRegions.back()));
+    textLines.emplace_back(ShapeSingleTextLine(line, lang, &multilineGlyphRegions.back()));
   });
 
   return textLines;

--- a/libs/drape/texture_manager.hpp
+++ b/libs/drape/texture_manager.hpp
@@ -138,8 +138,12 @@ public:
   using TMultilineGlyphsBuffer = buffer_vector<TGlyphsBuffer, 4>;
 
   using TShapedTextLines = buffer_vector<text::TextMetrics, 4>;
-  text::TextMetrics ShapeSingleTextLine(std::string_view utf8, TGlyphsBuffer * glyphRegions);
-  TShapedTextLines ShapeMultilineText(std::string_view utf8, char const * delimiters,
+  // `lang` is a StringUtf8Multilang code identifying the language of `utf8`. HarfBuzz uses it
+  // for OpenType `locl` substitutions, so non-English callers (Serbian Cyrillic, Turkish
+  // dotted-i, CJK regional forms) should pass the actual label language for correct glyph
+  // shapes. kUnsupportedLanguageCode means "no language hint -- skip locl".
+  text::TextMetrics ShapeSingleTextLine(std::string_view utf8, int8_t lang, TGlyphsBuffer * glyphRegions);
+  TShapedTextLines ShapeMultilineText(std::string_view utf8, char const * delimiters, int8_t lang,
                                       TMultilineGlyphsBuffer & multilineGlyphRegions);
 
   // This method must be called only on Frontend renderer's thread.

--- a/libs/drape_frontend/apply_feature_functors.cpp
+++ b/libs/drape_frontend/apply_feature_functors.cpp
@@ -442,8 +442,12 @@ void ApplyPointFeature::ProcessPointRules(SymbolRuleProto const * symbolRule, Ca
     CaptionDefProto const * auxRule = captionRule->has_secondary() ? &captionRule->secondary() : nullptr;
 
     params.m_titleDecl.m_primaryText = m_captions.GetMainText();
+    params.m_titleDecl.m_primaryLang = m_captions.GetMainTextLang();
     if (auxRule)
+    {
       params.m_titleDecl.m_secondaryText = m_captions.GetAuxText();
+      params.m_titleDecl.m_secondaryLang = m_captions.GetAuxTextLang();
+    }
     ASSERT(!params.m_titleDecl.m_primaryText.empty(), ());
 
     ExtractCaptionParams(capRule, auxRule, params);
@@ -466,7 +470,9 @@ void ApplyPointFeature::ProcessPointRules(SymbolRuleProto const * symbolRule, Ca
     TextViewParams params;
     CaptionDefProto const * capRule = &houseNumberRule->primary();
 
+    // House numbers come straight from OSM addr:housenumber in the MWM's local script.
     params.m_titleDecl.m_primaryText = m_captions.GetHouseNumberText();
+    params.m_titleDecl.m_primaryLang = m_captions.GetMwmRegionLang();
     ASSERT(!params.m_titleDecl.m_primaryText.empty(), ());
 
     ExtractCaptionParams(capRule, nullptr, params);
@@ -830,15 +836,20 @@ void ApplyLineFeatureAdditional::GetRoadShieldsViewParams(ref_ptr<dp::TextureMan
   textParams.m_depthLayer = DepthLayer::OverlayLayer;
   textParams.m_depthTestEnabled = false;
   textParams.m_depth = m_shieldDepth;
+  // Road shield ref/additional come from OSM tags in the MWM's local script. Use the same
+  // lang for both so the additional-text rendering matches its primary.
+  auto const regionLang = m_captions.GetMwmRegionLang();
   textParams.m_titleDecl.m_anchor = anchor;
   textParams.m_titleDecl.m_primaryText = roadNumber;
+  textParams.m_titleDecl.m_primaryLang = regionLang;
+  textParams.m_titleDecl.m_secondaryLang = regionLang;
   textParams.m_titleDecl.m_primaryTextFont = font;
   textParams.m_titleDecl.m_primaryOffset = shieldOffset + shieldTextOffset;
   textParams.m_titleDecl.m_primaryOptional = false;
   textParams.m_titleDecl.m_secondaryOptional = false;
   textParams.m_startOverlayRank = dp::OverlayRank1;
 
-  auto const textMetrics = texMng->ShapeSingleTextLine(roadNumber, nullptr);
+  auto const textMetrics = texMng->ShapeSingleTextLine(roadNumber, regionLang, nullptr);
   float const textRatio = font.m_size * fontScale / dp::kBaseFontSizePixels;
   float const textWidthInPixels = textMetrics.m_lineWidthInPixels * textRatio;
   float const textHeightInPixels = textMetrics.m_maxLineHeightInPixels * textRatio;
@@ -955,6 +966,7 @@ void ApplyLineFeatureAdditional::ProcessAdditionalLineRules(PathTextRuleProto co
     params.m_auxText = m_captions.GetAuxText();
     params.m_textFont = fontDecl;
     params.m_baseGtoPScale = m_params.m_currentScaleGtoP;
+    params.m_lang = m_captions.GetMainTextLang();
 
     uint32_t textIndex = kPathTextBaseTextIndex;
     for (auto const & spline : m_clippedSplines)

--- a/libs/drape_frontend/drape_engine.cpp
+++ b/libs/drape_frontend/drape_engine.cpp
@@ -10,6 +10,9 @@
 
 #include "indexer/map_style_reader.hpp"
 
+#include "coding/string_utf8_multilang.hpp"
+
+#include "platform/preferred_languages.hpp"
 #include "platform/settings.hpp"
 
 #include <unordered_map>
@@ -35,6 +38,12 @@ DrapeEngine::DrapeEngine(Params && params)
   SetFontScaleFactor(params.m_fontsScaleFactor);
 
   gui::DrapeGui::Instance().SetSurfaceSize(m2::PointF(m_viewport.GetWidth(), m_viewport.GetHeight()));
+
+  // DrapeGui is a process-wide singleton; call unconditionally so a recreated engine under an
+  // unsupported locale cannot inherit a previous engine's UI lang. GetLangIndex returns
+  // kUnsupportedLanguageCode for unknown locales, which short-circuits to HB_LANGUAGE_INVALID
+  // in the shaper -- no locl hint, same outcome as before for these cases.
+  gui::DrapeGui::Instance().SetUILang(StringUtf8Multilang::GetLangIndex(languages::GetCurrentNorm()));
 
   m_textureManager = make_unique_dp<dp::TextureManager>();
   m_threadCommutator = make_unique_dp<ThreadsCommutator>();

--- a/libs/drape_frontend/gui/drape_gui.hpp
+++ b/libs/drape_frontend/gui/drape_gui.hpp
@@ -6,8 +6,11 @@
 
 #include "drape/drape_global.hpp"
 
+#include "coding/string_utf8_multilang.hpp"
+
 #include "geometry/rect2d.hpp"
 
+#include <cstdint>
 #include <mutex>
 
 class ScreenBase;
@@ -26,6 +29,13 @@ public:
   m2::PointF GetSurfaceSize() const;
   void SetVisibleViewport(m2::RectD const & rect);
   m2::RectD GetVisibleViewport() const;
+
+  // StringUtf8Multilang code of the system UI locale, used as the HarfBuzz `locl` hint when
+  // shaping UI text (ruler, copyright, debug overlays). Set once at engine init from
+  // languages::GetCurrentNorm() and remains kUnsupportedLanguageCode when the system locale is
+  // not recognized -- ToHarfbuzzLanguage short-circuits negative codes to HB_LANGUAGE_INVALID.
+  void SetUILang(int8_t lang) { m_uiLang = lang; }
+  int8_t GetUILang() const { return m_uiLang; }
 
   bool IsInUserAction() const { return m_inUserAction; }
   void SetInUserAction(bool isInUserAction) { m_inUserAction = isInUserAction; }
@@ -51,6 +61,7 @@ private:
   m2::PointF m_surfaceSize;
 
   bool m_inUserAction = false;
+  int8_t m_uiLang = StringUtf8Multilang::kUnsupportedLanguageCode;
   ScaleFpsHelper m_scaleFpsHelper;
 };
 }  // namespace gui

--- a/libs/drape_frontend/gui/gui_text.cpp
+++ b/libs/drape_frontend/gui/gui_text.cpp
@@ -1,6 +1,7 @@
 #include "drape_frontend/gui/gui_text.hpp"
 
 #include "drape_frontend/batcher_bucket.hpp"
+#include "drape_frontend/gui/drape_gui.hpp"
 #include "drape_frontend/visual_params.hpp"
 
 #include "shaders/programs.hpp"
@@ -119,7 +120,7 @@ dp::TGlyphs StaticLabel::CacheStaticText(std::string const & text, char const * 
       font.m_size * static_cast<float>(df::VisualParams::Instance().GetVisualScale() / dp::kBaseFontSizePixels);
 
   dp::TextureManager::TMultilineGlyphsBuffer buffers;
-  auto const shapedLines = mng->ShapeMultilineText(text, delimiters, buffers);
+  auto const shapedLines = mng->ShapeMultilineText(text, delimiters, DrapeGui::Instance().GetUILang(), buffers);
 
   ASSERT_EQUAL(shapedLines.size(), buffers.size(), ());
 
@@ -313,7 +314,7 @@ void MutableLabel::Precache(PrecacheParams const & params, PrecacheResult & resu
                 dp::kBaseFontSizePixels;
 
   // TODO(AB): Is this shaping/precaching really needed if the text changes every frame?
-  m_shapedText = mng->ShapeSingleTextLine(params.m_alphabet, &m_glyphRegions);
+  m_shapedText = mng->ShapeSingleTextLine(params.m_alphabet, DrapeGui::Instance().GetUILang(), &m_glyphRegions);
 
   auto const firstTexture = m_glyphRegions.front().GetTexture();
 #ifdef DEBUG
@@ -363,7 +364,7 @@ void MutableLabel::SetText(LabelResult & result, std::string text, ref_ptr<dp::T
 
   // TODO(AB): Calculate only the length for pre-cached glyphs in a simpler way?
   m_glyphRegions.clear();
-  m_shapedText = mng->ShapeSingleTextLine(text, &m_glyphRegions);
+  m_shapedText = mng->ShapeSingleTextLine(text, DrapeGui::Instance().GetUILang(), &m_glyphRegions);
 
   // TODO(AB): Reuse pre-calculated width and height?
   // float maxHeight = m_shapedText.m_maxLineHeightInPixels;

--- a/libs/drape_frontend/path_text_shape.cpp
+++ b/libs/drape_frontend/path_text_shape.cpp
@@ -36,7 +36,7 @@ PathTextShape::PathTextShape(m2::SharedSpline const & spline, PathTextViewParams
 bool PathTextShape::CalculateLayout(ref_ptr<dp::TextureManager> textures)
 {
   auto layout = make_unique_dp<PathTextLayout>(m_params.m_tileCenter, m_params.ConcatRenderText(),
-                                               m_params.m_textFont.m_size, textures);
+                                               m_params.m_textFont.m_size, textures, m_params.m_lang);
 
   if (0 == layout->GetGlyphCount())
   {

--- a/libs/drape_frontend/shape_view_params.hpp
+++ b/libs/drape_frontend/shape_view_params.hpp
@@ -110,6 +110,10 @@ struct PathTextViewParams : CommonOverlayViewParams
   std::string m_mainText;
   std::string m_auxText;
   double m_baseGtoPScale = 1.0;
+  // StringUtf8Multilang code of m_mainText for HarfBuzz `locl` shaping. The concatenated
+  // "main + aux" path-text is shaped under this single tag (aux is the minority case and
+  // typically shares main's script). kUnsupportedLanguageCode means "no locl hint".
+  int8_t m_lang = StringUtf8Multilang::kUnsupportedLanguageCode;
 
   std::string ConcatRenderText() const
   {

--- a/libs/drape_frontend/stylist.cpp
+++ b/libs/drape_frontend/stylist.cpp
@@ -3,6 +3,7 @@
 #include "indexer/classificator.hpp"
 #include "indexer/drules_include.hpp"
 #include "indexer/feature.hpp"
+#include "indexer/feature_utils.hpp"
 #include "indexer/feature_visibility.hpp"
 #include "indexer/scales.hpp"
 
@@ -57,13 +58,16 @@ std::string_view IsHatchingTerritoryChecker::GetHatch(feature::TypesHolder const
 void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int zoomLevel, feature::GeomType geomType,
                               bool auxCaptionExists)
 {
-  if (auto const * info = f.GetID().m_mwmId.GetInfo().get())
-  {
-    LangsBufferT mwmLangs;
-    info->GetRegionData().GetLanguages(mwmLangs);
-    if (!mwmLangs.empty())
-      m_mwmRegionLang = mwmLangs.front();
-  }
+  if (auto const & info = f.GetID().m_mwmId.GetInfo())
+    m_mwmRegionLang = feature::GetRegionLang(info->GetRegionData());
+
+  // An unqualified OSM `name=` is reported as kDefaultCode, which is not a real BCP-47 tag.
+  // Resolve it to the region's on-the-ground language so HarfBuzz applies the matching OpenType
+  // `locl` glyph variants (Turkish dotless-i, Serbian Cyrillic, CJK regional forms). Multi-lingual
+  // regions may guess wrong, but a shared-script mismatch is mostly harmless and strictly better
+  // than passing no hint at all.
+  auto const localizeLang = [this](int8_t lang)
+  { return lang == StringUtf8Multilang::kDefaultCode ? m_mwmRegionLang : lang; };
 
   feature::NameParamsOut out;
   // TODO(pastk) : remove forced secondary text for all lines and set it via styles for major roads and rivers only.
@@ -73,7 +77,7 @@ void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int zoomLevel,
     // Get both primary and secondary/aux names.
     f.GetPreferredNames(true /* allowTranslit */, deviceLang, out);
     m_auxText = out.secondary;
-    m_auxTextLang = out.secondaryLang;
+    m_auxTextLang = localizeLang(out.secondaryLang);
   }
   else
   {
@@ -81,7 +85,7 @@ void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int zoomLevel,
     f.GetReadableName(true /* allowTranslit */, deviceLang, out);
   }
   m_mainText = out.GetPrimary();
-  m_mainTextLang = out.primaryLang;
+  m_mainTextLang = localizeLang(out.primaryLang);
   ASSERT(m_auxText.empty() || !m_mainText.empty(), ("auxText without mainText"));
 
   uint8_t constexpr kLongCaptionsMaxZoom = 4;

--- a/libs/drape_frontend/stylist.cpp
+++ b/libs/drape_frontend/stylist.cpp
@@ -57,6 +57,14 @@ std::string_view IsHatchingTerritoryChecker::GetHatch(feature::TypesHolder const
 void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int zoomLevel, feature::GeomType geomType,
                               bool auxCaptionExists)
 {
+  if (auto const * info = f.GetID().m_mwmId.GetInfo().get())
+  {
+    LangsBufferT mwmLangs;
+    info->GetRegionData().GetLanguages(mwmLangs);
+    if (!mwmLangs.empty())
+      m_mwmRegionLang = mwmLangs.front();
+  }
+
   feature::NameParamsOut out;
   // TODO(pastk) : remove forced secondary text for all lines and set it via styles for major roads and rivers only.
   // ATM even minor paths/streams/etc use secondary which makes their pathtexts take much more space.
@@ -65,6 +73,7 @@ void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int zoomLevel,
     // Get both primary and secondary/aux names.
     f.GetPreferredNames(true /* allowTranslit */, deviceLang, out);
     m_auxText = out.secondary;
+    m_auxTextLang = out.secondaryLang;
   }
   else
   {
@@ -72,6 +81,7 @@ void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int zoomLevel,
     f.GetReadableName(true /* allowTranslit */, deviceLang, out);
   }
   m_mainText = out.GetPrimary();
+  m_mainTextLang = out.primaryLang;
   ASSERT(m_auxText.empty() || !m_mainText.empty(), ("auxText without mainText"));
 
   uint8_t constexpr kLongCaptionsMaxZoom = 4;
@@ -80,6 +90,7 @@ void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int zoomLevel,
   {
     m_mainText.clear();
     m_auxText.clear();
+    m_mainTextLang = m_auxTextLang = StringUtf8Multilang::kUnsupportedLanguageCode;
     return;
   }
 
@@ -98,7 +109,10 @@ void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int zoomLevel,
     // styles.
     m_houseNumberText = f.GetHouseNumber();
     if (!m_houseNumberText.empty() && !m_mainText.empty() && m_houseNumberText.find(m_mainText) != std::string::npos)
+    {
       m_mainText.clear();
+      m_mainTextLang = StringUtf8Multilang::kUnsupportedLanguageCode;
+    }
   }
 }
 

--- a/libs/drape_frontend/stylist.hpp
+++ b/libs/drape_frontend/stylist.hpp
@@ -47,6 +47,14 @@ struct CaptionDescription
   std::string const & GetMainText() const { return m_mainText; }
   std::string const & GetAuxText() const { return m_auxText; }
   std::string const & GetHouseNumberText() const { return m_houseNumberText; }
+  // StringUtf8Multilang code of the language actually selected for main/aux text. Drives
+  // HarfBuzz OpenType `locl` substitutions downstream. kUnsupportedLanguageCode when empty.
+  int8_t GetMainTextLang() const { return m_mainTextLang; }
+  int8_t GetAuxTextLang() const { return m_auxTextLang; }
+  // First language declared in the feature's MWM region metadata, or kDefaultCode when the
+  // MWM has none. Use as the locl hint for OSM-verbatim text that does not go through name
+  // selection (addr:housenumber, road shield ref tags).
+  int8_t GetMwmRegionLang() const { return m_mwmRegionLang; }
 
   bool IsNameExists() const { return !m_mainText.empty(); }
   bool IsHouseNumberExists() const { return !m_houseNumberText.empty(); }
@@ -55,6 +63,9 @@ private:
   std::string m_mainText;
   std::string m_auxText;
   std::string m_houseNumberText;
+  int8_t m_mainTextLang = StringUtf8Multilang::kUnsupportedLanguageCode;
+  int8_t m_auxTextLang = StringUtf8Multilang::kUnsupportedLanguageCode;
+  int8_t m_mwmRegionLang = StringUtf8Multilang::kDefaultCode;
 };
 
 class Stylist

--- a/libs/drape_frontend/stylist.hpp
+++ b/libs/drape_frontend/stylist.hpp
@@ -51,9 +51,9 @@ struct CaptionDescription
   // HarfBuzz OpenType `locl` substitutions downstream. kUnsupportedLanguageCode when empty.
   int8_t GetMainTextLang() const { return m_mainTextLang; }
   int8_t GetAuxTextLang() const { return m_auxTextLang; }
-  // First language declared in the feature's MWM region metadata, or kDefaultCode when the
-  // MWM has none. Use as the locl hint for OSM-verbatim text that does not go through name
-  // selection (addr:housenumber, road shield ref tags).
+  // First language declared in the feature's MWM region metadata, or kUnsupportedLanguageCode
+  // when the MWM declares none. Use as the locl hint for OSM-verbatim text that does not go
+  // through name selection (addr:housenumber, road shield ref tags).
   int8_t GetMwmRegionLang() const { return m_mwmRegionLang; }
 
   bool IsNameExists() const { return !m_mainText.empty(); }
@@ -65,7 +65,7 @@ private:
   std::string m_houseNumberText;
   int8_t m_mainTextLang = StringUtf8Multilang::kUnsupportedLanguageCode;
   int8_t m_auxTextLang = StringUtf8Multilang::kUnsupportedLanguageCode;
-  int8_t m_mwmRegionLang = StringUtf8Multilang::kDefaultCode;
+  int8_t m_mwmRegionLang = StringUtf8Multilang::kUnsupportedLanguageCode;
 };
 
 class Stylist

--- a/libs/drape_frontend/text_layout.cpp
+++ b/libs/drape_frontend/text_layout.cpp
@@ -279,7 +279,7 @@ dp::TGlyphs TextLayout::GetGlyphs() const
 }
 
 StraightTextLayout::StraightTextLayout(std::string_view text, float fontSize, ref_ptr<dp::TextureManager> textures,
-                                       dp::Anchor anchor, bool forceNoWrap)
+                                       dp::Anchor anchor, bool forceNoWrap, int8_t lang)
 {
   /// @todo Support multiline texts (e.g. in Bookmarks).
   auto iBreak = text.find_first_of("\r\n");
@@ -287,7 +287,7 @@ StraightTextLayout::StraightTextLayout(std::string_view text, float fontSize, re
     text = text.substr(0, iBreak);
 
   m_textSizeRatio = fontSize * static_cast<float>(VisualParams::Instance().GetFontScale()) / dp::kBaseFontSizePixels;
-  m_shapedGlyphs = textures->ShapeSingleTextLine(text, &m_glyphRegions);
+  m_shapedGlyphs = textures->ShapeSingleTextLine(text, lang, &m_glyphRegions);
 
   // TODO(AB): Use ICU's BreakIterator to split text properly in different languages without spaces.
   // TODO(AB): Implement SplitText for RTL languages.
@@ -378,7 +378,7 @@ void StraightTextLayout::CacheDynamicGeometry(glsl::vec2 const & pixelOffset,
 }
 
 PathTextLayout::PathTextLayout(m2::PointD const & tileCenter, std::string const & text, float fontSize,
-                               ref_ptr<dp::TextureManager> textureManager)
+                               ref_ptr<dp::TextureManager> textureManager, int8_t lang)
   : m_tileCenter(tileCenter)
 {
   ASSERT_EQUAL(std::string::npos, text.find('\n'), ("Multiline text is not expected", text));
@@ -387,7 +387,7 @@ PathTextLayout::PathTextLayout(m2::PointD const & tileCenter, std::string const 
   m_textSizeRatio = fontSize * fontScale / dp::kBaseFontSizePixels;
 
   // TODO(AB): StraightTextLayout used a logic to split a longer string into two strings.
-  m_shapedGlyphs = textureManager->ShapeSingleTextLine(text, &m_glyphRegions);
+  m_shapedGlyphs = textureManager->ShapeSingleTextLine(text, lang, &m_glyphRegions);
 }
 
 void PathTextLayout::CacheStaticGeometry(dp::TextureManager::ColorRegion const & colorRegion,

--- a/libs/drape_frontend/text_layout.hpp
+++ b/libs/drape_frontend/text_layout.hpp
@@ -49,7 +49,7 @@ class StraightTextLayout : public TextLayout
 
 public:
   StraightTextLayout(std::string_view text, float fontSize, ref_ptr<dp::TextureManager> textures, dp::Anchor anchor,
-                     bool forceNoWrap);
+                     bool forceNoWrap, int8_t lang);
 
   void CacheStaticGeometry(dp::TextureManager::ColorRegion const & colorRegion,
                            gpu::TTextStaticVertexBuffer & staticBuffer) const;
@@ -96,7 +96,7 @@ class PathTextLayout : public TextLayout
 
 public:
   PathTextLayout(m2::PointD const & tileCenter, std::string const & text, float fontSize,
-                 ref_ptr<dp::TextureManager> textures);
+                 ref_ptr<dp::TextureManager> textures, int8_t lang);
 
   void CacheStaticGeometry(dp::TextureManager::ColorRegion const & colorRegion,
                            dp::TextureManager::ColorRegion const & outlineRegion,

--- a/libs/drape_frontend/text_shape.cpp
+++ b/libs/drape_frontend/text_shape.cpp
@@ -240,7 +240,7 @@ void TextShape::Draw(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::Batcher> 
 
   ASSERT(!titleDecl.m_primaryText.empty(), ());
   StraightTextLayout primaryLayout(titleDecl.m_primaryText, titleDecl.m_primaryTextFont.m_size, textures,
-                                   titleDecl.m_anchor, titleDecl.m_forceNoWrap);
+                                   titleDecl.m_anchor, titleDecl.m_forceNoWrap, titleDecl.m_primaryLang);
 
   if (m_params.m_limitedText)
   {
@@ -248,7 +248,7 @@ void TextShape::Draw(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::Batcher> 
     {
       float const newFontSize = titleDecl.m_primaryTextFont.m_size * m_params.m_limits.y / y;
       primaryLayout = StraightTextLayout(titleDecl.m_primaryText, newFontSize, textures, titleDecl.m_anchor,
-                                         titleDecl.m_forceNoWrap);
+                                         titleDecl.m_forceNoWrap, titleDecl.m_primaryLang);
     }
   }
 
@@ -261,8 +261,12 @@ void TextShape::Draw(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::Batcher> 
   }
   else
   {
-    StraightTextLayout secondaryLayout{titleDecl.m_secondaryText, titleDecl.m_secondaryTextFont.m_size, textures,
-                                       titleDecl.m_anchor, titleDecl.m_forceNoWrap};
+    StraightTextLayout secondaryLayout{titleDecl.m_secondaryText,
+                                       titleDecl.m_secondaryTextFont.m_size,
+                                       textures,
+                                       titleDecl.m_anchor,
+                                       titleDecl.m_forceNoWrap,
+                                       titleDecl.m_secondaryLang};
 
     if (secondaryLayout.GetGlyphCount() > 0)
     {

--- a/libs/drape_frontend/transit_scheme_builder.cpp
+++ b/libs/drape_frontend/transit_scheme_builder.cpp
@@ -205,7 +205,10 @@ void PlaceTitles(std::vector<TitleInfo> & titles, float textSize, ref_ptr<dp::Te
   size_t summaryRowsCount = 0;
   for (auto & name : titles)
   {
-    StraightTextLayout layout(name.m_text, textSize, textures, dp::Left, false /* forceNoWrap */);
+    // Transit titles do not carry a lang code; pass kUnsupportedLanguageCode so HarfBuzz
+    // applies no `locl` substitutions.
+    StraightTextLayout layout(name.m_text, textSize, textures, dp::Left, false /* forceNoWrap */,
+                              StringUtf8Multilang::kUnsupportedLanguageCode);
     name.m_pixelSize = layout.GetPixelSize() + m2::PointF(4.0f * vs, 4.0f * vs);
     name.m_rowsCount = layout.GetRowsCount();
     summaryRowsCount += layout.GetRowsCount();

--- a/libs/drape_frontend/user_mark_shapes.cpp
+++ b/libs/drape_frontend/user_mark_shapes.cpp
@@ -131,7 +131,7 @@ void GenerateColoredSymbolShapes(ref_ptr<dp::GraphicsContext> context, ref_ptr<d
   {
     CHECK(renderInfo.m_titleDecl, ());
     auto const & titleDecl = renderInfo.m_titleDecl->operator[](0);
-    auto const textMetrics = textures->ShapeSingleTextLine(titleDecl.m_primaryText, nullptr);
+    auto const textMetrics = textures->ShapeSingleTextLine(titleDecl.m_primaryText, titleDecl.m_primaryLang, nullptr);
     auto const & vparams = VisualParams::Instance();
     auto const fontScale = static_cast<float>(vparams.GetFontScale() * vparams.GetVisualScale());
     float const textRatio = titleDecl.m_primaryTextFont.m_size * fontScale / dp::kBaseFontSizePixels;

--- a/libs/indexer/feature_utils.cpp
+++ b/libs/indexer/feature_utils.cpp
@@ -56,6 +56,23 @@ bool GetTransliteratedName(RegionData const & regionData, StrUtf8 const & src, s
   return false;
 }
 
+// OSM convention: an unqualified `name=` tag is in the on-the-ground language. The region's
+// first declared language is the closest in-data proxy (it is already the basis for
+// default-name transliteration in GetTransliteratedName above). HarfBuzz OpenType `locl`
+// substitutions need a real BCP-47 tag; the literal "default" string is meaningless to fonts,
+// so substituting here lights up Turkish/Serbian/CJK glyph variants for features that have
+// only an unqualified name. Multi-lingual regions are imperfect but strictly better than
+// passing no hint at all.
+void SubstituteRegionLangForDefault(int8_t & lang, RegionData const & regionData)
+{
+  if (lang != StrUtf8::kDefaultCode)
+    return;
+  LangsBufferT mwmLangs;
+  regionData.GetLanguages(mwmLangs);
+  if (!mwmLangs.empty())
+    lang = mwmLangs.front();
+}
+
 // Returns the StrUtf8 code of the selected name, or kUnsupportedLanguageCode if none was found.
 int8_t GetBestName(StrUtf8 const & src, LangsBufferT const & priorityList, std::string_view & out)
 {
@@ -131,6 +148,7 @@ void GetReadableNameImpl(NameParamsIn const & in, bool preferDefault, NameParams
   if (auto const lang = GetBestName(in.src, langPriority, out.primary); lang != StrUtf8::kUnsupportedLanguageCode)
   {
     out.primaryLang = lang;
+    SubstituteRegionLangForDefault(out.primaryLang, in.regionData);
     return;
   }
 
@@ -146,6 +164,7 @@ void GetReadableNameImpl(NameParamsIn const & in, bool preferDefault, NameParams
         lang != StrUtf8::kUnsupportedLanguageCode)
     {
       out.primaryLang = lang;
+      SubstituteRegionLangForDefault(out.primaryLang, in.regionData);
       return;
     }
   }
@@ -381,6 +400,9 @@ void GetPreferredNames(NameParamsIn const & in, NameParamsOut & out)
     out.secondary = {};
     out.secondaryLang = StrUtf8::kUnsupportedLanguageCode;
   }
+
+  SubstituteRegionLangForDefault(out.primaryLang, in.regionData);
+  SubstituteRegionLangForDefault(out.secondaryLang, in.regionData);
 }
 
 void GetReadableName(NameParamsIn const & in, NameParamsOut & out)

--- a/libs/indexer/feature_utils.cpp
+++ b/libs/indexer/feature_utils.cpp
@@ -56,23 +56,6 @@ bool GetTransliteratedName(RegionData const & regionData, StrUtf8 const & src, s
   return false;
 }
 
-// OSM convention: an unqualified `name=` tag is in the on-the-ground language. The region's
-// first declared language is the closest in-data proxy (it is already the basis for
-// default-name transliteration in GetTransliteratedName above). HarfBuzz OpenType `locl`
-// substitutions need a real BCP-47 tag; the literal "default" string is meaningless to fonts,
-// so substituting here lights up Turkish/Serbian/CJK glyph variants for features that have
-// only an unqualified name. Multi-lingual regions are imperfect but strictly better than
-// passing no hint at all.
-void SubstituteRegionLangForDefault(int8_t & lang, RegionData const & regionData)
-{
-  if (lang != StrUtf8::kDefaultCode)
-    return;
-  LangsBufferT mwmLangs;
-  regionData.GetLanguages(mwmLangs);
-  if (!mwmLangs.empty())
-    lang = mwmLangs.front();
-}
-
 // Returns the StrUtf8 code of the selected name, or kUnsupportedLanguageCode if none was found.
 int8_t GetBestName(StrUtf8 const & src, LangsBufferT const & priorityList, std::string_view & out)
 {
@@ -148,7 +131,6 @@ void GetReadableNameImpl(NameParamsIn const & in, bool preferDefault, NameParams
   if (auto const lang = GetBestName(in.src, langPriority, out.primary); lang != StrUtf8::kUnsupportedLanguageCode)
   {
     out.primaryLang = lang;
-    SubstituteRegionLangForDefault(out.primaryLang, in.regionData);
     return;
   }
 
@@ -164,7 +146,6 @@ void GetReadableNameImpl(NameParamsIn const & in, bool preferDefault, NameParams
         lang != StrUtf8::kUnsupportedLanguageCode)
     {
       out.primaryLang = lang;
-      SubstituteRegionLangForDefault(out.primaryLang, in.regionData);
       return;
     }
   }
@@ -356,6 +337,13 @@ LangsBufferT GetSimilar(int8_t lang)
   return langs;
 }
 
+int8_t GetRegionLang(RegionData const & regionData)
+{
+  LangsBufferT mwmLangs;
+  regionData.GetLanguages(mwmLangs);
+  return mwmLangs.empty() ? StrUtf8::kUnsupportedLanguageCode : mwmLangs.front();
+}
+
 void GetPreferredNames(NameParamsIn const & in, NameParamsOut & out)
 {
   out.Clear();
@@ -400,9 +388,6 @@ void GetPreferredNames(NameParamsIn const & in, NameParamsOut & out)
     out.secondary = {};
     out.secondaryLang = StrUtf8::kUnsupportedLanguageCode;
   }
-
-  SubstituteRegionLangForDefault(out.primaryLang, in.regionData);
-  SubstituteRegionLangForDefault(out.secondaryLang, in.regionData);
 }
 
 void GetReadableName(NameParamsIn const & in, NameParamsOut & out)

--- a/libs/indexer/feature_utils.cpp
+++ b/libs/indexer/feature_utils.cpp
@@ -20,14 +20,20 @@ namespace
 {
 using StrUtf8 = StringUtf8Multilang;
 
-void GetMwmLangName(feature::RegionData const & regionData, StrUtf8 const & src, std::string_view & out)
+// Convention for the lang code reported when transliteration fallback fires: target script is
+// Latin, so report English to drive Latin-script `locl` substitutions in HarfBuzz downstream.
+constexpr int8_t kTransliterationLang = StrUtf8::kEnglishCode;
+
+// Returns the StrUtf8 code of the selected name, or kUnsupportedLanguageCode if none was found.
+int8_t GetMwmLangName(feature::RegionData const & regionData, StrUtf8 const & src, std::string_view & out)
 {
   LangsBufferT mwmLangCodes;
   regionData.GetLanguages(mwmLangCodes);
 
   for (auto const code : mwmLangCodes)
     if (src.GetString(code, out))
-      return;
+      return code;
+  return StrUtf8::kUnsupportedLanguageCode;
 }
 
 bool GetTransliteratedName(RegionData const & regionData, StrUtf8 const & src, std::string & out)
@@ -50,7 +56,8 @@ bool GetTransliteratedName(RegionData const & regionData, StrUtf8 const & src, s
   return false;
 }
 
-bool GetBestName(StrUtf8 const & src, LangsBufferT const & priorityList, std::string_view & out)
+// Returns the StrUtf8 code of the selected name, or kUnsupportedLanguageCode if none was found.
+int8_t GetBestName(StrUtf8 const & src, LangsBufferT const & priorityList, std::string_view & out)
 {
   size_t bestIndex = priorityList.size();
 
@@ -69,11 +76,14 @@ bool GetBestName(StrUtf8 const & src, LangsBufferT const & priorityList, std::st
     return base::ControlFlow::Continue;
   });
 
+  if (bestIndex >= priorityList.size())
+    return StrUtf8::kUnsupportedLanguageCode;
+
   // There are many "junk" names in Arabian island.
-  if (bestIndex < priorityList.size() && priorityList[bestIndex] == StrUtf8::kInternationalCode)
+  if (priorityList[bestIndex] == StrUtf8::kInternationalCode)
     out = out.substr(0, out.find_first_of(','));
 
-  return bestIndex < priorityList.size();
+  return priorityList[bestIndex];
 }
 
 bool IsNativeLang(feature::RegionData const & regionData, int8_t deviceLang)
@@ -118,19 +128,29 @@ void GetReadableNameImpl(NameParamsIn const & in, bool preferDefault, NameParams
 {
   auto const langPriority = MakeLanguagesPriorityList(in.deviceLang, preferDefault);
 
-  if (GetBestName(in.src, langPriority, out.primary))
+  if (auto const lang = GetBestName(in.src, langPriority, out.primary); lang != StrUtf8::kUnsupportedLanguageCode)
+  {
+    out.primaryLang = lang;
     return;
+  }
 
   if (in.allowTranslit && GetTransliteratedName(in.regionData, in.src, out.transliterated))
+  {
+    out.primaryLang = kTransliterationLang;
     return;
+  }
 
   if (!preferDefault)
   {
-    if (GetBestName(in.src, {StrUtf8::kDefaultCode}, out.primary))
+    if (auto const lang = GetBestName(in.src, {StrUtf8::kDefaultCode}, out.primary);
+        lang != StrUtf8::kUnsupportedLanguageCode)
+    {
+      out.primaryLang = lang;
       return;
+    }
   }
 
-  GetMwmLangName(in.regionData, in.src, out.primary);
+  out.primaryLang = GetMwmLangName(in.regionData, in.src, out.primary);
 }
 
 // Filters types with |checker|, returns vector of raw type second components.
@@ -331,8 +351,12 @@ void GetPreferredNames(NameParamsIn const & in, NameParamsOut & out)
 
   auto const primaryCodes = MakeLanguagesPriorityList(in.deviceLang, false /* preferDefault */);
 
-  if (!GetBestName(in.src, primaryCodes, out.primary) && in.allowTranslit)
-    GetTransliteratedName(in.regionData, in.src, out.transliterated);
+  out.primaryLang = GetBestName(in.src, primaryCodes, out.primary);
+  if (out.primaryLang == StrUtf8::kUnsupportedLanguageCode && in.allowTranslit &&
+      GetTransliteratedName(in.regionData, in.src, out.transliterated))
+  {
+    out.primaryLang = kTransliterationLang;
+  }
 
   LangsBufferT secondaryCodes = {StrUtf8::kDefaultCode, StrUtf8::kInternationalCode};
 
@@ -342,12 +366,21 @@ void GetPreferredNames(NameParamsIn const & in, NameParamsOut & out)
 
   secondaryCodes.push_back(StrUtf8::kEnglishCode);
 
-  GetBestName(in.src, secondaryCodes, out.secondary);
+  out.secondaryLang = GetBestName(in.src, secondaryCodes, out.secondary);
 
-  if (out.primary.empty())
+  if (out.primary.empty() && !out.secondary.empty())
+  {
+    // Promote secondary to primary (carry its lang too). The both-empty case is left untouched
+    // so GetPrimary() can fall back to out.transliterated, whose lang we set above.
     out.primary.swap(out.secondary);
+    out.primaryLang = out.secondaryLang;
+    out.secondaryLang = StrUtf8::kUnsupportedLanguageCode;
+  }
   else if (!out.secondary.empty() && out.primary.find(out.secondary) != std::string::npos)
+  {
     out.secondary = {};
+    out.secondaryLang = StrUtf8::kUnsupportedLanguageCode;
+  }
 }
 
 void GetReadableName(NameParamsIn const & in, NameParamsOut & out)
@@ -384,7 +417,7 @@ int8_t GetNameForSearchOnBooking(RegionData const & regionData, StrUtf8 const & 
 bool GetPreferredName(StrUtf8 const & src, int8_t deviceLang, std::string_view & out)
 {
   auto const priorityList = MakeLanguagesPriorityList(deviceLang, true /* preferDefault */);
-  return GetBestName(src, priorityList, out);
+  return GetBestName(src, priorityList, out) != StrUtf8::kUnsupportedLanguageCode;
 }
 
 LangsBufferT GetDescriptionLangPriority(RegionData const & regionData, int8_t const deviceLang)

--- a/libs/indexer/feature_utils.hpp
+++ b/libs/indexer/feature_utils.hpp
@@ -58,6 +58,12 @@ int GetFeatureViewportScale(FeatureID const & fid, TypesHolder const & types);
 // - languages that we know are similar to |lang|;
 LangsBufferT GetSimilar(int8_t deviceLang);
 
+// Returns the first language declared for the MWM region, or kUnsupportedLanguageCode if the
+// region declares none. Used as a HarfBuzz `locl` hint for text in the region's on-the-ground
+// language: OSM-verbatim strings (addr:housenumber, road shield ref) and unqualified `name=`
+// tags, whose selected code (kDefaultCode) carries no real BCP-47 language.
+int8_t GetRegionLang(RegionData const & regionData);
+
 struct NameParamsIn
 {
   NameParamsIn(StringUtf8Multilang const & src_, RegionData const & regionData_, int8_t deviceLang_,
@@ -85,10 +91,11 @@ struct NameParamsOut
   std::string_view primary, secondary;
   std::string transliterated;
 
-  // StringUtf8Multilang code of the language actually selected for primary/secondary. Drives
-  // HarfBuzz OpenType `locl` substitutions downstream. kEnglishCode is reported for the
-  // transliterated fallback (target script is Latin). kUnsupportedLanguageCode means no name
-  // was found at all.
+  // Raw StringUtf8Multilang code actually selected for primary/secondary, used downstream to
+  // drive HarfBuzz OpenType `locl` substitutions. kEnglishCode is reported for the transliterated
+  // fallback (target script is Latin); kUnsupportedLanguageCode means no name was found at all.
+  // An unqualified `name=` is reported verbatim as kDefaultCode, which carries no real BCP-47
+  // language: resolve it to the region's language (see feature::GetRegionLang) at the usage place.
   int8_t primaryLang = StringUtf8Multilang::kUnsupportedLanguageCode;
   int8_t secondaryLang = StringUtf8Multilang::kUnsupportedLanguageCode;
 

--- a/libs/indexer/feature_utils.hpp
+++ b/libs/indexer/feature_utils.hpp
@@ -85,6 +85,13 @@ struct NameParamsOut
   std::string_view primary, secondary;
   std::string transliterated;
 
+  // StringUtf8Multilang code of the language actually selected for primary/secondary. Drives
+  // HarfBuzz OpenType `locl` substitutions downstream. kEnglishCode is reported for the
+  // transliterated fallback (target script is Latin). kUnsupportedLanguageCode means no name
+  // was found at all.
+  int8_t primaryLang = StringUtf8Multilang::kUnsupportedLanguageCode;
+  int8_t secondaryLang = StringUtf8Multilang::kUnsupportedLanguageCode;
+
   /// Call this fuction to get primary name when allowTranslit == true.
   std::string_view GetPrimary() const { return (!primary.empty() ? primary : std::string_view(transliterated)); }
 
@@ -92,6 +99,7 @@ struct NameParamsOut
   {
     primary = secondary = {};
     transliterated.clear();
+    primaryLang = secondaryLang = StringUtf8Multilang::kUnsupportedLanguageCode;
   }
 };
 

--- a/libs/indexer/indexer_tests/feature_names_test.cpp
+++ b/libs/indexer/indexer_tests/feature_names_test.cpp
@@ -492,6 +492,93 @@ UNIT_TEST(GetReadableName)
   }
 }
 
+// Verifies that an unqualified `name=` (kDefaultCode) is reported with the region's first
+// language code so HarfBuzz can pick the right OpenType `locl` rules downstream (see
+// SubstituteRegionLangForDefault in feature_utils.cpp).
+UNIT_TEST(GetPreferredNames_DefaultLang_SubstitutedWithRegionLang)
+{
+  bool const allowTranslit = false;
+
+  // Single-language region: default name should report the region's lang.
+  {
+    feature::RegionData regionData;
+    regionData.SetLanguages({"tr"});
+    StrUtf8 src;
+    src.AddString("default", "İstanbul");
+
+    feature::NameParamsIn in{src, regionData, StrUtf8::GetLangIndex("en"), allowTranslit};
+    feature::NameParamsOut out;
+    feature::GetPreferredNames(in, out);
+
+    TEST_EQUAL(out.GetPrimary(), "İstanbul", ());
+    TEST_EQUAL(out.primaryLang, StrUtf8::GetLangIndex("tr"), ());
+  }
+
+  // Multi-language region: first listed language wins (matches GetMwmRegionLang convention).
+  {
+    feature::RegionData regionData;
+    regionData.SetLanguages({"sr", "hr"});
+    StrUtf8 src;
+    src.AddString("default", "Београд");
+
+    feature::NameParamsIn in{src, regionData, StrUtf8::GetLangIndex("en"), allowTranslit};
+    feature::NameParamsOut out;
+    feature::GetPreferredNames(in, out);
+
+    TEST_EQUAL(out.GetPrimary(), "Београд", ());
+    TEST_EQUAL(out.primaryLang, StrUtf8::GetLangIndex("sr"), ());
+  }
+
+  // Region with no declared languages: substitution is a no-op, kDefaultCode preserved.
+  {
+    feature::RegionData regionData;
+    StrUtf8 src;
+    src.AddString("default", "Atlantis");
+
+    feature::NameParamsIn in{src, regionData, StrUtf8::GetLangIndex("en"), allowTranslit};
+    feature::NameParamsOut out;
+    feature::GetPreferredNames(in, out);
+
+    TEST_EQUAL(out.GetPrimary(), "Atlantis", ());
+    TEST_EQUAL(out.primaryLang, StrUtf8::kDefaultCode, ());
+  }
+
+  // Native-device-lang path (IsNativeOrSimilarLang): goes through GetReadableNameImpl;
+  // unqualified `name=` selected as primary should still be substituted.
+  {
+    feature::RegionData regionData;
+    regionData.SetLanguages({"tr"});
+    StrUtf8 src;
+    src.AddString("default", "İstanbul");
+
+    feature::NameParamsIn in{src, regionData, StrUtf8::GetLangIndex("tr"), allowTranslit};
+    feature::NameParamsOut out;
+    feature::GetPreferredNames(in, out);
+
+    TEST_EQUAL(out.GetPrimary(), "İstanbul", ());
+    TEST_EQUAL(out.primaryLang, StrUtf8::GetLangIndex("tr"), ());
+  }
+
+  // Non-default primary stays untouched (only kDefaultCode is substituted).
+  {
+    feature::RegionData regionData;
+    regionData.SetLanguages({"tr"});
+    StrUtf8 src;
+    src.AddString("en", "Istanbul");
+    src.AddString("default", "İstanbul");
+
+    feature::NameParamsIn in{src, regionData, StrUtf8::GetLangIndex("en"), allowTranslit};
+    feature::NameParamsOut out;
+    feature::GetPreferredNames(in, out);
+
+    TEST_EQUAL(out.GetPrimary(), "Istanbul", ());
+    TEST_EQUAL(out.primaryLang, StrUtf8::kEnglishCode, ());
+    // Secondary picks the default and should be substituted too.
+    TEST_EQUAL(out.secondary, "İstanbul", ());
+    TEST_EQUAL(out.secondaryLang, StrUtf8::GetLangIndex("tr"), ());
+  }
+}
+
 /*
 UNIT_TEST(GetNameForSearchOnBooking)
 {

--- a/libs/indexer/indexer_tests/feature_names_test.cpp
+++ b/libs/indexer/indexer_tests/feature_names_test.cpp
@@ -492,14 +492,15 @@ UNIT_TEST(GetReadableName)
   }
 }
 
-// Verifies that an unqualified `name=` (kDefaultCode) is reported with the region's first
-// language code so HarfBuzz can pick the right OpenType `locl` rules downstream (see
-// SubstituteRegionLangForDefault in feature_utils.cpp).
-UNIT_TEST(GetPreferredNames_DefaultLang_SubstitutedWithRegionLang)
+// Name selection reports the raw StringUtf8Multilang code it picked. An unqualified OSM `name=`
+// is reported as kDefaultCode; the kDefaultCode -> region-language resolution that drives HarfBuzz
+// `locl` happens later, at the drape caption usage place (CaptionDescription::Init) via
+// feature::GetRegionLang.
+UNIT_TEST(GetPreferredNames_ReportsSelectedLangCode)
 {
   bool const allowTranslit = false;
 
-  // Single-language region: default name should report the region's lang.
+  // Unqualified `name=` is reported as kDefaultCode regardless of the region's languages.
   {
     feature::RegionData regionData;
     regionData.SetLanguages({"tr"});
@@ -511,40 +512,11 @@ UNIT_TEST(GetPreferredNames_DefaultLang_SubstitutedWithRegionLang)
     feature::GetPreferredNames(in, out);
 
     TEST_EQUAL(out.GetPrimary(), "İstanbul", ());
-    TEST_EQUAL(out.primaryLang, StrUtf8::GetLangIndex("tr"), ());
-  }
-
-  // Multi-language region: first listed language wins (matches GetMwmRegionLang convention).
-  {
-    feature::RegionData regionData;
-    regionData.SetLanguages({"sr", "hr"});
-    StrUtf8 src;
-    src.AddString("default", "Београд");
-
-    feature::NameParamsIn in{src, regionData, StrUtf8::GetLangIndex("en"), allowTranslit};
-    feature::NameParamsOut out;
-    feature::GetPreferredNames(in, out);
-
-    TEST_EQUAL(out.GetPrimary(), "Београд", ());
-    TEST_EQUAL(out.primaryLang, StrUtf8::GetLangIndex("sr"), ());
-  }
-
-  // Region with no declared languages: substitution is a no-op, kDefaultCode preserved.
-  {
-    feature::RegionData regionData;
-    StrUtf8 src;
-    src.AddString("default", "Atlantis");
-
-    feature::NameParamsIn in{src, regionData, StrUtf8::GetLangIndex("en"), allowTranslit};
-    feature::NameParamsOut out;
-    feature::GetPreferredNames(in, out);
-
-    TEST_EQUAL(out.GetPrimary(), "Atlantis", ());
     TEST_EQUAL(out.primaryLang, StrUtf8::kDefaultCode, ());
   }
 
-  // Native-device-lang path (IsNativeOrSimilarLang): goes through GetReadableNameImpl;
-  // unqualified `name=` selected as primary should still be substituted.
+  // Native-device-lang path (IsNativeOrSimilarLang) goes through GetReadableNameImpl and also
+  // reports the raw kDefaultCode for an unqualified name.
   {
     feature::RegionData regionData;
     regionData.SetLanguages({"tr"});
@@ -556,10 +528,10 @@ UNIT_TEST(GetPreferredNames_DefaultLang_SubstitutedWithRegionLang)
     feature::GetPreferredNames(in, out);
 
     TEST_EQUAL(out.GetPrimary(), "İstanbul", ());
-    TEST_EQUAL(out.primaryLang, StrUtf8::GetLangIndex("tr"), ());
+    TEST_EQUAL(out.primaryLang, StrUtf8::kDefaultCode, ());
   }
 
-  // Non-default primary stays untouched (only kDefaultCode is substituted).
+  // A qualified primary reports its own code; an unqualified secondary reports kDefaultCode.
   {
     feature::RegionData regionData;
     regionData.SetLanguages({"tr"});
@@ -573,9 +545,30 @@ UNIT_TEST(GetPreferredNames_DefaultLang_SubstitutedWithRegionLang)
 
     TEST_EQUAL(out.GetPrimary(), "Istanbul", ());
     TEST_EQUAL(out.primaryLang, StrUtf8::kEnglishCode, ());
-    // Secondary picks the default and should be substituted too.
     TEST_EQUAL(out.secondary, "İstanbul", ());
-    TEST_EQUAL(out.secondaryLang, StrUtf8::GetLangIndex("tr"), ());
+    TEST_EQUAL(out.secondaryLang, StrUtf8::kDefaultCode, ());
+  }
+}
+
+// feature::GetRegionLang reports the region's first declared language: the locl hint used for
+// OSM-verbatim text (housenumbers, road shields) and for resolving unqualified `name=` picks.
+UNIT_TEST(GetRegionLang)
+{
+  {
+    feature::RegionData regionData;
+    regionData.SetLanguages({"tr"});
+    TEST_EQUAL(feature::GetRegionLang(regionData), StrUtf8::GetLangIndex("tr"), ());
+  }
+  // Multi-language region: the first listed language wins.
+  {
+    feature::RegionData regionData;
+    regionData.SetLanguages({"sr", "hr"});
+    TEST_EQUAL(feature::GetRegionLang(regionData), StrUtf8::GetLangIndex("sr"), ());
+  }
+  // No declared languages: there is no hint to give.
+  {
+    feature::RegionData regionData;
+    TEST_EQUAL(feature::GetRegionLang(regionData), StrUtf8::kUnsupportedLanguageCode, ());
   }
 }
 


### PR DESCRIPTION
## Summary

Map labels were always shaped under a hardcoded `"en"` HarfBuzz language tag, so OpenType `locl` substitutions for non-English scripts never fired. This PR plumbs the StringUtf8Multilang code of each label all the way from name selection down to `hb_buffer_set_language`, so HarfBuzz now picks the right per-language glyph variants — Serbian Cyrillic (`б` ↔ `uniF6C5`), Turkish (no `fi` ligature), CJK regional forms, etc.

### What changed

- **`[indexer]` Surface selected lang code from name selection.** `feature::NameParamsOut` gains `primaryLang` / `secondaryLang`; `GetPreferredNames` / `GetReadableName` now report the language they actually picked. The lang travels alongside the text — including across the secondary→primary promotion path — so downstream code can rely on the invariant "empty text ⇒ kUnsupportedLanguageCode".
- **`[drape]` Thread label language to HarfBuzz shaping.** `TitleDecl` gains `m_primaryLang` / `m_secondaryLang`; `PathTextViewParams` gains `m_lang`. Site-specific fills: captions use the name-selection lang; house numbers and road shields use the MWM region's first declared lang (OSM `addr:*` and `ref` tags are written in the local script); transit titles pass `kUnsupportedLanguageCode`. `StraightTextLayout` / `PathTextLayout` / `TextShape` / `PathTextShape` forward the lang to `TextureManager::ShapeSingleTextLine`, which passes it to `GlyphManager::ShapeText`. `DrapeGui` caches the system UI lang once at engine init for GUI text (ruler, copyright, debug overlays).
- **`[drape]` Test lang plumbing through `ShapeText`.** Verified against bundled Roboto's Turkish `locl`: English/default shapes `"fi"` as a single ligature glyph, Turkish suppresses it into two glyphs. Any regression that drops the lang argument along the path would shape both inputs identically and fail this test.

### Implementation notes

- `int8_t → hb_language_t` conversion is cached per StringUtf8Multilang code; HarfBuzz language pointers are stable singletons so a value cached today is valid forever.
- Negative codes (`kUnsupportedLanguageCode`) short-circuit to `HB_LANGUAGE_INVALID`. The conversion deliberately avoids `hb_language_get_default()` because it calls `setlocale(LC_CTYPE, nullptr)` on first use — not thread-safe and would pull in the OS locale unrelated to map data.
- `DrapeGui::SetUILang` is called unconditionally on engine init so a recreated engine under an unsupported locale cannot inherit a previous engine's value through the singleton.

LLM tools (Claude) were used to write parts of the code and the tests.

## Test plan

- [x] `drape_tests` — new `ShapeText_LangParameterPlumbing` passes, all other drape tests green
- [x] `indexer_tests` — green (the new `NameParamsOut.primaryLang/secondaryLang` did not break existing name-selection coverage)
- [x] Full `ctest` sweep (36 tests) green on macOS Debug
- [x] Each of the 3 commits builds standalone (`drape`, `drape_frontend`, `drape_tests`, `indexer_tests`)
- [x] Verified bundled Roboto's `locl` behavior directly with `hb-shape --language=tr fi` (yields `f + i`) vs `hb-shape --language=en fi` (yields the ligature) — matches what the test asserts via `GlyphManager::ShapeText`
- [x] Manual visual check on iOS / Android with a Serbian or Turkish region — would be useful but I do not have a device build pipeline in this branch; happy to follow up if a reviewer wants screenshots

## Notes for review

- Every commit on this branch compiles and passes tests on its own (verified by checking out and rebuilding each).
- 20 files changed, ~206 / -47 lines; the bulk is the parameter threading, not new logic.