### PR TITLE
[drape] Persist north-up orientation during navigation

### DIFF
--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/search/SearchEngine.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/search/SearchEngine.cpp
@@ -350,7 +350,7 @@ JNIEXPORT void Java_app_organicmaps_sdk_search_SearchEngine_nativeSelectResult(J
     return;
   // Ideally this location mode change should happen in core automatically, without specifically changing the mode.
   auto const mode = g_framework->GetMyPositionMode();
-  if (mode == location::Follow || mode == location::FollowAndRotate)
+  if (location::IsFollowingMode(mode))
     g_framework->NativeFramework()->StopLocationFollow();
   g_framework->NativeFramework()->SelectSearchResult(g_results[index], true /* animation */);
 }

--- a/iphone/Maps/Core/Location/MWMLocationPredictor.mm
+++ b/iphone/Maps/Core/Location/MWMLocationPredictor.mm
@@ -30,7 +30,8 @@ NSUInteger constexpr kMaxPredictionCount = 20;
 
 - (void)setMyPositionMode:(MWMMyPositionMode)mode
 {
-  self.isLastPositionModeValid = (mode == MWMMyPositionModeFollowAndRotate);
+  // Predict while the camera follows the user, both heading-up (FollowAndRotate) and north-up (Follow).
+  self.isLastPositionModeValid = (mode == MWMMyPositionModeFollowAndRotate || mode == MWMMyPositionModeFollow);
   [self restart];
 }
 

--- a/libs/drape_frontend/drape_engine.cpp
+++ b/libs/drape_frontend/drape_engine.cpp
@@ -24,6 +24,7 @@ using namespace std::placeholders;
 namespace
 {
 std::string_view constexpr kLocationStateMode = "LastLocationStateMode";
+std::string_view constexpr kRoutingLocationStateMode = "LastRoutingLocationStateMode";
 std::string_view constexpr kLastEnterBackground = "LastEnterBackground";
 }  // namespace
 
@@ -70,6 +71,12 @@ DrapeEngine::DrapeEngine(Params && params)
       mode = Follow;
   }
 
+  // Restore the map orientation chosen during the previous navigation. Default to
+  // FollowAndRotate (heading up) for the first-ever navigation; MyPositionController
+  // normalizes any unexpected persisted value.
+  EMyPositionMode routingMode = FollowAndRotate;
+  (void)Get(kRoutingLocationStateMode, routingMode);
+
   if (!Get(kLastEnterBackground, m_startBackgroundTime))
     m_startBackgroundTime = base::Timer::LocalTime();
 
@@ -88,8 +95,8 @@ DrapeEngine::DrapeEngine(Params && params)
   //  effects.push_back(PostprocessRenderer::Antialiasing);
   //}
 
