### PR TITLE
[drape] Stop wetland/protected-area hatch glitching on zoom-pan

### DIFF
--- a/libs/drape/drape_tests/CMakeLists.txt
+++ b/libs/drape/drape_tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SRC
   img.cpp
   img.hpp
   memory_comparer.hpp
+  mipmap_tests.cpp
   object_pool_tests.cpp
   pointers_tests.cpp
   static_texture_tests.cpp

--- a/libs/drape/drape_tests/gl_functions.cpp
+++ b/libs/drape/drape_tests/gl_functions.cpp
@@ -230,7 +230,8 @@ void GLFunctions::glBindTexture(uint32_t textureID, glConst target)
   MOCK_CALL(glBindTexture(textureID, target));
 }
 
-void GLFunctions::glTexImage2D(int width, int height, glConst layout, glConst pixelType, void const * data)
+void GLFunctions::glTexImage2D(int width, int height, glConst layout, glConst pixelType, void const * data,
+                               int /* level */)
 {
   MOCK_CALL(glTexImage2D(width, height, layout, pixelType, data));
 }

--- a/libs/drape/drape_tests/mipmap_tests.cpp
+++ b/libs/drape/drape_tests/mipmap_tests.cpp
@@ -1,0 +1,63 @@
+#include "testing/testing.hpp"
+
+#include "drape/hw_texture.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace
+{
+UNIT_TEST(Mipmap_LevelsCount)
+{
+  TEST_EQUAL(dp::GetMipLevelsCount(16, 16), 5, ());  // 16,8,4,2,1
+  TEST_EQUAL(dp::GetMipLevelsCount(1, 1), 1, ());
+  TEST_EQUAL(dp::GetMipLevelsCount(8, 4), 4, ());  // 8x4,4x2,2x1,1x1
+  TEST_EQUAL(dp::GetMipLevelsCount(256, 1), 9, ());
+}
+
+UNIT_TEST(Mipmap_BuildLevels_DimsAndCount)
+{
+  std::vector<uint8_t> const lvl0(static_cast<size_t>(16) * 16 * 4, 0);
+  auto const levels = dp::BuildMipmapLevels(lvl0.data(), 16, 16, 4);
+
+  // Levels 1..N-1 (excludes level 0).
+  TEST_EQUAL(levels.size(), dp::GetMipLevelsCount(16, 16) - 1, ());
+  uint32_t const expected[] = {8, 4, 2, 1};
+  for (size_t i = 0; i < levels.size(); ++i)
+  {
+    TEST_EQUAL(levels[i].m_width, expected[i], (i));
+    TEST_EQUAL(levels[i].m_height, expected[i], (i));
+    TEST_EQUAL(levels[i].m_data.size(), static_cast<size_t>(expected[i]) * expected[i] * 4, (i));
+  }
+}
+
+// The crux: a fully transparent texel's RGB must not bleed into the downsampled colour, otherwise the
+// hatch darkens at coarse mips (gray halo). One opaque white texel + three transparent ones must average
+// to white RGB with quarter alpha - not to gray.
+UNIT_TEST(Mipmap_BuildLevels_AlphaWeightedNoHalo)
+{
+  // 2x2 RGBA: top-left opaque white, rest fully transparent with zero RGB.
+  std::vector<uint8_t> lvl0 = {
+      255, 255, 255, 255, /*TL*/ 0, 0, 0, 0, /*TR*/
+      0,   0,   0,   0,   /*BL*/ 0, 0, 0, 0, /*BR*/
+  };
+  auto const levels = dp::BuildMipmapLevels(lvl0.data(), 2, 2, 4);
+  TEST_EQUAL(levels.size(), 1, ());
+  auto const & px = levels[0].m_data;
+  TEST_EQUAL(px.size(), 4, ());
+  TEST_EQUAL(px[0], 255, ("R must stay white, not gray"));
+  TEST_EQUAL(px[1], 255, ("G must stay white, not gray"));
+  TEST_EQUAL(px[2], 255, ("B must stay white, not gray"));
+  TEST_EQUAL(px[3], 64, ("alpha is the plain average: (255+0+0+0+2)/4"));
+}
+
+UNIT_TEST(Mipmap_BuildLevels_SingleChannelPlainAverage)
+{
+  // 2x2 single-channel (e.g. coverage mask): plain box average, no alpha weighting.
+  std::vector<uint8_t> const lvl0 = {200, 100, 50, 10};
+  auto const levels = dp::BuildMipmapLevels(lvl0.data(), 2, 2, 1);
+  TEST_EQUAL(levels.size(), 1, ());
+  TEST_EQUAL(levels[0].m_data.size(), 1, ());
+  TEST_EQUAL(levels[0].m_data[0], static_cast<uint8_t>((200 + 100 + 50 + 10 + 2) / 4), ());  // 90
+}
+}  // namespace

--- a/libs/drape/gl_constants.cpp
+++ b/libs/drape/gl_constants.cpp
@@ -173,6 +173,7 @@ constexpr glConst GLMinFilter = GL_TEXTURE_MIN_FILTER;
 constexpr glConst GLMagFilter = GL_TEXTURE_MAG_FILTER;
 constexpr glConst GLWrapS = GL_TEXTURE_WRAP_S;
 constexpr glConst GLWrapT = GL_TEXTURE_WRAP_T;
+constexpr glConst GLTextureMaxLevel = GL_TEXTURE_MAX_LEVEL;
 
 constexpr glConst GLRepeat = GL_REPEAT;
 constexpr glConst GLMirroredRepeat = GL_MIRRORED_REPEAT;
@@ -180,6 +181,8 @@ constexpr glConst GLClampToEdge = GL_CLAMP_TO_EDGE;
 
 constexpr glConst GLLinear = GL_LINEAR;
 constexpr glConst GLNearest = GL_NEAREST;
+constexpr glConst GLLinearMipmapLinear = GL_LINEAR_MIPMAP_LINEAR;
+constexpr glConst GLNearestMipmapNearest = GL_NEAREST_MIPMAP_NEAREST;
 
 constexpr glConst GLByteType = GL_BYTE;
 constexpr glConst GLUnsignedByteType = GL_UNSIGNED_BYTE;

--- a/libs/drape/gl_constants.hpp
+++ b/libs/drape/gl_constants.hpp
@@ -92,6 +92,7 @@ extern glConst const GLMinFilter;
 extern glConst const GLMagFilter;
 extern glConst const GLWrapS;
 extern glConst const GLWrapT;
+extern glConst const GLTextureMaxLevel;
 
 /// Texture Wrap Modes
 extern glConst const GLRepeat;
@@ -101,6 +102,8 @@ extern glConst const GLClampToEdge;
 /// Texture Filter Modes
 extern glConst const GLLinear;
 extern glConst const GLNearest;
+extern glConst const GLLinearMipmapLinear;
+extern glConst const GLNearestMipmapNearest;
 
 /// OpenGL types
 extern glConst const GLByteType;

--- a/libs/drape/gl_functions.cpp
+++ b/libs/drape/gl_functions.cpp
@@ -1007,11 +1007,11 @@ void GLFunctions::glBindTexture(uint32_t textureID, glConst target)
   GLCHECK(::glBindTexture(target, textureID));
 }
 
