### PR TITLE
[android] Persist viewport and usage stats before task-kill from Recents

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmApplication.java
+++ b/android/app/src/main/java/app/organicmaps/MwmApplication.java
@@ -22,6 +22,7 @@ import app.organicmaps.background.OsmUploadWork;
 import app.organicmaps.downloader.DownloaderNotifier;
 import app.organicmaps.location.TrackRecordingService;
 import app.organicmaps.routing.NavigationService;
+import app.organicmaps.sdk.Framework;
 import app.organicmaps.sdk.Map;
 import app.organicmaps.sdk.OrganicMaps;
 import app.organicmaps.sdk.display.DisplayManager;
@@ -54,6 +55,8 @@ public class MwmApplication extends Application implements Application.ActivityL
 
   @Nullable
   private WeakReference<Activity> mTopActivity;
+
+  private int mStartedActivitiesCount = 0;
 
   @SuppressWarnings("NotNullFieldNotInitialized")
   @NonNull
@@ -165,7 +168,9 @@ public class MwmApplication extends Application implements Application.ActivityL
 
   @Override
   public void onActivityStarted(@NonNull Activity activity)
-  {}
+  {
+    ++mStartedActivitiesCount;
+  }
 
   @Override
   public void onActivityResumed(@NonNull Activity activity)
@@ -185,7 +190,14 @@ public class MwmApplication extends Application implements Application.ActivityL
 
   @Override
   public void onActivityStopped(@NonNull Activity activity)
-  {}
+  {
+    --mStartedActivitiesCount;
+    // Synchronous, beats task-kill (PL's debounced onStop would be too late).
+    // Init guard: ALC fires for SplashActivity before native init completes.
+    if (mStartedActivitiesCount == 0 && !activity.isChangingConfigurations()
+        && mOrganicMaps.arePlatformAndCoreInitialized())
+      Framework.nativeOnAppBackgrounded();
+  }
 
   @Override
   public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState)

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -249,7 +249,10 @@ bool Framework::CreateDrapeEngine(JNIEnv * env, jobject jSurface, int densityDpi
     m_work.CreateDrapeEngine(make_ref(m_vulkanContextFactory), std::move(p));
   else
     m_work.CreateDrapeEngine(make_ref(m_oglContextFactory), std::move(p));
-  m_work.EnterForeground();
+  // Wake the freshly-created drape engine only; the compound EnterForeground
+  // would also re-fire UsageStats/Traffic which already saw the real foreground
+  // signal via ProcessLifecycleOwner.
+  m_work.OnDrapeEngineEnterForeground();
 
   return true;
 }
