### PR TITLE
[ios] Drive app lifecycle from aggregate UIApplication notifications

### DIFF
--- a/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
+++ b/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
@@ -47,32 +47,9 @@ final class MainSceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
   }
 
-  // MARK: - Lifecycle forwarding
-
-  /// UIWindowSceneDelegate callbacks are per-scene. While CarPlay is connected it keeps its own scene
-  /// foregrounded, so the phone window scene backgrounding/resigning (lock screen, app switcher) must
-  /// not drive the app-wide background path — that would pause the render loop and location updates the
-  /// CarPlay session still needs against the same shared map. Forward only when CarPlay is inactive.
-  private func forwardLifecycleEventUnlessCarPlayActive(_ forward: (MapsAppDelegate) -> Void) {
-    guard !CarPlayService.shared.isCarplayActivated else { return }
-    forward(MapsAppDelegate.theApp())
-  }
-
-  func sceneDidBecomeActive(_: UIScene) {
-    forwardLifecycleEventUnlessCarPlayActive { $0.applicationDidBecomeActive(.shared) }
-  }
-
-  func sceneWillResignActive(_: UIScene) {
-    forwardLifecycleEventUnlessCarPlayActive { $0.applicationWillResignActive(.shared) }
-  }
-
-  func sceneWillEnterForeground(_: UIScene) {
-    forwardLifecycleEventUnlessCarPlayActive { $0.applicationWillEnterForeground(.shared) }
-  }
-
-  func sceneDidEnterBackground(_: UIScene) {
-    forwardLifecycleEventUnlessCarPlayActive { $0.applicationDidEnterBackground(.shared) }
-  }
+  // Activate/background transitions are handled app-wide by MapsAppDelegate observing the aggregate
+  // UIApplication lifecycle notifications, so this scene delegate intentionally does not forward
+  // per-scene sceneDid/Will* callbacks (they would fire while CarPlay keeps the app active).
 
   // MARK: - URL / user activity / shortcut forwarding
 

