### PR TITLE
[android] Pack point id, not back-URL, in MapObject.mApiId

### DIFF
--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/MapObject.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/MapObject.cpp
@@ -37,7 +37,7 @@ jobject CreateMapObject(JNIEnv * env, place_page::Info const & info, int mapObje
     "Ljava/lang/String;"                              // subtitle
     "Ljava/lang/String;"                              // address
     "DD"                                              // lat, lon
-    "Ljava/lang/String;"                              // appId
+    "Ljava/lang/String;"                              // apiId
     "Lapp/organicmaps/sdk/routing/RoutePointInfo;"    // routePointInfo
     "I"                                               // openingMode
     "Ljava/lang/String;"                              // wikiArticle
@@ -57,7 +57,7 @@ jobject CreateMapObject(JNIEnv * env, place_page::Info const & info, int mapObje
     jni::ToJavaStringWithSupplementalCharsFix(env, info.GetSecondarySubtitle()),
     lat,
     lon,
-    jni::ToJavaString(env, parseApi ? info.GetApiUrl() : ""),
+    jni::ToJavaString(env, parseApi ? info.GetApiId() : ""),
     routingPointInfo,
     static_cast<jint>(info.GetOpeningMode()),
     jni::ToJavaString(env, info.GetWikiDescription()),
@@ -92,7 +92,9 @@ jobject CreateMapObject(JNIEnv * env, place_page::Info const & info)
                            routingPointInfo.get(), jrawTypes.get());
   }
 
