### PR TITLE
[android] Lifecycle test logs

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1079,6 +1079,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   protected void onResume()
   {
+    Logger.i(TAG, "[LIFECYCLE_TEST] MwmActivity.onResume begin");
     super.onResume();
     ThemeSwitcher.INSTANCE.synchronizeApplicationTheme();
     ThemeSwitcher.INSTANCE.synchronizeMapStyle(this, mMapController.isRenderingActive());
@@ -1099,6 +1100,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     refreshLightStatusBar();
 
     MwmApplication.from(this).getSensorHelper().addListener(this);
+    Logger.i(TAG, "[LIFECYCLE_TEST] MwmActivity.onResume end");
   }
 
   @Override
@@ -1111,17 +1113,20 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   protected void onPause()
   {
+    Logger.i(TAG, "[LIFECYCLE_TEST] MwmActivity.onPause begin");
     if (mOnmapDownloader != null)
       mOnmapDownloader.onPause();
     MwmApplication.from(this).getSensorHelper().removeListener(this);
     dismissLocationErrorDialog();
     dismissAlertDialog();
     super.onPause();
+    Logger.i(TAG, "[LIFECYCLE_TEST] MwmActivity.onPause end");
   }
 
   @Override
   protected void onStart()
   {
+    Logger.i(TAG, "[LIFECYCLE_TEST] MwmActivity.onStart begin");
     super.onStart();
     Framework.nativePlacePageActivationListener(this);
     BookmarkManager.INSTANCE.addLoadingListener(this);
@@ -1131,11 +1136,13 @@ public class MwmActivity extends BaseMwmFragmentActivity
     MwmApplication.from(this).getLocationHelper().addListener(this);
     mSearchController.attach(this);
     Utils.keepScreenOn(Config.isKeepScreenOnEnabled() || RoutingController.get().isNavigating(), getWindow());
+    Logger.i(TAG, "[LIFECYCLE_TEST] MwmActivity.onStart end");
   }
 
   @Override
   protected void onStop()
   {
+    Logger.i(TAG, "[LIFECYCLE_TEST] MwmActivity.onStop begin");
     super.onStop();
     Framework.nativeRemovePlacePageActivationListener(this);
     BookmarkManager.INSTANCE.removeLoadingListener(this);
@@ -1151,6 +1158,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     final String backUrl = Framework.nativeGetParsedBackUrl();
     if (!TextUtils.isEmpty(backUrl))
       Utils.openUri(this, Uri.parse(backUrl), null);
+    Logger.i(TAG, "[LIFECYCLE_TEST] MwmActivity.onStop end");
   }
 
   @CallSuper

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/OrganicMaps.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/OrganicMaps.cpp
@@ -4,6 +4,8 @@
 
 #include "app/organicmaps/sdk/core/jni_helper.hpp"
 
