### PR TITLE
[bookmarks] Fixed Tracks render crash after MoveTrack.

### DIFF
--- a/libs/drape_frontend/user_mark_generator.cpp
+++ b/libs/drape_frontend/user_mark_generator.cpp
@@ -91,7 +91,10 @@ void UserMarkGenerator::UpdateIndex(kml::MarkGroupId groupId)
 
   for (auto const & markId : idCollection.m_markIds)
   {
-    UserMarkRenderParams const & params = *m_marks[markId];
+    auto const markIt = m_marks.find(markId);
+    CHECK(markIt != m_marks.end() && markIt->second != nullptr, (markId, groupId));
+
+    UserMarkRenderParams const & params = *markIt->second;
     int const startZoom = GetNearestIndexZoom(kMarkIndexingLevels, params.m_minZoom);
     for (int zoomLevel : kMarkIndexingLevels)
     {
@@ -109,7 +112,10 @@ void UserMarkGenerator::UpdateIndex(kml::MarkGroupId groupId)
     // Collect unique intersected tiles.
     std::set<TileKey> tiles;
 
-    UserLineRenderParams const & params = *m_lines[lineId];
+    auto const lineIt = m_lines.find(lineId);
+    CHECK(lineIt != m_lines.end() && lineIt->second != nullptr, (lineId, groupId));
+
+    UserLineRenderParams const & params = *lineIt->second;
 
     int const startZoom = GetNearestIndexZoom(kLineIndexingLevels, params.m_minZoom);
     for (int zoomLevel : kLineIndexingLevels)

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -525,6 +525,7 @@ void BookmarkManager::MoveTrack(kml::TrackId trackID, kml::MarkGroupId curGroupI
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   DetachTrack(trackID, curGroupID);
   AttachTrack(trackID, newGroupID);
+  m_changesTracker.OnUpdateLine(trackID);
 
   SetLastEditedBmCategory(newGroupID);
 }

--- a/libs/map/track.cpp
+++ b/libs/map/track.cpp
@@ -204,11 +204,13 @@ void Track::ForEachGeometry(GeometryFnT && fn) const
 void Track::Attach(kml::MarkGroupId groupId)
 {
   ASSERT_EQUAL(m_groupID, kml::kInvalidMarkGroupId, ());
+  m_isDirty = true;
   m_groupID = groupId;
 }
 
 void Track::Detach()
 {
+  m_isDirty = true;
   m_groupID = kml::kInvalidMarkGroupId;
 }
 


### PR DESCRIPTION
Move a track from an invisible to a visible group.