### PR TITLE
[platform] Force HTTP/1.1 for OSM hosts on Qt <= 6.4 (QTBUG-111417)

### DIFF
--- a/libs/platform/http_client_qt.cpp
+++ b/libs/platform/http_client_qt.cpp
@@ -8,6 +8,7 @@
 #include <QPointer>
 #include <QThread>
 #include <QUrl>
+#include <QtGlobal>  // QT_VERSION, QT_VERSION_CHECK
 
 namespace
 {
@@ -79,6 +80,12 @@ QNetworkReply * IssueRequest(QNetworkAccessManager & manager, std::string const 
 
 namespace platform
 {
+bool IsOsmHost(QString const & host)
+{
+  return host.compare(QLatin1String("openstreetmap.org"), Qt::CaseInsensitive) == 0 ||
+         host.endsWith(QLatin1String(".openstreetmap.org"), Qt::CaseInsensitive);
+}
+
 HttpClientReply::HttpClientReply(QNetworkReply * reply, HttpClient::CompletionHandler handler,
                                  HttpClient::ProgressHandler progressHandler, HttpClient::DataHandler dataHandler,
                                  CancelChecker cancelChecker, bool loadHeaders, bool followRedirects,
@@ -473,6 +480,16 @@ HttpClient::RequestHandle HttpClient::RunHttpRequestAsync(CompletionHandler hand
   QNetworkRequest request(QUrl(QString::fromStdString(m_urlRequested)));
 
   request.setTransferTimeout(static_cast<int>(m_timeoutSec * 1000));
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 1)
+  // QTBUG-111417: on Qt <= 6.4 an HTTP/2 QNetworkReply can stall without ever emitting
+  // finished() until the peer closes the connection, hanging the blocking RunHttpRequest()
+  // far past setTransferTimeout. OSM login/OAuth (www) and the editing API negotiate HTTP/2,
+  // so force HTTP/1.1 for OSM hosts. Fixed in Qt 6.5.1/6.6.0 — this block compiles out on
+  // newer Qt, where HTTP/2 is used again.
+  if (IsOsmHost(request.url().host()))
+    request.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
+#endif
 
   // Disable Qt's automatic cookie handling — we manage cookies manually via
   // SetCookies() / CombinedCookies(), matching Apple's HTTPShouldHandleCookies=NO.

--- a/libs/platform/http_client_qt.hpp
+++ b/libs/platform/http_client_qt.hpp
@@ -14,6 +14,13 @@ namespace platform
 {
 using CancelChecker = HttpClient::CancelChecker;
 
+// True for OpenStreetMap hosts: production www.openstreetmap.org / api.openstreetmap.org and
+// the dev server master.apis.dev.openstreetmap.org (any *.openstreetmap.org subdomain plus the
+// bare apex). Their TLS-negotiated HTTP/2 can hang a QNetworkReply on Qt <= 6.4 (QTBUG-111417),
+// so RunHttpRequestAsync forces HTTP/1.1 for them on affected Qt versions. Free function with
+// external linkage so platform_tests can exercise it directly.
+bool IsOsmHost(QString const & host);
+
 // QObject helper that bridges Qt signals to HttpClient::CompletionHandler.
 // Lives on the network thread, destroyed when the reply finishes.
 class HttpClientReply : public QObject

--- a/libs/platform/http_client_qt.hpp
+++ b/libs/platform/http_client_qt.hpp
@@ -15,10 +15,7 @@ namespace platform
 using CancelChecker = HttpClient::CancelChecker;
 
 // True for OpenStreetMap hosts: production www.openstreetmap.org / api.openstreetmap.org and
-// the dev server master.apis.dev.openstreetmap.org (any *.openstreetmap.org subdomain plus the
-// bare apex). Their TLS-negotiated HTTP/2 can hang a QNetworkReply on Qt <= 6.4 (QTBUG-111417),
-// so RunHttpRequestAsync forces HTTP/1.1 for them on affected Qt versions. Free function with
-// external linkage so platform_tests can exercise it directly.
+// the dev server master.apis.dev.openstreetmap.org (any *.openstreetmap.org subdomain plus the bare apex).
 bool IsOsmHost(QString const & host);
 
 // QObject helper that bridges Qt signals to HttpClient::CompletionHandler.

--- a/libs/platform/platform_tests/CMakeLists.txt
+++ b/libs/platform/platform_tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SRC
 # (macOS uses http_client_apple.mm instead).
 if (PLATFORM_DESKTOP AND NOT PLATFORM_MAC)
   list(APPEND SRC http_client_qt_retry_test.cpp)
+  list(APPEND SRC http_client_qt_http2_test.cpp)
 endif()
 
 omim_add_test(${PROJECT_NAME} ${SRC} REQUIRE_QT REQUIRE_SERVER)

--- a/libs/platform/platform_tests/http_client_qt_http2_test.cpp
+++ b/libs/platform/platform_tests/http_client_qt_http2_test.cpp
@@ -1,0 +1,37 @@
+#include "testing/testing.hpp"
+
+#include "platform/http_client_qt.hpp"
+
+namespace http_client_qt_http2_test
+{
+using platform::IsOsmHost;
+
+UNIT_TEST(HttpClientQt_IsOsmHost_ProdAndDevHosts)
+{
+  // OSM OAuth handshake (www), editing API, and the dev server — all force HTTP/1.1 on Qt <= 6.4.
+  TEST(IsOsmHost("www.openstreetmap.org"), ());
+  TEST(IsOsmHost("api.openstreetmap.org"), ());
+  TEST(IsOsmHost("master.apis.dev.openstreetmap.org"), ());
+  // Bare apex.
+  TEST(IsOsmHost("openstreetmap.org"), ());
+}
+
+UNIT_TEST(HttpClientQt_IsOsmHost_CaseInsensitive)
+{
+  // QUrl::host() lowercases hosts, but the predicate is robust to mixed case regardless.
+  TEST(IsOsmHost("WWW.OpenStreetMap.ORG"), ());
+  TEST(IsOsmHost("OPENSTREETMAP.ORG"), ());
+}
+
+UNIT_TEST(HttpClientQt_IsOsmHost_RejectsLookAlikes)
+{
+  // The suffix must sit on a real subdomain boundary — these are NOT OSM hosts and must
+  // keep HTTP/2. A naive endsWith("openstreetmap.org") would wrongly accept the first two.
+  TEST(!IsOsmHost("notopenstreetmap.org"), ());
+  TEST(!IsOsmHost("evil-openstreetmap.org"), ());
+  TEST(!IsOsmHost("openstreetmap.org.evil.com"), ());
+  TEST(!IsOsmHost("openstreetmap.com"), ());
+  TEST(!IsOsmHost("example.com"), ());
+  TEST(!IsOsmHost(""), ());
+}
+}  // namespace http_client_qt_http2_test


### PR DESCRIPTION
Workaround for https://bugreports.qt.io/browse/QTBUG-111417

Should fix randomly failing auth_test on CI

Closes https://github.com/organicmaps/organicmaps/pull/12899