### PR TITLE
[kml] Export OSM metadata for feature bookmarks

### DIFF
--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/BookmarkManager.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/BookmarkManager.cpp
@@ -297,7 +297,10 @@ JNIEXPORT jobject Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_native
   bmData.m_color.m_predefinedColor = frm()->LastEditedBMColor();
 
   if (info.IsFeature())
+  {
     SaveFeatureTypes(info.GetTypes(), bmData);
+    SaveFeatureProperties(*frm(), info, bmData);
+  }
 
   auto const * createdBookmark = bmMng.GetEditSession().CreateBookmark(std::move(bmData), lastEditedCategory);
 

--- a/iphone/Maps/UI/PlacePage/PlacePageManager/MWMPlacePageManager.mm
+++ b/iphone/Maps/UI/PlacePage/PlacePageManager/MWMPlacePageManager.mm
@@ -207,8 +207,13 @@ using namespace storage;
   bmData.m_name = info.FormatNewBookmarkName();
   bmData.m_color.m_predefinedColor = f.LastEditedBMColor();
   bmData.m_point = location_helpers::ToMercator(data.locationCoordinate);
+
   if (info.IsFeature())
+  {
     SaveFeatureTypes(info.GetTypes(), bmData);
+    SaveFeatureProperties(f, info, bmData);
+  }
+
   auto editSession = bmManager.GetEditSession();
   auto const * bookmark = editSession.CreateBookmark(std::move(bmData), categoryId);
 

--- a/libs/kml/kml_tests/geojson_tests.cpp
+++ b/libs/kml/kml_tests/geojson_tests.cpp
@@ -1510,4 +1510,43 @@ UNIT_TEST(GeoJson_Writer_Elevation_AllDefault)
     TEST_EQUAL(pt.GetAltitude(), geometry::kInvalidAltitude, ());
 }
 
+UNIT_TEST(GeoJson_SavesOsmBookmarkProperties)
+{
+  kml::FileData fileData;
+  auto & bookmark = fileData.m_bookmarksData.emplace_back();
+
+  bookmark.m_properties["osm_id"] = "123456";
+  bookmark.m_properties["osm_type"] = "node";
+  bookmark.m_properties["addr:street"] = "Ellis Street";
+  bookmark.m_properties["addr:housenumber"] = "63";
+  bookmark.m_properties["addr:city"] = "San Francisco";
+  bookmark.m_properties["addr:postcode"] = "94102";
+  bookmark.m_properties["addr:country"] = "USA";
+
+  auto const json = SaveToGeoJsonString(fileData, true);
+
+  TEST(json.find("\"osm_id\":\"123456\"") != std::string::npos, (json));
+  TEST(json.find("\"osm_type\":\"node\"") != std::string::npos, (json));
+  TEST(json.find("\"addr:street\":\"Ellis Street\"") != std::string::npos, (json));
+  TEST(json.find("\"addr:housenumber\":\"63\"") != std::string::npos, (json));
+  TEST(json.find("\"addr:city\":\"San Francisco\"") != std::string::npos, (json));
+  TEST(json.find("\"addr:postcode\":\"94102\"") != std::string::npos, (json));
+  TEST(json.find("\"addr:country\":\"USA\"") != std::string::npos, (json));
+}
+
+UNIT_TEST(GeoJson_DoesNotSaveUnsupportedBookmarkProperties)
+{
+  kml::FileData fileData;
+  auto & bookmark = fileData.m_bookmarksData.emplace_back();
+
+  bookmark.m_properties["unsupported"] = "should not be exported";
+  bookmark.m_properties["addr:street"] = "Ellis Street";
+
+  auto const json = SaveToGeoJsonString(fileData, true);
+
+  TEST(json.find("\"addr:street\":\"Ellis Street\"") != std::string::npos, (json));
+  TEST(json.find("unsupported") == std::string::npos, (json));
+  TEST(json.find("should not be exported") == std::string::npos, (json));
+}
+
 }  // namespace geojson_tests

--- a/libs/kml/kml_tests/gpx_tests.cpp
+++ b/libs/kml/kml_tests/gpx_tests.cpp
@@ -494,4 +494,51 @@ UNIT_TEST(MapGarminColor)
   TEST_EQUAL("DarkYellow", kml::MapGarminColor(0xb5b721ff), ());
 }
 