-  if (info.HasApiUrl())
+  // Classify as an API point when the mark carries a return point id and/or a back URL.
+  // (A bare API mark with neither has nothing to surface and falls through to POI below.)
+  if (info.HasApiUrl() || info.HasApiId())
   {
     return CreateMapObject(env, info, kApiPoint, ll.m_lat, ll.m_lon, true /* parseMeta */, true /* parseApi */,
                            routingPointInfo.get(), jrawTypes.get());

--- a/libs/map/map_tests/CMakeLists.txt
+++ b/libs/map/map_tests/CMakeLists.txt
@@ -2,6 +2,7 @@ project(map_tests)
 
 set(SRC
   address_tests.cpp
+  api_mark_tests.cpp
   bookmarks_test.cpp
   chart_generator_tests.cpp
   check_mwms.cpp

--- a/libs/map/map_tests/api_mark_tests.cpp
+++ b/libs/map/map_tests/api_mark_tests.cpp
@@ -1,0 +1,51 @@
+#include "testing/testing.hpp"
+
+#include "map/api_mark_point.hpp"
+#include "map/framework.hpp"
+
+#include <string>
+
+namespace api_mark_tests
+{
+// Returns the single API mark parsed from an om:// deep link. ExecuteMapApiRequest()
+// materializes the marks described by the URL into the API user-mark group.
+ApiMarkPoint const * CreateSingleApiMark(Framework & fm, std::string const & url)
+{
+  TEST_EQUAL(fm.ParseAndSetApiURL(url), url_scheme::ParsedMapApi::UrlType::Map, (url));
+  fm.ExecuteMapApiRequest();
+  auto const & ids = fm.GetBookmarkManager().GetUserMarkIds(UserMark::Type::API);
+  TEST_EQUAL(ids.size(), 1, (url));
+  return fm.GetBookmarkManager().GetMark<ApiMarkPoint>(*ids.begin());
+}
+
+// The per-point "id" and the global "backurl" are independent API inputs: a request may
+// carry either, both, or neither. FillApiMarkInfo() copies the mark's GetApiID() and
+// GenerateApiBackUrl() into place_page::Info::GetApiId()/GetApiUrl() respectively -- the
+// two values the place page surfaces, with the id returned to the caller (Android
+// EXTRA_POINT_ID). This pins down that the id is surfaced independently of the back URL.
+UNIT_TEST(ApiPoint_PointIdIsIndependentOfBackUrl)
+{
+  Framework fm(FrameworkParams(false /* m_enableDiffs */));
+
+  // id without backurl: id present, back URL empty.
+  {
+    auto const * mark = CreateSingleApiMark(fm, "om://map?ll=1,2&id=foo");
+    TEST_EQUAL(mark->GetApiID(), "foo", ());
+    TEST(fm.GenerateApiBackUrl(*mark).empty(), ("No backurl -> empty back URL, id still present"));
+  }
+
+  // backurl without id: a back URL but no point id to echo back.
+  {
+    auto const * mark = CreateSingleApiMark(fm, "om://map?ll=1,2&backurl=testapp");
+    TEST(mark->GetApiID().empty(), ("No id -> empty point id"));
+    TEST(!fm.GenerateApiBackUrl(*mark).empty(), ());
+  }
+
+  // Both present: the point id and the back URL are distinct, separately surfaced fields.
+  {
+    auto const * mark = CreateSingleApiMark(fm, "om://map?ll=1,2&id=foo&backurl=testapp");
+    TEST_EQUAL(mark->GetApiID(), "foo", ());
+    TEST_NOT_EQUAL(mark->GetApiID(), fm.GenerateApiBackUrl(*mark), ("point id and back URL are distinct"));
+  }
+}
+}  // namespace api_mark_tests

--- a/libs/map/place_page_info.hpp
+++ b/libs/map/place_page_info.hpp
@@ -211,6 +211,8 @@ public:
 
   /// Api
   void SetApiId(std::string const & apiId) { m_apiId = apiId; }
+  std::string const & GetApiId() const { return m_apiId; }
+  bool HasApiId() const { return !m_apiId.empty(); }
   void SetApiUrl(std::string const & url) { m_apiUrl = url; }
   std::string const & GetApiUrl() const { return m_apiUrl; }
 
@@ -322,9 +324,12 @@ private:
   /// Whether to treat it as plain feature.
   bool m_hasMetadata = false;
 
-  /// Api ID passed for the selected object. It's automatically included in api url below.
+  /// Per-point API id (om://map?...&id=...) echoed back to the calling app
+  /// (Android EXTRA_POINT_ID). Independent of m_apiUrl: set even when the request
+  /// carried no back_url, in which case m_apiUrl is empty.
   std::string m_apiId;
-  /// [Deep] link to open when "Back" button is pressed in a Place Page.
+  /// Back-navigation deep link opened on "Back" (the API back_url).
+  /// Empty when the request carried no back_url.
   std::string m_apiUrl;
   /// Formatted feature address for inner using.
   std::string m_address;


### PR DESCRIPTION
## What & why

The Android JNI bridge packed `place_page::Info::GetApiUrl()` (a back-URL) into the Java field `mApiId`, so the `EXTRA_POINT_ID` returned to API clients carried a back-URL — or an empty string — instead of the per-point id. Separately, only marks with a `back_url` were classified as `kApiPoint`; a mark from `om://map?...&id=…` **without** `back_url` fell through to the POI branch and had its id dropped entirely.

The per-point `id` and the global `back_url` are independent API inputs: a request may carry either, both, or neither (`GenerateApiBackUrl()` returns an empty string when no `back_url` is set). The old "id is always included in the back URL" assumption never held.

## Changes

- `CreateMapObject()` classifies a place page as `kApiPoint` when a point id **and/or** a back-URL is present.
- The JNI bridge reads `m_apiId` via a new `GetApiId()`/`HasApiId()` pair on `place_page::Info`.
- Corrected the stale `m_apiId` doc comment (it claimed the id is "automatically included in api url", which is false without a `back_url`).
- Added a `map_tests` regression test (`ApiPoint_PointIdIsIndependentOfBackUrl`) covering id-only, back-url-only, and both — asserting the point id is surfaced independently of the back URL.

## Testing

- `cmake --build cmake-build-debug --target map_tests` builds clean.
- `map_tests --filter=ApiPoint_PointIdIsIndependentOfBackUrl` passes.

Fixes the empty `EXTRA_POINT_ID` round-trip observed by `organicmaps/api-android` clients that pass `&id=…` without `&back_url=`.

---
_The comment fixes and regression test in the latest revision were prepared with LLM (Claude) assistance._
