### PR TITLE
[android] More robust and simplified Logger logic.

### DIFF
--- a/android/app/src/main/java/app/organicmaps/util/Utils.java
+++ b/android/app/src/main/java/app/organicmaps/util/Utils.java
@@ -179,7 +179,7 @@ public class Utils
     }
     catch (ActivityNotFoundException e)
     {
-      Logger.e(TAG, "Failed to start activity", e);
+      Logger.w(TAG, "Failed to start activity", e);
     }
   }
 
@@ -243,7 +243,7 @@ public class Utils
     {
       if (failMessage != null)
         Toast.makeText(context, context.getString(failMessage), Toast.LENGTH_LONG).show();
-      Logger.e(TAG, "ActivityNotFoundException", e);
+      Logger.w(TAG, "ActivityNotFoundException", e);
     }
   }
 
@@ -332,7 +332,7 @@ public class Utils
     }
     catch (ActivityNotFoundException e)
     {
-      Logger.e(TAG, "Failed to call phone", e);
+      Logger.w(TAG, "Failed to call phone", e);
     }
   }
 

--- a/android/libs/car/src/main/java/app/organicmaps/car/screens/NavigationScreen.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/screens/NavigationScreen.java
@@ -121,7 +121,7 @@ public class NavigationScreen extends BaseMapScreen implements RoutingController
     final JunctionInfo[] points = Framework.nativeGetRouteJunctionPoints(kMaxDistM);
     if (points == null)
     {
-      Logger.e(TAG, "Navigation has not started yet");
+      Logger.w(TAG, "Navigation has not started yet");
       return;
     }
 

--- a/android/libs/car/src/main/java/app/organicmaps/car/util/IntentUtils.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/util/IntentUtils.java
@@ -130,11 +130,11 @@ public final class IntentUtils
       screenManager.popToRoot();
       screenManager.push(builder.build());
       return;
-    case RequestType.ROUTE: Logger.e(TAG, "Route API is not supported by Android Auto: " + uri); return;
-    case RequestType.CROSSHAIR: Logger.e(TAG, "Crosshair API is not supported by Android Auto: " + uri); return;
-    case RequestType.MENU: Logger.e(TAG, "Menu API is not supported by Android Auto: " + uri); return;
-    case RequestType.SETTINGS: Logger.e(TAG, "Settings API is not supported by Android Auto: " + uri); return;
-    case RequestType.OAUTH2: Logger.e(TAG, "OAuth2 API is not supported by Android Auto: " + uri);
+    case RequestType.ROUTE: Logger.w(TAG, "Route API is not supported by Android Auto: " + uri); return;
+    case RequestType.CROSSHAIR: Logger.w(TAG, "Crosshair API is not supported by Android Auto: " + uri); return;
+    case RequestType.MENU: Logger.w(TAG, "Menu API is not supported by Android Auto: " + uri); return;
+    case RequestType.SETTINGS: Logger.w(TAG, "Settings API is not supported by Android Auto: " + uri); return;
+    case RequestType.OAUTH2: Logger.w(TAG, "OAuth2 API is not supported by Android Auto: " + uri);
     }
   }
 

--- a/android/libs/googleassistant/src/main/java/app/organicmaps/intent/GoogleAssistantIntentHandler.java
+++ b/android/libs/googleassistant/src/main/java/app/organicmaps/intent/GoogleAssistantIntentHandler.java
@@ -127,7 +127,7 @@ public abstract class GoogleAssistantIntentHandler
     }
     catch (Exception e)
     {
-      Logger.e(TAG, "Failed to parse destination", e);
+      Logger.w(TAG, "Failed to parse destination", e);
     }
 
     return dst;
@@ -175,7 +175,7 @@ public abstract class GoogleAssistantIntentHandler
     }
     catch (Exception e)
     {
-      Logger.e(TAG, "Failed to apply avoid options", e);
+      Logger.w(TAG, "Failed to apply avoid options", e);
     }
   }
 