+UNIT_TEST(Gpx_SavesOsmBookmarkProperties)
+{
+  kml::FileData fileData;
+  kml::BookmarkData bookmarkData;
+
+  bookmarkData.m_point = mercator::FromLatLon(37.8546481, -122.071516);
+  kml::SetDefaultStr(bookmarkData.m_name, "Test bookmark");
+  bookmarkData.m_properties = {
+      {"osm_id", "123456"},       {"osm_type", "node"},           {"addr:street", "Ellis Street"},
+      {"addr:housenumber", "63"}, {"addr:city", "San Francisco"}, {"addr:postcode", "94102"},
+      {"addr:country", "USA"}};
+
+  fileData.m_bookmarksData.push_back(std::move(bookmarkData));
+
+  auto const gpx = Serialize(fileData);
+
+  TEST(gpx.find("<omaps>") != std::string::npos, (gpx));
+  TEST(gpx.find("<osm_id>") != std::string::npos, (gpx));
+  TEST(gpx.find("123456") != std::string::npos, (gpx));
+  TEST(gpx.find("<osm_type>") != std::string::npos, (gpx));
+  TEST(gpx.find("node") != std::string::npos, (gpx));
+  TEST(gpx.find("<addr_street>") != std::string::npos, (gpx));
+  TEST(gpx.find("Ellis Street") != std::string::npos, (gpx));
+  TEST(gpx.find("<addr_housenumber>") != std::string::npos, (gpx));
+  TEST(gpx.find("<addr_city>") != std::string::npos, (gpx));
+  TEST(gpx.find("<addr_postcode>") != std::string::npos, (gpx));
+  TEST(gpx.find("<addr_country>") != std::string::npos, (gpx));
+}
+
+UNIT_TEST(Gpx_DoesNotSaveEmptyOsmBookmarkProperties)
+{
+  kml::FileData fileData;
+  kml::BookmarkData bookmarkData;
+
+  bookmarkData.m_point = mercator::FromLatLon(37.8546481, -122.071516);
+  kml::SetDefaultStr(bookmarkData.m_name, "Test bookmark");
+  bookmarkData.m_properties = {{"osm_id", ""}, {"addr:street", ""}};
+
+  fileData.m_bookmarksData.push_back(std::move(bookmarkData));
+
+  auto const gpx = Serialize(fileData);
+
+  TEST(gpx.find("<omaps>") == std::string::npos, (gpx));
+  TEST(gpx.find("<osm_id>") == std::string::npos, (gpx));
+  TEST(gpx.find("<addr_street>") == std::string::npos, (gpx));
+}
+
 }  // namespace gpx_tests

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -11,8 +11,21 @@
 #include "geometry/point_with_altitude.hpp"
 
 #include <algorithm>
+#include <array>
 #include <map>
 #include <string>
+
+namespace
+{
+
+// Helper to get only the OSM keys we want to export.
+bool ShouldExportOsmProperty(std::string_view key)
+{
+  static constexpr std::array<std::string_view, 7> kOsmExportKeys = {
+      "osm_id", "osm_type", "addr:street", "addr:housenumber", "addr:city", "addr:postcode", "addr:country"};
+  return std::find(kOsmExportKeys.begin(), kOsmExportKeys.end(), key) != kOsmExportKeys.end();
+}
+}  // namespace
 
 namespace kml
 {
@@ -558,6 +571,13 @@ void GeoJsonWriter::Write(FileData const & fileData, bool minimizeOutput)
                                       {"marker-color", ToGeoJsonColor(bookmark.m_color)}};
     if (!bookmark.m_description.empty())
       bookmarkProperties["description"] = GetDefaultStr(bookmark.m_description);
+
+    for (auto const & [key, value] : bookmark.m_properties)
+    {
+      // Save only OSM properties we want to export.
+      if (!value.empty() && ShouldExportOsmProperty(key))
+        bookmarkProperties[key] = value;
+    }
 
     // Add '_umap_options' if needed.
     if (auto const umapOptionsPair = bookmark.m_properties.find("_umap_options");

--- a/libs/kml/serdes_gpx.cpp
+++ b/libs/kml/serdes_gpx.cpp
@@ -488,6 +488,41 @@ uint32_t BookmarkColor(BookmarkData const & bookmarkData)
   return kInvalidColor;
 }
 