-  MyPositionController::Params mpParams(mode, base::Timer::LocalTime() - m_startBackgroundTime, params.m_hints,
-                                        params.m_isRoutingActive, params.m_isAutozoomEnabled,
+  MyPositionController::Params mpParams(mode, routingMode, base::Timer::LocalTime() - m_startBackgroundTime,
+                                        params.m_hints, params.m_isRoutingActive, params.m_isAutozoomEnabled,
                                         std::bind(&DrapeEngine::MyPositionModeChanged, this, _1, _2));
 
   FrontendRenderer::Params frParams(
@@ -445,6 +452,8 @@ void DrapeEngine::ModelViewChanged(ScreenBase const & screen)
 void DrapeEngine::MyPositionModeChanged(location::EMyPositionMode mode, bool routingActive)
 {
   settings::Set(kLocationStateMode, mode);
+  if (routingActive && location::IsFollowingMode(mode))
+    settings::Set(kRoutingLocationStateMode, mode);
   if (m_myPositionModeChanged)
     m_myPositionModeChanged(mode, routingActive);
 }

--- a/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
+++ b/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRC
   area_shape_tests.cpp
   clip_splines_builder_tests.cpp
   frame_values_tests.cpp
+  my_position_controller_tests.cpp
   navigator_test.cpp
   path_text_test.cpp
   rainbow_line_gpu_test.cpp

--- a/libs/drape_frontend/drape_frontend_tests/my_position_controller_tests.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/my_position_controller_tests.cpp
@@ -1,0 +1,180 @@
+#include "testing/testing.hpp"
+
+#include "drape_frontend/my_position_controller.hpp"
+#include "drape_frontend/visual_params.hpp"
+
+#include "geometry/screenbase.hpp"
+
+namespace my_position_controller_tests
+{
+ScreenBase MakeScreen()
+{
+  ScreenBase screen;
+  screen.SetFromRects(m2::AnyRectD(m2::RectD(0.0, 0.0, 100.0, 100.0)), m2::RectD(0.0, 0.0, 1000.0, 1000.0));
+  return screen;
+}
+
+location::GpsInfo MakeGpsInfo(double timestamp)
+{
+  location::GpsInfo info;
+  info.m_source = location::EUser;
+  info.m_timestamp = timestamp;
+  info.m_latitude = 10.0;
+  info.m_longitude = 20.0;
+  info.m_horizontalAccuracy = 5.0;
+  info.m_bearing = 45.0;
+  info.m_speed = 5.0;
+  return info;
+}
+
+df::MyPositionController::Params MakeParams(location::EMyPositionMode initMode, location::EMyPositionMode routingMode,
+                                            bool isRoutingActive)
+{
+  return {initMode,
+          routingMode,
+          0.0 /* timeInBackground */,
+          df::Hints(),
+          isRoutingActive,
+          false /* isAutozoomEnabled */,
+          location::TMyPositionModeChanged()};
+}
+
+class TestListener : public df::MyPositionController::Listener
+{
+public:
+  void PositionChanged(m2::PointD const & /* position */, bool /* hasPosition */) override {}
+
+  void ChangeModelView(m2::PointD const & /* center */, int zoomLevel,
+                       df::TAnimationCreator const & /* parallelAnimCreator */) override
+  {
+    m_lastZoomLevel = zoomLevel;
+  }
+
+  void ChangeModelView(double /* azimuth */, df::TAnimationCreator const & /* parallelAnimCreator */) override {}
+
+  void ChangeModelView(m2::RectD const & /* rect */, df::TAnimationCreator const & /* parallelAnimCreator */) override
+  {}
+
+  void ChangeModelView(m2::PointD const & /* userPos */, double /* azimuth */, m2::PointD const & /* pxZero */,
+                       int zoomLevel, df::Animation::TAction const & /* onFinishAction */,
+                       df::TAnimationCreator const & /* parallelAnimCreator */) override
+  {
+    m_lastZoomLevel = zoomLevel;
+  }
+
+  void ChangeModelView(double /* autoScale */, m2::PointD const & /* userPos */, double /* azimuth */,
+                       m2::PointD const & /* pxZero */,
+                       df::TAnimationCreator const & /* parallelAnimCreator */) override
+  {}
+
+  int m_lastZoomLevel = -1;
+};
+
+UNIT_TEST(MyPositionController_RoutingStartKeepsSavedNorthUp)
+{
+  df::VisualParams::Init(1.0, 1024);
+
+  auto params = MakeParams(location::NotFollow, location::Follow, false /* isRoutingActive */);
+  df::MyPositionController controller(std::move(params), ref_ptr<df::DrapeNotifier>());
+  controller.EnablePerspectiveInRouting(true /* enablePerspective */);
+
+  TestListener listener;
+  controller.SetListener(ref_ptr<df::MyPositionController::Listener>(&listener));
+
+  controller.ActivateRouting(16 /* zoomLevel */, 17 /* zoomLevelIn3d */, false /* enableAutoZoom */,
+                             true /* isArrowGlued */);
+
+  TEST_EQUAL(controller.GetCurrentMode(), location::Follow, ());
+  TEST(!controller.ShouldEnablePerspectiveInRouting(), ());
+  TEST_EQUAL(listener.m_lastZoomLevel, 16, ());
+}
+
+UNIT_TEST(MyPositionController_RoutingStartUses3dZoomForHeadingUp)
+{
+  df::VisualParams::Init(1.0, 1024);
+
+  auto params = MakeParams(location::NotFollow, location::FollowAndRotate, false /* isRoutingActive */);
+  df::MyPositionController controller(std::move(params), ref_ptr<df::DrapeNotifier>());
+  controller.EnablePerspectiveInRouting(true /* enablePerspective */);
+
+  TestListener listener;
+  controller.SetListener(ref_ptr<df::MyPositionController::Listener>(&listener));
+
+  controller.ActivateRouting(16 /* zoomLevel */, 17 /* zoomLevelIn3d */, false /* enableAutoZoom */,
+                             true /* isArrowGlued */);
+
+  TEST_EQUAL(controller.GetCurrentMode(), location::FollowAndRotate, ());
+  TEST(controller.ShouldEnablePerspectiveInRouting(), ());
+  TEST_EQUAL(listener.m_lastZoomLevel, 17, ());
+}
+
+UNIT_TEST(MyPositionController_RoutingPerspectiveFollowsOrientation)
+{
+  df::VisualParams::Init(1.0, 1024);
+
+  auto screen = MakeScreen();
+  auto params = MakeParams(location::FollowAndRotate, location::FollowAndRotate, true /* isRoutingActive */);
+  df::MyPositionController controller(std::move(params), ref_ptr<df::DrapeNotifier>());
+  controller.EnablePerspectiveInRouting(true /* enablePerspective */);
+  controller.OnUpdateScreen(screen);
+
+  TEST(controller.ShouldEnablePerspectiveInRouting(), ());
+
+  controller.OnLocationUpdate(MakeGpsInfo(1.0), true /* isNavigable */, screen);
+  TEST_EQUAL(controller.GetCurrentMode(), location::FollowAndRotate, ());
+  TEST(controller.ShouldEnablePerspectiveInRouting(), ());
+
+  controller.NextMode(screen);
+  TEST_EQUAL(controller.GetCurrentMode(), location::Follow, ());
+  TEST(!controller.ShouldEnablePerspectiveInRouting(), ());
+
+  controller.NextMode(screen);
+  TEST_EQUAL(controller.GetCurrentMode(), location::FollowAndRotate, ());
+  TEST(controller.ShouldEnablePerspectiveInRouting(), ());
+
+  controller.EnablePerspectiveInRouting(false /* enablePerspective */);
+  TEST(!controller.ShouldEnablePerspectiveInRouting(), ());
+}
+
+UNIT_TEST(MyPositionController_RoutingNorthUpSurvivesLocationLoss)
+{
+  df::VisualParams::Init(1.0, 1024);
+
+  auto screen = MakeScreen();
+  auto params = MakeParams(location::FollowAndRotate, location::FollowAndRotate, true /* isRoutingActive */);
+  df::MyPositionController controller(std::move(params), ref_ptr<df::DrapeNotifier>());
+  controller.OnUpdateScreen(screen);
+
+  controller.OnLocationUpdate(MakeGpsInfo(1.0), true /* isNavigable */, screen);
+  TEST_EQUAL(controller.GetCurrentMode(), location::FollowAndRotate, ());
+
+  controller.NextMode(screen);
+  TEST_EQUAL(controller.GetCurrentMode(), location::Follow, ());
+
+  controller.LoseLocation();
+  TEST_EQUAL(controller.GetCurrentMode(), location::PendingPosition, ());
+
+  controller.OnLocationUpdate(MakeGpsInfo(2.0), true /* isNavigable */, screen);
+  TEST_EQUAL(controller.GetCurrentMode(), location::Follow, ());
+}
+
+UNIT_TEST(MyPositionController_RoutingNotFollowReturnsToPreferredNorthUp)
+{
+  df::VisualParams::Init(1.0, 1024);
+
+  auto screen = MakeScreen();
+  auto params = MakeParams(location::FollowAndRotate, location::FollowAndRotate, true /* isRoutingActive */);
+  df::MyPositionController controller(std::move(params), ref_ptr<df::DrapeNotifier>());
+  controller.OnUpdateScreen(screen);
+  controller.OnLocationUpdate(MakeGpsInfo(1.0), true /* isNavigable */, screen);
+
+  controller.NextMode(screen);
+  TEST_EQUAL(controller.GetCurrentMode(), location::Follow, ());
+
+  controller.StopLocationFollow();
+  TEST_EQUAL(controller.GetCurrentMode(), location::NotFollow, ());
+
+  controller.NextMode(screen);
+  TEST_EQUAL(controller.GetCurrentMode(), location::Follow, ());
+}
+}  // namespace my_position_controller_tests

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -685,7 +685,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
 
   case Message::Type::EnablePerspective:
   {
-    AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(true /* isAutoPerspective */));
+    UpdateRoutingPerspective();
     break;
   }
 
@@ -698,7 +698,10 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
     if (m_enablePerspectiveInNavigation == msg->AllowPerspective() &&
         m_enablePerspectiveInNavigation != screen.isPerspective())
     {
-      AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(m_enablePerspectiveInNavigation));
+      if (m_myPositionController->IsInRouting())
+        UpdateRoutingPerspective();
+      else
+        AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(m_enablePerspectiveInNavigation));
     }
 #endif
 