@@ -235,7 +235,7 @@ public abstract class GoogleAssistantIntentHandler
     }
     catch (Exception e)
     {
-      Logger.e(TAG, "Failed to parse action parameter", e);
+      Logger.w(TAG, "Failed to parse action parameter", e);
       return null;
     }
   }
@@ -319,7 +319,7 @@ public abstract class GoogleAssistantIntentHandler
     }
     catch (Exception e)
     {
-      Logger.e(TAG, "Failed to handle custom action", e);
+      Logger.w(TAG, "Failed to handle custom action", e);
       return false;
     }
   }
@@ -380,7 +380,7 @@ public abstract class GoogleAssistantIntentHandler
     }
     catch (Exception e)
     {
-      Logger.e(TAG, "Failed to process assistant intent", e);
+      Logger.w(TAG, "Failed to process assistant intent", e);
       return false;
     }
   }

--- a/android/sdk/location/gms/google/src/main/java/app/organicmaps/sdk/location/gms/GoogleFusedLocationProvider.java
+++ b/android/sdk/location/gms/google/src/main/java/app/organicmaps/sdk/location/gms/GoogleFusedLocationProvider.java
@@ -136,7 +136,7 @@ class GoogleFusedLocationProvider extends BaseLocationProvider
           }
           // Location settings are not satisfied. However, we have no way to fix the
           // settings so we won't show the dialog.
-          Logger.e(TAG, "Service is not available: " + e);
+          Logger.w(TAG, "Service is not available: " + e);
           // Call this callback in the next event loop to allow LocationHelper::start() to finish.
           UiThread.runLater(mListener::onFusedLocationUnsupported);
         });

--- a/android/sdk/src/main/java/app/organicmaps/sdk/location/AndroidNativeProvider.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/location/AndroidNativeProvider.java
@@ -100,7 +100,7 @@ public class AndroidNativeProvider extends BaseLocationProvider
     if (mProviders.isEmpty())
     {
       // Call this callback in the next event loop to allow LocationHelper::start() to finish.
-      Logger.e(TAG, "No providers available");
+      Logger.w(TAG, "No providers available");
       runLater(mListener::onLocationDisabled);
       return;
     }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/location/PlatformSocket.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/location/PlatformSocket.java
@@ -102,7 +102,7 @@ class PlatformSocket
     }
     catch (IOException e)
     {
-      Logger.e(TAG, "Failed to create the ssl socket, mHost = " + host + " mPort = " + port);
+      Logger.w(TAG, "Failed to create the ssl socket, mHost = " + host + " mPort = " + port);
     }
     return socket;
   }
@@ -118,7 +118,7 @@ class PlatformSocket
     }
     catch (IOException e)
     {
-      Logger.e(TAG, "Failed to create the socket, mHost = " + host + " mPort = " + port);
+      Logger.w(TAG, "Failed to create the socket, mHost = " + host + " mPort = " + port);
     }
     return socket;
   }