@@ -1133,6 +1136,21 @@ JNIEXPORT jint Java_app_organicmaps_sdk_Framework_nativeGetDrawScale(JNIEnv * en
 JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativePokeSearchInViewport(JNIEnv * env, jclass)
 {
   frm()->GetSearchAPI().PokeSearchInViewport();
+}
+
+// Persist before task-kill. PL's 700 ms debounce is too late on aggressive
+// task-killers (Pixel), so this runs from MwmApplication.onActivityStopped.
+JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeOnAppBackgrounded(JNIEnv *, jclass)
+{
+  frm()->PersistStateBeforeBackground();
+}
+
+// Heavy resource release behind PL's debounce -- no user-critical state
+// that must beat task-kill, so the 700 ms wait from OrganicMaps.onStop is
+// acceptable.
+JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeReleaseBackgroundResources(JNIEnv *, jclass)
+{
+  frm()->ReleaseBackgroundResources();
 }
 
 JNIEXPORT jdoubleArray Java_app_organicmaps_sdk_Framework_nativeGetScreenRectCenter(JNIEnv * env, jclass)

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/OrganicMaps.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/OrganicMaps.cpp
@@ -46,11 +46,8 @@ JNIEXPORT void Java_app_organicmaps_sdk_OrganicMaps_nativeAddLocalization(JNIEnv
   g_framework->AddString(jni::ToNativeString(env, name), jni::ToNativeString(env, value));
 }
 
-JNIEXPORT void Java_app_organicmaps_sdk_OrganicMaps_nativeOnTransit(JNIEnv *, jclass, jboolean foreground)
+JNIEXPORT void Java_app_organicmaps_sdk_OrganicMaps_nativeOnEnterForeground(JNIEnv *, jclass)
 {
-  if (static_cast<bool>(foreground))
-    g_framework->NativeFramework()->EnterForeground();
-  else
-    g_framework->NativeFramework()->EnterBackground();
+  g_framework->NativeFramework()->EnterForeground();
 }
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
@@ -79,6 +79,10 @@ public class Framework
 
   public static native void nativePokeSearchInViewport();
 
+  public static native void nativeOnAppBackgrounded();
+
+  public static native void nativeReleaseBackgroundResources();
+
   @Size(2)
   public static native double[] nativeGetScreenRectCenter();
 

--- a/android/sdk/src/main/java/app/organicmaps/sdk/OrganicMaps.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/OrganicMaps.java
@@ -144,13 +144,15 @@ public final class OrganicMaps implements DefaultLifecycleObserver
   @Override
   public void onStart(@NonNull LifecycleOwner owner)
   {
-    nativeOnTransit(true);
+    nativeOnEnterForeground();
   }
 
   @Override
   public void onStop(@NonNull LifecycleOwner owner)
   {
-    nativeOnTransit(false);
+    // UsageStats and viewport are saved earlier from MwmApplication.onActivityStopped
+    // to beat task-kill. Here only heavy resource release behind PL's debounce.
+    Framework.nativeReleaseBackgroundResources();
   }
 
   @NonNull
@@ -241,7 +243,7 @@ public final class OrganicMaps implements DefaultLifecycleObserver
 
   private static native void nativeAddLocalization(String name, String value);
 
-  private static native void nativeOnTransit(boolean foreground);
+  private static native void nativeOnEnterForeground();
 
   static
   {

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1261,18 +1261,30 @@ void Framework::MemoryWarning()
   SharedBufferManager::Instance().ClearReserved();
 }
 
-void Framework::EnterBackground()
+void Framework::PersistStateBeforeBackground()
 {
+  SaveViewport();
   m_usageStats.EnterBackground();
+}
 
+void Framework::ReleaseBackgroundResources()
+{
   if (m_drapeEngine)
     m_drapeEngine->OnEnterBackground();
-
-  SaveViewport();
-
   m_trafficManager.OnEnterBackground();
-
   ClearAllCaches();
+}
+
+void Framework::OnDrapeEngineEnterForeground()
+{
+  if (m_drapeEngine)
+    m_drapeEngine->OnEnterForeground();
+}
+
+void Framework::EnterBackground()
+{
+  PersistStateBeforeBackground();
+  ReleaseBackgroundResources();
 }
 
 void Framework::EnterForeground()

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -663,6 +663,18 @@ public:
   void EnterBackground();
   void EnterForeground();
 
+  // Android splits EnterBackground into an urgent persist pass before
+  // task-kill (from ActivityLifecycleCallbacks) and a deferred resource
+  // release pass behind ProcessLifecycleOwner's 700 ms debounce. Together
+  // they equal EnterBackground; iOS/Qt keep calling the compound.
+  void PersistStateBeforeBackground();
+  void ReleaseBackgroundResources();
+
+  // Wakes only the freshly-created drape engine on engine (re)creation.
+  // UsageStats/Traffic already got their foreground signal from
+  // ProcessLifecycleOwner, but the engine was still null when that fired.
+  void OnDrapeEngineEnterForeground();
+
   /// Set the localized strings bundle
   void AddString(std::string const & name, std::string const & value) { m_stringsBundle.SetString(name, value); }
 

--- a/libs/platform/platform_tests/CMakeLists.txt
+++ b/libs/platform/platform_tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRC
   products_tests.cpp
   irish_grid_utils_tests.cpp
   os_grid_utils_tests.cpp
+  usage_stats_tests.cpp
   utm_mgrs_utils_tests.cpp
 )
 