@@ -714,7 +717,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
       m_enablePerspectiveInNavigation = msg->AllowPerspective();
       m_myPositionController->EnablePerspectiveInRouting(m_enablePerspectiveInNavigation);
       if (m_myPositionController->IsInRouting())
-        AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(m_enablePerspectiveInNavigation));
+        UpdateRoutingPerspective();
     }
     break;
   }
@@ -1137,15 +1140,21 @@ void FrontendRenderer::UpdateContextDependentResources()
 void FrontendRenderer::FollowRoute(int preferredZoomLevel, int preferredZoomLevelIn3d, bool enableAutoZoom,
                                    bool isArrowGlued)
 {
-  m_myPositionController->ActivateRouting(
-      !m_enablePerspectiveInNavigation ? preferredZoomLevel : preferredZoomLevelIn3d, enableAutoZoom, isArrowGlued);
+  m_myPositionController->ActivateRouting(preferredZoomLevel, preferredZoomLevelIn3d, enableAutoZoom, isArrowGlued);
 
-  if (m_enablePerspectiveInNavigation)
-    AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(true /* isAutoPerspective */));
+  UpdateRoutingPerspective();
 
   m_routeRenderer->SetFollowingEnabled(true);
   CHECK(m_context != nullptr, ());
   m_postprocessRenderer->OnChangedRouteFollowingMode(m_context, true /* active */);
