### PR TITLE
VS Code: remove twxs.cmake from recommended extentions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,11 @@
         "ms-vscode.cpptools",
         "ms-vscode.cpp-devtools",
         "xaver.clang-format",
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "ms-python.black-formatter",
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpp-devtools",
+        "ms-vscode.cpptools",
+        "xaver.clang-format"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,6 @@
         "ms-vscode.cpptools",
         "ms-vscode.cpp-devtools",
         "xaver.clang-format",
-        "llvm-vs-code-extensions.vscode-clangd",
+        "llvm-vs-code-extensions.vscode-clangd"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,5 @@
         "ms-vscode.cpp-devtools",
         "xaver.clang-format",
         "llvm-vs-code-extensions.vscode-clangd",
-        "twxs.cmake"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,5 @@
 {
     "recommendations": [
-        "ms-vscode.cmake-tools",
-        "ms-python.black-formatter",
-        "ms-vscode.cpptools",
-        "ms-vscode.cpp-devtools",
-        "xaver.clang-format",
         "llvm-vs-code-extensions.vscode-clangd",
         "ms-python.black-formatter",
         "ms-vscode.cmake-tools",


### PR DESCRIPTION
It's deprecated - VSC suggests uninstall it.
Already recommended "ms-vscode.cmake-tools" apparently fulfills the need.