+std::string MakeGpxOsmPropertyTag(std::string_view key)
+{
+  std::string tag(key);
+  std::replace(tag.begin(), tag.end(), ':', '_');
+  return tag;
+}
+
+// Helper to know if there are OSM properties to export.
+bool HasOsmProperties(BookmarkData const & bookmarkData)
+{
+  for (auto const & [key, value] : bookmarkData.m_properties)
+    if (!value.empty() && ShouldExportOsmProperty(key))
+      return true;
+  return false;
+}
+
+void SaveOsmProperties(Writer & writer, BookmarkData const & bookmarkData)
+{
+  writer << kIndent4 << "<omaps>\n";
+
+  for (auto const & [key, value] : bookmarkData.m_properties)
+  {
+    if (value.empty() || !ShouldExportOsmProperty(key))
+      continue;
+
+    auto const tag = MakeGpxOsmPropertyTag(key);
+
+    writer << kIndent6 << "<" << tag << ">";
+    SaveStringWithCDATA(writer, value);
+    writer << "</" << tag << ">\n";
+  }
+
+  writer << kIndent4 << "</omaps>\n";
+}
+
 void SaveBookmarkData(Writer & writer, BookmarkData const & bookmarkData)
 {
   auto const [lat, lon] = mercator::ToLatLon(bookmarkData.m_point);
@@ -508,12 +543,23 @@ void SaveBookmarkData(Writer & writer, BookmarkData const & bookmarkData)
     SaveStringWithCDATA(writer, *description);
     writer << "</desc>\n";
   }
-  if (auto const color = BookmarkColor(bookmarkData); color != kInvalidColor)
+
+  auto const color = BookmarkColor(bookmarkData);
+  bool const hasColor = color != kInvalidColor;
+  bool const hasOsmProperties = HasOsmProperties(bookmarkData);
+
+  if (hasColor || hasOsmProperties)
   {
     writer << kIndent2 << "<extensions>\n";
-    writer << kIndent4 << "<xsi:gpx><color>#";
-    SaveColorToARGB(writer, color);
-    writer << "</color></xsi:gpx>\n";
+    if (hasColor)
+    {
+      writer << kIndent4 << "<xsi:gpx><color>#";
+      SaveColorToARGB(writer, color);
+      writer << "</color></xsi:gpx>\n";
+    }
+    if (hasOsmProperties)
+      SaveOsmProperties(writer, bookmarkData);
+
     writer << kIndent2 << "</extensions>\n";
   }
   writer << "</wpt>\n";

--- a/libs/map/bookmark_helpers.cpp
+++ b/libs/map/bookmark_helpers.cpp
@@ -24,6 +24,11 @@
 
 #include "std/target_os.hpp"
 
+#include "map/framework.hpp"
+#include "map/place_page_info.hpp"
+
+#include "search/reverse_geocoder.hpp"
+
 #include <algorithm>
 #include <array>
 #include <ranges>
@@ -764,6 +769,52 @@ BookmarkMatchInfo GetBookmarkMatchInfo(uint32_t type)
   while (TruncType(typeStr));
 
   return {kml::BookmarkIcon::None, BookmarkBaseType::None};
+}
+
+namespace
+{
+void SaveNonEmptyProperty(kml::BookmarkData & bmData, char const * key, std::string_view value)
+{
+  if (!value.empty())
+    bmData.m_properties[key].assign(value);
+}
+
+void SplitRegionAddress(std::string const & regionAddress, std::string & city, std::string & country)
+{
+  auto const separator = regionAddress.rfind(", ");
+  if (separator != std::string::npos)
+  {
+    city = regionAddress.substr(0, separator);
+    country = regionAddress.substr(separator + 2);
+  }
+  else
+  {
+    country = regionAddress;
+  }
+}
+}  // namespace
+
+void SaveFeatureProperties(Framework const & framework, place_page::Info const & info, kml::BookmarkData & bmData)
+{
+  using Metadata = feature::Metadata::EType;
+
+  auto const address = framework.GetAddressAtPoint(bmData.m_point);
+
+  std::string city;
+  std::string country;
+  SplitRegionAddress(framework.GetLocalizedRegionAddressAtPoint(bmData.m_point), city, country);
+
+  std::string_view osmType;
+  std::string osmId;
+  framework.GetOsmObjectId(info.GetID(), osmType, osmId);
+
+  SaveNonEmptyProperty(bmData, "osm_type", osmType);
+  SaveNonEmptyProperty(bmData, "osm_id", osmId);
+  SaveNonEmptyProperty(bmData, "addr:street", address.GetStreetName());
+  SaveNonEmptyProperty(bmData, "addr:housenumber", address.GetHouseNumber());
+  SaveNonEmptyProperty(bmData, "addr:postcode", info.GetMetadata(Metadata::FMD_POSTCODE));
+  SaveNonEmptyProperty(bmData, "addr:city", city);
+  SaveNonEmptyProperty(bmData, "addr:country", country);
 }
 
 void SaveFeatureTypes(feature::TypesHolder const & types, kml::BookmarkData & bmData)

