### PR TITLE
fix: correct apartment building changeset text

### DIFF
--- a/libs/editor/changeset_wrapper.cpp
+++ b/libs/editor/changeset_wrapper.cpp
@@ -46,7 +46,7 @@ std::string GetTypeForFeature(editor::XMLFeature const & node)
       if (value == "yes")
         return std::string{key};
       else if (key == "building" && value == "apartments")
-        return "apartment building";
+        return "apartment building";  // "apartments" is already plural; avoids "apartments building(s)"
       else if (key == "shop" || key == "office" || key == "building" || key == "entrance")
         return value.append(" ").append(key);  // "convenience shop"
       else if (!value.empty() && value.back() == 's')

--- a/libs/editor/changeset_wrapper.cpp
+++ b/libs/editor/changeset_wrapper.cpp
@@ -45,6 +45,8 @@ std::string GetTypeForFeature(editor::XMLFeature const & node)
       std::string value = node.GetTagValue(key);
       if (value == "yes")
         return std::string{key};
+      else if (key == "building" && value == "apartments")
+        return "apartment building";
       else if (key == "shop" || key == "office" || key == "building" || key == "entrance")
         return value.append(" ").append(key);  // "convenience shop"
       else if (!value.empty() && value.back() == 's')


### PR DESCRIPTION
## Description

Special-cases `building=apartments` when generating OSM changeset descriptions so multiple apartment buildings are described as "apartment buildings" instead of "apartments buildings".

## Related Issues

Resolves #5514

## Verification

- `git diff --check`