### PR TITLE
[android] Seed navigation UI on show to avoid empty placeholder

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/NavigationController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/NavigationController.java
@@ -170,7 +170,11 @@ public class NavigationController implements TrafficManager.TrafficCallback, Nav
   public void show(boolean show)
   {
     if (show && !UiUtils.isVisible(mFrame))
+    {
       collapseNavMenu();
+      // Seed the panel from the already-built route so it isn't empty until the first GPS fix arrives.
+      update(RoutingController.get().getCachedRoutingInfo());
+    }
     UiUtils.showIf(show, mFrame);
   }
 


### PR DESCRIPTION
## What                                                                                                                                                  
                                                                                                                                                           
  Seed the navigation panel from the already-built route the moment it becomes visible, instead of waiting for the next different GPS  fix.                                        
                                                                                                                                                           
  ## Why
                                                                                                                                                           
  Fixes #12912 — at the start of navigation the panel (next turn,  distance, ETA, street names) flashes empty for up to a few seconds. Regression from 2816f3e7be, which removed the per-compass-tick UI render that had been incidentally seeding the panel.