+}
+
+void FrontendRenderer::UpdateRoutingPerspective()
+{
+  if (!m_myPositionController->IsInRouting())
+    return;
+
+  AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(m_myPositionController->ShouldEnablePerspectiveInRouting()));
 }
 
 bool FrontendRenderer::CheckRouteRecaching(ref_ptr<BaseSubrouteData> subrouteData)
@@ -2607,6 +2616,12 @@ void FrontendRenderer::AddUserEvent(drape_ptr<UserEvent> && event)
 void FrontendRenderer::PositionChanged(m2::PointD const & position, bool hasPosition)
 {
   m_userPositionChangedHandler(position, hasPosition);
+}
+
+void FrontendRenderer::MyPositionModeChanged(location::EMyPositionMode /* mode */, bool routingActive)
+{
+  if (routingActive)
+    UpdateRoutingPerspective();
 }
 
 void FrontendRenderer::ChangeModelView(m2::PointD const & center, int zoomLevel,

--- a/libs/drape_frontend/frontend_renderer.hpp
+++ b/libs/drape_frontend/frontend_renderer.hpp
@@ -154,6 +154,7 @@ public:
                        TAnimationCreator const & parallelAnimCreator) override;
   void ChangeModelView(double autoScale, m2::PointD const & userPos, double azimuth, m2::PointD const & pxZero,
                        TAnimationCreator const & parallelAnimCreator) override;
