### PR TITLE
[platform] Fix random CI test aborts: TOCTOU race in Qt MkDir

### DIFF
--- a/libs/platform/platform_qt.cpp
+++ b/libs/platform/platform_qt.cpp
@@ -51,14 +51,18 @@ void Platform::GetFilesByRegExp(std::string const & directory, std::string const
 // static
 Platform::EError Platform::MkDir(std::string const & dirName)
 {
+  // Try to create the directory first: the mkdir syscall is atomic, while a preceding
+  // QDir::exists() check would be a TOCTOU race when several processes/threads create the
+  // same directory concurrently (e.g. parallel test binaries creating ~/.config/OMaps).
+  if (QDir().mkdir(dirName.c_str()))
+    return Platform::ERR_OK;
+  // mkdir failed: most commonly because the directory already exists. QDir::mkdir() doesn't
+  // expose errno, so re-check to map this benign case to ERR_FILE_ALREADY_EXISTS (which
+  // MkDirRecursively/MkDirChecked tolerate) instead of a misleading ERR_UNKNOWN.
   if (QDir().exists(dirName.c_str()))
     return Platform::ERR_FILE_ALREADY_EXISTS;
-  if (!QDir().mkdir(dirName.c_str()))
-  {
-    LOG(LWARNING, ("Can't create directory: ", dirName));
-    return Platform::ERR_UNKNOWN;
-  }
-  return Platform::ERR_OK;
+  LOG(LWARNING, ("Can't create directory:", dirName));
+  return Platform::ERR_UNKNOWN;
 }
 
 void Platform::SetupMeasurementSystem() const

--- a/libs/platform/platform_tests/platform_test.cpp
+++ b/libs/platform/platform_tests/platform_test.cpp
@@ -10,11 +10,15 @@
 #include "base/scope_guard.hpp"
 #include "base/stl_helpers.hpp"
 
+#include <algorithm>
+#include <atomic>
 #include <functional>
 #include <initializer_list>
 #include <set>
 #include <string>
+#include <thread>
 #include <utility>
+#include <vector>
 
 #include "defines.hpp"
 
@@ -264,6 +268,50 @@ UNIT_TEST(MkDirRecursively)
   TEST(!Platform::IsFileExistsByFullPath(path), ());
 
   CHECK(Platform::RmDirRecursively(workPath), ());
+}
+
+// Regression guard for a TOCTOU race in Platform::MkDir: when several threads (mimicking the
+// parallel ctest binaries that all create ~/.config/OMaps on a fresh runner) create the same
+// not-yet-existing directory at once, every MkDirRecursively call must succeed instead of one
+// failing because a peer won the create. The race window is tiny, so hammer it across many
+// iterations with fresh, deep paths.
+UNIT_TEST(MkDirRecursively_Concurrent)
+{
+  auto const workPath = base::JoinPath(GetPlatform().WritableDir(), "MkDirRecursivelyConcurrent");
+  SCOPE_GUARD(removeWorkPath, [&workPath] { Platform::RmDirRecursively(workPath); });
+  if (Platform::IsFileExistsByFullPath(workPath))
+    CHECK(Platform::RmDirRecursively(workPath), ());
+
+  auto const kThreads = std::max<unsigned>(4, std::thread::hardware_concurrency());
+  size_t const kIterations = 100;
+
+  for (size_t i = 0; i < kIterations; ++i)
+  {
+    // A fresh, deep target each round so every thread truly races to create the components.
+    auto const target = base::JoinPath(workPath, std::to_string(i), "a", "b", "c");
+
+    std::atomic<bool> start{false};
+    std::atomic<size_t> failures{0};
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (unsigned t = 0; t < kThreads; ++t)
+    {
+      threads.emplace_back([&]
+      {
+        // Spin so all threads enter MkDirRecursively at (nearly) the same instant.
+        while (!start.load(std::memory_order_acquire))
+        {}
+        if (!Platform::MkDirRecursively(target))
+          failures.fetch_add(1, std::memory_order_relaxed);
+      });
+    }
+    start.store(true, std::memory_order_release);
+    for (auto & thread : threads)
+      thread.join();
+
+    TEST_EQUAL(failures.load(), 0, ("Concurrent MkDirRecursively must not fail on a shared path:", target));
+    TEST(Platform::IsDirectory(target), (target));
+  }
 }
 
 UNIT_TEST(Platform_ThreadRunner)


### PR DESCRIPTION
## What

Fixes a TOCTOU race in `Platform::MkDir` (Qt/desktop impl) that randomly aborts test binaries during parallel `ctest -j` runs.

## Why

Example failure (test `bsdiff_tests` aborted, but the failing test is incidental):
https://github.com/organicmaps/organicmaps/actions/runs/27704937730/job/81950848730?pr=12965

```
Can't create directory:  /home/runner/.config/OMaps
terminate called after throwing an instance of 'FileSystemException'
  what():  FileSystemException .../libs/platform/platform_linux.cpp:91, "Can't create directory /home/runner/.config/OMaps"
```

Every test binary builds the `Platform` singleton at startup, which creates the settings dir `~/.config/OMaps`. CI runs `ctest -j$(nproc --all)`, so on a fresh runner several binaries race to create that shared directory at once.

`MkDirRecursively`/`MkDirChecked` are written to tolerate the concurrent-create case (they accept `ERR_FILE_ALREADY_EXISTS`), but the Qt `MkDir` defeated that:

```cpp
if (QDir().exists(dirName.c_str()))      // (1) check
  return Platform::ERR_FILE_ALREADY_EXISTS;
if (!QDir().mkdir(dirName.c_str()))      // (2) create
  return Platform::ERR_UNKNOWN;          // EEXIST collapsed into ERR_UNKNOWN
```

`QDir::mkdir()` returns only a bool and yields `false` when the directory already exists. When a peer process creates the dir in the window between (1) and (2), `MkDir` returns `ERR_UNKNOWN` instead of `ERR_FILE_ALREADY_EXISTS`, so `MkDirRecursively` falls into its `default: return false` branch → `FileSystemException` thrown from the `Platform` ctor → uncaught → `std::terminate` → `Subprocess aborted`. It's intermittent because it needs ≥2 binaries inside that tiny window, and only before the dir exists.

## How

Attempt `mkdir` first (it is atomic) and only re-check existence on failure, matching the POSIX `platform_ios.mm` / `platform_android.cpp` implementations which already do `mkdir()` + `ErrnoToError()` and are race-safe. Now a concurrently-created dir maps to `ERR_FILE_ALREADY_EXISTS`, which the callers already handle.

## Testing

- Added `MkDirRecursively_Concurrent` regression test that hammers `MkDirRecursively` from `max(4, hardware_concurrency)` threads racing on the same fresh path across 100 iterations. It **fails reliably on the old code** (reproduces the exact `Can't create directory:  ...` double-space log) and **passes with the fix**.
- Full `platform_tests` pass locally (Linux/Qt Debug).

LLM tools (Claude Code) were used to investigate the CI logs and draft this change.