### PR TITLE
[android] Fix NPE in bookmark list after deleting from sort/search

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
@@ -68,11 +68,6 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
       return (!mDataSource.getData().getAnnotation().isEmpty() || !mDataSource.getData().getDescription().isEmpty());
     }
 
-    void invalidate()
-    {
-      mDataSource.invalidate();
-    }
-
     public abstract int getSectionsCount();
     public abstract boolean isEditable(int sectionIndex);
     public abstract boolean hasTitle(int sectionIndex);
@@ -82,7 +77,6 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
     public abstract int getItemsType(int sectionIndex);
     public abstract long getBookmarkId(@NonNull SectionPosition pos);
     public abstract long getTrackId(@NonNull SectionPosition pos);
-    public abstract void onDelete(@NonNull SectionPosition pos);
   }
 
   private static class CategorySectionsDataSource extends SectionsDataSource
@@ -165,15 +159,6 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
     }
 
     @Override
-    public void onDelete(@NonNull SectionPosition pos)
-    {
-      // we must invalidate datasource before calculate sections
-      invalidate();
-
-      calculateSections();
-    }
-
-    @Override
     public long getBookmarkId(@NonNull SectionPosition pos)
     {
       return getCategory().getBookmarkIdByPosition(pos.getItemIndex());
@@ -231,12 +216,6 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
     public int getItemsType(int sectionIndex)
     {
       return TYPE_BOOKMARK;
-    }
-
-    @Override
-    public void onDelete(@NonNull SectionPosition pos)
-    {
-      mSearchResults.remove(pos.getItemIndex());
     }
 
     @Override
@@ -324,27 +303,6 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
       return TYPE_TRACK;
     }
 
-    @Override
-    public void onDelete(@NonNull SectionPosition pos)
-    {
-      if (isDescriptionSection(pos.getSectionIndex()))
-        throw new IllegalArgumentException("Delete failed. Invalid section index.");
-
-      int blockIndex = pos.getSectionIndex() - (hasDescription() ? 1 : 0);
-      SortedBlock block = mSortedBlocks.get(blockIndex);
-      if (block.isBookmarksBlock())
-      {
-        block.getBookmarkIds().remove(pos.getItemIndex());
-        if (block.getBookmarkIds().isEmpty())
-          mSortedBlocks.remove(blockIndex);
-        return;
-      }
-
-      block.getTrackIds().remove(pos.getItemIndex());
-      if (block.getTrackIds().isEmpty())
-        mSortedBlocks.remove(blockIndex);
-    }
-
     public long getBookmarkId(@NonNull SectionPosition pos)
     {
       return getSortedBlock(pos.getSectionIndex()).getBookmarkIds().get(pos.getItemIndex());
@@ -370,6 +328,12 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
       mSectionsDataSource = new SortedSectionsDataSource(mDataSource, mSortedResults);
     else
       mSectionsDataSource = new CategorySectionsDataSource(mDataSource);
+  }
+
+  void refreshDataSource()
+  {
+    mDataSource.invalidate();
+    refreshSections();
   }
 
   private SectionPosition getSectionPosition(int position)
@@ -523,13 +487,32 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
     return itemCount;
   }
 