--- a/libs/map/bookmark_helpers.hpp
+++ b/libs/map/bookmark_helpers.hpp
@@ -142,7 +142,16 @@ namespace feature
 {
 class TypesHolder;
 }
+
+namespace place_page
+{
+class Info;
+}
+
+class Framework;
+
 void SaveFeatureTypes(feature::TypesHolder const & types, kml::BookmarkData & bmData);
+void SaveFeatureProperties(Framework const & framework, place_page::Info const & info, kml::BookmarkData & bmData);
 
 std::string GetPreferredBookmarkName(kml::BookmarkData const & bmData);
 

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -68,7 +68,12 @@
 
 #include "std/target_os.hpp"
 
+#include "base/geo_object_id.hpp"
+#include "indexer/feature_to_osm.hpp"
+#include "search/region_address_getter.hpp"
+
 #include <algorithm>
+#include <string_view>
 
 using namespace location;
 using namespace routing;
@@ -727,6 +732,12 @@ search::ReverseGeocoder::Address Framework::GetAddressAtPoint(m2::PointD const &
   return addr;
 }
 
+std::string Framework::GetLocalizedRegionAddressAtPoint(m2::PointD const & pt) const
+{
+  search::RegionAddressGetter regionAddressGetter(m_featuresFetcher.GetDataSource(), *m_infoGetter);
+  return regionAddressGetter.GetLocalizedRegionAddress(pt);
+}
+
 std::vector<Track::TrackSelectionInfo> Framework::FindRelationTracksInTapPosition(
     std::vector<std::pair<double, FeatureID>> const & lineCandidates, m2::PointD const & mercator)
 {
@@ -1325,6 +1336,31 @@ bool Framework::NeedUpdateForRoutes() const
 {
   auto const version = GetMwmVersion(GetViewportCenter());
   return version > 0 && version < 250801;
+}
+
+bool Framework::GetOsmObjectId(FeatureID const & fid, std::string_view & osmType, std::string & osmId) const
+{
+  if (!fid.IsValid())
+    return false;
+
+  indexer::FeatureIdToGeoObjectIdOneWay mapper(m_featuresFetcher.GetDataSource());
+  if (!mapper.Load())
+    return false;
+
+  base::GeoObjectId geoObjectId;
+  if (!mapper.GetGeoObjectId(fid, geoObjectId))
+    return false;
+
+  switch (geoObjectId.GetType())
+  {
+  case base::GeoObjectId::Type::OsmNode: osmType = "node"; break;
+  case base::GeoObjectId::Type::OsmWay: osmType = "way"; break;
+  case base::GeoObjectId::Type::OsmRelation: osmType = "relation"; break;
+  default: return false;
+  }
+
+  osmId = std::to_string(geoObjectId.GetSerialId());
+  return true;
 }
 
 /*

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -63,6 +63,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace osm
@@ -239,6 +240,8 @@ public:
   /// @return 0 if there is no country under point or country is not loaded.
   int64_t GetMwmVersion(m2::PointD const & pt) const;
   bool NeedUpdateForRoutes() const;
+
+  bool GetOsmObjectId(FeatureID const & fid, std::string_view & osmType, std::string & osmId) const;
 
   enum class DoAfterUpdate
   {
@@ -637,6 +640,7 @@ private:
 
 public:
   search::ReverseGeocoder::Address GetAddressAtPoint(m2::PointD const & pt) const;
+  std::string GetLocalizedRegionAddressAtPoint(m2::PointD const & pt) const;
 
   /// Delegates to SelectionProcessor::GetFeatureAtPoint.
   FeatureID GetFeatureAtPoint(m2::PointD const & mercator) const;


### PR DESCRIPTION
Fixes #9379.

Save selected OSM-related metadata when a feature is saved as a bookmark, including address fields and OSM object identity when available.

Export the stored metadata to GeoJSON bookmark properties and GPX bookmark extensions. Add tests for GeoJSON and GPX serialization of the supported OSM properties.