-void GLFunctions::glTexImage2D(int width, int height, glConst layout, glConst pixelType, void const * data)
+void GLFunctions::glTexImage2D(int width, int height, glConst layout, glConst pixelType, void const * data, int level)
 {
   ASSERT_EQUAL(CurrentApiVersion, dp::ApiVersion::OpenGLES3, ());
   int const internalFormat = TextureInternalFormatByLayout(layout, pixelType);
-  GLCHECK(::glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, layout, pixelType, data));
+  GLCHECK(::glTexImage2D(GL_TEXTURE_2D, level, internalFormat, width, height, 0, layout, pixelType, data));
 }
 
 void GLFunctions::glTexImage2DArray(int width, int height, int layers, glConst layout, glConst pixelType,

--- a/libs/drape/gl_functions.hpp
+++ b/libs/drape/gl_functions.hpp
@@ -139,7 +139,7 @@ public:
   static uint32_t glGenTexture();
   static void glDeleteTexture(uint32_t id);
   static void glBindTexture(uint32_t textureID, glConst target = gl_const::GLTexture2D);
-  static void glTexImage2D(int width, int height, glConst layout, glConst pixelType, void const * data);
+  static void glTexImage2D(int width, int height, glConst layout, glConst pixelType, void const * data, int level = 0);
   static void glTexImage2DArray(int width, int height, int layers, glConst layout, glConst pixelType,
                                 void const * data);
   static void glTexSubImage2D(int x, int y, int width, int height, glConst layout, glConst pixelType,

--- a/libs/drape/hw_texture.cpp
+++ b/libs/drape/hw_texture.cpp
@@ -4,9 +4,12 @@
 #include "drape/gl_functions.hpp"
 #include "drape/utils/gpu_mem_tracker.hpp"
 
+#include "base/bits.hpp"
 #include "base/logging.hpp"
 
 #include "std/target_os.hpp"
+
+#include <algorithm>
 
 #if defined(OMIM_OS_IPHONE)
 #include "drape/hw_texture_ios.hpp"
@@ -87,6 +90,85 @@ glConst DecodeTextureWrapping(TextureWrapping wrapping)
   UNREACHABLE();
 }
 
+bool CanBuildMipmaps(HWTexture::Params const & params, bool hasData)
+{
+  return params.m_useMipmaps && params.m_layerCount == 1 && hasData;
+}
+
+uint32_t GetMipLevelsCount(uint32_t width, uint32_t height)
+{
+  return 1 + bits::FloorLog(std::max(width, height));
+}
+
+std::vector<MipLevel> BuildMipmapLevels(uint8_t const * level0Data, uint32_t width, uint32_t height,
+                                        uint8_t bytesPerPixel)
+{
+  std::vector<MipLevel> levels;
+  levels.reserve(GetMipLevelsCount(width, height) - 1);
+
+  uint32_t sw = width, sh = height;  // current source-level dimensions
+  while (sw > 1 || sh > 1)
+  {
+    // The source is level 0, then each previously generated level.
+    uint8_t const * const src = levels.empty() ? level0Data : levels.back().m_data.data();
+    uint32_t const dw = std::max(sw >> 1, 1u);
+    uint32_t const dh = std::max(sh >> 1, 1u);
+
+    MipLevel level{dw, dh, std::vector<uint8_t>(static_cast<size_t>(dw) * dh * bytesPerPixel)};
+    uint8_t * const dst = level.m_data.data();
+    for (uint32_t y = 0; y < dh; ++y)
+    {
+      uint32_t const sy0 = std::min(y * 2, sh - 1);
+      uint32_t const sy1 = std::min(sy0 + 1, sh - 1);
+      for (uint32_t x = 0; x < dw; ++x)
+      {
+        uint32_t const sx0 = std::min(x * 2, sw - 1);
+        uint32_t const sx1 = std::min(sx0 + 1, sw - 1);
+        uint8_t const * const p[4] = {src + (static_cast<size_t>(sy0) * sw + sx0) * bytesPerPixel,
+                                      src + (static_cast<size_t>(sy0) * sw + sx1) * bytesPerPixel,
+                                      src + (static_cast<size_t>(sy1) * sw + sx0) * bytesPerPixel,
+                                      src + (static_cast<size_t>(sy1) * sw + sx1) * bytesPerPixel};
+        uint8_t * const d = dst + (static_cast<size_t>(y) * dw + x) * bytesPerPixel;
+        if (bytesPerPixel == 4)
+        {
+          // Alpha-weighted RGB so fully transparent texels (whose RGB is meaningless) don't darken edges.
+          uint32_t const a = p[0][3] + p[1][3] + p[2][3] + p[3][3];
+          for (int c = 0; c < 3; ++c)
+          {
+            d[c] = a == 0
+                     ? 0
+                     : static_cast<uint8_t>(
+                           (p[0][c] * p[0][3] + p[1][c] * p[1][3] + p[2][c] * p[2][3] + p[3][c] * p[3][3] + a / 2) / a);
+          }
+          d[3] = static_cast<uint8_t>((a + 2) / 4);
+        }
+        else
+        {
+          for (uint8_t c = 0; c < bytesPerPixel; ++c)
+            d[c] = static_cast<uint8_t>((p[0][c] + p[1][c] + p[2][c] + p[3][c] + 2) / 4);
+        }
+      }
+    }
+
+    levels.push_back(std::move(level));
+    sw = dw;
+    sh = dh;
+  }
+  return levels;
+}
+
+namespace
+{
+// Minification filter for a texture: trilinear across mip levels when present, otherwise the plain filter.
+// Magnification always uses the plain filter (there's nothing to interpolate above level 0).
+glConst GetGLMinFilter(TextureFilter filter, bool useMipmaps)
+{
+  if (!useMipmaps)
+    return DecodeTextureFilter(filter);
+  return filter == TextureFilter::Linear ? gl_const::GLLinearMipmapLinear : gl_const::GLNearestMipmapNearest;
+}
+}  // namespace
+
 HWTexture::~HWTexture()
 {
 #if defined(TRACK_GPU_MEM)
@@ -100,9 +182,12 @@ void HWTexture::Create(ref_ptr<dp::GraphicsContext> context, Params const & para
   Create(context, params, nullptr);
 }
 
-void HWTexture::Create(ref_ptr<dp::GraphicsContext>, Params const & params, ref_ptr<void>)
+void HWTexture::Create(ref_ptr<dp::GraphicsContext>, Params const & params, ref_ptr<void> data)
 {
   m_params = params;
+  // Single source of truth for "does this texture get a mip chain": every backend calls Base::Create
+  // first and then just reads m_params.m_useMipmaps (for the descriptor, upload and sampler/min filter).
+  m_params.m_useMipmaps = CanBuildMipmaps(params, data != nullptr);
 
 #if defined(TRACK_GPU_MEM)
   uint32_t const memSize = (CHAR_BIT * bytesPerPixel * m_params.m_width * m_params.m_height) >> 3;
@@ -196,8 +281,23 @@ void OpenGLHWTexture::Create(ref_ptr<dp::GraphicsContext> context, Params const 
   else
   {
     GLFunctions::glTexImage2D(m_params.m_width, m_params.m_height, m_unpackedLayout, m_unpackedPixelType, data.get());
+
+    // Upload the CPU-built mip chain as explicit levels.
+    if (m_params.m_useMipmaps)
+    {
+      auto const levels = BuildMipmapLevels(static_cast<uint8_t const *>(data.get()), m_params.m_width,
+                                            m_params.m_height, GetBytesPerPixel(m_params.m_format));
+      for (size_t i = 0; i < levels.size(); ++i)
+      {
+        GLFunctions::glTexImage2D(static_cast<int>(levels[i].m_width), static_cast<int>(levels[i].m_height),
+                                  m_unpackedLayout, m_unpackedPixelType, levels[i].m_data.data(),
+                                  static_cast<int>(i + 1));
+      }
+      GLFunctions::glTexParameter(gl_const::GLTextureMaxLevel, static_cast<glConst>(levels.size()), m_target);
+    }
   }
-  GLFunctions::glTexParameter(gl_const::GLMinFilter, f, m_target);
+  GLFunctions::glTexParameter(gl_const::GLMinFilter, GetGLMinFilter(m_params.m_filter, m_params.m_useMipmaps),
+                              m_target);
   GLFunctions::glTexParameter(gl_const::GLMagFilter, f, m_target);
   GLFunctions::glTexParameter(gl_const::GLWrapS, DecodeTextureWrapping(m_params.m_wrapSMode), m_target);
   GLFunctions::glTexParameter(gl_const::GLWrapT, DecodeTextureWrapping(m_params.m_wrapTMode), m_target);
@@ -275,9 +375,8 @@ void OpenGLHWTexture::SetFilter(TextureFilter filter)
   if (m_params.m_filter != filter)
   {
     m_params.m_filter = filter;
-    auto const f = DecodeTextureFilter(m_params.m_filter);
-    GLFunctions::glTexParameter(gl_const::GLMinFilter, f, m_target);
-    GLFunctions::glTexParameter(gl_const::GLMagFilter, f, m_target);
+    GLFunctions::glTexParameter(gl_const::GLMinFilter, GetGLMinFilter(filter, m_params.m_useMipmaps), m_target);
+    GLFunctions::glTexParameter(gl_const::GLMagFilter, DecodeTextureFilter(filter), m_target);
   }
 }
 

--- a/libs/drape/hw_texture.hpp
+++ b/libs/drape/hw_texture.hpp
@@ -6,6 +6,7 @@
 #include "drape/texture_types.hpp"
 
 #include <cstdint>
+#include <vector>
 
 namespace dp
 {
@@ -25,6 +26,9 @@ public:
     TextureWrapping m_wrapSMode = TextureWrapping::ClampToEdge;
     TextureWrapping m_wrapTMode = TextureWrapping::ClampToEdge;
     TextureFormat m_format = TextureFormat::Unspecified;
+    // Build a full mip chain and sample it trilinearly. Only for standalone, self-contained textures
+    // (e.g. the hatching masks) - never for packed atlases, where coarse levels bleed across entries.
+    bool m_useMipmaps = false;
     bool m_usePixelBuffer = false;
     bool m_isRenderTarget = false;
     bool m_isMutable = false;
@@ -113,4 +117,25 @@ drape_ptr<HWTextureAllocator> CreateAllocator(ref_ptr<dp::GraphicsContext> conte
 void UnpackFormat(ref_ptr<dp::GraphicsContext> context, TextureFormat format, glConst & layout, glConst & pixelType);
 glConst DecodeTextureFilter(TextureFilter filter);
 glConst DecodeTextureWrapping(TextureWrapping wrapping);
+
+// Whether a CPU mip chain should be built for this texture: only standalone, single-layer textures that
+// are uploaded with data. Shared by every backend so they can't disagree on what "mipmapped" means.
+bool CanBuildMipmaps(HWTexture::Params const & params, bool hasData);
+
+// Number of mip levels in a full chain for a width x height texture (down to 1x1), e.g. 16x16 -> 5.
+uint32_t GetMipLevelsCount(uint32_t width, uint32_t height);
+
+// One generated mip level: its dimensions and pixel data.
+struct MipLevel
+{
+  uint32_t m_width;
+  uint32_t m_height;
+  std::vector<uint8_t> m_data;
+};
+
+// Box-downsamples power-of-two level-0 data into mip levels 1..N-1 (index 0 is mip level 1). For 4-byte
+// RGBA the colour is alpha-weighted so fully transparent texels don't bleed their RGB into edges; other
+// formats use a plain average.
+std::vector<MipLevel> BuildMipmapLevels(uint8_t const * level0Data, uint32_t width, uint32_t height,
+                                        uint8_t bytesPerPixel);
 }  // namespace dp

--- a/libs/drape/metal/metal_base_context.hpp
+++ b/libs/drape/metal/metal_base_context.hpp
@@ -66,7 +66,8 @@ public:
   id<MTLRenderCommandEncoder> GetCommandEncoder() const;
   id<MTLDepthStencilState> GetDepthStencilState();
   id<MTLRenderPipelineState> GetPipelineState(ref_ptr<GpuProgram> program, bool blendingEnabled);
-  id<MTLSamplerState> GetSamplerState(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode);
+  id<MTLSamplerState> GetSamplerState(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode,
+                                      bool useMipmaps);
 
   void SetSystemPrograms(drape_ptr<GpuProgram> && programClearColor, drape_ptr<GpuProgram> && programClearDepth,
                          drape_ptr<GpuProgram> && programClearColorAndDepth);

--- a/libs/drape/metal/metal_base_context.mm
+++ b/libs/drape/metal/metal_base_context.mm
@@ -353,9 +353,9 @@ id<MTLRenderPipelineState> MetalBaseContext::GetPipelineState(ref_ptr<GpuProgram
 }
 
 id<MTLSamplerState> MetalBaseContext::GetSamplerState(TextureFilter filter, TextureWrapping wrapSMode,
-                                                      TextureWrapping wrapTMode)
+                                                      TextureWrapping wrapTMode, bool useMipmaps)
 {
-  MetalStates::SamplerKey const key(filter, wrapSMode, wrapTMode);
+  MetalStates::SamplerKey const key(filter, wrapSMode, wrapTMode, useMipmaps);
   return m_metalStates.GetSamplerState(m_device, key);
 }
 

--- a/libs/drape/metal/metal_states.hpp
+++ b/libs/drape/metal/metal_states.hpp
@@ -51,12 +51,13 @@ public:
   struct SamplerKey
   {
     SamplerKey() = default;
-    SamplerKey(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode);
-    void Set(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode);
+    SamplerKey(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode, bool useMipmaps);
+    void Set(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode, bool useMipmaps);
     bool operator<(SamplerKey const & rhs) const;
     MTLSamplerDescriptor * BuildDescriptor() const;
 
     uint32_t m_sampler = 0;
+    bool m_useMipmaps = false;
   };
 
   id<MTLDepthStencilState> GetDepthStencilState(id<MTLDevice> device, DepthStencilKey const & key);

--- a/libs/drape/metal/metal_states.mm
+++ b/libs/drape/metal/metal_states.mm
@@ -305,22 +305,27 @@ MTLRenderPipelineDescriptor * MetalStates::PipelineKey::BuildDescriptor() const
   return desc;
 }
 
-MetalStates::SamplerKey::SamplerKey(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode)
+MetalStates::SamplerKey::SamplerKey(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode,
+                                    bool useMipmaps)
 {
-  Set(filter, wrapSMode, wrapTMode);
+  Set(filter, wrapSMode, wrapTMode, useMipmaps);
 }
 
-void MetalStates::SamplerKey::Set(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode)
+void MetalStates::SamplerKey::Set(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode,
+                                  bool useMipmaps)
 {
   SetStateByte(m_sampler, static_cast<uint8_t>(filter), kMinFilterByte);
   SetStateByte(m_sampler, static_cast<uint8_t>(filter), kMagFilterByte);
   SetStateByte(m_sampler, static_cast<uint8_t>(wrapSMode), kWrapSModeByte);
   SetStateByte(m_sampler, static_cast<uint8_t>(wrapTMode), kWrapTModeByte);
+  m_useMipmaps = useMipmaps;
 }
 
 bool MetalStates::SamplerKey::operator<(SamplerKey const & rhs) const
 {
-  return m_sampler < rhs.m_sampler;
+  if (m_sampler != rhs.m_sampler)
+    return m_sampler < rhs.m_sampler;
+  return m_useMipmaps < rhs.m_useMipmaps;
 }
 
 MTLSamplerDescriptor * MetalStates::SamplerKey::BuildDescriptor() const
@@ -330,6 +335,9 @@ MTLSamplerDescriptor * MetalStates::SamplerKey::BuildDescriptor() const
   desc.magFilter = DecodeTextureFilter(GetStateByte(m_sampler, kMagFilterByte));
   desc.sAddressMode = DecodeTextureWrapping(GetStateByte(m_sampler, kWrapSModeByte));
   desc.tAddressMode = DecodeTextureWrapping(GetStateByte(m_sampler, kWrapTModeByte));
+  // Trilinear across mip levels when the texture has them; default leaves mipFilter NotMipmapped.
+  if (m_useMipmaps)
+    desc.mipFilter = MTLSamplerMipFilterLinear;
   return desc;
 }
 }  // namespace metal

