### PR TITLE
[android] Add minimal Wear OS shell

### DIFF
--- a/.github/workflows/android-check.yaml
+++ b/.github/workflows/android-check.yaml
@@ -132,6 +132,12 @@ jobs:
           ninja --version
           ./gradlew -P${{ matrix.arch }} assemble${{ matrix.flavor }}
 
+      - name: Compile Wear Google Debug
+        if: matrix.flavor == 'WebDebug'
+        shell: bash
+        working-directory: android
+        run: ./gradlew :wear:assembleGoogleDebug
+
       - name: Free disk space for emulator
         if: matrix.run-tests == true
         run: |

--- a/android/libs/wear-protocol/build.gradle
+++ b/android/libs/wear-protocol/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'com.android.library'
+}
+
+apply from: "${rootProject.rootDir}/groovy/common-config.gradle"
+
+android {
+    namespace 'app.organicmaps.wear.protocol'
+}

--- a/android/libs/wear-protocol/src/main/AndroidManifest.xml
+++ b/android/libs/wear-protocol/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/android/libs/wear-protocol/src/main/java/app/organicmaps/wear/protocol/WearNavigationMode.java
+++ b/android/libs/wear-protocol/src/main/java/app/organicmaps/wear/protocol/WearNavigationMode.java
@@ -1,0 +1,7 @@
+package app.organicmaps.wear.protocol;
+
+public enum WearNavigationMode
+{
+  NORMAL,
+  NAVIGATION
+}