@@ -151,7 +151,7 @@ class PlatformSocket
     }
     catch (IOException e)
     {
-      Logger.e(TAG, "Failed to close socket: " + this + "\n");
+      Logger.w(TAG, "Failed to close socket: " + this + "\n");
     }
     finally
     {
@@ -188,7 +188,7 @@ class PlatformSocket
 
           if (read == 0)
           {
-            Logger.e(TAG, "0 bytes are obtained. It's considered as error\n");
+            Logger.w(TAG, "0 bytes are obtained. It's considered as error\n");
             break;
           }
 
@@ -198,10 +198,10 @@ class PlatformSocket
         catch (SocketTimeoutException e)
         {
           long readingTime = SystemClock.elapsedRealtime() - startTime;
-          Logger.e(TAG, "Socked timeout has occurred after " + readingTime + " (ms)\n ");
+          Logger.w(TAG, "Socked timeout has occurred after " + readingTime + " (ms)\n ");
           if (readingTime > mTimeout)
           {
-            Logger.e(TAG, "Socket wrapper timeout has occurred, requested count = " + (count - readBytes)
+            Logger.w(TAG, "Socket wrapper timeout has occurred, requested count = " + (count - readBytes)
                               + ", readBytes = " + readBytes + "\n");
             break;
           }
@@ -210,7 +210,7 @@ class PlatformSocket
     }
     catch (IOException e)
     {
-      Logger.e(TAG, "Failed to read data from socket: " + this + "\n");
+      Logger.w(TAG, "Failed to read data from socket: " + this + "\n");
     }
 
     return count == readBytes;
@@ -236,11 +236,11 @@ class PlatformSocket
     catch (SocketTimeoutException e)
     {
       long writingTime = SystemClock.elapsedRealtime() - startTime;
-      Logger.e(TAG, "Socked timeout has occurred after " + writingTime + " (ms)\n");
+      Logger.w(TAG, "Socked timeout has occurred after " + writingTime + " (ms)\n");
     }
     catch (IOException e)
     {
-      Logger.e(TAG, "Failed to write data to socket: " + this + "\n");
+      Logger.w(TAG, "Failed to write data to socket: " + this + "\n");
     }
 
     return false;
@@ -277,7 +277,7 @@ class PlatformSocket
     }
     catch (SocketException e)
     {
-      Logger.e(TAG, "Failed to set system socket timeout: " + millis + "ms, " + this + "\n");
+      Logger.w(TAG, "Failed to set system socket timeout: " + millis + "ms, " + this + "\n");
     }
   }
 

--- a/android/sdk/src/main/java/app/organicmaps/sdk/sound/TtsPlayer.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/sound/TtsPlayer.java
@@ -83,7 +83,7 @@ public enum TtsPlayer
 
     private void handleError(@NonNull String utteranceId, int errorCode)
     {
-      Logger.e(TAG, "TTS Utterance error: " + utteranceId + ", code: " + errorCode);
+      Logger.w(TAG, "TTS Utterance error: " + utteranceId + ", code: " + errorCode);
       handleStop(utteranceId);
     }
 

--- a/android/sdk/src/main/java/app/organicmaps/sdk/util/Utils.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/util/Utils.java
@@ -65,7 +65,7 @@ public class Utils
     }
     catch (Throwable e)
     {
-      Logger.e(TAG, "Failed to obtain a currency for locale: " + locale, e);
+      Logger.w(TAG, "Failed to obtain a currency for locale: " + locale, e);
       return null;
     }
   }
@@ -118,7 +118,7 @@ public class Utils
     }
     catch (Throwable e)
     {
-      Logger.e(TAG, "Failed to obtain currency symbol by currency code = " + currencyCode, e);
+      Logger.w(TAG, "Failed to obtain currency symbol by currency code = " + currencyCode, e);
     }
 
     return currencyCode;

--- a/android/sdk/src/main/java/app/organicmaps/sdk/util/log/Logger.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/util/log/Logger.java
@@ -6,13 +6,17 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import app.organicmaps.sdk.BuildConfig;
 import app.organicmaps.sdk.util.Assert;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /// Thread-safe
 public final class Logger
@@ -20,84 +24,82 @@ public final class Logger
   private static final String TAG = Logger.class.getSimpleName();
   private static final String CORE_TAG = "OMcore";
   private static final String FILENAME = "app.log";
