### PR TITLE
[android] Add profileable build type for performance profiling

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -205,6 +205,17 @@ android {
         }
       }
     }
+
+    // Release-like build for performance/battery profiling.
+    // Debug-signed so it works without secure.properties, installed as
+    // app.organicmaps.profileable to coexist with other variants.
+    profileable {
+      initWith release
+      applicationIdSuffix '.profileable'
+      versionNameSuffix '-profileable'
+      signingConfig = signingConfigs.debug
+      matchingFallbacks = ['release']
+    }
   }
 
   // We don't compress these extensions in assets/ because our random FileReader can't read zip-compressed files from apk.
@@ -301,10 +312,10 @@ def allowedPermissions = [
     // comes from androidx.core:core:1.17.0
     // Regex to allow it for the following app packages:
     // app.organicmaps
-    // app.organicmaps.(debug|beta)
+    // app.organicmaps.(debug|beta|profileable)
     // app.organicmaps.web
-    // app.organicmaps.web.(debug|beta)
-    ~/name='app\.organicmaps(\.web)?(\.debug|\.beta)?\.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION'/
+    // app.organicmaps.web.(debug|beta|profileable)
+    ~/name='app\.organicmaps(\.web)?(\.debug|\.beta|\.profileable)?\.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION'/
 ]
 registerCheckApkPermissionsTasks(project, allowedPermissions)
 
@@ -317,6 +328,13 @@ androidComponents {
     onVariants(selector().withBuildType("debug")) { variant ->
       variant.packaging.jniLibs.keepDebugSymbols.add("**/liborganicmaps.so")
     }
+  }
+
+  // Keep native debug symbols in profileable builds so simpleperf / Studio Profiler
+  // can resolve liborganicmaps.so addresses to function names. Unconditional —
+  // symbol-less profiling is useless, which is the whole point of this variant.
+  onVariants(selector().withBuildType("profileable")) { variant ->
+    variant.packaging.jniLibs.keepDebugSymbols.add("**/liborganicmaps.so")
   }
 
   onVariants(selector().all()) { variant ->

--- a/android/app/src/profileable/AndroidManifest.xml
+++ b/android/app/src/profileable/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
+  <!-- Variant-only overrides for the `profileable` build type.
+    Enables Studio Profiler / simpleperf on this Release-like build without
+    touching the production manifest. -->
+  <application>
+    <profileable
+      android:shell="true"
+      android:enabled="true"
+      tools:targetApi="29" />
+  </application>
+</manifest>

--- a/android/app/src/profileable/res/values/donottranslate.xml
+++ b/android/app/src/profileable/res/values/donottranslate.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="app_name" translatable="false">Profile Organic Maps</string>
+</resources>


### PR DESCRIPTION
Summary
                                                                                                                                                           
  Adds a new profileable Android build type — Release-like (R8-shrunk, release-flavored ProGuard rules), debug-signed so it works without secure.properties — for CPU and battery profiling on real devices with Studio Profiler / simpleperf.                                                                      
   Coexists with debug / release / beta via .profileable applicationIdSuffix and a variant-scoped launcher label "Profile Organic Maps", so multiple variants can be installed side by side without visual ambiguity.

Separate PR, source: https://github.com/organicmaps/organicmaps/pull/12789