-  void onDelete(int position)
+  void removeDeletedItem(long itemId, int type)
   {
-    SectionPosition sp = getSectionPosition(position);
-    mSectionsDataSource.onDelete(sp);
-    // In case of the search results editing reset cached sorted blocks.
-    if (isSearchResults())
+    if (mSearchResults != null)
+    {
+      if (type == TYPE_BOOKMARK)
+        mSearchResults.remove(Long.valueOf(itemId));
+      // The cached sorted snapshot is hidden while search results are shown. Drop it because it
+      // can contain the deleted bookmark or track and would be reused after search is closed.
       mSortedResults = null;
+      return;
+    }
+
+    if (mSortedResults == null)
+      return;
+
+    for (int i = 0; i < mSortedResults.size(); ++i)
+    {
+      SortedBlock block = mSortedResults.get(i);
+      final List<Long> ids = type == TYPE_BOOKMARK ? block.getBookmarkIds() : block.getTrackIds();
+      if (!ids.remove(Long.valueOf(itemId)))
+        continue;
+
+      if (block.getBookmarkIds().isEmpty() && block.getTrackIds().isEmpty())
+        mSortedResults.remove(i);
+      return;
+    }
   }
 
   boolean isSearchResults()

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
@@ -434,26 +434,23 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
   @Override
   public void onBookmarksSortingCompleted(@NonNull SortedBlock[] sortedBlocks, long timestamp)
   {
-    if (mLastSortTimestamp != timestamp)
-      return;
-    mLastSortTimestamp = 0;
-
-    BookmarkListAdapter adapter = getBookmarkListAdapter();
-    adapter.setSortedResults(sortedBlocks);
-    adapter.notifyDataSetChanged();
-
-    updateSortingProgressBar();
+    applySortedResults(sortedBlocks, timestamp);
   }
 
   @Override
   public void onBookmarksSortingCancelled(long timestamp)
   {
-    if (mLastSortTimestamp != timestamp)
+    applySortedResults(null, timestamp);
+  }
+
+  private void applySortedResults(@Nullable SortedBlock[] sortedBlocks, long timestamp)
+  {
+    if (mLastSortTimestamp == 0 || mLastSortTimestamp != timestamp)
       return;
     mLastSortTimestamp = 0;
 
     BookmarkListAdapter adapter = getBookmarkListAdapter();
-    adapter.setSortedResults(null);
+    adapter.setSortedResults(sortedBlocks);
     adapter.notifyDataSetChanged();
 
     updateSortingProgressBar();
@@ -754,8 +751,8 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
 
   private void onDeleteTrackSelected(long trackId)
   {
-    BookmarkManager.INSTANCE.deleteTrack(trackId);
-    getBookmarkListAdapter().notifyDataSetChanged();
+    deleteBookmarkListItem(trackId, BookmarkListAdapter.TYPE_TRACK,
+                           () -> BookmarkManager.INSTANCE.deleteTrack(trackId));
   }
 
   private void onShareActionSelected()
@@ -803,10 +800,22 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
   {
     if (mSelectedItemId == -1)
       return;
-    BookmarkManager.INSTANCE.deleteBookmark(mSelectedItemId);
-    getBookmarkListAdapter().notifyDataSetChanged();
+    final long bookmarkId = mSelectedItemId;
+    deleteBookmarkListItem(bookmarkId, BookmarkListAdapter.TYPE_BOOKMARK,
+                           () -> BookmarkManager.INSTANCE.deleteBookmark(bookmarkId));
+  }
+
+  private void deleteBookmarkListItem(long itemId, int type, @NonNull Runnable deleteAction)
+  {
+    final BookmarkListAdapter adapter = getBookmarkListAdapter();
+    adapter.removeDeletedItem(itemId, type);
+    deleteAction.run();
+    adapter.refreshDataSource();
+    adapter.notifyDataSetChanged();
     if (mSearchMode)
       mNeedUpdateSorting = true;
+    mSelectedItemId = -1;
+    mSelectedItemType = -1;
     updateSearchVisibility();
     updateRecyclerVisibility();
   }

--- a/android/libs/car/src/main/java/app/organicmaps/car/screens/bookmarks/BookmarksLoader.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/screens/bookmarks/BookmarksLoader.java
@@ -62,6 +62,8 @@ class BookmarksLoader implements BookmarkManager.BookmarksSortingListener
   @NonNull
   private final BookmarkCategory mBookmarkCategory;
   private final int mBookmarksListSize;
+  private long mLastSortTimestamp = 0;
+  private boolean mIsLoading = false;
 
   public BookmarksLoader(@NonNull CarContext carContext, @NonNull LocationHelper locationHelper,
                          @NonNull BookmarkCategory bookmarkCategory, @NonNull OnBookmarksLoaded onBookmarksLoaded)
@@ -79,26 +81,34 @@ class BookmarksLoader implements BookmarkManager.BookmarksSortingListener
 
   public void load()
   {
+    if (mIsLoading)
+      return;
+    mIsLoading = true;
+
     UiThread.runLater(() -> {
+      if (!mIsLoading)
+        return;
       BookmarkManager.INSTANCE.addSortingListener(this);
       if (sortBookmarks())
         return;
 
-      final List<Long> bookmarkIds = new ArrayList<>();
-      for (int i = 0; i < mBookmarksListSize; ++i)
-        bookmarkIds.add(mBookmarkCategory.getBookmarkIdByPosition(i));
-      loadBookmarks(bookmarkIds);
+      loadBookmarksWithoutSorting();
     });
   }
 
   public void cancel()
   {
-    BookmarkManager.INSTANCE.removeSortingListener(this);
     if (mBookmarkLoaderTask != null)
-    {
       mBookmarkLoaderTask.cancel(true);
-      mBookmarkLoaderTask = null;
-    }
+    finishLoading();
+  }
+
+  private void finishLoading()
+  {
+    mIsLoading = false;
+    mLastSortTimestamp = 0;
+    BookmarkManager.INSTANCE.removeSortingListener(this);
+    mBookmarkLoaderTask = null;
   }
 
   /**
@@ -123,31 +133,56 @@ class BookmarksLoader implements BookmarkManager.BookmarksSortingListener
     final double lat = hasMyPosition ? loc.getLatitude() : 0;
     final double lon = hasMyPosition ? loc.getLongitude() : 0;
 
-    BookmarkManager.INSTANCE.getSortedCategory(mBookmarkCategory.getId(), sortingType, hasMyPosition, lat, lon, 0);
+    mLastSortTimestamp = System.nanoTime();
+    BookmarkManager.INSTANCE.getSortedCategory(mBookmarkCategory.getId(), sortingType, hasMyPosition, lat, lon,
+                                               mLastSortTimestamp);
 
     return true;
   }
 
+  private void loadBookmarksWithoutSorting()
+  {
+    final List<Long> bookmarkIds = new ArrayList<>();
+    for (int i = 0; i < getCurrentBookmarksListSize(); ++i)
+      bookmarkIds.add(mBookmarkCategory.getBookmarkIdByPosition(i));
+    loadBookmarks(bookmarkIds);
+  }
+
+  private int getCurrentBookmarksListSize()
+  {
+    for (final BookmarkCategory category : BookmarkManager.INSTANCE.getCategories())
+    {
+      if (category.equals(mBookmarkCategory))
+        return Math.min(category.getBookmarksCount(), mBookmarksListSize);
+    }
+    return 0;
+  }
+
   private void loadBookmarks(@NonNull List<Long> bookmarksIds)
   {
-    final BookmarkInfo[] bookmarks = new BookmarkInfo[mBookmarksListSize];
+    final List<BookmarkInfo> bookmarks = new ArrayList<>();
     for (int i = 0; i < mBookmarksListSize && i < bookmarksIds.size(); ++i)
     {
       final long id = bookmarksIds.get(i);
-      bookmarks[i] = BookmarkManager.INSTANCE.getBookmarkInfo(id);
+      @Nullable
+      final BookmarkInfo bookmark = BookmarkManager.INSTANCE.getBookmarkInfo(id);
+      if (bookmark != null)
+        bookmarks.add(bookmark);
     }
 
     mBookmarkLoaderTask = ThreadPool.getWorker().submit(() -> {
       final ItemList bookmarksList = createBookmarksList(bookmarks);
       UiThread.run(() -> {
-        cancel();
+        if (!mIsLoading)
+          return;
+        finishLoading();
         mOnBookmarksLoaded.onBookmarksLoaded(bookmarksList);
       });
     });
   }
 
   @NonNull
-  private ItemList createBookmarksList(@NonNull BookmarkInfo[] bookmarks)
+  private ItemList createBookmarksList(@NonNull List<BookmarkInfo> bookmarks)
   {
     final Location location = mLocationHelper.getSavedLocation();
     final ItemList.Builder builder = new ItemList.Builder();
@@ -205,9 +240,22 @@ class BookmarksLoader implements BookmarkManager.BookmarksSortingListener
   @Override
   public void onBookmarksSortingCompleted(@NonNull SortedBlock[] sortedBlocks, long timestamp)
   {
+    if (mLastSortTimestamp == 0 || mLastSortTimestamp != timestamp)
+      return;
+    mLastSortTimestamp = 0;
+
     final List<Long> bookmarkIds = new ArrayList<>();
     for (final SortedBlock block : sortedBlocks)
       bookmarkIds.addAll(block.getBookmarkIds());
     loadBookmarks(bookmarkIds);
+  }
+
+  @Override
+  public void onBookmarksSortingCancelled(long timestamp)
+  {
+    if (mLastSortTimestamp == 0 || mLastSortTimestamp != timestamp)
+      return;
+    mLastSortTimestamp = 0;
+    loadBookmarksWithoutSorting();
   }
 }


### PR DESCRIPTION
## Summary
- `BookmarkViewHolder.bind` crashed with `NullPointerException` at `Holders.java:373` when the user scrolled a bookmark list after deleting an item — first seen in `2026.04.07-8-android`. Regression was introduced by e152a342754 ([android] Added bookmark category color), which dropped the `adapter.onDelete(position)` call when both delete handlers switched from position- to id-based selection. The cached id snapshots in `BookmarkListAdapter` (`mSearchResults` in search mode, the per-block id lists in `mSortedResults` in sort mode) then kept the dangling id, and on the next bind `BookmarkManager.getBookmarkInfo(id)` returned `null`.
- Fix in `BookmarksListFragment.deleteBookmarkListItem`: prune the snapshot first (`adapter.removeDeletedItem`), then run the native delete, then refresh the data source and notify. `removeDeletedItem` also drops a hidden sorted snapshot when deleting in search mode (so it can’t reappear stale after search is closed) and drops empty `SortedBlock`s to keep section bookkeeping consistent.
- `BookmarksLoader` (Android Auto) had the same class of bug from the opposite direction — fixed-size `BookmarkInfo[]` assembled from ids without null-checking native lookups, sort callbacks accepted regardless of timestamp. Added `mLastSortTimestamp` guard + `onBookmarksSortingCancelled` fallback, re-read the current bookmarks count before iterating, gated `load()`/`cancel()` with `mIsLoading` so a cancellation mid-load can’t publish a list of deleted ids, and skip `null` `BookmarkInfo`s when collecting results.

Fixes the crash report from `2026.04.07-8-android` (`Holders$BookmarkViewHolder.bind` NPE at line 373).

LLM tools (Claude Code) were used during root-cause investigation and to draft the commit/PR text; the final fix in `BookmarkListAdapter`, `BookmarksListFragment`, and `BookmarksLoader` was authored by hand.

## Test plan
- [ ] Open a category with ≥20 bookmarks, sort by Name (or Distance / Time), long-press a row → Delete → scroll the list. No crash.
- [ ] Same category, activate in-list search → match a few results → long-press → Delete → scroll. No crash; the deleted row is gone, remaining rows render correctly.
- [ ] Sort → delete the last bookmark of a `SortedBlock` (e.g. the only "B"-prefix bookmark when sorted by Name). The block’s section header disappears; total row count drops by 2.
- [ ] Search → delete a row → close search → the unsorted view does not show a phantom sorted snapshot containing the deleted id.
- [ ] Track deletion: delete a track via its menu in both sort and search modes → no crash; section bookkeeping consistent.
- [ ] Android Auto: open a category in the car app, trigger a sort, then quickly back out (cancellation path). No crash; bookmark list renders.
- [ ] Android Auto: open a category, delete a bookmark in the phone UI in parallel (or via a deep link), then reload in the car. Loader doesn’t dereference the deleted id.
- [ ] `./gradlew :app:compileGoogleDebugJavaWithJavac :libs:car:compileDebugJavaWithJavac -Parm64` — clean.
- [ ] `./gradlew :app:testGoogleDebugUnitTest -Parm64` — passes.