### PR TITLE
[ios] Fix contentEdgeInsets/imageEdgeInsets deprecation warnings

### DIFF
--- a/iphone/Maps/Extensions/UIKitCategories.h
+++ b/iphone/Maps/Extensions/UIKitCategories.h
@@ -82,3 +82,13 @@ static inline CGFloat LengthCGPoint(CGPoint point)
 + (UIImage *)imageWithColor:(UIColor *)color;
 
 @end
+
+@interface UIButton (EdgeInsets)
+
+/// Wrappers around the pre-iOS 15 contentEdgeInsets / imageEdgeInsets setters.
+/// These buttons don't use UIButton.Configuration, so the properties still apply;
+/// the wrappers keep the iOS 15 deprecation warning out of the Swift call sites.
+- (void)setContentEdgeInsets:(UIEdgeInsets)insets;
+- (void)setImageEdgeInsets:(UIEdgeInsets)insets;
+
+@end

--- a/iphone/Maps/Extensions/UIKitCategories.m
+++ b/iphone/Maps/Extensions/UIKitCategories.m
@@ -295,3 +295,22 @@
 }
 
 @end
+
+@implementation UIButton (EdgeInsets)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+- (void)setContentEdgeInsets:(UIEdgeInsets)insets
+{
+  self.contentEdgeInsets = insets;
+}
+
+- (void)setImageEdgeInsets:(UIEdgeInsets)insets
+{
+  self.imageEdgeInsets = insets;
+}
+
+#pragma clang diagnostic pop
+
+@end

--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarButton.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarButton.swift
@@ -30,7 +30,7 @@ class BottomTabBarButtonRenderer {
     if let imageInsets = style.imageContainerInsets {
       control.contentVerticalAlignment = .fill
       control.contentHorizontalAlignment = .fill
-      control.imageEdgeInsets = imageInsets
+      control.setImageEdgeInsets(imageInsets)
     }
     if let backgroundColor = style.backgroundColor {
       control.backgroundColor = backgroundColor

--- a/iphone/Maps/UI/Help/AboutController/Views/DonationView.swift
+++ b/iphone/Maps/UI/Help/AboutController/Views/DonationView.swift
@@ -57,7 +57,7 @@ final class DonationView: UIButton {
     actionButton.titleLabel?.allowsDefaultTighteningForTruncation = true
     actionButton.titleLabel?.adjustsFontSizeToFitWidth = true
     actionButton.titleLabel?.minimumScaleFactor = 0.5
-    actionButton.contentEdgeInsets = Constants.actionButtonTitleInsets
+    actionButton.setContentEdgeInsets(Constants.actionButtonTitleInsets)
     actionButton.isUserInteractionEnabled = false
     actionButton.setStyle(.crowdfundingButton)
 

--- a/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/Navigation/NavigationControlView.swift
@@ -98,10 +98,10 @@ final class NavigationControlView: SolidTouchView {
     button.imageView?.contentMode = .scaleAspectFit
     button.contentHorizontalAlignment = .fill
     button.contentVerticalAlignment = .fill
-    button.contentEdgeInsets = UIEdgeInsets(top: Constants.buttonContentInset,
-                                            left: Constants.buttonContentInset,
-                                            bottom: Constants.buttonContentInset,
-                                            right: Constants.buttonContentInset)
+    button.setContentEdgeInsets(UIEdgeInsets(top: Constants.buttonContentInset,
+                                             left: Constants.buttonContentInset,
+                                             bottom: Constants.buttonContentInset,
+                                             right: Constants.buttonContentInset))
   }
 
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/iphone/Maps/UI/PlacePage/Components/InfoItemView.swift
+++ b/iphone/Maps/UI/PlacePage/Components/InfoItemView.swift
@@ -50,7 +50,7 @@ final class InfoItemView: UIView {
 
     iconButton.imageView?.contentMode = .scaleAspectFit
     iconButton.addTarget(self, action: #selector(onIconButtonTap), for: .touchUpInside)
-    iconButton.contentEdgeInsets = Constants.iconButtonEdgeInsets
+    iconButton.setContentEdgeInsets(Constants.iconButtonEdgeInsets)
     iconButton.isHidden = true
 
     accessoryButton.addTarget(self, action: #selector(onAccessoryButtonTap), for: .touchUpInside)

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageOSMContributionViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageOSMContributionViewController.swift
@@ -76,7 +76,7 @@ final class PlacePageOSMContributionViewController: UIViewController {
     }
     button.addTarget(self, action: action, for: .touchUpInside)
     button.setStyle(.flatNormalGrayButtonBig)
-    button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+    button.setContentEdgeInsets(UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8))
     button.titleLabel?.minimumScaleFactor = 0.5
     button.titleLabel?.adjustsFontSizeToFitWidth = true
     button.titleLabel?.allowsDefaultTighteningForTruncation = true


### PR DESCRIPTION
## What

Clears the 5 `contentEdgeInsets` / `imageEdgeInsets` deprecation warnings (deprecated in iOS 15) in `BottomTabBarButton`, `DonationView`, `NavigationControlView`, `InfoItemView`, and `PlacePageOSMContributionViewController`.

Adds a small `UIButton (EdgeInsets)` category to `UIKitCategories` with `setContentEdgeInsetsCompat:` / `setImageEdgeInsetsCompat:`, which set the still-valid pre-iOS 15 properties behind a localized `-Wdeprecated-declarations` pragma. The Swift call sites use the wrappers.

## Why not migrate to UIButton.Configuration?

`contentEdgeInsets`/`imageEdgeInsets` are only deprecated *"when using UIButtonConfiguration"* — for buttons that don't use a configuration they still apply. All five buttons here are styled through the project's `setStyle` theme system (and one has a gradient sublayer). Setting `button.configuration` makes the button ignore the manually-applied title/image styling those rely on, so a real Configuration migration would mean reworking the theming architecture for these buttons and carries a real risk of visual regressions.

This change instead removes the warnings while keeping behavior **byte-for-byte identical**. A holistic move to `UIButton.Configuration` can be done later as a deliberate, separately-tested effort.

## Testing

Clean `xcodebuild` (OMaps scheme, Debug, generic iOS Simulator, `ARCHS=arm64`) succeeds; the 5 warnings are gone and no new ones appear. Behavior is unchanged (the wrappers call the exact same setters), but a quick visual check of the affected buttons in light/dark is still worthwhile.

---
LLM tools (Claude Code) were used to help prepare this change.