--- a/libs/drape/metal/metal_texture.mm
+++ b/libs/drape/metal/metal_texture.mm
@@ -50,7 +50,7 @@ MTLTextureDescriptor * CreateTextureDescriptor(HWTexture::Params const & params)
   return [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:UnpackFormat(params.m_format)
                                                             width:params.m_width
                                                            height:params.m_height
-                                                        mipmapped:NO];
+                                                        mipmapped:(params.m_useMipmaps ? YES : NO)];
 }
 }  // namespace
 
@@ -65,7 +65,7 @@ void MetalTexture::Create(ref_ptr<dp::GraphicsContext> context, Params const & p
   ref_ptr<MetalBaseContext> metalContext = context;
   id<MTLDevice> metalDevice = metalContext->GetMetalDevice();
 
-  MTLTextureDescriptor * texDesc = CreateTextureDescriptor(params);
+  MTLTextureDescriptor * texDesc = CreateTextureDescriptor(m_params);
   texDesc.usage = MTLTextureUsageShaderRead;
   m_isMutable = params.m_isMutable;
   if (params.m_isRenderTarget)
@@ -82,11 +82,29 @@ void MetalTexture::Create(ref_ptr<dp::GraphicsContext> context, Params const & p
     CHECK(m_texture != nil, ());
     if (data)
     {
-      auto const imageBytes = GetBytesPerPixel(params.m_format) * params.m_width * params.m_height;
+      auto const bytesPerPixel = GetBytesPerPixel(params.m_format);
+      auto const imageBytes = bytesPerPixel * params.m_width * params.m_height;
       for (uint32_t layer = 0; layer < params.m_layerCount; ++layer)
       {
         void * layerData = static_cast<uint8_t *>(data.get()) + layer * imageBytes;
         UploadDataImpl(0, 0, params.m_width, params.m_height, layer, make_ref(layerData));
+      }
+
+      // Upload the CPU-built mip chain as explicit levels.
+      if (m_params.m_useMipmaps)
+      {
+        auto const levels =
+            BuildMipmapLevels(static_cast<uint8_t const *>(data.get()), params.m_width, params.m_height, bytesPerPixel);
+        for (size_t i = 0; i < levels.size(); ++i)
+        {
+          MTLRegion const region = MTLRegionMake2D(0, 0, levels[i].m_width, levels[i].m_height);
+          [m_texture replaceRegion:region
+                       mipmapLevel:(i + 1)
+                             slice:0
+                         withBytes:levels[i].m_data.data()
+                       bytesPerRow:(levels[i].m_width * bytesPerPixel)
+                     bytesPerImage:0];
+        }
       }
     }
   }

--- a/libs/drape/metal/render_state_metal.mm
+++ b/libs/drape/metal/render_state_metal.mm
@@ -55,7 +55,7 @@ void ApplyTexturesForMetal(ref_ptr<GraphicsContext> context, ref_ptr<GpuProgram>
       if (vsBindingInfo.m_samplerBindingIndex >= 0)
       {
         id<MTLSamplerState> samplerState =
-            metalContext->GetSamplerState(params.m_filter, params.m_wrapSMode, params.m_wrapTMode);
+            metalContext->GetSamplerState(params.m_filter, params.m_wrapSMode, params.m_wrapTMode, params.m_useMipmaps);
         [encoder setVertexSamplerState:samplerState atIndex:vsBindingInfo.m_samplerBindingIndex];
       }
     }
@@ -68,7 +68,7 @@ void ApplyTexturesForMetal(ref_ptr<GraphicsContext> context, ref_ptr<GpuProgram>
       if (fsBindingInfo.m_samplerBindingIndex >= 0)
       {
         id<MTLSamplerState> samplerState =
-            metalContext->GetSamplerState(params.m_filter, params.m_wrapSMode, params.m_wrapTMode);
+            metalContext->GetSamplerState(params.m_filter, params.m_wrapSMode, params.m_wrapTMode, params.m_useMipmaps);
         [encoder setFragmentSamplerState:samplerState atIndex:fsBindingInfo.m_samplerBindingIndex];
       }
     }

--- a/libs/drape/static_texture.cpp
+++ b/libs/drape/static_texture.cpp
@@ -94,7 +94,8 @@ StaticTexture::StaticTexture() : m_info(make_unique_dp<StaticResourceInfo>()) {}
 
 StaticTexture::StaticTexture(ref_ptr<dp::GraphicsContext> context, std::string const & textureName,
                              std::string const & skinPathName, dp::TextureFormat format,
-                             ref_ptr<HWTextureAllocator> allocator, bool allowOptional /* = false */)
+                             ref_ptr<HWTextureAllocator> allocator, bool allowOptional /* = false */,
+                             bool useMipmaps /* = false */)
   : m_info(make_unique_dp<StaticResourceInfo>())
 {
   auto completionHandler = [&](unsigned char * data, uint32_t width, uint32_t height)
@@ -106,6 +107,7 @@ StaticTexture::StaticTexture(ref_ptr<dp::GraphicsContext> context, std::string c
     p.m_height = height;
     p.m_wrapSMode = TextureWrapping::Repeat;
     p.m_wrapTMode = TextureWrapping::Repeat;
+    p.m_useMipmaps = useMipmaps;
 
     Create(context, p, make_ref(data));
   };

--- a/libs/drape/static_texture.hpp
+++ b/libs/drape/static_texture.hpp
@@ -23,7 +23,8 @@ public:
 
   /// @todo All xxxName can be std::string_view after Platform::GetReader (StyleReader) refactoring.
   StaticTexture(ref_ptr<dp::GraphicsContext> context, std::string const & textureName, std::string const & skinPathName,
-                dp::TextureFormat format, ref_ptr<HWTextureAllocator> allocator, bool allowOptional = false);
+                dp::TextureFormat format, ref_ptr<HWTextureAllocator> allocator, bool allowOptional = false,
+                bool useMipmaps = false);
 
   ref_ptr<ResourceInfo> FindResource(Key const & key, bool & newResource) override;
   void Create(ref_ptr<dp::GraphicsContext> context, Params const & params) override;