+  private static final LogFileWriter FILE_WRITER = new LogFileWriter();
 
   public static void v(String tag)
   {
-    log(Log.VERBOSE, tag, "", null);
+    logJava(Log.VERBOSE, tag, "", null);
   }
 
   public static void v(String tag, String msg)
   {
-    log(Log.VERBOSE, tag, msg, null);
+    logJava(Log.VERBOSE, tag, msg, null);
   }
 
   public static void v(String tag, String msg, Throwable tr)
   {
-    log(Log.VERBOSE, tag, msg, tr);
+    logJava(Log.VERBOSE, tag, msg, tr);
   }
 
   public static void d(String tag)
   {
-    log(Log.DEBUG, tag, "", null);
+    logJava(Log.DEBUG, tag, "", null);
   }
 
   public static void d(String tag, String msg)
   {
-    log(Log.DEBUG, tag, msg, null);
+    logJava(Log.DEBUG, tag, msg, null);
   }
 
   public static void d(String tag, String msg, Throwable tr)
   {
-    log(Log.DEBUG, tag, msg, tr);
+    logJava(Log.DEBUG, tag, msg, tr);
   }
 
   public static void i(String tag)
   {
-    log(Log.INFO, tag, "", null);
+    logJava(Log.INFO, tag, "", null);
   }
 
   public static void i(String tag, String msg)
   {
-    log(Log.INFO, tag, msg, null);
+    logJava(Log.INFO, tag, msg, null);
   }
 
   public static void i(String tag, String msg, Throwable tr)
   {
-    log(Log.INFO, tag, msg, tr);
+    logJava(Log.INFO, tag, msg, tr);
   }
 
   public static void w(String tag, String msg)
   {
-    log(Log.WARN, tag, msg, null);
+    logJava(Log.WARN, tag, msg, null);
   }
 
   public static void w(String tag, String msg, Throwable tr)
   {
-    log(Log.WARN, tag, msg, tr);
+    logJava(Log.WARN, tag, msg, tr);
   }
 
   public static void e(String tag, String msg)
   {
-    log(Log.ERROR, tag, msg, null);
+    logJava(Log.ERROR, tag, msg, null);
   }
 
   public static void e(String tag, String msg, Throwable tr)
   {
-    log(Log.ERROR, tag, msg, tr);
+    logJava(Log.ERROR, tag, msg, tr);
   }
 
   @NonNull
   private static String getSourcePoint()
   {
     final StackTraceElement[] stackTrace = new Throwable().getStackTrace();
-    // Skip the chain of Logger.x() -> Logger.log() calls.
-    int f = 0;
-    for (; f < stackTrace.length && stackTrace[f].getClassName().equals(Logger.class.getName()); f++)
-      ;
-    // The stack trace should have at least one non-logger frame, but who wants to crash here if it doesn't?
-    if (f == stackTrace.length)
+    // getSourcePoint() -> logImpl() -> logJava() -> Logger.x() -> caller.
+    final int callerFrame = 4;
+    if (stackTrace.length <= callerFrame)
       return "Unknown";
-    final StackTraceElement st = stackTrace[f];
+    final StackTraceElement st = stackTrace[callerFrame];
     StringBuilder sb = new StringBuilder(80);
     final String fileName = st.getFileName();
     if (fileName != null)
@@ -112,9 +114,20 @@ public final class Logger
     return sb.toString();
   }
 
+  private static void logJava(int level, @Nullable String tag, @NonNull String msg, @Nullable Throwable tr)
+  {
+    logImpl(level, tag, msg, tr, true /* addJavaSourcePoint */);
+  }
+
   // Also called from JNI to proxy native code logging (with tag == null).
   @Keep
   private static void log(int level, @Nullable String tag, @NonNull String msg, @Nullable Throwable tr)