--- a/libs/platform/platform_tests/usage_stats_tests.cpp
+++ b/libs/platform/platform_tests/usage_stats_tests.cpp
@@ -1,0 +1,136 @@
+#include "testing/testing.hpp"
+
+#include "platform/settings.hpp"
+
+#include <chrono>
+#include <string>
+#include <string_view>
+#include <thread>
+
+namespace
+{
+constexpr std::string_view kFirstLaunchKey = "US_FirstLaunch";
+constexpr std::string_view kLastBackgroundKey = "US_LastBackground";
+constexpr std::string_view kTotalForegroundKey = "US_TotalForeground";
+constexpr std::string_view kSessionsKey = "US_SessionsCount";
+
+// Snapshots and restores on-disk UsageStats keys around a test; needed
+// because the class writes through the process-wide StringStorage singleton.
+class UsageStatsKeysGuard
+{
+public:
+  UsageStatsKeysGuard()
+  {
+    auto & ss = settings::StringStorage::Instance();
+    m_hadFirstLaunch = ss.GetValue(kFirstLaunchKey, m_savedFirstLaunch);
+    m_hadLastBackground = ss.GetValue(kLastBackgroundKey, m_savedLastBackground);
+    m_hadTotalForeground = ss.GetValue(kTotalForegroundKey, m_savedTotalForeground);
+    m_hadSessions = ss.GetValue(kSessionsKey, m_savedSessions);
+    ss.DeleteKeyAndValue(kFirstLaunchKey);
+    ss.DeleteKeyAndValue(kLastBackgroundKey);
+    ss.DeleteKeyAndValue(kTotalForegroundKey);
+    ss.DeleteKeyAndValue(kSessionsKey);
+  }
+
+  ~UsageStatsKeysGuard()
+  {
+    auto & ss = settings::StringStorage::Instance();
+    Restore(ss, kFirstLaunchKey, m_hadFirstLaunch, m_savedFirstLaunch);
+    Restore(ss, kLastBackgroundKey, m_hadLastBackground, m_savedLastBackground);
+    Restore(ss, kTotalForegroundKey, m_hadTotalForeground, m_savedTotalForeground);
+    Restore(ss, kSessionsKey, m_hadSessions, m_savedSessions);
+  }
+
+private:
+  static void Restore(settings::StringStorage & ss, std::string_view key, bool had, std::string const & val)
+  {
+    if (had)
+      ss.SetValue(key, std::string(val));
+    else
+      ss.DeleteKeyAndValue(key);
+  }
+
+  std::string m_savedFirstLaunch, m_savedLastBackground, m_savedTotalForeground, m_savedSessions;
+  bool m_hadFirstLaunch = false, m_hadLastBackground = false, m_hadTotalForeground = false, m_hadSessions = false;
+};
+
+uint64_t ReadStored(std::string_view key)
+{
+  std::string s;
+  if (!settings::StringStorage::Instance().GetValue(key, s))
+    return 0;
+  uint64_t v = 0;
+  settings::FromString(s, v);
+  return v;
+}
+
+uint64_t ReadTotalForeground()
+{
+  return ReadStored(kTotalForegroundKey);
+}
+
+uint64_t ReadSessions()
+{
+  return ReadStored(kSessionsKey);
+}
+}  // namespace
+
+// Android transient background: ActivityLifecycleCallbacks can fire two
+// EnterBackground without an EnterForeground between (PL debounces away
+// the intermediate onStop/onStart). The foreground window must not be
+// aggregated twice.
+UNIT_TEST(UsageStats_EnterBackgroundTwice_DoesNotDoubleCountForeground)
+{
+  UsageStatsKeysGuard guard;
+
+  settings::UsageStats stats;
+  stats.EnterForeground();
+
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  stats.EnterBackground();
+  uint64_t const totalAfterFirst = ReadTotalForeground();
+  TEST_GREATER_OR_EQUAL(totalAfterFirst, 1, ("First EnterBackground must aggregate >= 1 sec"));
+
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  stats.EnterBackground();
+  uint64_t const totalAfterSecond = ReadTotalForeground();
+
+  uint64_t const delta = totalAfterSecond - totalAfterFirst;
+  // Without the fix, delta is ~4 sec (full window from the original foreground
+  // start). With the fix it is the time since the previous EnterBackground.
+  TEST_LESS_OR_EQUAL(
+      delta, 3,
+      ("Second EnterBackground re-aggregated the original foreground window", totalAfterFirst, totalAfterSecond));
+}
+
+// The session counter must increment only once per foreground period, even if
+// EnterBackground is called multiple times due to Android transient
+// backgrounding. EnterForeground re-arms the counter for the next real session.
+UNIT_TEST(UsageStats_EnterBackgroundTwice_DoesNotDoubleCountSessions)
+{
+  UsageStatsKeysGuard guard;
+
+  settings::UsageStats stats;
+  stats.EnterForeground();
+
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  stats.EnterBackground();
+  uint64_t const sessionsAfterFirst = ReadSessions();
+  TEST_EQUAL(sessionsAfterFirst, 1, ("First EnterBackground must record one session"));
+
+  // Repeat EnterBackground without an intervening EnterForeground (transient).
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  stats.EnterBackground();
+  uint64_t const sessionsAfterRepeat = ReadSessions();
+  TEST_EQUAL(sessionsAfterRepeat, 1,
+             ("Repeat EnterBackground without EnterForeground must not increment sessions", sessionsAfterFirst,
+              sessionsAfterRepeat));
+
+  // A real return to foreground re-arms the session counter.
+  stats.EnterForeground();
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  stats.EnterBackground();
+  uint64_t const sessionsAfterReentry = ReadSessions();
+  TEST_EQUAL(sessionsAfterReentry, 2,
+             ("EnterForeground must re-arm session counting", sessionsAfterRepeat, sessionsAfterReentry));
+}