+  void MyPositionModeChanged(location::EMyPositionMode mode, bool routingActive) override;
 
   drape_ptr<ScenarioManager> const & GetScenarioManager() const { return m_scenarioManager; }
   location::EMyPositionMode GetMyPositionMode() const { return m_myPositionController->GetCurrentMode(); }
@@ -277,6 +278,7 @@ private:
   void RemoveRenderGroupsLater(TRenderGroupRemovePredicate const & predicate);
 
   void FollowRoute(int preferredZoomLevel, int preferredZoomLevelIn3d, bool enableAutoZoom, bool isArrowGlued);
+  void UpdateRoutingPerspective();
 
   bool CheckRouteRecaching(ref_ptr<BaseSubrouteData> subrouteData);
 

--- a/libs/drape_frontend/my_position_controller.cpp
+++ b/libs/drape_frontend/my_position_controller.cpp
@@ -113,9 +113,9 @@ void ResetNotification(uint64_t & notifyId)
   notifyId = DrapeNotifier::kInvalidId;
 }
 
-bool IsModeChangeViewport(location::EMyPositionMode mode)
+location::EMyPositionMode NormalizeRoutingMode(location::EMyPositionMode mode)
 {
-  return mode == location::Follow || mode == location::FollowAndRotate;
+  return location::IsFollowingMode(mode) ? mode : location::FollowAndRotate;
 }
 }  // namespace
 
@@ -124,6 +124,7 @@ MyPositionController::MyPositionController(Params && params, ref_ptr<DrapeNotifi
   , m_modeChangeCallback(std::move(params.m_myPositionModeCallback))
   , m_hints(params.m_hints)
   , m_isInRouting(params.m_isRoutingActive)
+  , m_preferredRoutingMode(NormalizeRoutingMode(params.m_routingMode))
   , m_needBlockAnimation(false)
   , m_wasRotationInScaling(false)
   , m_errorRadius(0.0)
@@ -175,6 +176,9 @@ MyPositionController::MyPositionController(Params && params, ref_ptr<DrapeNotifi
       m_mode = NotFollowNoPosition;
   }
 
+  if (m_isInRouting && (m_desiredInitMode == PendingPosition || location::IsFollowingMode(m_desiredInitMode)))
+    m_desiredInitMode = m_preferredRoutingMode;
+
   if (m_modeChangeCallback)
     m_modeChangeCallback(m_mode, m_isInRouting);
 }
@@ -218,7 +222,7 @@ double MyPositionController::GetHorizontalAccuracy() const
 
 bool MyPositionController::IsModeChangeViewport() const
 {
-  return df::IsModeChangeViewport(m_mode);
+  return location::IsFollowingMode(m_mode);
 }
 
 bool MyPositionController::IsModeHasPosition() const
@@ -367,10 +371,10 @@ void MyPositionController::NextMode(ScreenBase const & screen)
   if (currentZoom < kZoomThreshold)
     preferredZoomLevel = std::min(GetZoomLevel(screen, m_position, m_errorRadius), kMaxScaleZoomLevel);
 
-  // In routing not-follow -> follow-and-rotate, otherwise not-follow -> follow.
+  // In routing not-follow returns to the preferred routing mode, otherwise not-follow -> follow.
   if (m_mode == location::NotFollow)
   {
-    ChangeMode(m_isInRouting ? location::FollowAndRotate : location::Follow);
+    ChangeMode(m_isInRouting ? m_preferredRoutingMode : location::Follow);
     UpdateViewport(preferredZoomLevel);
     return;
   }