--- a/libs/drape/texture_manager.cpp
+++ b/libs/drape/texture_manager.cpp
@@ -502,11 +502,13 @@ void TextureManager::Init(ref_ptr<dp::GraphicsContext> context, Params const & p
                                                         dp::TextureFormat::RGBA8, make_ref(m_textureAllocator));
 
   /// @todo Introduce array of keys and use them as mask file name prefix.
-  m_hatchingTextures[k45dHatching] = make_unique_dp<StaticTexture>(
-      context, "area-hatching.png", m_resPostfix, dp::TextureFormat::RGBA8, make_ref(m_textureAllocator));
-  m_hatchingTextures[kDashHatching] =
-      make_unique_dp<StaticTexture>(context, "dash-hatching.png", StaticTexture::kDefaultResource,
-                                    dp::TextureFormat::RGBA8, make_ref(m_textureAllocator));
+  // Mipmaps + trilinear sampling stop the thin hatch lines from shimmering/aliasing on zoom-pan (#12804).
+  m_hatchingTextures[k45dHatching] =
+      make_unique_dp<StaticTexture>(context, "area-hatching.png", m_resPostfix, dp::TextureFormat::RGBA8,
+                                    make_ref(m_textureAllocator), false /* allowOptional */, true /* useMipmaps */);
+  m_hatchingTextures[kDashHatching] = make_unique_dp<StaticTexture>(
+      context, "dash-hatching.png", StaticTexture::kDefaultResource, dp::TextureFormat::RGBA8,
+      make_ref(m_textureAllocator), false /* allowOptional */, true /* useMipmaps */);
 
   m_arrowTexture = CreateArrowTexture(context, make_ref(m_textureAllocator), params.m_arrowTexturePath,
                                       params.m_arrowTextureUseDefaultResourceFolder);

