### PR TITLE
[map] Fix relation track selection mark position

### DIFF
--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -2366,13 +2366,13 @@ bool Framework::BuildTrackPlacePage(Track::TrackSelectionInfo const & trackSelec
   if (trackSelectionInfo.IsRelation())
   {
     auto trackData = TryBuildRelationTrack(selectedInfo);
-
     if (!trackData)
       return false;
 
     bm.SetTempRelationTrack(std::move(trackData.value()));
     track = bm.GetTrack(kml::kTempRelationTrackId);
-    track->UpdateSelectionInfo(selectedInfo.m_trackPoint, selectedInfo);
+    auto const tapPoint = selectedInfo.m_trackPoint;  // Copy tap point before mutation.
+    track->UpdateSelectionInfo(tapPoint, selectedInfo);
   }
   else
   {


### PR DESCRIPTION
The relation-track selection path was reusing selectedInfo.m_trackPoint as both the immutable tap reference and the mutable snap target. Track::UpdateSelectionInfo() mutates that field while searching segments, so the selection point could drift to the start of the rebuilt relation track.

Fix:
Copy the original tap point before rebuilding the temporary relation track. Use that preserved point when snapping the rebuilt track selection.