### PR TITLE
[ios] Fix crash on macOS window close during app termination

### DIFF
--- a/iphone/CoreApi/CoreApi/Framework/Framework.cpp
+++ b/iphone/CoreApi/CoreApi/Framework/Framework.cpp
@@ -19,3 +19,8 @@ void DeleteFramework()
   delete g_framework;
   g_framework = nullptr;
 }
+
+bool IsFrameworkDestroyed()
+{
+  return g_wasDeleted;
+}

--- a/iphone/CoreApi/CoreApi/Framework/Framework.h
+++ b/iphone/CoreApi/CoreApi/Framework/Framework.h
@@ -7,3 +7,5 @@
 Framework & GetFramework();
 /// Releases framework resources
 void DeleteFramework();
+/// Returns true after DeleteFramework() destroyed the singleton (app is terminating).
+bool IsFrameworkDestroyed();

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.h
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.h
@@ -55,6 +55,8 @@ NS_SWIFT_NAME(FrameworkHelper)
 + (void)setTheme:(MWMTheme)theme;
 + (MWMDayTime)daytimeAtLocation:(nullable CLLocation *)location;
 + (void)createFramework;
+/// Returns YES after the C++ Framework was destroyed during app termination.
++ (BOOL)isFrameworkDestroyed;
 + (MWMMarkID)invalidBookmarkId;
 + (MWMMarkGroupID)invalidCategoryId;
 + (void)zoomMap:(MWMZoomMode)mode;

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
@@ -92,6 +92,11 @@ static Framework::ProductsPopupCloseReason ConvertProductPopupCloseReasonToCore(
   UNUSED_VALUE(GetFramework());
 }
 
++ (BOOL)isFrameworkDestroyed
+{
+  return IsFrameworkDestroyed();
+}
+
 + (MWMMarkID)invalidBookmarkId
 {
   return kml::kInvalidMarkId;

--- a/iphone/Maps/Core/Theme/Core/ThemeManager.swift
+++ b/iphone/Maps/Core/Theme/Core/ThemeManager.swift
@@ -52,6 +52,10 @@ final class ThemeManager: NSObject {
   }
 
   @objc static func invalidate() {
+    // On macOS, UIKit keeps delivering appearance/trait changes while the app terminates,
+    // after applicationWillTerminate: has destroyed the C++ Framework. Skip theming to avoid
+    // calling GetFramework() on a destroyed singleton (which trips its CHECK and aborts).
+    guard !FrameworkHelper.isFrameworkDestroyed() else { return }
     instance.update(theme: Settings.theme())
   }
 


### PR DESCRIPTION
## Problem

On the Mac Catalyst ("Designed for iPad" running on Apple Silicon) build, pressing the window's red **X** aborts on `CHECK(!g_wasDeleted)` in `GetFramework()` during termination:

```
#4  GetFramework() at Framework.cpp:10            // CHECK(!g_wasDeleted) fails
#5  +[MWMRouter isRoutingActive]
#6  closure #1 in ThemeManager.update(theme:)
#8  static ThemeManager.invalidate()
#10 -[MWMNavigationController traitCollectionDidChange:]
...
#23 _UIApplicationFlushCATransaction
#40 -[NSApplication _shouldTerminate]
#41 -[NSApplication terminate:]
```

`applicationWillTerminate:` calls `DeleteFramework()`, which destroys the C++ `Framework` singleton (`g_wasDeleted = true`). Unlike iOS — where the process is killed right after — AppKit keeps spinning run loops while tearing down, so closing the window still delivers `traitCollectionDidChange:` to a live view controller. That reaches `ThemeManager.invalidate()` → `MWMRouter.isRoutingActive()` → `GetFramework()`, tripping the `CHECK` that exists precisely to catch use-after-destruction.

## Fix

- Expose the existing `g_wasDeleted` state as `IsFrameworkDestroyed()` through the `FrameworkHelper` bridge.
- Short-circuit `ThemeManager.invalidate()` once the framework is destroyed.

`invalidate()` is the single choke point every theme entry path funnels through (trait changes, settings, CarPlay, startup), so the guard covers them all without touching the macOS teardown order. Both `isRoutingActive()` and `FrameworkHelper.setTheme()` inside `update()` reach `GetFramework()`, so skipping the whole pass is necessary — guarding only the routing check would still crash on `setTheme`.

Gating on `g_wasDeleted` (destroyed) rather than "framework is null" preserves the existing lazy-create-on-first-theme behavior at launch.

## Testing

Manual: run the iPad app on macOS (Debug) and press the window close button — the app now exits cleanly instead of aborting in `GetFramework`. This is an AppKit termination-ordering path with no practical unit test.

## Notes

- LLM tooling (Claude Code) was used to diagnose the crash and draft this change.