--- a/libs/drape/vulkan/vulkan_object_manager.cpp
+++ b/libs/drape/vulkan/vulkan_object_manager.cpp
@@ -149,7 +149,7 @@ VulkanObject VulkanObjectManager::CreateBuffer(VulkanMemoryManager::ResourceType
 
 VulkanObject VulkanObjectManager::CreateImage(VkImageUsageFlags usageFlags, VkFormat format, VkImageTiling tiling,
                                               VkImageAspectFlags aspectFlags, uint32_t width, uint32_t height,
-                                              uint32_t layerCount)
+                                              uint32_t layerCount, uint32_t mipLevels)
 {
   VulkanObject result;
   VkImageCreateInfo imageCreateInfo = {};
@@ -157,7 +157,7 @@ VulkanObject VulkanObjectManager::CreateImage(VkImageUsageFlags usageFlags, VkFo
   imageCreateInfo.pNext = nullptr;
   imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
   imageCreateInfo.format = format;
-  imageCreateInfo.mipLevels = 1;
+  imageCreateInfo.mipLevels = mipLevels;
   imageCreateInfo.arrayLayers = layerCount;
   imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
   imageCreateInfo.tiling = tiling;
@@ -199,7 +199,7 @@ VulkanObject VulkanObjectManager::CreateImage(VkImageUsageFlags usageFlags, VkFo
   }
   viewCreateInfo.subresourceRange.aspectMask = aspectFlags;
   viewCreateInfo.subresourceRange.baseMipLevel = 0;
-  viewCreateInfo.subresourceRange.levelCount = 1;
+  viewCreateInfo.subresourceRange.levelCount = mipLevels;
   viewCreateInfo.subresourceRange.baseArrayLayer = 0;
   viewCreateInfo.subresourceRange.layerCount = layerCount;
   viewCreateInfo.image = result.m_image;
@@ -486,6 +486,9 @@ VkSampler VulkanObjectManager::GetSampler(SamplerKey const & key)
   samplerCreateInfo.magFilter = samplerCreateInfo.minFilter = GetVulkanFilter(key.GetTextureFilter());
   samplerCreateInfo.addressModeU = GetVulkanSamplerAddressMode(key.GetWrapSMode());
   samplerCreateInfo.addressModeV = GetVulkanSamplerAddressMode(key.GetWrapTMode());
+  // Trilinear across mip levels when present; otherwise clamp to level 0 (maxLod 0).
+  samplerCreateInfo.mipmapMode = key.GetUseMipmaps() ? VK_SAMPLER_MIPMAP_MODE_LINEAR : VK_SAMPLER_MIPMAP_MODE_NEAREST;
+  samplerCreateInfo.maxLod = key.GetUseMipmaps() ? VK_LOD_CLAMP_NONE : 0.0f;
 
   VkSampler sampler;
   CHECK_VK_CALL(vkCreateSampler(m_device, &samplerCreateInfo, nullptr, &sampler));

--- a/libs/drape/vulkan/vulkan_object_manager.hpp
+++ b/libs/drape/vulkan/vulkan_object_manager.hpp
@@ -67,7 +67,8 @@ public:
 
   VulkanObject CreateBuffer(VulkanMemoryManager::ResourceType resourceType, uint32_t sizeInBytes, uint64_t batcherHash);
   VulkanObject CreateImage(VkImageUsageFlags usageFlags, VkFormat format, VkImageTiling tiling,
-                           VkImageAspectFlags aspectFlags, uint32_t width, uint32_t height, uint32_t layerCount);
+                           VkImageAspectFlags aspectFlags, uint32_t width, uint32_t height, uint32_t layerCount,
+                           uint32_t mipLevels = 1);
   DescriptorSetGroup CreateDescriptorSetGroup(ref_ptr<VulkanGpuProgram> program);
 
   // Use unsafe function ONLY if an object exists on one thread, otherwise

--- a/libs/drape/vulkan/vulkan_texture.cpp
+++ b/libs/drape/vulkan/vulkan_texture.cpp
@@ -19,11 +19,11 @@ namespace vulkan
 namespace
 {
 VkBufferImageCopy BufferCopyRegion(uint32_t x, uint32_t y, uint32_t width, uint32_t height, uint32_t stagingOffset,
-                                   uint32_t startLayer, uint32_t numLayers)
+                                   uint32_t startLayer, uint32_t numLayers, uint32_t mipLevel = 0)
 {
   VkBufferImageCopy bufferCopyRegion = {};
   bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-  bufferCopyRegion.imageSubresource.mipLevel = 0;
+  bufferCopyRegion.imageSubresource.mipLevel = mipLevel;
   bufferCopyRegion.imageSubresource.baseArrayLayer = startLayer;
   bufferCopyRegion.imageSubresource.layerCount = numLayers;
   bufferCopyRegion.imageExtent.width = width;
@@ -99,6 +99,14 @@ void VulkanTexture::Create(ref_ptr<dp::GraphicsContext> context, Params const & 
   }
   else
   {
+    // CPU-built mip chain (single-layer textures only). mipLevelsCount includes level 0.
+    auto const bytesPerPixel = GetBytesPerPixel(params.m_format);
+    std::vector<MipLevel> mipLevels;
+    if (m_params.m_useMipmaps)
+      mipLevels =
+          BuildMipmapLevels(static_cast<uint8_t const *>(data.get()), params.m_width, params.m_height, bytesPerPixel);
+    uint32_t const mipLevelsCount = static_cast<uint32_t>(mipLevels.size()) + 1;
+
     if (data != nullptr || params.m_usePersistentStagingBuffer)
     {
       std::lock_guard<std::mutex> lock(m_dedicatedStagingBufferMutex);
@@ -106,9 +114,11 @@ void VulkanTexture::Create(ref_ptr<dp::GraphicsContext> context, Params const & 
       if (m_dedicatedStagingBuffer.m_buffer)
         m_objectManager->DestroyObject(m_dedicatedStagingBuffer);
 
-      // Create dedicated staging buffer.
-      auto const notAlignedSize =
-          GetBytesPerPixel(params.m_format) * params.m_width * params.m_height * params.m_layerCount;
+      // Create dedicated staging buffer large enough for level 0 plus the whole mip chain.
+      auto const level0Size = bytesPerPixel * params.m_width * params.m_height * params.m_layerCount;
+      uint32_t notAlignedSize = level0Size;
+      for (auto const & level : mipLevels)
+        notAlignedSize += static_cast<uint32_t>(level.m_data.size());
       auto bufferSize = VulkanMemoryManager::GetAligned(notAlignedSize, 64);
 
       auto constexpr kStagingBuffer = VulkanMemoryManager::ResourceType::Staging;
@@ -133,9 +143,21 @@ void VulkanTexture::Create(ref_ptr<dp::GraphicsContext> context, Params const & 
 
       if (data != nullptr)
       {
-        m_objectManager->Fill(m_dedicatedStagingBuffer, data.get(), notAlignedSize);
+        uint32_t offset = 0;
+        m_objectManager->Fill(m_dedicatedStagingBuffer, data.get(), level0Size, offset);
         m_copyRegions.emplace_back(
-            BufferCopyRegion(0, 0, params.m_width, params.m_height, 0 /* offset */, 0, params.m_layerCount));
+            BufferCopyRegion(0, 0, params.m_width, params.m_height, offset, 0, params.m_layerCount, 0 /* mipLevel */));
+        offset += level0Size;
+
+        for (size_t i = 0; i < mipLevels.size(); ++i)
+        {
+          auto const & level = mipLevels[i];
+          auto const levelSize = static_cast<uint32_t>(level.m_data.size());
+          m_objectManager->Fill(m_dedicatedStagingBuffer, level.m_data.data(), levelSize, offset);
+          m_copyRegions.emplace_back(
+              BufferCopyRegion(0, 0, level.m_width, level.m_height, offset, 0, 1, static_cast<uint32_t>(i + 1)));
+          offset += levelSize;
+        }
       }
     }
     m_usePersistentStagingBuffer = params.m_usePersistentStagingBuffer;
@@ -143,7 +165,7 @@ void VulkanTexture::Create(ref_ptr<dp::GraphicsContext> context, Params const & 
     // Create image.
     m_textureObject =
         m_objectManager->CreateImage(VK_IMAGE_USAGE_SAMPLED_BIT, format, tiling, VK_IMAGE_ASPECT_COLOR_BIT,
-                                     params.m_width, params.m_height, params.m_layerCount);
+                                     params.m_width, params.m_height, params.m_layerCount, mipLevelsCount);
   }
 }
 
@@ -267,7 +289,7 @@ bool VulkanTexture::Validate() const
 
 SamplerKey VulkanTexture::GetSamplerKey() const
 {
-  return SamplerKey(m_params.m_filter, m_params.m_wrapSMode, m_params.m_wrapTMode);
+  return SamplerKey(m_params.m_filter, m_params.m_wrapSMode, m_params.m_wrapTMode, m_params.m_useMipmaps);
 }
 
 void VulkanTexture::MakeImageLayoutTransition(VkCommandBuffer commandBuffer, VkImageLayout newLayout,

--- a/libs/drape/vulkan/vulkan_utils.cpp
+++ b/libs/drape/vulkan/vulkan_utils.cpp
@@ -172,17 +172,18 @@ VkFormat VulkanFormatUnpacker::Unpack(TextureFormat format)
   UNREACHABLE();
 }
 
-SamplerKey::SamplerKey(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode)
+SamplerKey::SamplerKey(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode, bool useMipmaps)
 {
-  Set(filter, wrapSMode, wrapTMode);
+  Set(filter, wrapSMode, wrapTMode, useMipmaps);
 }
 
-void SamplerKey::Set(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode)
+void SamplerKey::Set(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode, bool useMipmaps)
 {
   SetStateByte(m_sampler, static_cast<uint8_t>(filter), kMinFilterByte);
   SetStateByte(m_sampler, static_cast<uint8_t>(filter), kMagFilterByte);
   SetStateByte(m_sampler, static_cast<uint8_t>(wrapSMode), kWrapSModeByte);
   SetStateByte(m_sampler, static_cast<uint8_t>(wrapTMode), kWrapTModeByte);
+  m_useMipmaps = useMipmaps;
 }
 
 TextureFilter SamplerKey::GetTextureFilter() const
@@ -202,7 +203,9 @@ TextureWrapping SamplerKey::GetWrapTMode() const
 
 bool SamplerKey::operator<(SamplerKey const & rhs) const
 {
-  return m_sampler < rhs.m_sampler;
+  if (m_sampler != rhs.m_sampler)
+    return m_sampler < rhs.m_sampler;
+  return m_useMipmaps < rhs.m_useMipmaps;
 }
 }  // namespace vulkan
 }  // namespace dp