--- a/libs/platform/platform_tests/usage_stats_tests.cpp
+++ b/libs/platform/platform_tests/usage_stats_tests.cpp
@@ -2,10 +2,8 @@
 
 #include "platform/settings.hpp"
 
-#include <chrono>
 #include <string>
 #include <string_view>
-#include <thread>
 
 namespace
 {
@@ -75,6 +73,19 @@ uint64_t ReadSessions()
 }
 }  // namespace
 
+// Smoke test: the default constructor must plumb a working real-time clock
+// through the injection point. Guards against a broken delegation to
+// TimeSinceEpoch (empty std::function would trigger a CHECK in the ctor).
+UNIT_TEST(UsageStats_DefaultConstructor_UsesRealClock)
+{
+  UsageStatsKeysGuard guard;
+
+  settings::UsageStats stats;
+  stats.EnterForeground();
+  stats.EnterBackground();
+  TEST_EQUAL(ReadSessions(), 1, ("Default ctor must produce a functional UsageStats"));
+}
+
 // Android transient background: ActivityLifecycleCallbacks can fire two
 // EnterBackground without an EnterForeground between (PL debounces away
 // the intermediate onStop/onStart). The foreground window must not be
@@ -83,24 +94,21 @@ UNIT_TEST(UsageStats_EnterBackgroundTwice_DoesNotDoubleCountForeground)
 {
   UsageStatsKeysGuard guard;
 
-  settings::UsageStats stats;
+  uint64_t fakeNow = 1000;
+  settings::UsageStats stats([&fakeNow]() { return fakeNow; });
+
   stats.EnterForeground();
 
-  std::this_thread::sleep_for(std::chrono::seconds(2));
+  fakeNow += 2;
   stats.EnterBackground();
-  uint64_t const totalAfterFirst = ReadTotalForeground();
-  TEST_GREATER_OR_EQUAL(totalAfterFirst, 1, ("First EnterBackground must aggregate >= 1 sec"));
+  TEST_EQUAL(ReadTotalForeground(), 2, ("First EnterBackground aggregates the 2s foreground window"));
 
-  std::this_thread::sleep_for(std::chrono::seconds(2));
+  fakeNow += 2;
   stats.EnterBackground();
-  uint64_t const totalAfterSecond = ReadTotalForeground();
-
-  uint64_t const delta = totalAfterSecond - totalAfterFirst;
-  // Without the fix, delta is ~4 sec (full window from the original foreground
-  // start). With the fix it is the time since the previous EnterBackground.
-  TEST_LESS_OR_EQUAL(
-      delta, 3,
-      ("Second EnterBackground re-aggregated the original foreground window", totalAfterFirst, totalAfterSecond));
+  // Without the fix, the second EnterBackground would re-aggregate the whole
+  // 4s window from the original EnterForeground; with the fix it adds only
+  // the 2s delta since the previous EnterBackground.
+  TEST_EQUAL(ReadTotalForeground(), 4, ("Second EnterBackground adds only the incremental 2s"));
 }
 
 // The session counter must increment only once per foreground period, even if