--- a/android/libs/wear-protocol/src/main/java/app/organicmaps/wear/protocol/WearNavigationState.java
+++ b/android/libs/wear-protocol/src/main/java/app/organicmaps/wear/protocol/WearNavigationState.java
@@ -1,0 +1,21 @@
+package app.organicmaps.wear.protocol;
+
+public final class WearNavigationState
+{
+  private final WearNavigationMode mMode;
+
+  public WearNavigationState(WearNavigationMode mode)
+  {
+    mMode = mode;
+  }
+
+  public static WearNavigationState normal()
+  {
+    return new WearNavigationState(WearNavigationMode.NORMAL);
+  }
+
+  public WearNavigationMode getMode()
+  {
+    return mMode;
+  }
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -24,6 +24,9 @@ include ':libs:downloader'
 include ':libs:googleassistant'
 include ':libs:routing'
 include ':libs:utils'
+include ':libs:wear-protocol'
+
+include ':wear'
 
 include ':sdk'
 include ':sdk:car'

--- a/android/wear/build.gradle
+++ b/android/wear/build.gradle
@@ -9,6 +9,8 @@ android {
 
     defaultConfig {
         applicationId rootProject.ext.appId
+        // Keep the Wear artifact version code unique from the phone app while preserving
+        // the same base Organic Maps version code for Google Play multi-form-factor uploads.
         versionCode rootProject.ext.versionCode * 10 + 1
         versionName rootProject.ext.versionName
         minSdk 26
@@ -32,5 +34,6 @@ android {
 }
 
 dependencies {
+    implementation project(':libs:branding')
     implementation project(':libs:wear-protocol')
 }

--- a/android/wear/build.gradle
+++ b/android/wear/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'com.android.application'
+}
+
+apply from: "${rootProject.rootDir}/groovy/common-config.gradle"
+
+android {
+    namespace 'app.organicmaps.wear'
+
+    defaultConfig {
+        applicationId rootProject.ext.appId
+        versionCode rootProject.ext.versionCode * 10 + 1
+        versionName rootProject.ext.versionName
+        minSdk 26
+    }
+
+    flavorDimensions 'default'
+
+    productFlavors {
+        google {
+            dimension 'default'
+            versionName = android.defaultConfig.versionName + '-Google'
+        }
+    }
+
+    buildTypes {
+        debug {
+            applicationIdSuffix '.debug'
+            versionNameSuffix '-debug'
+        }
+    }
+}
+
+dependencies {
+    implementation project(':libs:wear-protocol')
+}

--- a/android/wear/src/main/AndroidManifest.xml
+++ b/android/wear/src/main/AndroidManifest.xml
@@ -5,7 +5,9 @@
     android:required="true" />
 
   <application
+    android:icon="@mipmap/ic_launcher"
     android:label="@string/app_name"
+    android:roundIcon="@mipmap/ic_launcher_round"
     android:theme="@style/WearTheme">
 
     <meta-data

--- a/android/wear/src/main/AndroidManifest.xml
+++ b/android/wear/src/main/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <uses-feature
+    android:name="android.hardware.type.watch"
+    android:required="true" />
+
+  <application
+    android:label="@string/app_name"
+    android:theme="@style/WearTheme">
+
+    <meta-data
+      android:name="com.google.android.wearable.standalone"
+      android:value="false" />
+
+    <activity
+      android:name=".MainActivity"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+
+  </application>
+</manifest>

--- a/android/wear/src/main/java/app/organicmaps/wear/MainActivity.java
+++ b/android/wear/src/main/java/app/organicmaps/wear/MainActivity.java
@@ -1,0 +1,41 @@
+package app.organicmaps.wear;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.Gravity;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import app.organicmaps.wear.protocol.WearNavigationState;
+
+public final class MainActivity extends Activity
+{
+  @Override
+  protected void onCreate(Bundle savedInstanceState)
+  {
+    super.onCreate(savedInstanceState);
+
+    WearNavigationState state = WearNavigationState.normal();
+
+    LinearLayout layout = new LinearLayout(this);
+    layout.setGravity(Gravity.CENTER);
+    layout.setOrientation(LinearLayout.VERTICAL);
+    int padding = getResources().getDimensionPixelSize(R.dimen.screen_padding);
+    layout.setPadding(padding, padding, padding, padding);
+
+    TextView title = new TextView(this);
+    title.setGravity(Gravity.CENTER);
+    title.setText(R.string.app_name);
+    title.setTextSize(18);
+
+    TextView subtitle = new TextView(this);
+    subtitle.setGravity(Gravity.CENTER);
+    subtitle.setText(R.string.wear_no_navigation_message);
+    subtitle.setTextSize(14);
+
+    layout.addView(title);
+    layout.addView(subtitle);
+
+    setContentView(layout);
+  }
+}

--- a/android/wear/src/main/res/values/dimens.xml
+++ b/android/wear/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+  <dimen name="screen_padding">16dp</dimen>
+</resources>

--- a/android/wear/src/main/res/values/strings.xml
+++ b/android/wear/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <resources>
-  <string name="app_name">Organic Maps</string>
-  <string name="wear_no_navigation_message">Open Organic Maps on your phone to start navigation.</string>
+    <string name="app_name" translatable="false">Organic Maps</string>
 </resources>

--- a/android/wear/src/main/res/values/strings.xml
+++ b/android/wear/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="app_name">Organic Maps</string>
+  <string name="wear_no_navigation_message">Open Organic Maps on your phone to start navigation.</string>
+</resources>

--- a/android/wear/src/main/res/values/styles.xml
+++ b/android/wear/src/main/res/values/styles.xml
@@ -1,0 +1,7 @@
+<resources>
+  <style name="WearTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
+    <item name="android:windowNoTitle">true</item>
+    <item name="android:windowActionBar">false</item>
+    <item name="android:windowLightStatusBar">false</item>
+  </style>
+</resources>

--- a/android/wear/src/main/res/values/wear_strings.xml
+++ b/android/wear/src/main/res/values/wear_strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- SECTION: Other translations -->
+    <!-- Displayed in the Wear OS app when no navigation is active on the phone. -->
+    <string name="wear_no_navigation_message">Open Organic Maps on your phone to start navigation.</string>
+</resources>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -44131,3 +44131,8 @@ uk = Сітка
 vi = Lưới
 zh-Hans = 网格
 zh-Hant = 網格
+
+[wear_no_navigation_message]
+comment = Displayed in the Wear OS app when no navigation is active on the phone.
+tags = android-wear
+en = Open Organic Maps on your phone to start navigation.

--- a/tools/unix/generate_localizations.sh
+++ b/tools/unix/generate_localizations.sh
@@ -60,6 +60,7 @@ GenerateStringResource "strings.txt" android/sdk/src/main/res android android-sd
 GenerateStringResource "strings.txt" android/libs/car/src/main/res android android-libs-car ""
 GenerateStringResource "strings.txt" android/libs/downloader/src/main/res android android-libs-downloader ""
 GenerateStringResource "strings.txt" android/libs/routing/src/main/res android android-libs-routing ""
+GenerateStringResource "strings.txt" android/wear/src/main/res android android-wear "wear_strings.xml"
 
 # Generate iPhone strings
 GenerateStringResource "strings.txt" iphone/Maps/LocalizedStrings apple apple-maps ""


### PR DESCRIPTION
## Summary

Add a minimal Wear OS shell for Organic Maps Google Play builds.

Scope intentionally kept minimal:

- add `:wear` module;
- add `:libs:wear-protocol` module;
- add a simple Wear launcher activity;
- no phone/watch communication;
- no Data Layer integration;
- no routing integration;
- no navigation mirroring;
- no Google Play Services dependency.
- Built only for Google Play builds as discussed in #12200 / #12532.

## Validation

Tested locally:

- `:wear:assembleGoogleDebug`
- `:wear:lintGoogleDebug`
- `assembleWebDebug`
- `assembleFdroidDebug`
- `lintAllModules`

Goal: establish a minimal Wear OS module structure and verify clean integration with the existing Android build setup.

Related:

- [#12200](https://github.com/organicmaps/organicmaps/issues/12200)