--- a/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
+++ b/iphone/Maps/Core/AppDelegate/MainSceneDelegate.swift
@@ -7,17 +7,25 @@ final class MainSceneDelegate: UIResponder, UIWindowSceneDelegate {
   func scene(_ scene: UIScene,
              willConnectTo _: UISceneSession,
              options connectionOptions: UIScene.ConnectionOptions) {
-    guard let windowScene = scene as? UIWindowScene,
-          let sceneWindow = windowScene.windows.first
-    else {
-      assertionFailure("Main UIWindowScene is missing the storyboard-loaded window.")
+    guard let windowScene = scene as? UIWindowScene else {
+      assertionFailure("Main scene is not a UIWindowScene.")
       return
     }
-    window = sceneWindow
-    MapsAppDelegate.theApp().window = sceneWindow
 
-    // CarPlay scene can connect before the main phone scene; once the main window is ready,
-    // retry attaching the shared map view to the CarPlay controller if it was deferred.
+    let app = MapsAppDelegate.theApp()
+    // Build the window around the single shared root navigation controller. On a CarPlay-first cold
+    // launch CarPlayService may have already created it (so the map could render on the head unit);
+    // reusing it here keeps one MapViewController and one Drape engine across both scenes instead of
+    // instantiating a second map. We create the window explicitly (no UISceneStoryboardFile) so the
+    // system does not auto-load a duplicate MapViewController from the storyboard.
+    let sceneWindow = UIWindow(windowScene: windowScene)
+    sceneWindow.rootViewController = app.mainNavigationController
+    window = sceneWindow
+    app.window = sceneWindow
+    sceneWindow.makeKeyAndVisible()
+
+    // CarPlay scene can connect before the main phone scene; now that the window is ready, attach the
+    // shared map view to the CarPlay controller if it was deferred.
     CarPlayService.shared.attachMapIfNeeded()
 
     // Route cold-launch payloads delivered via the scene. Pre-UIScene iOS received these via
@@ -25,6 +33,7 @@ final class MainSceneDelegate: UIResponder, UIWindowSceneDelegate {
     // MapViewController was ready. Mirror that deferred flow by seeding DeepLinkHandler here;
     // MapViewController.viewDidLoad drains it via handleDeepLinkAndReset().
     if !connectionOptions.urlContexts.isEmpty {
+      // iOS delivers a single URL on a cold launch, so the arbitrary Set order is not a concern here.
       if let launchURL = connectionOptions.urlContexts.first?.url {
         DeepLinkHandler.shared.applicationDidFinishLaunching([.url: launchURL])
       }
@@ -40,20 +49,29 @@ final class MainSceneDelegate: UIResponder, UIWindowSceneDelegate {
 
   // MARK: - Lifecycle forwarding
 
+  /// UIWindowSceneDelegate callbacks are per-scene. While CarPlay is connected it keeps its own scene
+  /// foregrounded, so the phone window scene backgrounding/resigning (lock screen, app switcher) must
+  /// not drive the app-wide background path — that would pause the render loop and location updates the
+  /// CarPlay session still needs against the same shared map. Forward only when CarPlay is inactive.
+  private func forwardLifecycleEventUnlessCarPlayActive(_ forward: (MapsAppDelegate) -> Void) {
+    guard !CarPlayService.shared.isCarplayActivated else { return }
+    forward(MapsAppDelegate.theApp())
+  }
+
   func sceneDidBecomeActive(_: UIScene) {
-    MapsAppDelegate.theApp().applicationDidBecomeActive(.shared)
+    forwardLifecycleEventUnlessCarPlayActive { $0.applicationDidBecomeActive(.shared) }
   }
 
   func sceneWillResignActive(_: UIScene) {
-    MapsAppDelegate.theApp().applicationWillResignActive(.shared)
+    forwardLifecycleEventUnlessCarPlayActive { $0.applicationWillResignActive(.shared) }
   }
 
   func sceneWillEnterForeground(_: UIScene) {
-    MapsAppDelegate.theApp().applicationWillEnterForeground(.shared)
+    forwardLifecycleEventUnlessCarPlayActive { $0.applicationWillEnterForeground(.shared) }
   }
 
   func sceneDidEnterBackground(_: UIScene) {
-    MapsAppDelegate.theApp().applicationDidEnterBackground(.shared)
+    forwardLifecycleEventUnlessCarPlayActive { $0.applicationDidEnterBackground(.shared) }
   }
 
   // MARK: - URL / user activity / shortcut forwarding

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
@@ -13,6 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic) UIWindow * window;
 
+// The connected main window, or nil before MainSceneDelegate attaches it (e.g. a CarPlay-first
+// cold launch, where only the CarPlay scene exists). Use this instead of `window` when the phone
+// scene may not have connected yet.
+@property(nonatomic, readonly, nullable) UIWindow * connectedWindow;
+
+// The Main storyboard's root navigation controller. Lazily instantiated so a single shared
+// MapViewController exists even before the phone window scene connects.
+@property(nonatomic, readonly) UINavigationController * mainNavigationController;
 @property(nonatomic, readonly) MapViewController * mapViewController;
 @property(nonatomic, readonly) BOOL isDrapeEngineCreated;
 

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
@@ -112,6 +112,54 @@ using namespace osm_auth_ios;
   [UIApplication.sharedApplication setMinimumBackgroundFetchInterval:minimumBackgroundFetchIntervalInSeconds];
   [self updateApplicationIconBadgeNumber];
   [TrackRecordingManager.shared setup];
+  [self observeApplicationLifecycle];
+}
+
+// Under the UIScene lifecycle, UIKit delivers activate/background transitions to each scene's
+// delegate rather than to the app delegate. With CarPlay connected the phone UIWindowScene can
+// background (lock screen, app switcher) while the CPTemplateApplicationScene stays foregrounded, so
+// reacting per-scene would pause the framework the CarPlay session still drives. UIApplication posts
+// the aggregate notifications only once *all* scenes reach a state, so observing them keeps the
+// framework foreground/active exactly while any scene — phone or CarPlay — is active.
+- (void)observeApplicationLifecycle
+{
+  NSNotificationCenter * nc = NSNotificationCenter.defaultCenter;
+  [nc addObserver:self
+         selector:@selector(onApplicationDidBecomeActive:)
+             name:UIApplicationDidBecomeActiveNotification
+           object:nil];
+  [nc addObserver:self
+         selector:@selector(onApplicationWillResignActive:)
+             name:UIApplicationWillResignActiveNotification
+           object:nil];
+  [nc addObserver:self
+         selector:@selector(onApplicationWillEnterForeground:)
+             name:UIApplicationWillEnterForegroundNotification
+           object:nil];
+  [nc addObserver:self
+         selector:@selector(onApplicationDidEnterBackground:)
+             name:UIApplicationDidEnterBackgroundNotification
+           object:nil];
+}
+
+- (void)onApplicationDidBecomeActive:(NSNotification *)notification
+{
+  [self applicationDidBecomeActive:UIApplication.sharedApplication];
+}
+
+- (void)onApplicationWillResignActive:(NSNotification *)notification
+{
+  [self applicationWillResignActive:UIApplication.sharedApplication];
+}
+
+- (void)onApplicationWillEnterForeground:(NSNotification *)notification
+{
+  [self applicationWillEnterForeground:UIApplication.sharedApplication];
+}
+
+- (void)onApplicationDidEnterBackground:(NSNotification *)notification
+{
+  [self applicationDidEnterBackground:UIApplication.sharedApplication];
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
@@ -68,6 +68,9 @@ using namespace osm_auth_ios;
 @end
 
 @implementation MapsAppDelegate
+{
+  UINavigationController * _mainNavigationController;
+}
 
 + (MapsAppDelegate *)theApp
 {
@@ -368,9 +371,27 @@ using namespace osm_auth_ios;
 
 #pragma mark - Properties
 
+- (UIWindow *)connectedWindow
+{
+  return self.window;
+}
+
+- (UINavigationController *)mainNavigationController
+{
+  // Lazily load the Main storyboard's root navigation controller so a single shared MapViewController
+  // (and its Drape engine) exists even on a CarPlay-first cold launch, before MainSceneDelegate connects
+  // the phone window scene. Both the phone scene and CarPlayService reuse this same instance.
+  if (!_mainNavigationController)
+  {
+    UIStoryboard * storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+    _mainNavigationController = (UINavigationController *)[storyboard instantiateInitialViewController];
+  }
+  return _mainNavigationController;
+}
+
 - (MapViewController *)mapViewController
 {
-  for (id vc in [(UINavigationController *)self.window.rootViewController viewControllers])
+  for (id vc in _mainNavigationController.viewControllers)
     if ([vc isKindOfClass:[MapViewController class]])
       return vc;
   NSAssert(false, @"Please check the logic");

--- a/iphone/Maps/Core/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayService.swift
@@ -74,7 +74,7 @@ final class CarPlayService: NSObject {
     FrameworkHelper.updatePositionArrowOffset(false, offset: 5)
 
     CarPlayWindowScaleAdjuster.updateAppearance(
-      fromWindow: MapsAppDelegate.theApp().window,
+      fromWindow: MapsAppDelegate.theApp().connectedWindow,
       toWindow: window,
       isCarplayActivated: true
     )
@@ -157,23 +157,31 @@ final class CarPlayService: NSObject {
     if let window {
       CarPlayWindowScaleAdjuster.updateAppearance(
         fromWindow: window,
-        toWindow: MapsAppDelegate.theApp().window,
+        toWindow: MapsAppDelegate.theApp().connectedWindow,
         isCarplayActivated: false
       )
     }
   }
 
-  @objc func attachMapIfNeeded() {
+  func attachMapIfNeeded() {
     guard isCarplayActivated,
           let window,
-          let carplayVC = window.rootViewController as? CarPlayMapViewController,
-          let mapVC = MapViewController.shared() else { return }
+          let carplayVC = window.rootViewController as? CarPlayMapViewController else { return }
     guard carplayVC.mapView == nil else { return }
+
+    // On a CarPlay-first cold launch the phone window scene has not connected yet, so eagerly create
+    // the single shared MapViewController (and its map view / Drape engine) before attaching it here.
+    _ = MapsAppDelegate.theApp().mainNavigationController
+    guard let mapVC = MapViewController.shared() else { return }
+    mapVC.loadViewIfNeeded()
 
     currentPositionMode = mapVC.currentPositionMode
     mapVC.enableCarPlayRepresentation()
     carplayVC.addMapView(mapVC.mapView, mapButtonSafeAreaLayoutGuide: window.mapButtonSafeAreaLayoutGuide)
     mapVC.add(self)
+    // The base template may have been built with the default position mode before the map existed;
+    // refresh the leading nav button to the map's actual mode now that the listener is attached.
+    processMyPositionStateModeEvent(mapVC.currentPositionMode)
   }
 
   @objc func destroy() {
@@ -814,7 +822,7 @@ extension CarPlayService {
     template.updateEstimates(estimates, for: trip)
   }
 
-  private func dismissTemplate(_: CPAlertAction? = nil) {
+  private func dismissTemplate() {
     interfaceController?.dismissTemplate(animated: true) { _, error in
       if let error {
         LOG(.warning, "Failed to dismiss CarPlay template: \(error.localizedDescription)")
@@ -829,14 +837,14 @@ extension CarPlayService {
       preparedToPreviewTrips = trips
       dismissTemplate()
     })
-    let noAction = CPAlertAction(title: L("no"), style: .cancel, handler: dismissTemplate)
+    let noAction = CPAlertAction(title: L("no"), style: .cancel, handler: { [unowned self] _ in dismissTemplate() })
     let alert = CPAlertTemplate(titleVariants: [L("redirect_route_alert")], actions: [noAction, yesAction])
     alert.userInfo = [CPConstants.TemplateKey.alert: CPConstants.TemplateType.redirectRoute]
     presentAlert(alert, animated: true)
   }
 
   func showKeyboardAlert() {
-    let okAction = CPAlertAction(title: L("ok"), style: .default, handler: dismissTemplate)
+    let okAction = CPAlertAction(title: L("ok"), style: .default, handler: { [unowned self] _ in dismissTemplate() })
     let alert = CPAlertTemplate(titleVariants: [L("keyboard_availability_alert")], actions: [okAction])
     presentAlert(alert, animated: true)
   }
@@ -870,7 +878,7 @@ extension CarPlayService {
       return
     }
 
-    let okAction = CPAlertAction(title: L("ok"), style: .cancel, handler: dismissTemplate)
+    let okAction = CPAlertAction(title: L("ok"), style: .cancel, handler: { [unowned self] _ in dismissTemplate() })
     let alert = CPAlertTemplate(titleVariants: titleVariants, actions: [okAction])
     presentAlert(alert, animated: true)
   }

--- a/iphone/Maps/Core/CarPlay/CarPlayWindowScaleAdjuster.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayWindowScaleAdjuster.swift
@@ -3,10 +3,13 @@ import UIKit
 
 enum CarPlayWindowScaleAdjuster {
   static func updateAppearance(
-    fromWindow sourceWindow: UIWindow,
-    toWindow destinationWindow: UIWindow,
+    fromWindow sourceWindow: UIWindow?,
+    toWindow destinationWindow: UIWindow?,
     isCarplayActivated: Bool
   ) {
+    // Either window can be nil on a CarPlay-first cold launch, before the phone window scene connects.
+    // There is no phone-vs-CarPlay scale mismatch to reconcile yet, so skip.
+    guard let sourceWindow, let destinationWindow else { return }
     let sourceContentScale = sourceWindow.screen.scale
     let destinationContentScale = destinationWindow.screen.scale
 

--- a/iphone/Maps/OMaps.plist
+++ b/iphone/Maps/OMaps.plist
@@ -369,8 +369,6 @@
 					<string>Main</string>
 					<key>UISceneDelegateClassName</key>
 					<string>MainSceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>

--- a/iphone/Maps/Tests/Classes/MainSceneDelegateTests.swift
+++ b/iphone/Maps/Tests/Classes/MainSceneDelegateTests.swift
@@ -10,12 +10,8 @@ final class MainSceneDelegateTests: XCTestCase {
     XCTAssertEqual(NSStringFromClass(MainSceneDelegate.self), "MainSceneDelegate")
   }
 
-  func testRespondsToSceneLifecycleSelectors() {
+  func testRespondsToForwardingSelectors() {
     let delegate = MainSceneDelegate()
-    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneDidBecomeActive(_:))))
-    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneWillResignActive(_:))))
-    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneWillEnterForeground(_:))))
-    XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.sceneDidEnterBackground(_:))))
     XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.scene(_:openURLContexts:))))
     XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.scene(_:continue:))))
     XCTAssertTrue(delegate.responds(to: #selector(MainSceneDelegate.windowScene(_:performActionFor:completionHandler:))))

--- a/iphone/Maps/UI/AvailableArea/TabBarArea.swift
+++ b/iphone/Maps/UI/AvailableArea/TabBarArea.swift
@@ -2,7 +2,8 @@ final class TabBarArea: AvailableArea {
   override var areaFrame: CGRect {
     var areaFrame = frame
     // Spacing is used only for devices with zero bottom safe area (such as SE).
-    let additionalBottomSpacing: CGFloat = MapsAppDelegate.theApp().window.safeAreaInsets.bottom.isZero ? -10 : .zero
+    // window can be nil during a CarPlay-first cold launch, before the phone window scene connects.
+    let additionalBottomSpacing: CGFloat = (MapsAppDelegate.theApp().connectedWindow?.safeAreaInsets.bottom ?? 0).isZero ? -10 : .zero
     areaFrame.origin.y += additionalBottomSpacing
     return areaFrame
   }

--- a/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/BottomActionsMenu/RouteActionsBottomMenuView.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/BottomActionsMenu/RouteActionsBottomMenuView.swift
@@ -1,7 +1,7 @@
 final class RouteActionsBottomMenuView: UIView {
   enum Constants {
     static let height: CGFloat = 44
-    static let insets = UIEdgeInsets(top: 16, left: 16, bottom: MapsAppDelegate.theApp().window.safeAreaInsets.bottom.isZero ? 8 : 0, right: 16)
+    static let insets = UIEdgeInsets(top: 16, left: 16, bottom: (MapsAppDelegate.theApp().connectedWindow?.safeAreaInsets.bottom ?? 0).isZero ? 8 : 0, right: 16)
     fileprivate static let animationDuration: TimeInterval = kDefaultAnimationDuration / 2
     static let spacing: CGFloat = 12
   }

--- a/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointsView.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointsView.swift
@@ -5,7 +5,7 @@ final class RoutePointsView: UIView {
       let bottomActionBartHeight = RouteActionsBottomMenuView.Constants.height +
         RouteActionsBottomMenuView.Constants.insets.top +
         RouteActionsBottomMenuView.Constants.insets.bottom
-      let safeAreaInsets = MapsAppDelegate.theApp().window.safeAreaInsets
+      let safeAreaInsets = MapsAppDelegate.theApp().connectedWindow?.safeAreaInsets ?? .zero
       return bottomActionBartHeight + safeAreaInsets.bottom + safeAreaInsets.top
     }
   }


### PR DESCRIPTION
Follow-up to #12612. Refines the iOS app-lifecycle handling under the UIScene + CarPlay model. **Targets the #12612 branch**, so the diff here is only the incremental change; it will be retargeted to `master` once #12612 merges.

## Problem

#12612 forwards the phone `UIWindowScene`'s `sceneDidBecomeActive` / `sceneWillResignActive` / `sceneWillEnterForeground` / `sceneDidEnterBackground` to the matching `MapsAppDelegate` methods, gated on `!CarPlayService.shared.isCarplayActivated` so the phone scene backgrounding would not pause the framework while CarPlay drives the shared map.

That gating leaves an edge case: if the phone scene backgrounds **while CarPlay is active** and CarPlay **then disconnects**, nothing drives the app-wide background path, so the framework stays in the foreground state (render loop running, location active) while every scene is backgrounded.

## Change

Drive the transitions from the aggregate `UIApplication` lifecycle notifications instead of per-scene callbacks:

- `MapsAppDelegate` observes `UIApplicationDidBecomeActive/WillResignActive/WillEnterForeground/DidEnterBackground` and routes them to the existing `applicationDid*/applicationWill*` handlers. `UIApplication` posts these only once **all** scenes reach a state, so the framework stays foreground/active exactly while any scene — phone or CarPlay — is active, and backgrounds only when both are. This also restores the pre-UIScene behaviour where these handlers ran on every foreground/background transition.
- `MainSceneDelegate` no longer forwards per-scene lifecycle callbacks; the `!isCarplayActivated` special-case is removed.

## Testing

- Built the `OMaps` scheme for the iOS Simulator (arm64): 0 errors, 0 new warnings.
- Phone-first foreground/background validated in the simulator.
- The CarPlay-active edge cases need a CarPlay head unit / CarPlay Simulator to exercise at runtime.

## Still deferred

- Re-running `CarPlayWindowScaleAdjuster` when the phone window connects after a CarPlay-first launch.
- Runtime validation on real CarPlay hardware.
- Any exploration of a second, independent map per scene — OM has a single `Framework` / Drape engine today, so the shared-instance model from #12612 is the pragmatic approach.

> Generated with assistance from Claude Code.