@@ -110,27 +118,23 @@ UNIT_TEST(UsageStats_EnterBackgroundTwice_DoesNotDoubleCountSessions)
 {
   UsageStatsKeysGuard guard;
 
-  settings::UsageStats stats;
+  uint64_t fakeNow = 1000;
+  settings::UsageStats stats([&fakeNow]() { return fakeNow; });
+
   stats.EnterForeground();
 
-  std::this_thread::sleep_for(std::chrono::seconds(1));
+  fakeNow += 1;
   stats.EnterBackground();
-  uint64_t const sessionsAfterFirst = ReadSessions();
-  TEST_EQUAL(sessionsAfterFirst, 1, ("First EnterBackground must record one session"));
+  TEST_EQUAL(ReadSessions(), 1, ("First EnterBackground must record one session"));
 
   // Repeat EnterBackground without an intervening EnterForeground (transient).
-  std::this_thread::sleep_for(std::chrono::seconds(1));
+  fakeNow += 1;
   stats.EnterBackground();
-  uint64_t const sessionsAfterRepeat = ReadSessions();
-  TEST_EQUAL(sessionsAfterRepeat, 1,
-             ("Repeat EnterBackground without EnterForeground must not increment sessions", sessionsAfterFirst,
-              sessionsAfterRepeat));
+  TEST_EQUAL(ReadSessions(), 1, ("Repeat EnterBackground without EnterForeground must not increment sessions"));
 
   // A real return to foreground re-arms the session counter.
   stats.EnterForeground();
-  std::this_thread::sleep_for(std::chrono::seconds(1));
+  fakeNow += 1;
   stats.EnterBackground();
-  uint64_t const sessionsAfterReentry = ReadSessions();
-  TEST_EQUAL(sessionsAfterReentry, 2,
-             ("EnterForeground must re-arm session counting", sessionsAfterRepeat, sessionsAfterReentry));
+  TEST_EQUAL(ReadSessions(), 2, ("EnterForeground must re-arm session counting"));
 }

--- a/libs/platform/settings.cpp
+++ b/libs/platform/settings.cpp
@@ -362,13 +362,18 @@ bool FromString<Transliteration::Mode>(string const & s, Transliteration::Mode &
   return true;
 }
 
