### PR TITLE
[android] Fix map controls hidden behind route plan after POI close

### DIFF
--- a/android/app/src/main/java/app/organicmaps/maplayer/MapButtonsController.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/MapButtonsController.java
@@ -58,6 +58,7 @@ public class MapButtonsController extends Fragment
   FloatingActionButton mTrackRecordingStatusButton;
   @Nullable
   private MyPositionButton mNavMyPosition;
+  private View mMainMenuFrame;
   private SearchWheel mSearchWheel;
   private BadgeDrawable mBadgeDrawable;
   @Nullable
@@ -100,6 +101,7 @@ public class MapButtonsController extends Fragment
     mInnerLeftButtonsFrame = mFrame.findViewById(R.id.map_buttons_inner_left);
     mInnerRightButtonsFrame = mFrame.findViewById(R.id.map_buttons_inner_right);
     mBottomButtonsFrame = mFrame.findViewById(R.id.map_buttons_bottom);
+    mMainMenuFrame = activity.findViewById(R.id.menu_frame);
 
     final FloatingActionButton helpButton = mFrame.findViewById(R.id.help_button);
     final View zoomFrame = mFrame.findViewById(R.id.zoom_buttons_container);
@@ -333,6 +335,9 @@ public class MapButtonsController extends Fragment
   {
     if (mContentHeight == 0)
       return;
+
+    if (UiUtils.isVisible(mMainMenuFrame) && mMainMenuFrame.getTop() > 0)
+      translationY = Math.min(translationY, mMainMenuFrame.getTop());
 
     // Move the buttons containers to follow the place page
     if (mInnerRightButtonsFrame != null


### PR DESCRIPTION
## Summary
  - Side map controls (My Position, zoom, bookmarks, search) end up behind the route plan summary panel after closing a place page that was opened during route planning.
  - Root cause: `PlacePageDistanceToTop` is a single `LiveData` shared by two writers — `PlacePageController.onSlide` and `MainMenu`'s visibility callback in `MwmActivity`. On PP close the slide writer sets a value
 - Fix: clamp `MapButtonsController.move()` to `menuFrame.getTop()` while the panel is visible, so buttons settle above it. 

Fixes: https://github.com/organicmaps/organicmaps/issues/12833