### PR TITLE
[android] Fix detekt issues in track color picker

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/colorpicker/ColorGridView.kt
+++ b/android/app/src/main/java/app/organicmaps/widget/colorpicker/ColorGridView.kt
@@ -119,34 +119,33 @@ class ColorGridView @JvmOverloads constructor(context: Context, attrs: Attribute
         }
     }
 
-    override fun onTouchEvent(event: MotionEvent): Boolean {
-        when (event.actionMasked) {
-            MotionEvent.ACTION_DOWN -> {
-                isTracking = true
-                parent?.requestDisallowInterceptTouchEvent(true)
-                selectFromTouch(event.x, event.y)
-                return true
-            }
-
-            MotionEvent.ACTION_MOVE -> {
-                selectFromTouch(event.x, event.y)
-                return true
-            }
-
-            MotionEvent.ACTION_UP -> {
-                isTracking = false
-                performClick()
-                parent?.requestDisallowInterceptTouchEvent(false)
-                return true
-            }
-
-            MotionEvent.ACTION_CANCEL -> {
-                isTracking = false
-                parent?.requestDisallowInterceptTouchEvent(false)
-                return true
-            }
+    override fun onTouchEvent(event: MotionEvent): Boolean = when (event.actionMasked) {
+        MotionEvent.ACTION_DOWN -> {
+            isTracking = true
+            parent?.requestDisallowInterceptTouchEvent(true)
+            selectFromTouch(event.x, event.y)
+            true
         }
-        return super.onTouchEvent(event)
+
+        MotionEvent.ACTION_MOVE -> {
+            selectFromTouch(event.x, event.y)
+            true
+        }
+
+        MotionEvent.ACTION_UP -> {
+            isTracking = false
+            performClick()
+            parent?.requestDisallowInterceptTouchEvent(false)
+            true
+        }
+
+        MotionEvent.ACTION_CANCEL -> {
+            isTracking = false
+            parent?.requestDisallowInterceptTouchEvent(false)
+            true
+        }
+
+        else -> super.onTouchEvent(event)
     }
 
     private fun selectFromTouch(x: Float, y: Float) {

--- a/android/app/src/main/java/app/organicmaps/widget/colorpicker/ColorSlidersView.kt
+++ b/android/app/src/main/java/app/organicmaps/widget/colorpicker/ColorSlidersView.kt
@@ -5,7 +5,6 @@ import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
 import android.text.Editable
 import android.text.InputFilter
-import android.text.TextWatcher
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.Gravity
@@ -15,6 +14,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.ColorInt
 import androidx.annotation.StringRes
+import androidx.core.widget.doAfterTextChanged
 import app.organicmaps.R
 import app.organicmaps.util.ThemeUtils
 
@@ -81,8 +81,11 @@ class ColorSlidersView @JvmOverloads constructor(
         blueSlider.onValueChangedListener = sliderListener
     }
 
+    private fun isUserAdjusting() =
+        redSlider.isTracking || greenSlider.isTracking || blueSlider.isTracking || isEditingHex
+
     fun setColor(@ColorInt color: Int) {
-        if (redSlider.isTracking || greenSlider.isTracking || blueSlider.isTracking || isEditingHex) return
+        if (isUserAdjusting()) return
         val r = Color.red(color)
         val g = Color.green(color)
         val b = Color.blue(color)
@@ -247,30 +250,24 @@ class ColorSlidersView @JvmOverloads constructor(
                 topMargin = resources.getDimensionPixelSize(R.dimen.color_picker_hex_row_margin_top)
             },
         )
-        input.addTextChangedListener(
-            object : TextWatcher {
-                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-                override fun afterTextChanged(s: Editable?) {
-                    if (updatingFromCode) return
-                    val hex = s?.toString() ?: return
-                    if (hex.length != 6) return
-                    val parsed = hex.toLongOrNull(16) ?: return
-                    isEditingHex = true
-                    try {
-                        red = ((parsed shr 16) and 0xFF).toInt()
-                        green = ((parsed shr 8) and 0xFF).toInt()
-                        blue = (parsed and 0xFF).toInt()
-                        updateUI(updateSliders = true)
-                        onColorChangedListener?.onColorChanged(getColor())
-                    } finally {
-                        isEditingHex = false
-                    }
-                }
-            },
-        )
+        input.doAfterTextChanged(::applyHexInput)
 
         return input to row
+    }
+
+    private fun applyHexInput(editable: Editable?) {
+        if (updatingFromCode) return
+        val parsed = editable?.toString()?.takeIf { it.length == 6 }?.toLongOrNull(16) ?: return
+        isEditingHex = true
+        try {
+            red = ((parsed shr 16) and 0xFF).toInt()
+            green = ((parsed shr 8) and 0xFF).toInt()
+            blue = (parsed and 0xFF).toInt()
+            updateUI(updateSliders = true)
+            onColorChangedListener?.onColorChanged(getColor())
+        } finally {
+            isEditingHex = false
+        }
     }
 
     private enum class Channel(@StringRes val labelRes: Int) {

--- a/android/app/src/main/java/app/organicmaps/widget/colorpicker/RoundSlider.kt
+++ b/android/app/src/main/java/app/organicmaps/widget/colorpicker/RoundSlider.kt
@@ -97,34 +97,33 @@ class RoundSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
         canvas.drawCircle(thumbX, thumbY, thumbRadius, thumbStrokePaint)
     }
 
-    override fun onTouchEvent(event: MotionEvent): Boolean {
-        when (event.actionMasked) {
-            MotionEvent.ACTION_DOWN -> {
-                isTracking = true
-                parent?.requestDisallowInterceptTouchEvent(true)
-                updateFromTouch(event.x)
-                return true
-            }
-
-            MotionEvent.ACTION_MOVE -> {
-                updateFromTouch(event.x)
-                return true
-            }
-
-            MotionEvent.ACTION_UP -> {
-                isTracking = false
-                performClick()
-                parent?.requestDisallowInterceptTouchEvent(false)
-                return true
-            }
-
-            MotionEvent.ACTION_CANCEL -> {
-                isTracking = false
-                parent?.requestDisallowInterceptTouchEvent(false)
-                return true
-            }
+    override fun onTouchEvent(event: MotionEvent): Boolean = when (event.actionMasked) {
+        MotionEvent.ACTION_DOWN -> {
+            isTracking = true
+            parent?.requestDisallowInterceptTouchEvent(true)
+            updateFromTouch(event.x)
+            true
         }
-        return super.onTouchEvent(event)
+
+        MotionEvent.ACTION_MOVE -> {
+            updateFromTouch(event.x)
+            true
+        }
+
+        MotionEvent.ACTION_UP -> {
+            isTracking = false
+            performClick()
+            parent?.requestDisallowInterceptTouchEvent(false)
+            true
+        }
+
+        MotionEvent.ACTION_CANCEL -> {
+            isTracking = false
+            parent?.requestDisallowInterceptTouchEvent(false)
+            true
+        }
+
+        else -> super.onTouchEvent(event)
     }
 
     private fun updateFromTouch(x: Float) {

--- a/android/app/src/main/java/app/organicmaps/widget/colorpicker/SpectrumColorView.kt
+++ b/android/app/src/main/java/app/organicmaps/widget/colorpicker/SpectrumColorView.kt
@@ -164,35 +164,34 @@ class SpectrumColorView @JvmOverloads constructor(
         }
     }
 
-    override fun onTouchEvent(event: MotionEvent): Boolean {
-        when (event.actionMasked) {
-            MotionEvent.ACTION_DOWN -> {
-                isTracking = true
-                parent?.requestDisallowInterceptTouchEvent(true)
-                updateFromTouch(event.x, event.y)
-                return true
-            }
-
-            MotionEvent.ACTION_MOVE -> {
-                updateFromTouch(event.x, event.y)
-                return true
-            }
-
-            MotionEvent.ACTION_UP -> {
-                updateFromTouch(event.x, event.y)
-                isTracking = false
-                performClick()
-                parent?.requestDisallowInterceptTouchEvent(false)
-                return true
-            }
-
-            MotionEvent.ACTION_CANCEL -> {
-                isTracking = false
-                parent?.requestDisallowInterceptTouchEvent(false)
-                return true
-            }
+    override fun onTouchEvent(event: MotionEvent): Boolean = when (event.actionMasked) {
+        MotionEvent.ACTION_DOWN -> {
+            isTracking = true
+            parent?.requestDisallowInterceptTouchEvent(true)
+            updateFromTouch(event.x, event.y)
+            true
         }
-        return super.onTouchEvent(event)
+
+        MotionEvent.ACTION_MOVE -> {
+            updateFromTouch(event.x, event.y)
+            true
+        }
+
+        MotionEvent.ACTION_UP -> {
+            updateFromTouch(event.x, event.y)
+            isTracking = false
+            performClick()
+            parent?.requestDisallowInterceptTouchEvent(false)
+            true
+        }
+
+        MotionEvent.ACTION_CANCEL -> {
+            isTracking = false
+            parent?.requestDisallowInterceptTouchEvent(false)
+            true
+        }
+
+        else -> super.onTouchEvent(event)
     }
 
     private fun updateFromTouch(x: Float, y: Float) {

--- a/android/app/src/main/java/app/organicmaps/widget/colorpicker/TrackColorPickerFragment.kt
+++ b/android/app/src/main/java/app/organicmaps/widget/colorpicker/TrackColorPickerFragment.kt
@@ -98,6 +98,10 @@ class TrackColorPickerFragment : BottomSheetDialogFragment() {
 
         updateLayoutForOrientation(resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE)
 
+        observeViewModel()
+    }
+
+    private fun observeViewModel() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {

--- a/android/detekt.yml
+++ b/android/detekt.yml
@@ -3,6 +3,10 @@ build:
 
 complexity:
   active: true
+  NestedBlockDepth:
+    active: false
+  TooManyFunctions:
+    active: false
 
 coroutines:
   active: true
@@ -29,4 +33,6 @@ potential-bugs:
 style:
   active: true
   MagicNumber:
+    active: false
+  ReturnCount:
     active: false


### PR DESCRIPTION
 ## Summary                                                                                                                                               
                                                                                                                                                         
  - Resolves the detekt warnings the track color picker module accrued
    after detekt was wired into the build, without changing behavior.
  - Kotlin cleanups along the way: `doAfterTextChanged` instead of a bare                                                                                  
    `TextWatcher`, `when`-expression touch handlers, an
    `observeViewModel()` extraction from `onViewCreated`, an                                                                                               
    `isUserAdjusting()` helper to keep the slider-tracking guard                                                                                         
    self-documenting, and an extracted `applyHexInput` that owns the                                                                                       
    `isEditingHex` re-entry guard.                                                                                                                         
  - `detekt.yml`: disabled `NestedBlockDepth`, `TooManyFunctions` and                                                                                      
    `ReturnCount` per maintainer feedback — these rules don't fit Kotlin's                                                                                 
    natural early-return / guard-clause style.