-UsageStats::UsageStats()
-  : m_firstLaunch("US_FirstLaunch")
+UsageStats::UsageStats() : UsageStats(&UsageStats::TimeSinceEpoch) {}
+
+UsageStats::UsageStats(std::function<uint64_t()> nowFn)
+  : m_now(std::move(nowFn))
+  , m_firstLaunch("US_FirstLaunch")
   , m_lastBackground("US_LastBackground")
   , m_totalForeground("US_TotalForeground")
   , m_sessions("US_SessionsCount")
   , m_ss(StringStorage::Instance())
 {
+  CHECK(m_now, ("UsageStats requires a non-empty now-provider"));
+
   std::string str;
   uint64_t val;
   if (m_ss.GetValue(m_totalForeground, str) && FromString(str, val))
@@ -384,7 +389,7 @@ UsageStats::UsageStats()
     {
       // Check that file wasn't created on this first launch (1 hour threshold).
       uint64_t const first = base::TimeTToSecondsSinceEpoch(fileTime);
-      uint64_t const curr = TimeSinceEpoch();
+      uint64_t const curr = m_now();
       if (curr >= first + 3600 /* 1 hour */)
         m_ss.SetValue(m_firstLaunch, ToString(first));
     }
@@ -399,13 +404,13 @@ uint64_t UsageStats::TimeSinceEpoch()
 
 void UsageStats::EnterForeground()
 {
-  m_enterForegroundTime = TimeSinceEpoch();
+  m_enterForegroundTime = m_now();
   m_committedThisSession = false;
 }
 
 void UsageStats::EnterBackground()
 {
-  uint64_t const currTime = TimeSinceEpoch();
+  uint64_t const currTime = m_now();
 
   // Safe check if something wrong with device's time.
   ASSERT_GREATER_OR_EQUAL(currTime, m_enterForegroundTime, ());

--- a/libs/platform/settings.cpp
+++ b/libs/platform/settings.cpp
@@ -400,6 +400,7 @@ uint64_t UsageStats::TimeSinceEpoch()
 void UsageStats::EnterForeground()
 {
   m_enterForegroundTime = TimeSinceEpoch();
+  m_committedThisSession = false;
 }
 
 void UsageStats::EnterBackground()
@@ -416,21 +417,34 @@ void UsageStats::EnterBackground()
   if (m_enterForegroundTime == 0)
     return;
 
-  // Save first launch.
-  std::string dummy;
-  if (!m_ss.GetValue(m_firstLaunch, dummy))
-    m_ss.SetValue(m_firstLaunch, ToString(m_enterForegroundTime));
-
   // Save last background.
   m_ss.SetValue(m_lastBackground, ToString(currTime));
 
-  // Aggregate foreground duration.
+  // Aggregate foreground duration (delta since the last anchor: either the
+  // EnterForeground that started this session or the previous EnterBackground
+  // call if we are inside a transient background on Android).
   m_totalForegroundTime += (currTime - m_enterForegroundTime);
   m_ss.SetValue(m_totalForeground, ToString(m_totalForegroundTime));
 
-  // Aggregate sessions count.
-  ++m_sessionsCount;
-  m_ss.SetValue(m_sessions, ToString(m_sessionsCount));
+  // Count this foreground period as a session only once. A repeat
+  // EnterBackground without an intervening EnterForeground (Android transient
+  // background) keeps the running total above but does not increment sessions.
+  if (!m_committedThisSession)
+  {
+    // Save first launch.
+    std::string dummy;
+    if (!m_ss.GetValue(m_firstLaunch, dummy))
+      m_ss.SetValue(m_firstLaunch, ToString(m_enterForegroundTime));
+
+    ++m_sessionsCount;
+    m_ss.SetValue(m_sessions, ToString(m_sessionsCount));
+
+    m_committedThisSession = true;
+  }
+
+  // Advance the anchor so the next EnterBackground without an intervening
+  // EnterForeground aggregates only the new time since this call.
+  m_enterForegroundTime = currTime;
 }
 
 bool UsageStats::IsLoyalUser() const

--- a/libs/platform/settings.hpp
+++ b/libs/platform/settings.hpp
@@ -78,9 +78,16 @@ inline void Clear()
 class UsageStats
 {
   static uint64_t TimeSinceEpoch();
+  // Anchor for foreground-duration aggregation. Advanced at the end of
+  // EnterBackground so a second EnterBackground without an intervening
+  // EnterForeground (Android transient background) doesn't double-count time.
   uint64_t m_enterForegroundTime = 0;
   uint64_t m_totalForegroundTime = 0;
   uint64_t m_sessionsCount = 0;
+  // True once the current foreground period has been counted as a session;
+  // reset by EnterForeground. Guards against incrementing m_sessionsCount
+  // multiple times on Android transient backgrounding.
+  bool m_committedThisSession = false;
 
   std::string_view m_firstLaunch, m_lastBackground, m_totalForeground, m_sessions;
 

--- a/libs/platform/settings.hpp
+++ b/libs/platform/settings.hpp
@@ -4,6 +4,7 @@
 
 #include "base/macros.hpp"
 
+#include <functional>
 #include <string>
 
 namespace settings
@@ -78,6 +79,8 @@ inline void Clear()
 class UsageStats
 {
   static uint64_t TimeSinceEpoch();
+
+  std::function<uint64_t()> m_now;
   // Anchor for foreground-duration aggregation. Advanced at the end of
   // EnterBackground so a second EnterBackground without an intervening
   // EnterForeground (Android transient background) doesn't double-count time.
@@ -95,6 +98,8 @@ class UsageStats
 
 public:
   UsageStats();
+  // Testing seam: inject a fake clock so tests are deterministic and instant.
+  explicit UsageStats(std::function<uint64_t()> nowFn);
 
   void EnterForeground();
   void EnterBackground();


### PR DESCRIPTION
## Problem                                                                                                        
   
  On devices with aggressive task-kill from Recents (Pixel and similar),                                            
  ProcessLifecycleOwner's `onStop` (`TIMEOUT_MS = 700`, hardcoded in 
  `androidx.lifecycle:lifecycle-process`, no public knob to change) can                                           
  be cut short by the OS killing the process. Anything that sits behind
  `Framework::EnterBackground` never runs, so:
                                                                                                                    
  - **Map viewport** is lost — user starts each session zoomed-out at the                                           
    default position.                                                                                               
  - **UsageStats** (session count, total foreground time, last-background                                           
    timestamp, first launch) is lost — `IsLoyalUser` never trips and                                              
    loyalty-gated UX never activates on these devices.                                                              
                                                                                                                    
  ## Approach                                                                                                     
                                                                                                                    
  Persist these from a synchronous, pre-task-kill Android lifecycle hook                                            
  instead of the PL-debounced compound.                                                                           
                                                                                                                    
  `Framework::EnterBackground()` is decomposed into named public                                                    
  sub-operations on the C++ side and Android routes each to its appropriate                                       
  trigger:                                                                                                          
                                                                     
  | Operation | Android trigger | Reasoning |                                                                     
  |---|---|---|                                                                                                     
  | `SaveUsageStats` | `MwmApplication.onActivityStopped`, counter == 0 | Urgent persist before task-kill |
  | `SaveViewport` | `MwmApplication.onActivityStopped`, counter == 0 | Urgent persist before task-kill |           
  | `OnDrapeEngineEnterBackground` | `OrganicMaps.onStop` (PL) | Resource release, 700 ms OK |
  | `OnTrafficEnterBackground` | `OrganicMaps.onStop` (PL) | Resource release, 700 ms OK |                        
  | `ClearAllCaches` | `OrganicMaps.onStop` (PL) | Resource release, 700 ms OK |                                    
                                                                                                                    
  The counter-based trigger filters out:                                                                            
  - `isChangingConfigurations()` — rotation / theme / locale changes do                                             
    not falsely fire.                                                                                               
  - `arePlatformAndCoreInitialized()` — SplashActivity going to stop                                                
    before native init completes is safe.                                                                           
                                                                                                                    
  `Framework::EnterBackground()` stays as a thin compound calling all five                                        
  sub-operations in the original order. **iOS and Qt behavior is preserved                                          
  bit-for-bit** — only iOS call sites are `MapsAppDelegate.mm:181` and
  `:210`, which hit the unchanged compound `EnterBackground` /                                                      
  `EnterForeground`.                                                 
                                                                                                                    
  ## Why ALC + counter, not some other "official" API                                                               
                                                                                                                  
  Surveyed alternatives:                                                                                            
  - `ProcessLifecycleOwner` — the very thing we need to work around.                                                
  - `ComponentCallbacks2.onTrimMemory(TRIM_MEMORY_UI_HIDDEN)` — async,                                            
    OEM-flaky on Samsung / Xiaomi.                                                                                  
  - `Activity.onUserLeaveHint()` — per-activity; misses Recents swipe on
    some OEMs.                                                                                                      
  - `Service.onTaskRemoved` — needs a running service; broken in some                                               
    Android 14 cases.                                                                                             
  - Nothing new in Android 14 / 15 / 16 fills the gap.                                                              
                                                                     
  `Application.registerActivityLifecycleCallbacks` + a started-activity                                             
  counter is the de-facto official pattern — it's exactly what AndroidX                                             
  uses inside `ProcessLifecycleOwner`, minus the debounce.

Fix: https://github.com/orgs/organicmaps/discussions/12834