### PR TITLE
add CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,17 @@
+{
+    "version": 8,
+    "configurePresets": [
+        {
+            "name": "default",
+            "generator": "Ninja"
+        },
+        {
+            "name": "debug",
+            "inherits": "default",
+            "description": "Default debug build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Make use [CMake Preset](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) feature to configure build.

Among the benefits:
- Allows to configure the build in a standard, declarative way, without relying on custom scripts.
- Many IDE's supporting CMake Preset can now discover the build configuration automatically ([VS Code](https://code.visualstudio.com/docs/cpp/CMake-linux#_configure-using-cmake-presets), Qt Creator, etc.).
- Users are still free to use custom scripts as a legacy way to configure build (so the change is harmless).
- Portable.
- Customizable with user-local `CMakeUserPresets.json`.

<img width="1032" height="590" alt="image" src="https://github.com/user-attachments/assets/ee160c48-99f9-4042-a156-d5ddcd461482" />