+#include "base/logging.hpp"
+
 extern "C"
 {
 // static void nativeSetSettingsDir(String settingsPath);
@@ -48,6 +50,7 @@ JNIEXPORT void Java_app_organicmaps_sdk_OrganicMaps_nativeAddLocalization(JNIEnv
 
 JNIEXPORT void Java_app_organicmaps_sdk_OrganicMaps_nativeOnTransit(JNIEnv *, jclass, jboolean foreground)
 {
+  LOG(LINFO, ("[LIFECYCLE_TEST] JNI nativeOnTransit foreground =", static_cast<bool>(foreground)));
   if (static_cast<bool>(foreground))
     g_framework->NativeFramework()->EnterForeground();
   else

--- a/android/sdk/src/main/java/app/organicmaps/sdk/OrganicMaps.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/OrganicMaps.java
@@ -144,12 +144,28 @@ public final class OrganicMaps implements DefaultLifecycleObserver
   @Override
   public void onStart(@NonNull LifecycleOwner owner)
   {
+    Logger.i(TAG, "[LIFECYCLE_TEST] ProcessLifecycleOwner.onStart -> EnterForeground");
     nativeOnTransit(true);
+  }
+
+  @Override
+  public void onResume(@NonNull LifecycleOwner owner)
+  {
+    Logger.i(TAG, "[LIFECYCLE_TEST] ProcessLifecycleOwner.onResume");
+    DefaultLifecycleObserver.super.onResume(owner);
+  }
+
+  @Override
+  public void onPause(@NonNull LifecycleOwner owner)
+  {
+    Logger.i(TAG, "[LIFECYCLE_TEST] ProcessLifecycleOwner.onPause");
+    DefaultLifecycleObserver.super.onPause(owner);
   }
 
   @Override
   public void onStop(@NonNull LifecycleOwner owner)
   {
+    Logger.i(TAG, "[LIFECYCLE_TEST] ProcessLifecycleOwner.onStop -> EnterBackground");
     nativeOnTransit(false);
   }
 

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1190,6 +1190,7 @@ void Framework::MemoryWarning()
 
 void Framework::EnterBackground()
 {
+  LOG(LINFO, ("[LIFECYCLE_TEST] Framework::EnterBackground begin"));
   m_usageStats.EnterBackground();
 
   if (m_drapeEngine)
@@ -1200,10 +1201,12 @@ void Framework::EnterBackground()
   m_trafficManager.OnEnterBackground();
 
   ClearAllCaches();
+  LOG(LINFO, ("[LIFECYCLE_TEST] Framework::EnterBackground end"));
 }
 
 void Framework::EnterForeground()
 {
+  LOG(LINFO, ("[LIFECYCLE_TEST] Framework::EnterForeground"));
   m_usageStats.EnterForeground();
 
   if (m_drapeEngine)


### PR DESCRIPTION
## Google Pixel 6 - Android 16

#### Launch app (same for all cases)
(main) OrganicMaps.java:147 onStart(): [LIFECYCLE_TEST] ProcessLifecycleOwner.onStart -> EnterForeground
(main) sdk/OrganicMaps.cpp:53 Java_app_organicmaps_sdk_OrganicMaps_nativeOnTransit(): [LIFECYCLE_TEST] JNI nativeOnTransit foreground = 1
(main) map/framework.cpp:1209 EnterForeground(): [LIFECYCLE_TEST] Framework::EnterForeground
(main) OrganicMaps.java:154 onResume(): [LIFECYCLE_TEST] ProcessLifecycleOwner.onResume
(main) MwmActivity.java:1129 onStart(): [LIFECYCLE_TEST] MwmActivity.onStart begin
(main) MwmActivity.java:1139 onStart(): [LIFECYCLE_TEST] MwmActivity.onStart end
(main) MwmActivity.java:1082 onResume(): [LIFECYCLE_TEST] MwmActivity.onResume begin
(main) MwmActivity.java:1103 onResume(): [LIFECYCLE_TEST] MwmActivity.onResume end
(main) map/framework.cpp:1209 EnterForeground(): [LIFECYCLE_TEST] Framework::EnterForeground

### 1. Issue case (launch app -> recent apps -> swipe up -> process killed)
#### -> recent apps -> swipe up
(main) MwmActivity.java:1116 onPause(): [LIFECYCLE_TEST] MwmActivity.onPause begin
(main) MwmActivity.java:1123 onPause(): [LIFECYCLE_TEST] MwmActivity.onPause end
(main) MwmActivity.java:1145 onStop(): [LIFECYCLE_TEST] MwmActivity.onStop begin
(main) MwmActivity.java:1161 onStop(): [LIFECYCLE_TEST] MwmActivity.onStop end
#### -> process killed

### 2. Normal case (launch app -> click home -> recent apps -> swipe up -> process killed)
#### -> click home
(main) MwmActivity.java:1116 onPause(): [LIFECYCLE_TEST] MwmActivity.onPause begin
(main) MwmActivity.java:1123 onPause(): [LIFECYCLE_TEST] MwmActivity.onPause end
(main) MwmActivity.java:1145 onStop(): [LIFECYCLE_TEST] MwmActivity.onStop begin
(main) MwmActivity.java:1161 onStop(): [LIFECYCLE_TEST] MwmActivity.onStop end
(main) OrganicMaps.java:161 onPause(): [LIFECYCLE_TEST] ProcessLifecycleOwner.onPause
(main) OrganicMaps.java:168 onStop(): [LIFECYCLE_TEST] ProcessLifecycleOwner.onStop -> EnterBackground
(main) sdk/OrganicMaps.cpp:53 Java_app_organicmaps_sdk_OrganicMaps_nativeOnTransit(): [LIFECYCLE_TEST] JNI nativeOnTransit foreground = 0
(main) map/framework.cpp:1193 EnterBackground(): [LIFECYCLE_TEST] Framework::EnterBackground begin
(main) map/framework.cpp:1204 EnterBackground(): [LIFECYCLE_TEST] Framework::EnterBackground end
#### -> recent apps -> swipe up
#### -> process killed