+  {
+    logImpl(level, tag, msg, tr, false /* addJavaSourcePoint */);
+  }
+
+  private static void logImpl(int level, @Nullable String tag, @NonNull String msg, @Nullable Throwable tr,
+                              boolean addJavaSourcePoint)
   {
     final String logsFolder = LogsManager.INSTANCE.getEnabledLogsFolder();
 
@@ -122,7 +135,7 @@ public final class Logger
     {
       final StringBuilder sb = new StringBuilder(180);
       // Add source point info for file logging, debug builds and ERRORs if its not from core.
-      if (tag != null && (logsFolder != null || BuildConfig.DEBUG || level == Log.ERROR))
+      if (addJavaSourcePoint && tag != null && (logsFolder != null || BuildConfig.DEBUG || level == Log.ERROR))
         sb.append(getSourcePoint()).append(": ");
       sb.append(msg);
       if (tr != null)
@@ -137,7 +150,11 @@ public final class Logger
       if (logsFolder != null)
       {
         sb.insert(0, String.valueOf(getLevelChar(level)) + '/' + tag + ": ");
-        LogsManager.EXECUTOR.execute(new WriteTask(logsFolder + File.separator + FILENAME, threadName + sb.toString()));
+        final String data = threadName + sb.toString();
+        if (level >= Log.ERROR)
+          FILE_WRITER.writeSync(logsFolder, data);
+        else
+          FILE_WRITER.writeAsync(logsFolder, level, data);
       }
     }
   }
@@ -156,55 +173,336 @@ public final class Logger
     return '_';
   }
 
