### PR TITLE
[search] Show operator for unnamed results

### DIFF
--- a/libs/search/ranker.cpp
+++ b/libs/search/ranker.cpp
@@ -413,12 +413,18 @@ private:
     center = feature::GetCenter(*ft);
     m_ranker.GetBestMatchName(*ft, name);
 
-    // Use brand instead of empty result name.
+    // Use brand instead of empty result name. If no brand try to use operator.
     if (!m_isViewportMode && name.empty())
     {
       std::string_view brand = (*ft).GetMetadata(feature::Metadata::FMD_BRAND);
       if (!brand.empty())
         name = platform::GetLocalizedBrandName(std::string{brand});
+      else
+      {
+        std::string_view op = (*ft).GetMetadata(feature::Metadata::FMD_OPERATOR);
+        if (!op.empty())
+          name = op;
+      }
     }
 
     /// @todo Ensure that we actually need to get and assign address here? Needed for the ranking?

--- a/libs/search/ranker.cpp
+++ b/libs/search/ranker.cpp
@@ -416,15 +416,10 @@ private:
     // Use brand instead of empty result name. If no brand try to use operator.
     if (!m_isViewportMode && name.empty())
     {
-      std::string_view brand = (*ft).GetMetadata(feature::Metadata::FMD_BRAND);
-      if (!brand.empty())
-        name = platform::GetLocalizedBrandName(std::string{brand});
-      else
-      {
-        std::string_view op = (*ft).GetMetadata(feature::Metadata::FMD_OPERATOR);
-        if (!op.empty())
-          name = op;
-      }
+    if (auto const brand = ft->GetMetadata(feature::Metadata::FMD_BRAND); !brand.empty())
+      name = platform::GetLocalizedBrandName(std::string{brand});
+    else if (auto const op = ft->GetMetadata(feature::Metadata::FMD_OPERATOR); !op.empty())
+      name = op;
     }
 
     /// @todo Ensure that we actually need to get and assign address here? Needed for the ranking?

--- a/libs/search/ranker.cpp
+++ b/libs/search/ranker.cpp
@@ -416,10 +416,10 @@ private:
     // Use brand instead of empty result name. If no brand try to use operator.
     if (!m_isViewportMode && name.empty())
     {
-    if (auto const brand = ft->GetMetadata(feature::Metadata::FMD_BRAND); !brand.empty())
-      name = platform::GetLocalizedBrandName(std::string{brand});
-    else if (auto const op = ft->GetMetadata(feature::Metadata::FMD_OPERATOR); !op.empty())
-      name = op;
+      if (auto const brand = ft->GetMetadata(feature::Metadata::FMD_BRAND); !brand.empty())
+        name = platform::GetLocalizedBrandName(std::string{brand});
+      else if (auto const op = ft->GetMetadata(feature::Metadata::FMD_OPERATOR); !op.empty())
+        name = op;
     }
 
     /// @todo Ensure that we actually need to get and assign address here? Needed for the ranking?


### PR DESCRIPTION
This uses feature operator metadata as a fallback display name when the search
result has no matched name and no brand metadata.
Currently no exceptions - it works for any feature.
Fixes #12875 