### PR TITLE
[ios] Fix map style change on focus loss during routing on macOS

### DIFF
--- a/iphone/Maps/UI/ReusableComponents/MWMNavigationController.m
+++ b/iphone/Maps/UI/ReusableComponents/MWMNavigationController.m
@@ -61,8 +61,12 @@
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {
   [super traitCollectionDidChange:previousTraitCollection];
-  // Update the app theme when the device appearance is changing.
-  if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection])
+  // React only to a genuine light/dark switch: the map style and themed colors depend
+  // solely on userInterfaceStyle. -hasDifferentColorAppearanceComparedToTraitCollection: also
+  // fires on contrast/gamut/interface-level deltas, and macOS emits such spurious trait changes
+  // on focus loss/restore. Re-deriving the map style there flips an active vehicle route to the
+  // dimmed MapStyleVehicle* palette.
+  if (self.traitCollection.userInterfaceStyle != previousTraitCollection.userInterfaceStyle)
     [MWMThemeManager invalidate];
 }
 


### PR DESCRIPTION
Tested on Mac. 

MWMNavigationController re-applies the theme from -traitCollectionDidChange: to follow system light/dark changes, but it triggered on any color-appearance delta via -hasDifferentColorAppearanceComparedToTraitCollection: (which also covers accessibility contrast, display gamut and interface level). macOS emits such spurious color-appearance trait changes when the window loses or regains focus. That re-derived the map style through ThemeManager, and with an active vehicle route it flipped the map to the dimmed MapStyleVehicle* palette ("less contrast") on every focus change.

The map style and themed colors depend only on light vs dark, so gate the refresh on a real userInterfaceStyle change. When the style is unchanged the refresh was already a no-op (same map style; the non-dynamic style re-apply is night-mode gated), so this is a behavioral no-op on iOS apart from removing the macOS regression.