### PR TITLE
Add Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,38 @@
+FROM fedora
+
+RUN dnf config-manager disable fedora-cisco-openh264 && \
+    dnf -y update && \
+    dnf -y install --setopt=tsflags=nodocs --setopt=install_weak_deps=False \
+    cmake \
+    gcc \
+    gcc-c++ \
+    ninja-build \
+    libstdc++-devel \
+    mesa-libGL-devel \
+    libglvnd-devel \
+    qt6-qtbase-devel \
+    qt6-qtpositioning-devel \
+    qt6-qtsvg-devel \
+    sqlite-devel \
+    # for GLFW X11 backend
+    libXrandr-devel libXinerama-devel libXcursor-devel libXi-devel \
+    # for WITH_SYSTEM_PROVIDED_3PARTY=ON
+    gflags-devel expat-devel pugixml-devel utf8cpp-devel gtest-devel fast_float-devel freetype-devel boost-devel \
+    #
+    ccache \
+    git \
+    bash-completion \
+    # to stop build in VS Code
+    procps-ng \
+    && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*
+
+# needed for Docker
+ARG USERNAME=dev
+RUN useradd $USERNAME && \
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME
+USER $USERNAME
+
+# vim: autowrite

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,0 +1,19 @@
+services:
+  organicmaps:
+    build: .
+    volumes:
+      - ..:/workspace
+      - /home
+      - $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY:/tmp/$WAYLAND_DISPLAY:ro
+      - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro
+    environment:
+      XDG_RUNTIME_DIR: /tmp
+      WAYLAND_DISPLAY:
+    devices:
+      - /dev/dri
+    command: sleep infinity
+      
+    # Podman-specific
+    security_opt:
+      - label:disable
+    userns_mode: keep-id

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "dockerComposeFile": "compose.yaml",
+  "service": "organicmaps",
+  "workspaceFolder": "/workspace"
+}

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -146,8 +146,6 @@ sudo dnf install -y \
     gcc \
     gcc-c++ \
     ninja-build \
-    freetype-devel \
-    libicu-devel \
     libstdc++-devel \
     mesa-libGL-devel \
     libglvnd-devel \
@@ -157,6 +155,7 @@ sudo dnf install -y \
     qt6-qtsvg-devel \
     sqlite-devel
 ```
+Please see more accurate list of dependencies in the [Dockerfile](/.devcontainer/Dockerfile).
 
 #### Alpine
 


### PR DESCRIPTION
Adds Dev Container support for build/run/develop the project on Linux (but not only).

Features:
- Direct access to GPU graphics acceleration hardware via Wayland. Should work on Windows 11, too.
- Access to host's Location service.
- Instantly accessible development workflow (edit/build/run/test) on many IDEs with Dev Containers support (VS Code, QT Creator, IntelliJ IDEA, etc.).
- Terminal access to the container.
- Includes all the tools developer would typically need to work on this project:
  - gcc C++ toolchain
  - ccache
  - GMake/Ninja build systems
  - CMake
  - Qt6 and all the other dependencies
  - git
  - bash-completion
- `sudo` access to add/remove any other packages to the container (Fedora based image).
- Project source code is shared with host (`/workspace` in the container. You can also clone into the container volume).
- Persistent `/home` volume for settings and other storage (OMaps data and settings, VS Code Extensions, etc.).
- Works with Flatpak IDEs distributions, too (tested with VS Code Flatpak).
- Portable. Works on any OS with Docker/Podman support (graphics works on Linux natively, easily achievable on Windows 11 via WSL2, macOS might need some tweaking).
- Zero overhead. Uses kernel namespaces and other features so the container is extremely fast and lightweight. It's not a VM.  

Prerequisites:
- Podman/Docker with Compose engine
- (preferable) IDE with Dev Containers support (tested with VS Code Flatpak).
- Wayland compositor (almost every Linux system nowadays, also should work on Windows 11 and macOS with some setup).

Notes:
- Flatpak IDEs need some [setup](https://github.com/bam80/flathub/blob/741334c26dd7c9d5837ea65b1fc762528a0c7b30/README.md).
- VS Code will find the Dev Container support in your project and suggest to install the required Dev Containers extension to build the Container and re-open the project in there:
  <img width="1176" height="737" alt="image" src="https://github.com/user-attachments/assets/366eb5c7-a68d-43cd-a344-6fbfbb0eb486" />
- CMake Configure within the container:
  <img width="1280" height="995" alt="image" src="https://github.com/user-attachments/assets/4e69fd87-01bd-4a1c-a812-be249c9b870a" />
- Build within the container:
  <img width="1280" height="995" alt="image" src="https://github.com/user-attachments/assets/c5c41755-ab39-42cc-9e89-b68c641cfd17" />
- Run within the container:
  <img width="1279" height="997" alt="image" src="https://github.com/user-attachments/assets/9fc6630d-97c2-4afe-a50c-989b419fd29e" />