--- a/libs/drape/vulkan/vulkan_utils.hpp
+++ b/libs/drape/vulkan/vulkan_utils.hpp
@@ -45,14 +45,16 @@ uint8_t GetStateByte(T & state, uint8_t byteNumber)
 struct SamplerKey
 {
   SamplerKey() = default;
-  SamplerKey(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode);
-  void Set(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode);
+  SamplerKey(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode, bool useMipmaps);
+  void Set(TextureFilter filter, TextureWrapping wrapSMode, TextureWrapping wrapTMode, bool useMipmaps);
   TextureFilter GetTextureFilter() const;
   TextureWrapping GetWrapSMode() const;
   TextureWrapping GetWrapTMode() const;
+  bool GetUseMipmaps() const { return m_useMipmaps; }
   bool operator<(SamplerKey const & rhs) const;
 
   uint32_t m_sampler = 0;
+  bool m_useMipmaps = false;
 };
 
 class DebugName

--- a/libs/drape_frontend/area_shape.cpp
+++ b/libs/drape_frontend/area_shape.cpp
@@ -10,8 +10,16 @@
 
 #include "base/buffer_vector.hpp"
 
+#include <cmath>
+
 namespace df
 {
+
+double CalcHatchingPhaseAnchor(double bboxMin, uint32_t maskSizePx, double baseGtoPScale)
+{
+  double const period = maskSizePx / baseGtoPScale;  // world units per mask repeat
+  return std::floor(bboxMin / period) * period;
+}
 
 AreaShape::AreaShape(std::vector<m2::PointD> triangleList, BuildingOutline && buildingOutline,
                      AreaViewParams const & params)
@@ -118,13 +126,18 @@ void AreaShape::DrawHatchingArea(ref_ptr<dp::GraphicsContext> context, ref_ptr<d
   double const maxU = m_params.m_baseGtoPScale / hatchingTexture->GetWidth();
   double const maxV = m_params.m_baseGtoPScale / hatchingTexture->GetHeight();
 
+  // Anchor the repeated mask to a global, period-aligned grid instead of the clipped bbox, so the hatch
+  // phase stays continuous across tile seams and LOD changes. See CalcHatchingPhaseAnchor / issue #12804.
+  double const anchorX = CalcHatchingPhaseAnchor(bbox.minX(), hatchingTexture->GetWidth(), m_params.m_baseGtoPScale);
+  double const anchorY = CalcHatchingPhaseAnchor(bbox.minY(), hatchingTexture->GetHeight(), m_params.m_baseGtoPScale);
+
   gpu::VBReservedSizeT<gpu::HatchingAreaVertex> vertexes;
   vertexes.reserve(m_vertexes.size());
   for (m2::PointD const & vertex : m_vertexes)
   {
-    vertexes.emplace_back(ToShapeVertex3(vertex), uv,
-                          glsl::vec2(static_cast<float>(maxU * (vertex.x - bbox.minX())),
-                                     static_cast<float>(maxV * (vertex.y - bbox.minY()))));
+    vertexes.emplace_back(
+        ToShapeVertex3(vertex), uv,
+        glsl::vec2(static_cast<float>(maxU * (vertex.x - anchorX)), static_cast<float>(maxV * (vertex.y - anchorY))));
   }
 
   auto state = CreateRenderState(gpu::Program::HatchingArea, DepthLayer::GeometryLayer);

--- a/libs/drape_frontend/area_shape.hpp
+++ b/libs/drape_frontend/area_shape.hpp
@@ -21,6 +21,20 @@ struct BuildingOutline
   bool m_generateOutline = false;
 };
 
+// Returns the world-space anchor for one axis of a hatching-area's repeated mask UVs.
+//
+// Hatching UVs are 'maxU * (vertex - anchor)' with maxU = baseGtoPScale / maskSizePx, so one mask repeat
+// spans 'maskSizePx / baseGtoPScale' world units. Anchoring to the clipped per-shape bbox.min is unstable:
+// non-building area triangles are clipped to the tile rect (ApplyAreaFeature::operator(), via
+// m2::ClipTriangleByRect), so bbox.min jumps whenever a feature is re-tiled or the LOD changes, snapping
+// the dash phase (see issue #12804).
+//
+// This snaps the anchor down to the nearest multiple of the mask period, i.e. a global, tile-independent
+// grid. The sampled texel (UV mod 1) then depends only on the world coordinate, so the pattern stays
+// continuous across tile seams, while '(vertex - anchor)' stays small (< bbox size + one period) to keep
+// float precision in the GPU attribute.
+double CalcHatchingPhaseAnchor(double bboxMin, uint32_t maskSizePx, double baseGtoPScale);
+
 class AreaShape : public MapShape
 {
 public:

--- a/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
+++ b/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SRC
   area_shape_tests.cpp
   clip_splines_builder_tests.cpp
   frame_values_tests.cpp
+  hatching_area_gpu_test.cpp
   navigator_test.cpp
   path_text_test.cpp
   rainbow_line_gpu_test.cpp

--- a/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
+++ b/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(drape_frontend_tests)
 
 set(SRC
+  area_shape_tests.cpp
   clip_splines_builder_tests.cpp
   frame_values_tests.cpp
   navigator_test.cpp

--- a/libs/drape_frontend/drape_frontend_tests/area_shape_tests.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/area_shape_tests.cpp
@@ -1,0 +1,74 @@
+#include "testing/testing.hpp"
+
+#include "drape_frontend/area_shape.hpp"
+
+#include <cmath>
+
+namespace
+{
+double Frac(double v)
+{
+  return v - std::floor(v);
+}
+
+// Reproduces the GPU mask UV that DrawHatchingArea bakes into the vertex buffer:
+//   maxU * (worldCoord - anchor),  maxU = baseGtoPScale / maskSizePx.
+double HatchUV(double worldCoord, double bboxMin, uint32_t maskSizePx, double baseGtoPScale)
+{
+  double const maxU = baseGtoPScale / maskSizePx;
+  return maxU * (worldCoord - df::CalcHatchingPhaseAnchor(bboxMin, maskSizePx, baseGtoPScale));
+}
+}  // namespace
+
+// The dash mask is sampled with Repeat wrapping, so only the fractional part of the UV (the phase)
+// selects a texel. The phase must be a function of the world coordinate alone — independent of how a
+// feature happens to be clipped into per-tile bounding boxes — otherwise the pattern snaps/shifts and
+// breaks at tile seams when geometry is re-tiled or the LOD changes (issue #12804).
+UNIT_TEST(HatchingPhaseAnchor_StableAcrossTileClipping)
+{
+  uint32_t const kMaskPx = 16;                                      // dash-hatching.png is 16x16
+  double const kBaseGtoP = 4096.0;                                  // pixels per mercator unit at some zoom level
+  double const kPeriod = static_cast<double>(kMaskPx) / kBaseGtoP;  // world units per mask repeat
+
+  // A world vertex lying on the shared edge of two adjacent tiles.
+  double const worldX = 123.4567;
+
+  // The two tiles clip the same feature differently => arbitrary, non-period-aligned bbox mins.
+  double const bboxMinA = 123.40;
+  double const bboxMinB = 122.91;
+
+  double const anchorA = df::CalcHatchingPhaseAnchor(bboxMinA, kMaskPx, kBaseGtoP);
+  double const anchorB = df::CalcHatchingPhaseAnchor(bboxMinB, kMaskPx, kBaseGtoP);
+
+  // Anchor sits on the global period grid, just below the bbox min (so UVs stay small for float precision).
+  TEST(anchorA <= bboxMinA && bboxMinA - anchorA < kPeriod, (anchorA, bboxMinA, kPeriod));
+  TEST(anchorB <= bboxMinB && bboxMinB - anchorB < kPeriod, (anchorB, bboxMinB, kPeriod));
+
+  // The invariant: the sampled texel (UV mod 1) for the shared vertex matches across both tiles.
+  double const uvA = HatchUV(worldX, bboxMinA, kMaskPx, kBaseGtoP);
+  double const uvB = HatchUV(worldX, bboxMinB, kMaskPx, kBaseGtoP);
+  TEST_ALMOST_EQUAL_ABS(Frac(uvA), Frac(uvB), 1e-5, (uvA, uvB));
+
+  // Guard against regression: the previous bbox-anchored formula did NOT have this property.
+  double const oldA = (kBaseGtoP / kMaskPx) * (worldX - bboxMinA);
+  double const oldB = (kBaseGtoP / kMaskPx) * (worldX - bboxMinB);
+  TEST_GREATER(std::abs(Frac(oldA) - Frac(oldB)), 1e-3, (oldA, oldB));
+}
+
+// Phase stability must also hold when the same feature is rendered at different zoom levels: at a fixed
+// world coordinate the texel depends only on baseGtoPScale, not on the (clipped) bbox.
+UNIT_TEST(HatchingPhaseAnchor_IndependentOfBBoxAtFixedScale)
+{
+  uint32_t const kMaskPx = 16;
+  double const kBaseGtoP = 256.0;
+  double const worldX = -57.318;  // negative coordinate => floor() must round toward -inf, not toward 0
+
+  // Many distinct clip bboxes, all containing worldX, must yield the same phase.
+  double const refUV = HatchUV(worldX, worldX - 0.001, kMaskPx, kBaseGtoP);
+  for (double offset : {0.0123, 0.5, 1.7, 13.0, 100.25})
+  {
+    double const bboxMin = worldX - offset;
+    double const uv = HatchUV(worldX, bboxMin, kMaskPx, kBaseGtoP);
+    TEST_ALMOST_EQUAL_ABS(Frac(uv), Frac(refUV), 1e-4, (offset, uv, refUV));
+  }
+}

--- a/libs/drape_frontend/drape_frontend_tests/hatching_area_gpu_test.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/hatching_area_gpu_test.cpp
@@ -1,0 +1,71 @@
+#include "testing/testing.hpp"
+
+#include "drape_frontend/area_shape.hpp"
+#include "drape_frontend/drape_frontend_tests/shape_test_fixture.hpp"
+
+#include "drape/color.hpp"
+#include "drape/hatching_decl.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include <vector>
+
+namespace hatching_area_gpu_test
+{
+df::AreaViewParams MakeHatchParams(double baseGtoPScale)
+{
+  df::AreaViewParams p;
+  p.m_tileCenter = {0, 0};
+  p.m_color = dp::Color(0, 160, 160, 255);  // teal, clearly distinct from the white background
+  p.m_depth = 0;
+  p.m_depthTestEnabled = false;
+  p.m_depthLayer = df::DepthLayer::GeometryLayer;
+  p.m_minVisibleScale = 0;
+  p.m_rank = 0;
+  p.m_hatching = dp::kDashHatching;  // mipmapped mask (see TextureManager init)
+  p.m_baseGtoPScale = baseGtoPScale;
+  return p;
+}
+}  // namespace hatching_area_gpu_test
+
+// Renders a wetland-style dash-hatched area through the real GL pipeline with the mask minified
+// (baseGtoPScale > 1 => the 16px pattern is squeezed below 1 texel/pixel), so a generated mip level is
+// actually sampled. Asserts the hatch colour shows up: an incomplete mip chain would sample black and an
+// unbound/empty mask would leave the frame white - both would fail this.
+UNIT_TEST(HatchingAreaGpuTest)
+{
+  using namespace hatching_area_gpu_test;
+
+  df::test_support::ShapeTestFixture fixture;
+  uint32_t constexpr kW = 256, kH = 256;
+  fixture.Render("Hatching area (mipmapped mask)", kW, kH, [](df::test_support::ShapeTestFixture & f)
+  {
+    // Quad covering most of the viewport (two triangles), in world == pixel-from-center coords.
+    std::vector<m2::PointD> triangles = {{-110, -110}, {110, -110}, {110, 110}, {-110, -110}, {110, 110}, {-110, 110}};
+    f.AddShape(make_unique_dp<df::AreaShape>(std::move(triangles), df::BuildingOutline{},
+                                             MakeHatchParams(2.0 /* baseGtoPScale */)));
+  });
+
+  QImage const & img = fixture.GetLastImage();
+  if (img.isNull())
+    return;  // Headless env without a usable GL context - nothing to assert.
+
+  uint32_t teal = 0, opaqueBlack = 0;
+  for (int y = 0; y < img.height(); ++y)
+  {
+    for (int x = 0; x < img.width(); ++x)
+    {
+      QColor const c = img.pixelColor(x, y);
+      // Hatch colour: green & blue clearly above red (teal over white => G,B > R).
+      if (c.green() > c.red() + 20 && c.blue() > c.red() + 20)
+        ++teal;
+      // An incomplete mip chain samples as opaque black (0,0,0,1). Transparent dash gaps are (0,0,0,0)
+      // and must not count - only opaque near-black pixels indicate the failure.
+      if (c.alpha() > 200 && c.red() < 8 && c.green() < 8 && c.blue() < 8)
+        ++opaqueBlack;
+    }
+  }
+
+  TEST_GREATER(teal, 0u, ("Hatch colour not visible - mask not sampled?"));
+  TEST_EQUAL(opaqueBlack, 0u, ("Opaque black pixels indicate an incomplete mipmap chain"));
+}

--- a/libs/drape_frontend/drape_frontend_tests/shape_test_fixture.hpp
+++ b/libs/drape_frontend/drape_frontend_tests/shape_test_fixture.hpp
@@ -41,6 +41,9 @@ public:
   /// Add a shape to the current batch. Only valid inside RenderShapesToImage callback.
   void AddShape(drape_ptr<MapShape> && shape);
 
+  /// The last rendered frame; valid after Render() returns.
+  QImage const & GetLastImage() const { return m_lastImage; }
+
 private:
   bool Init(uint32_t width, uint32_t height);
   void Flush();


### PR DESCRIPTION
Fixes the wetland/bog/marsh/protected-area hatch (and helps streams) glitching, shifting and shimmering when zooming/panning, reported in #12804. Two independent root causes, one commit each.

## 1. `[drape] Anchor hatching mask phase to a stable global grid`

The hatch UVs were anchored to each shape's **clipped** bounding box. Non-building area triangles are clipped to the tile rect (`ApplyAreaFeature::operator()` → `m2::ClipTriangleByRect`), so `bbox.min` jumps whenever a feature is re-tiled or the LOD changes — snapping the dash phase and breaking the pattern at tile seams (the "shift / form odd and cut-off lines" symptom).

Anchor the phase to a global grid aligned to the mask's world-space period instead (`floor(min / period) * period`). The sampled texel then depends only on the world coordinate, so the hatch stays continuous across tiles, while `(vertex − anchor)` stays small to preserve float precision.

## 2. `[drape] Mipmap the hatching masks to stop zoom-pan shimmer`

The hatch is a tiny repeated mask sampled with linear filtering and **no mipmaps**, so the thin 1-px lines alias and shimmer/crawl under minification (the "flicker and glitch" symptom; the engine had no mipmap support at all).

Add optional mipmaps for standalone textures:
- `HWTexture::Params::m_useMipmaps` + a shared CPU mip generator (alpha-weighted box filter so transparent texels don't bleed RGB into edges).
- Trilinear min filter derived from the texture's own flag — magnification and the per-draw filter override are unchanged, so no render-state API change.
- Levels uploaded through each backend's existing path: GL `glTexImage2D(level)`, Metal `replaceRegion:mipmapLevel:`, Vulkan one `VkBufferImageCopy` per level (avoids a command buffer at creation and the `vkCmdBlitImage` format-feature dependency).
- Enabled on the dash/45d hatching masks only; packed atlases stay un-mipmapped to avoid cross-entry bleeding.

## How tested

- Unit tests: hatch phase stability across differently-clipped tiles (`area_shape_tests.cpp`); mip generator dims/count + alpha-weighted no-halo (`mipmap_tests.cpp`).
- GPU test renders a minified hatched area through real GL and asserts the mask samples correctly with no incomplete-texture black (`hatching_area_gpu_test.cpp`).
- GL validated on Apple M2 Max (GLES3); Metal and Vulkan compile-checked; full desktop app links; `drape_tests` + `drape_frontend_tests` pass.

## Not in this PR (follow-up)

The dark theme's `@river #062026` is nearly indistinguishable from the dark basemap background (`#0f0f0f`), so thin streams stay hard to see regardless of the rendering fixes, and the bright `@wetland #7fd3d3` maximizes how visible any residual aliasing is. That is a palette decision in `data/styles/default/dark/colors.mapcss`, owned by the styles team — better handled as a separate styles change than bundled with these rendering fixes.

https://github.com/organicmaps/organicmaps/pull/12954

Issue: #12804

---
LLM note (per CONTRIBUTING): analysis and code produced with Claude Code, reviewed and verified by me.
