### PR TITLE
[android][ios] Fix and pass lat/lon coordinates when opening Editor view.

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -662,7 +662,13 @@ public class MwmActivity extends BaseMwmFragmentActivity
         break;
       case Editor:
         if (Framework.nativeIsDownloadedMapAtScreenCenter())
-          startActivity(new Intent(MwmActivity.this, FeatureCategoryActivity.class));
+        {
+          // Snapshot the position now: by the time the user picks a category the viewport may
+          // have drifted (location follow, layout changes) and the recheck inside the JNI
+          // create call would land on a different — possibly unloaded — MWM.
+          final double[] editorCenter = Framework.nativeGetScreenRectCenter();
+          FeatureCategoryActivity.start(MwmActivity.this, editorCenter[0], editorCenter[1]);
+        }
         else
         {
           dismissAlertDialog();

--- a/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryActivity.java
+++ b/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryActivity.java
@@ -1,6 +1,8 @@
 package app.organicmaps.editor;
 
+import android.content.Context;
 import android.content.Intent;
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import app.organicmaps.base.BaseMwmFragmentActivity;
 import app.organicmaps.sdk.editor.Editor;
@@ -10,6 +12,15 @@ public class FeatureCategoryActivity
     extends BaseMwmFragmentActivity implements FeatureCategoryFragment.FeatureCategoryListener
 {
   public static final String EXTRA_FEATURE_CATEGORY = "FeatureCategory";
+  static final String EXTRA_POSITION_LAT = "PositionLat";
+  static final String EXTRA_POSITION_LON = "PositionLon";
+
+  public static void start(@NonNull Context context, double lat, double lon)
+  {
+    context.startActivity(new Intent(context, FeatureCategoryActivity.class)
+                              .putExtra(EXTRA_POSITION_LAT, lat)
+                              .putExtra(EXTRA_POSITION_LON, lon));
+  }
 
   @Override
   protected Class<? extends Fragment> getFragmentClass()
@@ -20,7 +31,10 @@ public class FeatureCategoryActivity
   @Override
   public void onFeatureCategorySelected(FeatureCategory category)
   {
-    Editor.createMapObject(category);
+    final Intent in = getIntent();
+    final double lat = in.getDoubleExtra(EXTRA_POSITION_LAT, 0);
+    final double lon = in.getDoubleExtra(EXTRA_POSITION_LON, 0);
+    Editor.createMapObject(category, lat, lon);
     final Intent intent = new Intent(this, EditorActivity.class);
     intent.putExtra(EXTRA_FEATURE_CATEGORY, category);
     intent.putExtra(EditorActivity.EXTRA_NEW_OBJECT, true);

--- a/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryFragment.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmRecyclerFragment;
-import app.organicmaps.sdk.Framework;
 import app.organicmaps.sdk.editor.Editor;
 import app.organicmaps.sdk.editor.OsmOAuth;
 import app.organicmaps.sdk.editor.data.FeatureCategory;
@@ -158,9 +157,13 @@ public class FeatureCategoryFragment
       return;
     }
 
-    final double[] center = Framework.nativeGetScreenRectCenter();
-    final double lat = center[0];
-    final double lon = center[1];
+    final Bundle args = requireArguments();
+    final double lat = args.getDouble(FeatureCategoryActivity.EXTRA_POSITION_LAT, Double.NaN);
+    final double lon = args.getDouble(FeatureCategoryActivity.EXTRA_POSITION_LON, Double.NaN);
+    // No native CHECK on the note path (unlike CreateMapObject), so an invariant
+    // break would silently post the note to (0, 0). Crash explicitly instead.
+    if (Double.isNaN(lat) || Double.isNaN(lon))
+      throw new IllegalStateException("FeatureCategoryFragment missing position extras");
 
     if (!MwmApplication.prefs(requireContext().getApplicationContext()).contains(NOTE_CONFIRMATION_SHOWN))
     {

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/editor/Editor.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/editor/Editor.cpp
@@ -10,6 +10,8 @@
 #include "indexer/feature_utils.hpp"
 #include "indexer/validate_and_format_contacts.hpp"
 
+#include "geometry/mercator.hpp"
+
 #include "coding/string_utf8_multilang.hpp"
 
 #include "base/assert.hpp"
@@ -333,11 +335,12 @@ JNIEXPORT void Java_app_organicmaps_sdk_editor_Editor_nativeStartEdit(JNIEnv *, 
   CHECK(fr->GetEditableMapObject(info.GetID(), g_editableMapObject), ("Invalid feature in the place page."));
 }
 
-JNIEXPORT void Java_app_organicmaps_sdk_editor_Editor_nativeCreateMapObject(JNIEnv * env, jclass, jstring featureType)
+JNIEXPORT void Java_app_organicmaps_sdk_editor_Editor_nativeCreateMapObject(JNIEnv * env, jclass, jstring featureType,
+                                                                            jdouble lat, jdouble lon)
 {
   ::Framework * fr = frm();
   auto const type = classif().GetTypeByReadableObjectName(jni::ToNativeString(env, featureType));
-  CHECK(fr->CreateMapObject(fr->GetViewportCenter(), type, g_editableMapObject),
+  CHECK(fr->CreateMapObject(mercator::FromLatLon(lat, lon), type, g_editableMapObject),
         ("Couldn't create mapobject, wrong coordinates of missing mwm"));
 }
 

--- a/android/sdk/src/main/java/app/organicmaps/sdk/editor/Editor.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/editor/Editor.java
@@ -156,15 +156,18 @@ public final class Editor
   public static native void nativeAddToRecentCategories(@NonNull String type);
 
   /**
-   * Creates new object on the map. Places it in the center of current viewport.
+   * Creates new object on the map at the given lat/lon. Capture the point with
+   * {@link Framework#nativeGetScreenRectCenter()} at the moment the user confirms
+   * the position; do not pass live viewport coordinates here, otherwise the point
+   * can drift between the position check and creation.
    * {@link Framework#nativeIsDownloadedMapAtScreenCenter()} should be called before
    * to check whether new feature can be created on the map.
    */
-  public static void createMapObject(FeatureCategory category)
+  public static void createMapObject(FeatureCategory category, double lat, double lon)
   {
-    nativeCreateMapObject(category.getType());
+    nativeCreateMapObject(category.getType(), lat, lon);
   }
-  public static native void nativeCreateMapObject(@NonNull String type);
+  public static native void nativeCreateMapObject(@NonNull String type, double lat, double lon);
   public static native void nativeCreateNote(String text);
   public static native void nativePlaceDoesNotExist(@NonNull String comment);
   public static native void nativeRollbackMapObject();

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageOSMContributionData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageOSMContributionData.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, readonly) BOOL showAddPlace;
 @property(nonatomic, readonly) BOOL showEditPlace;
+@property(nonatomic, readonly) BOOL canEditPlace;
 
 @property(nonatomic, readonly) PlacePageOSMContributionState state;
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageOSMContributionData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageOSMContributionData.mm
@@ -18,6 +18,7 @@
 
     BOOL shouldShowAddPlace = rawData.ShouldShowAddPlace() || rawData.ShouldShowAddBusiness();
     BOOL shouldShowEditPlace = rawData.ShouldShowEditPlace();
+    BOOL canEditPlace = rawData.CanEditPlace();
     switch (mapAttributes.nodeStatus)
     {
     case MWMMapNodeStatusUndefined:
@@ -25,6 +26,7 @@
       _state = PlacePageOSMContributionStateCanAddOrEditPlace;
       _showAddPlace = shouldShowAddPlace;
       _showEditPlace = shouldShowEditPlace;
+      _canEditPlace = canEditPlace;
       break;
     case MWMMapNodeStatusDownloading:
     case MWMMapNodeStatusApplying:
@@ -33,11 +35,12 @@
     case MWMMapNodeStatusNotDownloaded:
     case MWMMapNodeStatusOnDiskOutOfDate:
     case MWMMapNodeStatusPartly:
-      BOOL needsToUpdateMap = !rawData.CanEditPlace();
+      BOOL needsToUpdateMap = !canEditPlace;
       _state = needsToUpdateMap ? PlacePageOSMContributionStateShouldUpdateMap
                                 : PlacePageOSMContributionStateCanAddOrEditPlace;
       _showAddPlace = !needsToUpdateMap && shouldShowAddPlace;
       _showEditPlace = !needsToUpdateMap && shouldShowEditPlace;
+      _canEditPlace = canEditPlace;
       break;
     }
     return self;

--- a/iphone/Maps/UI/Editor/MWMEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/MWMEditorViewController.mm
@@ -1126,6 +1126,7 @@ void registerCellsForTableView(std::vector<MWMEditorCellID> const & cells, UITab
     auto const type = *(m_mapObject.GetTypes().begin());
     auto const readableType = classif().GetReadableObjectName(type);
     [dvc setSelectedCategory:readableType];
+    [dvc setCreatedPosition:m_mapObject.GetMercator()];
   }
   else if ([segue.identifier isEqualToString:kAdditionalNamesEditorSegue])
   {

--- a/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.h
+++ b/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.h
@@ -1,5 +1,7 @@
 #import "MWMViewController.h"
 
+#include "geometry/point2d.hpp"
+
 #include <string>
 
 namespace osm
@@ -18,5 +20,9 @@ class EditableMapObject;
 @property(weak, nonatomic) id<MWMObjectsCategorySelectorDelegate> delegate;
 
 - (void)setSelectedCategory:(std::string const &)type;
+// Position captured when the user confirms placement. Must be set before the controller is shown;
+// the picked category is created at this exact point instead of the live viewport center
+// (which can drift while the user browses categories).
+- (void)setCreatedPosition:(m2::PointD const &)position;
 
 @end

--- a/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.mm
+++ b/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.mm
@@ -19,7 +19,9 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
                                                     UITableViewDelegate,
                                                     UITableViewDataSource,
                                                     MWMKeyboardObserver>
-{}
+{
+  m2::PointD m_createdPosition;
+}
 
 @property(weak, nonatomic) IBOutlet UITableView * tableView;
 @property(nonatomic) UISearchController * searchViewController;
@@ -60,6 +62,11 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
 - (void)setSelectedCategory:(std::string const &)type
 {
   self.selectedType = @(type.c_str());
+}
+
+- (void)setCreatedPosition:(m2::PointD const &)position
+{
+  m_createdPosition = position;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle
@@ -200,9 +207,7 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
   EditableMapObject emo;
   auto & f = GetFramework();
   auto const type = classif().GetTypeByReadableObjectName(self.selectedType.UTF8String);
-  if (!f.CreateMapObject(f.GetViewportCenter(), type, emo))
-    NSAssert(false, @"This call should never fail, because IsPointCoveredByDownloadedMaps is "
-                    @"always called before!");
+  CHECK(f.CreateMapObject(m_createdPosition, type, emo), ());
   return emo;
 }
 

--- a/iphone/Maps/UI/Map/MapViewController.mm
+++ b/iphone/Maps/UI/Map/MapViewController.mm
@@ -11,6 +11,7 @@
 #import "MWMMapDownloadDialog.h"
 #import "MWMMapViewControlsManager.h"
 #import "MWMNetworkPolicy+UI.h"
+#import "MWMObjectsCategorySelectorController.h"
 #import "MWMPlacePageProtocol.h"
 #import "MapsAppDelegate.h"
 #import "SwiftBridge.h"
@@ -43,6 +44,8 @@ NSString * const kEditorSegue = @"Map2EditorSegue";
 NSString * const kUDViralAlertWasShown = @"ViralAlertWasShown";
 NSString * const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
 NSString * const kSettingsSegue = @"Map2Settings";
+// Mirrors kMapToCategorySelectorSegue in MWMMapViewControlsManager.mm.
+NSString * const kCategorySelectorSegue = @"MapToCategorySelectorSegue";
 }  // namespace
 
 @interface NSValueWrapper : NSObject
@@ -830,6 +833,13 @@ NSString * const kSettingsSegue = @"Map2Settings";
     MWMDownloadMapsViewController * dvc = segue.destinationViewController;
     NSNumber * mode = sender;
     dvc.mode = (MWMMapDownloaderMode)mode.integerValue;
+  }
+  else if ([segue.identifier isEqualToString:kCategorySelectorSegue])
+  {
+    MWMObjectsCategorySelectorController * dvc = segue.destinationViewController;
+    m2::PointD position;
+    [(NSValue *)sender getValue:&position];
+    [dvc setCreatedPosition:position];
   }
 }
 

--- a/iphone/Maps/UI/Map/MapViewControls/MWMMapViewControlsManager.mm
+++ b/iphone/Maps/UI/Map/MapViewControls/MWMMapViewControlsManager.mm
@@ -152,7 +152,14 @@ NSString * const kMapToCategorySelectorSegue = @"MapToCategorySelectorSegue";
       position:optionalPosition
       doneBlock:^{
         if ([MWMFrameworkHelper canEditMapAtViewportCenter])
-          [ownerController performSegueWithIdentifier:kMapToCategorySelectorSegue sender:nil];
+        {
+          // Snapshot the position now: by the time the user picks a category the viewport may
+          // have drifted (location follow, layout changes) and the recheck inside CreateMapObject
+          // would land on a different — possibly unloaded — MWM.
+          m2::PointD const position = GetFramework().GetViewportCenter();
+          NSValue * sender = [NSValue valueWithBytes:&position objCType:@encode(m2::PointD)];
+          [ownerController performSegueWithIdentifier:kMapToCategorySelectorSegue sender:sender];
+        }
         else
           [ownerController.alertController presentIncorrectFeauturePositionAlert];
 

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageOSMContributionViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageOSMContributionViewController.swift
@@ -112,6 +112,8 @@ final class PlacePageOSMContributionViewController: UIViewController {
     case .canAddOrEditPlace:
       addPlaceButton.isHidden = !buttonsData.showAddPlace
       editPlaceButton.isHidden = !buttonsData.showEditPlace
+      addPlaceButton.isEnabled = buttonsData.canEditPlace
+      editPlaceButton.isEnabled = buttonsData.canEditPlace
       updateMapButton.isHidden = true
     case .shouldUpdateMap:
       addPlaceButton.isHidden = true


### PR DESCRIPTION
Should fix:
https://play.google.com/console/u/0/developers/8084273541548442467/app/4972992444534608608/vitals/crashes/4c8ae6d9b60845e472536b50bec64ea3/details?days=28&versionCode=26050801&isUserPerceived=true

Fixes ASSERT(featureStatus != FeatureStatus::Obsolete) in iOS Editor::GetEditableProperties.