@@ -468,7 +472,7 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
   {
     if (m_isInRouting)
     {
-      ChangeMode(location::FollowAndRotate);
+      ChangeMode(m_preferredRoutingMode);
       UpdateViewport(kMaxScaleZoomLevel);
     }
     else
@@ -494,7 +498,7 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
   {
     if (m_isInRouting)
     {
-      ChangeMode(location::FollowAndRotate);
+      ChangeMode(m_preferredRoutingMode);
       UpdateViewport(kMaxScaleZoomLevel);
     }
     else
@@ -521,7 +525,7 @@ void MyPositionController::LoseLocation()
 {
   if (m_mode == location::NotFollowNoPosition)
     return;
-  else if (m_mode == location::Follow || m_mode == location::FollowAndRotate)
+  else if (location::IsFollowingMode(m_mode))
     ChangeMode(location::PendingPosition);
   else
     ChangeMode(location::NotFollowNoPosition);
@@ -553,11 +557,22 @@ void MyPositionController::OnCompassUpdate(location::CompassInfo const & info, S
 
 bool MyPositionController::UpdateViewportWithAutoZoom()
 {
-  double const autoScale = m_enablePerspectiveInRouting ? m_autoScale3d : m_autoScale2d;
-  if (autoScale > 0.0 && m_mode == location::FollowAndRotate && m_isInRouting && m_enableAutoZoomInRouting &&
-      !m_needBlockAutoZoom)
+  if (!m_isInRouting || !m_enableAutoZoomInRouting || m_needBlockAutoZoom)
+    return false;
+
+  if (m_mode == location::FollowAndRotate)
   {
-    ChangeModelView(autoScale, m_position, m_drawDirection, GetRoutingRotationPixelCenter());
+    double const autoScale = m_enablePerspectiveInRouting ? m_autoScale3d : m_autoScale2d;
+    if (autoScale > 0.0)
+    {
+      ChangeModelView(autoScale, m_position, m_drawDirection, GetRoutingRotationPixelCenter());
+      return true;
+    }
+  }
+  else if (m_mode == location::Follow && m_autoScale2d > 0.0)
+  {
+    // North-up navigation: use the 2D speed scale, keep north-up azimuth, and center the user.
+    ChangeModelView(m_autoScale2d, m_position, 0.0 /* north up */, m_visiblePixelRect.Center());
     return true;
   }
   return false;
@@ -603,7 +618,7 @@ void MyPositionController::Render(ref_ptr<dp::GraphicsContext> context, ref_ptr<
 
 bool MyPositionController::IsRouteFollowingActive() const
 {
-  return IsInRouting() && m_mode == location::FollowAndRotate;
+  return IsInRouting() && location::IsFollowingMode(m_mode);
 }
 
 bool MyPositionController::AlmostCurrentPosition(m2::PointD const & pos) const
@@ -626,12 +641,30 @@ void MyPositionController::SetDirection(double bearing)
 
 void MyPositionController::ChangeMode(location::EMyPositionMode newMode)
 {
-  if (m_isInRouting && (m_mode != newMode) && (newMode == location::FollowAndRotate))
-    ResetBlockAutoZoomTimer();
+  // When entering a following mode during routing: reset the auto-zoom block timer on an actual
+  // mode switch, and remember the orientation so north-up/heading-up survives recentering, location
+  // loss and navigation restarts (see m_preferredRoutingMode usages).
+  if (m_isInRouting && location::IsFollowingMode(newMode))
+  {
+    if (m_mode != newMode)
+      ResetBlockAutoZoomTimer();
+    m_preferredRoutingMode = newMode;
+  }
 
   m_mode = newMode;
   if (m_modeChangeCallback)
     m_modeChangeCallback(m_mode, m_isInRouting);
+  if (m_listener)
+    m_listener->MyPositionModeChanged(m_mode, m_isInRouting);
+}
+
+bool MyPositionController::ShouldEnablePerspectiveInRouting() const
+{
+  if (!m_isInRouting || !m_enablePerspectiveInRouting)
+    return false;
+
+  auto const mode = m_mode == location::PendingPosition ? m_desiredInitMode : m_mode;
+  return mode == location::FollowAndRotate;
 }
 
 bool MyPositionController::IsWaitingForLocation() const
@@ -647,7 +680,7 @@ bool MyPositionController::IsWaitingForLocation() const
 
 void MyPositionController::StopLocationFollow()
 {
-  if (m_mode == location::Follow || m_mode == location::FollowAndRotate)
+  if (location::IsFollowingMode(m_mode))
     ChangeMode(location::NotFollow);
   m_desiredInitMode = location::NotFollow;
 
@@ -662,7 +695,7 @@ void MyPositionController::OnEnterForeground(double backgroundTime)
     // When location was active during previous session the app will try to follow the user.
     if (m_mode == location::NotFollow)
     {
-      ChangeMode(m_isInRouting ? location::FollowAndRotate : location::Follow);
+      ChangeMode(m_isInRouting ? m_preferredRoutingMode : location::Follow);
       UpdateViewport(kDoNotChangeZoom);
     }
 
@@ -837,7 +870,7 @@ void MyPositionController::EnableAutoZoomInRouting(bool enableAutoZoom)
   ResetBlockAutoZoomTimer();
 }
 
-void MyPositionController::ActivateRouting(int zoomLevel, bool enableAutoZoom, bool isArrowGlued)
+void MyPositionController::ActivateRouting(int zoomLevel, int zoomLevelIn3d, bool enableAutoZoom, bool isArrowGlued)
 {
   if (!m_isInRouting)
   {
@@ -845,9 +878,17 @@ void MyPositionController::ActivateRouting(int zoomLevel, bool enableAutoZoom, b
     m_isArrowGluedInRouting = isArrowGlued;
     m_enableAutoZoomInRouting = enableAutoZoom;
 
-    ChangeMode(location::FollowAndRotate);
-    ChangeModelView(m_position, m_isDirectionAssigned ? m_drawDirection : 0.0, GetRoutingRotationPixelCenter(),
-                    zoomLevel, [this](ref_ptr<Animation> anim) { UpdateViewport(kDoNotChangeZoom); });
+    ChangeMode(m_preferredRoutingMode);
+    int const preferredZoomLevel = ShouldEnablePerspectiveInRouting() ? zoomLevelIn3d : zoomLevel;
+    if (m_preferredRoutingMode == location::FollowAndRotate)
+    {
+      ChangeModelView(m_position, m_isDirectionAssigned ? m_drawDirection : 0.0, GetRoutingRotationPixelCenter(),
+                      preferredZoomLevel, [this](ref_ptr<Animation> anim) { UpdateViewport(kDoNotChangeZoom); });
+    }
+    else
+    {
+      ChangeModelView(m_position, preferredZoomLevel);
+    }
     ResetRoutingNotFollowTimer();
   }
 }
@@ -888,7 +929,7 @@ void MyPositionController::CheckNotFollowRouting()
     CHECK_ON_TIMEOUT(m_routingNotFollowNotifyId, kMaxNotFollowRoutingTimeSec, CheckNotFollowRouting);
     if (m_routingNotFollowTimer.ElapsedSeconds() >= kMaxNotFollowRoutingTimeSec)
     {
-      ChangeMode(location::FollowAndRotate);
+      ChangeMode(m_preferredRoutingMode);
       UpdateViewport(kDoNotChangeZoom);
     }
   }

--- a/libs/drape_frontend/my_position_controller.hpp
+++ b/libs/drape_frontend/my_position_controller.hpp
@@ -45,13 +45,15 @@ public:
                                  TAnimationCreator const & parallelAnimCreator) = 0;
     virtual void ChangeModelView(double autoScale, m2::PointD const & userPos, double azimuth,
                                  m2::PointD const & pxZero, TAnimationCreator const & parallelAnimCreator) = 0;
+    virtual void MyPositionModeChanged(location::EMyPositionMode /* mode */, bool /* routingActive */) {}
   };
 
   struct Params
   {
-    Params(location::EMyPositionMode initMode, double timeInBackground, Hints const & hints, bool isRoutingActive,
-           bool isAutozoomEnabled, location::TMyPositionModeChanged && fn)
+    Params(location::EMyPositionMode initMode, location::EMyPositionMode routingMode, double timeInBackground,
+           Hints const & hints, bool isRoutingActive, bool isAutozoomEnabled, location::TMyPositionModeChanged && fn)
       : m_initMode(initMode)
+      , m_routingMode(routingMode)
       , m_timeInBackground(timeInBackground)
       , m_hints(hints)
       , m_isRoutingActive(isRoutingActive)
@@ -60,6 +62,7 @@ public:
     {}
 
     location::EMyPositionMode m_initMode;
+    location::EMyPositionMode m_routingMode;
     double m_timeInBackground;
     Hints m_hints;
     bool m_isRoutingActive;
@@ -102,7 +105,7 @@ public:
                       drape_ptr<MyPosition> && shape, Arrow3d::PreloadedData && preloadedData);
   void ResetRenderShape();
 
-  void ActivateRouting(int zoomLevel, bool enableAutoZoom, bool isArrowGlued);
+  void ActivateRouting(int zoomLevel, int zoomLevelIn3d, bool enableAutoZoom, bool isArrowGlued);
   void DeactivateRouting();
 
   void EnablePerspectiveInRouting(bool enablePerspective);
@@ -125,6 +128,7 @@ public:
 
   bool IsRotationAvailable() const { return m_isDirectionAssigned; }
   bool IsInRouting() const { return m_isInRouting; }
+  bool ShouldEnablePerspectiveInRouting() const;
   bool IsRouteFollowingActive() const;
   bool IsModeChangeViewport() const;
 
@@ -166,6 +170,7 @@ private:
   Hints m_hints;
 
   bool m_isInRouting = false;
+  location::EMyPositionMode m_preferredRoutingMode;
   bool m_isArrowGluedInRouting = false;
 
   bool m_needBlockAnimation;

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1699,8 +1699,9 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::GraphicsContextFactory> contextFac
   {
     GetPlatform().RunTask(Platform::Thread::Gui, [this, mode, routingActive]()
     {
-      // Deactivate selection (and hide place page) if we return to routing in F&R mode.
-      if (routingActive && mode == location::FollowAndRotate)
+      // Deactivate selection (and hide place page) when route-following resumes,
+      // be it heading-up (FollowAndRotate) or north-up (Follow).
+      if (routingActive && location::IsFollowingMode(mode))
         DeactivateMapSelection();
 
       if (m_myPositionListener != nullptr)

--- a/libs/platform/location.hpp
+++ b/libs/platform/location.hpp
@@ -138,6 +138,14 @@ enum EMyPositionMode
   FollowAndRotate
 };
 
+// True for the two modes where the camera follows the user position (centered): north-up (Follow)
+// and heading-up (FollowAndRotate). Note this does not imply routing by itself: combine with the
+// routing flag (e.g. MyPositionController::IsRouteFollowingActive()) to detect active navigation.
+inline bool IsFollowingMode(EMyPositionMode mode)
+{
+  return mode == Follow || mode == FollowAndRotate;
+}
+
 using TMyPositionModeChanged = std::function<void(location::EMyPositionMode, bool)>;
 
 }  // namespace location


### PR DESCRIPTION
Navigation forced "heading up" (FollowAndRotate) on start and on every not-follow auto-recenter, discarding a user's switch to "north up" (Follow): the choice was lost after ~20s or when navigation restarted.

Track the chosen routing orientation in MyPositionController and persist it under LastRoutingLocationStateMode, so switching to north-up during navigation survives location loss, the not-follow auto-recenter timeout and restarting navigation. The first-ever navigation still defaults to heading-up.

Until now routing always forced FollowAndRotate, so call sites used that mode as a proxy for "route following is active". North-up navigation follows the route in Follow, which broke those assumptions; add location::IsFollowingMode() (Follow || FollowAndRotate) and use it to fix:
  - place page staying open when route-follow resumed (framework);
  - the 30 fps power cap not engaging (IsRouteFollowingActive);
  - iOS location prediction/smoothing being disabled (MWMLocationPredictor);
  - speed-based auto zoom stopping (now applied north-up, 2D and centered). Keep "== FollowAndRotate" only where heading-up rotation is actually required.

iOS and Android need no UI changes: the location button already cycles modes through the core NextMode(). Add my_position_controller unit tests.

Fixes #5898

Also removes perspective in the "north up" navigation mode (it is not useful there).

Related #609 #6094 #805 #8640 #5076 #10783 #2219 #10740 #1461 #12248

@strider-dunadan @kirylkaveryn please help with review and testing.