### PR TITLE
[ios] Drop redundant background-task assertion for downloads

### DIFF
--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.h
@@ -6,9 +6,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MapsAppDelegate : UIResponder <UIApplicationDelegate>
-{
-  UIBackgroundTaskIdentifier m_backgroundTask;
-}
 
 @property(nonatomic) UIWindow * window;
 

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
@@ -165,13 +165,6 @@ using namespace osm_auth_ios;
 {
   LOG(LINFO, ("applicationDidEnterBackground - begin"));
   [DeepLinkHandler.shared reset];
-  if ([MWMStorage sharedStorage].downloadInProgress)
-  {
-    m_backgroundTask = [application beginBackgroundTaskWithExpirationHandler:^{
-      [application endBackgroundTask:self->m_backgroundTask];
-      self->m_backgroundTask = UIBackgroundTaskInvalid;
-    }];
-  }
 
   auto tasks = @[[[MWMBackgroundEditsUpload alloc] init]];
   [self runBackgroundTasks:tasks completionHandler:nil];


### PR DESCRIPTION
## What

Removes the `beginBackgroundTaskWithExpirationHandler:` block from `-applicationDidEnterBackground:` and the now-unused `m_backgroundTask` ivar.

## Why

The assertion guarded no in-process work:

- **Downloads survive suspension on their own.** Map downloads run on a background `NSURLSession` (`backgroundSessionConfigurationWithIdentifier:`, `sessionSendsLaunchEvents = YES`) owned by `nsurlsessiond`. The daemon keeps downloading while the app is suspended *or terminated*, and relaunches the app through `application:handleEventsForBackgroundURLSession:completionHandler:` to advance the multi-file queue and finish. By the time `applicationDidEnterBackground` returns, every in-flight task is already handed off (`[task resume]`), so the `UIApplication` assertion is not what keeps downloads alive — the daemon is. It only kept the app awake until its window expired: a small, recurring battery cost.

- **It masked a latent bug.** A single, unguarded `m_backgroundTask` ivar meant a background → foreground → background cycle mid-download overwrote a still-live identifier without ending it. Removing the block deletes that footgun.

Screen auto-lock during downloads is unaffected — that is handled separately by `processCountryEvent:` via `enable`/`disableStandby`. The edits-upload kicked off right after still has its own background assertion (`BackgroundFetchTask`).

This is a follow-on to "Remove dead download-indicator machinery" (part of the now-merged #12961), which removed the only path that would have ended the assertion early — leaving this block as the next clean removal.

## Testing

- Static verification: no remaining references to `m_backgroundTask` / `beginBackgroundTask` in `iphone/`; the now-unused `application:` parameter matches sibling delegate methods (`applicationWillResignActive:`, `applicationWillTerminate:`), and Obj-C method params are exempt from `-Wunused-parameter`.
- Behavioral reasoning traced against `libs/platform/background_downloader_ios.mm` (background-session config + `[task resume]` hand-off) and `MapsAppDelegate.mm` (`handleEventsForBackgroundURLSession:` relaunch path).
- CI covers compilation.

## Notes

- Pure deletion, no behavior change for downloads.
- LLM tooling (Claude) was used to analyze the background-task lifecycle and draft this change.
