### PR TITLE
[drape] Apply visual scale when sizing text background

### DIFF
--- a/libs/drape_frontend/user_mark_shapes.cpp
+++ b/libs/drape_frontend/user_mark_shapes.cpp
@@ -132,7 +132,8 @@ void GenerateColoredSymbolShapes(ref_ptr<dp::GraphicsContext> context, ref_ptr<d
     CHECK(renderInfo.m_titleDecl, ());
     auto const & titleDecl = renderInfo.m_titleDecl->operator[](0);
     auto const textMetrics = textures->ShapeSingleTextLine(titleDecl.m_primaryText, nullptr);
-    auto const fontScale = static_cast<float>(VisualParams::Instance().GetFontScale());
+    auto const & vparams = VisualParams::Instance();
+    auto const fontScale = static_cast<float>(vparams.GetFontScale() * vparams.GetVisualScale());
     float const textRatio = titleDecl.m_primaryTextFont.m_size * fontScale / dp::kBaseFontSizePixels;
 
     sizeInc.x = textMetrics.m_lineWidthInPixels * textRatio;


### PR DESCRIPTION
Fixes #10202

GenerateColoredSymbolShapes computed the text-fit increment from the raw font size, while GenerateTextShapes multiplies the font size by the visual scale before rendering. On Retina/HiDPI screens (vs > 1) the background ended up roughly 1/vs of the needed width — e.g. the red box behind the speed-camera "110" only covered the first digit.