### PR TITLE
Fix #10965: Improve visibility of system navigation buttons on Android 8

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -2400,6 +2400,27 @@ public class MwmActivity extends BaseMwmFragmentActivity
       Framework.nativeMemoryWarning();
   }
 
+  private void makeNavigationBarTransparentInLightMode()
+  {
+    final boolean isLightMode = !app.organicmaps.sdk.util.Utils.isDarkMode(this);
+    final Window window = getWindow();
+
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O_MR1) // Android 8 and below
+    {
+      // On Android 8 and below, system navigation buttons (Back, Home, Recent)
+      //were hard to see due to low contrast. This change sets a gray
+      //semitransparent navigation bar color on these versions to make the buttons
+      //more visible.
+      window.setNavigationBarColor(0xE1E1E1CC);
+      return;
+    }
+
+    window.setNavigationBarColor(Color.TRANSPARENT);
+    new WindowInsetsControllerCompat(window, window.getDecorView()).setAppearanceLightNavigationBars(isLightMode);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+      window.setNavigationBarContrastEnforced(false);
+  }
+
   private void reportUnsupported()
   {
     new MaterialAlertDialogBuilder(this, R.style.MwmTheme_AlertDialog)


### PR DESCRIPTION
On Android 8 and below, system navigation buttons (Back, Home, Recent) were hard to see due to low contrast. This change sets a grey semi- transparent navigation bar color on these versions to make the buttons more visible.

For Android 9 and above, the existing transparent navigation bar logic with light/dark appearance is preserved, so newer devices remain unaffected.