### PR TITLE
meta: VS Code: add "Git: Always Sign Off" setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git.alwaysSignOff": true
+}


### PR DESCRIPTION
Otherwise, CI doesn't pass commits.

The same patch was merged e.g. for OpenWrt:
https://github.com/openwrt/openwrt/commit/0668537d29b1bd2947609c49fb4015fa4ebbf8f7