-  private static class WriteTask implements Runnable
+  static void flushFileLogs()
   {
-    private static final int MAX_SIZE = 3000000;
-    @NonNull
-    private final String mFilePath;
+    FILE_WRITER.flush();
+  }
+
+  static void closeFileLogs()
+  {
+    FILE_WRITER.close();
+  }
+
+  /// Runs the action while holding the file writer lock and with the buffer flushed to disk,
+  /// so no log line is appended and no log file rotation happens concurrently.
+  /// Used to safely read/zip the log files.
+  static void runExclusively(@NonNull Runnable action)
+  {
+    FILE_WRITER.runExclusively(action);
+  }
+
+  private static class LogEntry
+  {
+    @Nullable
+    final String mLogsFolder;
     @NonNull
     private final String mData;
+    @Nullable
+    private final CountDownLatch mFlushLatch;
 
-    private WriteTask(@NonNull String filePath, @NonNull String data)
+    private LogEntry(@NonNull String logsFolder, @NonNull String data)
     {
-      mFilePath = filePath;
+      mLogsFolder = logsFolder;
       mData = data;
+      mFlushLatch = null;
     }
 
-    @Override
-    public void run()
+    private LogEntry(@NonNull CountDownLatch flushLatch)
     {
-      FileWriter fw = null;
+      mLogsFolder = null;
+      mData = "";
+      mFlushLatch = flushLatch;
+    }
+
+    boolean isFlush()
+    {
+      return mFlushLatch != null;
+    }
+  }
+
+  private static class LogFileWriter
+  {
+    private static final int MAX_SIZE = 3000000;
+    private static final int MAX_LOG_FILES = 6;
+    private static final int QUEUE_CAPACITY = 4096;
+    private static final int MAX_BATCH_SIZE = 256;
+    private static final int FLUSH_TIMEOUT_SECONDS = 2;
+
+    @NonNull
+    private final ArrayBlockingQueue<LogEntry> mQueue = new ArrayBlockingQueue<>(QUEUE_CAPACITY);
+    @NonNull
+    private final AtomicInteger mDroppedCount = new AtomicInteger();
+    @NonNull
+    private final Object mWriteLock = new Object();
+    @NonNull
+    private final SimpleDateFormat mDateFormat = new SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.US);
+    @Nullable
+    private BufferedWriter mWriter;
+    @Nullable
+    private String mFilePath;
+    private long mCurrentSize;
+
+    LogFileWriter()
+    {
+      final Thread thread = new Thread(this::loop, "LoggerFileWriter");
+      thread.setDaemon(true);
+      thread.start();
+    }
+
+    void writeAsync(@NonNull String logsFolder, int level, @NonNull String data)
+    {
+      final LogEntry entry = new LogEntry(logsFolder, data);
+      if (mQueue.offer(entry))
+        return;
+
+      if (level >= Log.WARN)
+      {
+        if (mQueue.poll() != null)
+          mDroppedCount.incrementAndGet();
+        if (mQueue.offer(entry))
+          return;
+      }
+
+      mDroppedCount.incrementAndGet();
+    }
+
+    void writeSync(@NonNull String logsFolder, @NonNull String data)
+    {
+      synchronized (mWriteLock)
+      {
+        // Error logs bypass the async queue so native CHECK/ASSERT messages are persisted
+        // before aborting, even if older debug/info logs are still waiting in the queue.
+        writeDroppedCountLocked(logsFolder);
+        writeLineLocked(logsFolder, data);
+        flushLocked();
+      }
+    }
+
+    void flush()
+    {
+      final CountDownLatch flushLatch = new CountDownLatch(1);
+      final LogEntry flushEntry = new LogEntry(flushLatch);
       try
       {
-        File file = new File(mFilePath);
-        if (!file.exists() || file.length() > MAX_SIZE)
+        boolean enqueued = mQueue.offer(flushEntry);
+        if (!enqueued)
         {
-          fw = new FileWriter(file, false);
-          fw.write(LogsManager.INSTANCE.getSystemInformation());
+          if (mQueue.poll() != null)
+            mDroppedCount.incrementAndGet();
+          enqueued = mQueue.offer(flushEntry, FLUSH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         }
-        else
+
+        // Max wait time here is 2 * FLUSH_TIMEOUT_SECONDS = 4 seconds + time for flushLocked.
+        // Still reasonable for UI Settings.
+        if (!enqueued || !flushLatch.await(FLUSH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
         {
-          fw = new FileWriter(mFilePath, true);
+          Log.e(TAG, "Timed out waiting for the file logger flush request");
+          synchronized (mWriteLock)
+          {
+            flushLocked();
+          }
         }
-        final DateFormat fmt = new SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.US);
-        fw.write(fmt.format(new Date()) + " " + mData + "\n");
+      }
+      catch (InterruptedException e)
+      {
+        Thread.currentThread().interrupt();
+        Log.e(TAG, "Interrupted while flushing file logs", e);
+      }
+    }
+
+    void close()
+    {
+      synchronized (mWriteLock)
+      {
+        mQueue.clear();
+        closeWriterLocked();
+      }
+    }
+
+    void runExclusively(@NonNull Runnable action)
+    {
+      synchronized (mWriteLock)
+      {
+        flushLocked();
+        action.run();
+      }
+    }
+
+    private void loop()
+    {
+      while (true)
+      {
+        try
+        {
+          processEntry(mQueue.take());
+          for (int i = 0; i < MAX_BATCH_SIZE; ++i)
+          {
+            final LogEntry entry = mQueue.poll();
+            if (entry == null)
+              break;
+            processEntry(entry);
+            if (entry.isFlush())
+              break;
+          }
+          synchronized (mWriteLock)
+          {
+            flushLocked();
+          }
+        }
+        catch (InterruptedException e)
+        {
+          Thread.currentThread().interrupt();
+          return;
+        }
+      }
+    }
+
+    private void processEntry(@NonNull LogEntry entry)
+    {
+      synchronized (mWriteLock)
+      {
+        if (entry.isFlush())
+        {
+          flushLocked();
+          entry.mFlushLatch.countDown();
+          return;
+        }
+
+        if (entry.mLogsFolder == null)
+          return;
+
+        writeDroppedCountLocked(entry.mLogsFolder);
+        writeLineLocked(entry.mLogsFolder, entry.mData);
+      }
+    }
+
+    private void writeDroppedCountLocked(@NonNull String logsFolder)
+    {
+      final int droppedCount = mDroppedCount.getAndSet(0);
+      if (droppedCount == 0)
+        return;
+
+      writeLineLocked(logsFolder, "(LoggerFileWriter) W/" + TAG + ": Dropped " + droppedCount
+                                      + " log lines because the file logger queue was full");
+    }
+
+    private void writeLineLocked(@NonNull String logsFolder, @NonNull String data)
+    {
+      final String line = mDateFormat.format(new Date()) + " " + data + "\n";
+      try
+      {
+        ensureWriterLocked(logsFolder, line.length());
+        if (mWriter == null)
+          return;
+
+        mWriter.write(line);
+        mCurrentSize += line.length();
       }
       catch (IOException e)
       {
-        Log.e(TAG, "Failed to write to " + mFilePath + ": " + mData, e);
+        Log.e(TAG, "Failed to write to " + getLogFile(logsFolder, 0).getPath() + ": " + data, e);
+        closeWriterLocked();
+      }
+    }
+
+    private void ensureWriterLocked(@NonNull String logsFolder, int nextLineSize) throws IOException
+    {
+      final File file = getLogFile(logsFolder, 0);
+      final String filePath = file.getPath();
+      if (!filePath.equals(mFilePath))
+      {
+        closeWriterLocked();
+        mFilePath = filePath;
+      }
+
+      if (mWriter != null && mCurrentSize + nextLineSize <= MAX_SIZE)
+        return;
+
+      if (mWriter != null)
+        rotateLocked(logsFolder);
+      else if (file.exists() && file.length() > MAX_SIZE)
+        rotateLocked(logsFolder);
+
+      final boolean writeSystemInfo = !file.exists() || file.length() == 0;
+      mWriter = new BufferedWriter(new FileWriter(file, true));
+      mCurrentSize = file.length();
+
+      if (writeSystemInfo)
+      {
+        final String systemInformation = LogsManager.INSTANCE.getSystemInformation();
+        mWriter.write(systemInformation);
+        mCurrentSize += systemInformation.length();
+      }
+    }
+
+    private void rotateLocked(@NonNull String logsFolder)
+    {
+      closeWriterLocked();
+
+      final File oldestFile = getLogFile(logsFolder, MAX_LOG_FILES - 1);
+      if (oldestFile.exists() && !oldestFile.delete())
+        Log.e(TAG, "Failed to delete old log file " + oldestFile.getPath());
+
+      for (int i = MAX_LOG_FILES - 2; i >= 0; --i)
+      {
+        final File from = getLogFile(logsFolder, i);
+        if (!from.exists())
+          continue;
+
+        final File to = getLogFile(logsFolder, i + 1);
+        if (!from.renameTo(to))
+          Log.e(TAG, "Failed to rotate log file " + from.getPath() + " to " + to.getPath());
+      }
+
+      mFilePath = getLogFile(logsFolder, 0).getPath();
+      mCurrentSize = 0;
+    }
+
+    private void flushLocked()
+    {
+      if (mWriter == null)
+        return;
+
+      try
+      {
+        mWriter.flush();
+      }
+      catch (IOException e)
+      {
+        Log.e(TAG, "Failed to flush file " + mFilePath, e);
+        closeWriterLocked();
+      }
+    }
+
+    private void closeWriterLocked()
+    {
+      if (mWriter == null)
+        return;
+
+      try
+      {
+        mWriter.close();
+      }
+      catch (IOException e)
+      {
+        Log.e(TAG, "Failed to close file " + mFilePath, e);
       }
       finally
       {
-        if (fw != null)
-          try
-          {
-            fw.close();
-          }
-          catch (IOException e)
-          {
-            Log.e(TAG, "Failed to close file " + mFilePath, e);
-          }
+        mWriter = null;
+        mFilePath = null;
+        mCurrentSize = 0;
       }
+    }
+
+    @NonNull
+    private File getLogFile(@NonNull String logsFolder, int index)
+    {
+      if (index == 0)
+        return new File(logsFolder, FILENAME);
+      // "app.log" -> "app.<index>.log"
+      final int dot = FILENAME.lastIndexOf('.');
+      return new File(logsFolder, FILENAME.substring(0, dot) + "." + index + FILENAME.substring(dot));
     }
   }
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/util/log/LogsManager.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/util/log/LogsManager.java
@@ -45,14 +45,14 @@ public final class LogsManager
 {
   public interface OnZipCompletedListener
   {
-    // Called from the logger thread.
+    // Called from the background logs task thread.
     void onCompleted(final boolean success, @Nullable final String zipPath);
   }
 
   private final static String TAG = LogsManager.class.getSimpleName();
 
   public final static LogsManager INSTANCE = new LogsManager();
-  final static ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+  private final static ExecutorService TASK_EXECUTOR = Executors.newSingleThreadExecutor();
 
   @Nullable
   private Context mApplicationContext;
@@ -168,6 +168,12 @@ public final class LogsManager
 
   private void switchFileLoggingEnabled(boolean enabled)
   {
+    if (!enabled)
+    {
+      Logger.flushFileLogs();
+      Logger.closeFileLogs();
+    }
+
     mIsFileLoggingEnabled = enabled;
     // Only Debug builds log DEBUG level to Android system log.
     nativeToggleCoreDebugLogs(enabled || BuildConfig.DEBUG);
@@ -220,7 +226,7 @@ public final class LogsManager
 
     Log.i(TAG, "Zipping log files in " + mLogsFolder);
     final Runnable task = new ZipLogsTask(mLogsFolder, mLogsFolder + ".zip", listener);
-    EXECUTOR.execute(task);
+    TASK_EXECUTOR.execute(task);
   }
 
   /**

--- a/android/sdk/src/main/java/app/organicmaps/sdk/util/log/ZipLogsTask.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/util/log/ZipLogsTask.java
@@ -35,10 +35,14 @@ class ZipLogsTask implements Runnable
   @Override
   public void run()
   {
+    // Drain the queue so pending lines are on disk, capture the system logcat (a separate file),
+    // then zip while the file writer is locked so no append or rotation races with reading.
+    Logger.flushFileLogs();
     saveSystemLogcat(mLogsPath);
-    final boolean success = zipFileAtPath(mLogsPath, mZipPath);
+    final boolean[] success = new boolean[1];
+    Logger.runExclusively(() -> success[0] = zipFileAtPath(mLogsPath, mZipPath));
     if (mOnCompletedListener != null)
-      mOnCompletedListener.onCompleted(success, mZipPath);
+      mOnCompletedListener.onCompleted(success[0], mZipPath);
   }
 
   private boolean zipFileAtPath(@NonNull String sourcePath, @NonNull String toLocation)
@@ -94,11 +98,12 @@ class ZipLogsTask implements Runnable
 
   private void saveSystemLogcat(String path)
   {
-    final String cmd = "logcat -d -v time";
     Process process;
     try
     {
-      process = Runtime.getRuntime().exec(cmd);
+      process = new ProcessBuilder("logcat", "-b", "main", "-b", "system", "-b", "crash", "-d", "-v", "threadtime")
+                    .redirectErrorStream(true)
+                    .start();
     }
     catch (IOException e)
     {
@@ -121,6 +126,15 @@ class ZipLogsTask implements Runnable
         writer.write(buffer, 0, n);
       }
       while (true);
+
+      final int exitCode = process.waitFor();
+      if (exitCode != 0)
+        Logger.e(TAG, "logcat finished with code " + exitCode);
+    }
+    catch (InterruptedException e)
+    {
+      Thread.currentThread().interrupt();
+      Logger.e(TAG, "Interrupted while saving system logcat to " + path, e);
     }
     catch (Throwable e)
     {


### PR DESCRIPTION
- split Java logs from JNI/native logs and made Java source-point lookup cheaper by using the known logger call depth instead of scanning logger frames.
- replaced per-line ExecutorService writes with a dedicated LoggerFileWriter thread, bounded queue, batching, and a kept-open BufferedWriter.
- ERROR and native CHECK/ASSERT logs now write synchronously and flush immediately.
- added rotation: app.log, app.log.1 ... app.log.5, preserving 6 files total instead of truncating the only file.
- flushes file logs before zipping.
- uses explicit logcat buffers: main, system, crash, with threadtime.