### PR TITLE
[ios] Remove deprecated setMinimumBackgroundFetchInterval call

### DIFF
--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
@@ -106,8 +106,6 @@ using namespace osm_auth_ios;
   [MapsAppDelegate customizeAppearance];
 
   self.standbyCounter = 0;
-  NSTimeInterval const minimumBackgroundFetchIntervalInSeconds = 6 * 60 * 60;
-  [UIApplication.sharedApplication setMinimumBackgroundFetchInterval:minimumBackgroundFetchIntervalInSeconds];
   [self updateApplicationIconBadgeNumber];
   [TrackRecordingManager.shared setup];
 }


### PR DESCRIPTION
## What

Removes the deprecated `-[UIApplication setMinimumBackgroundFetchInterval:]` call (and its now-unused local) from `MapsAppDelegate.commonInit`.

## Why removal, not a BGTaskScheduler migration

`setMinimumBackgroundFetchInterval:` only does something in combination with `application:performFetchWithCompletionHandler:`. That delegate method is **not implemented anywhere** in the app, so the call requested periodic background-fetch wake-ups that nothing handled — dead configuration (and deprecated since iOS 13).

The app's actual background work — uploading pending OSM edits via `MWMBackgroundFetchScheduler` — runs from `applicationDidEnterBackground` using `beginBackgroundTaskWithExpirationHandler:`, which is independent of this setting and is left untouched. So removing the deprecated call has no behavioral effect.

A genuine periodic background refresh would be a *new feature* built on `BGTaskScheduler` / `BGAppRefreshTask` (registration + Info.plist identifiers + a handler), not a migration of this dead call — out of scope here.

Note: the `fetch` entry in `UIBackgroundModes` is now also unused, but removing an app capability is a separate decision, so it's left in place to keep this change focused.

## Testing

Clean `xcodebuild` (OMaps scheme, Debug, generic iOS Simulator, `ARCHS=arm64`) succeeds; the deprecation warning is gone and there is no behavioral change.

---
LLM tools (Claude Code) were used to help analyze and prepare this change.
