### PR TITLE
Let the core resolve the map style family (vehicle / outdoors / default) + bugfixes

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1254,7 +1254,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     closeFloatingToolbarsAndPanels();
     ThemeSwitcher.INSTANCE.synchronizeApplicationTheme();
-    ThemeSwitcher.INSTANCE.synchronizeMapStyle(this, mMapController.isRenderingActive());
     NavigationService.stopService(this);
     mMapButtonsViewModel.setSearchOption(null);
     mMapButtonsViewModel.setLayoutMode(MapButtonsController.LayoutMode.regular);
@@ -1267,7 +1266,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
     if (layoutMode == MapButtonsController.LayoutMode.navigation)
     {
       ThemeSwitcher.INSTANCE.synchronizeApplicationTheme();
-      ThemeSwitcher.INSTANCE.synchronizeMapStyle(this, mMapController.isRenderingActive());
       Utils.keepScreenOn(true, getWindow());
     }
     mMapButtonsViewModel.setLayoutMode(layoutMode);
@@ -1279,7 +1277,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     closeFloatingToolbarsAndPanels();
     ThemeSwitcher.INSTANCE.synchronizeApplicationTheme();
-    ThemeSwitcher.INSTANCE.synchronizeMapStyle(this, mMapController.isRenderingActive());
     mMapButtonsViewModel.setLayoutMode(MapButtonsController.LayoutMode.navigation);
     refreshLightStatusBar();
 
@@ -1316,7 +1313,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     closeFloatingToolbarsAndPanels();
     ThemeSwitcher.INSTANCE.synchronizeApplicationTheme();
-    ThemeSwitcher.INSTANCE.synchronizeMapStyle(this, mMapController.isRenderingActive());
     NavigationService.stopService(this);
     mMapButtonsViewModel.setSearchOption(null);
     mMapButtonsViewModel.setLayoutMode(MapButtonsController.LayoutMode.planning);

--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1284,7 +1284,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     closeFloatingToolbarsAndPanels();
     ThemeSwitcher.INSTANCE.synchronizeApplicationTheme();
-    ThemeSwitcher.INSTANCE.synchronizeMapStyle(this, mMapController.isRenderingActive());
     NavigationService.stopService(this);
     mMapButtonsViewModel.setSearchOption(null);
     mMapButtonsViewModel.setLayoutMode(MapButtonsController.LayoutMode.regular);
@@ -1297,7 +1296,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
     if (layoutMode == MapButtonsController.LayoutMode.navigation)
     {
       ThemeSwitcher.INSTANCE.synchronizeApplicationTheme();
-      ThemeSwitcher.INSTANCE.synchronizeMapStyle(this, mMapController.isRenderingActive());
       Utils.keepScreenOn(true, getWindow());
     }
     mMapButtonsViewModel.setLayoutMode(layoutMode);
@@ -1309,7 +1307,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     closeFloatingToolbarsAndPanels();
     ThemeSwitcher.INSTANCE.synchronizeApplicationTheme();
-    ThemeSwitcher.INSTANCE.synchronizeMapStyle(this, mMapController.isRenderingActive());
     mMapButtonsViewModel.setLayoutMode(MapButtonsController.LayoutMode.navigation);
     refreshLightStatusBar();
 
@@ -1346,7 +1343,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     closeFloatingToolbarsAndPanels();
     ThemeSwitcher.INSTANCE.synchronizeApplicationTheme();
-    ThemeSwitcher.INSTANCE.synchronizeMapStyle(this, mMapController.isRenderingActive());
     NavigationService.stopService(this);
     mMapButtonsViewModel.setSearchOption(null);
     mMapButtonsViewModel.setLayoutMode(MapButtonsController.LayoutMode.planning);

--- a/android/app/src/main/java/app/organicmaps/util/ThemeSwitcher.java
+++ b/android/app/src/main/java/app/organicmaps/util/ThemeSwitcher.java
@@ -10,7 +10,6 @@ import androidx.annotation.UiContext;
 import androidx.appcompat.app.AppCompatDelegate;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.downloader.DownloaderStatusIcon;
-import app.organicmaps.sdk.Framework;
 import app.organicmaps.sdk.MapStyle;
 import app.organicmaps.sdk.routing.RoutingController;
 import app.organicmaps.sdk.util.Config;
@@ -88,11 +87,10 @@ public enum ThemeSwitcher
   @androidx.annotation.UiThread
   public void synchronizeMapStyle(@UiContext @NonNull Context context, boolean isRendererActive)
   {
-    var isDarkMode = ThemeUtils.isDarkTheme(context);
-    var mapStyle = calculateMapStyle(isDarkMode);
-
-    var oldStyle = MapStyle.get();
-    if (oldStyle != mapStyle)
+    // Push the effective darkness to the core (which owns the family) and apply what it resolves.
+    MapStyle.setNightMode(ThemeUtils.isDarkTheme(context));
+    var mapStyle = MapStyle.resolveForMode();
+    if (MapStyle.get() != mapStyle)
       setMapStyle(mapStyle, isRendererActive);
   }
 
@@ -121,21 +119,20 @@ public enum ThemeSwitcher
                                          + "and converted to either dark or light");
     }
 
+    // The AppCompat night-mode flip above recreates the activity asynchronously, so the map style
+    // would otherwise only re-sync in the following onResume. Push the darkness to the core now, so a
+    // concurrent routing-driven switch (e.g. the vehicle palette on navigation start) resolves at the
+    // right darkness immediately. SYSTEM is left to synchronizeMapStyle, which reads the settled config.
+    if (theme == Config.UiTheme.LIGHT)
+      MapStyle.setNightMode(false);
+    else if (theme == Config.UiTheme.DARK)
+      MapStyle.setNightMode(true);
+
     if (mLatestTheme != null && mLatestTheme != theme)
     {
       DownloaderStatusIcon.clearCache();
     }
     mLatestTheme = theme;
-  }
-
-  private MapStyle calculateMapStyle(boolean dark)
-  {
-    if (RoutingController.get().isVehicleNavigation())
-      return dark ? MapStyle.VehicleDark : MapStyle.VehicleClear;
-    else if (Framework.nativeIsOutdoorsLayerEnabled())
-      return dark ? MapStyle.OutdoorsDark : MapStyle.OutdoorsClear;
-    else
-      return dark ? MapStyle.Dark : MapStyle.Clear;
   }
 
   private void setMapStyle(MapStyle style, boolean isRendererActive)

--- a/android/app/src/main/java/app/organicmaps/util/ThemeSwitcher.java
+++ b/android/app/src/main/java/app/organicmaps/util/ThemeSwitcher.java
@@ -87,6 +87,10 @@ public enum ThemeSwitcher
   @androidx.annotation.UiThread
   public void synchronizeMapStyle(@UiContext @NonNull Context context, boolean isRendererActive)
   {
+    // While Android Auto owns the (shared) core map style, leave it to ThemeUtils: a phone event must
+    // not push the phone's darkness into the core and override the darkness the car chose.
+    if (isCarDisplayUsed())
+      return;
     // Push the effective darkness to the core (which owns the family) and apply what it resolves.
     MapStyle.setNightMode(ThemeUtils.isDarkTheme(context));
     var mapStyle = MapStyle.resolveForMode();
@@ -123,10 +127,14 @@ public enum ThemeSwitcher
     // would otherwise only re-sync in the following onResume. Push the darkness to the core now, so a
     // concurrent routing-driven switch (e.g. the vehicle palette on navigation start) resolves at the
     // right darkness immediately. SYSTEM is left to synchronizeMapStyle, which reads the settled config.
-    if (theme == Config.UiTheme.LIGHT)
-      MapStyle.setNightMode(false);
-    else if (theme == Config.UiTheme.DARK)
-      MapStyle.setNightMode(true);
+    // Skip while Android Auto owns the (shared) core map style; it pushes its own darkness via ThemeUtils.
+    if (!isCarDisplayUsed())
+    {
+      if (theme == Config.UiTheme.LIGHT)
+        MapStyle.setNightMode(false);
+      else if (theme == Config.UiTheme.DARK)
+        MapStyle.setNightMode(true);
+    }
 
     if (mLatestTheme != null && mLatestTheme != theme)
     {
@@ -137,15 +145,18 @@ public enum ThemeSwitcher
 
   private void setMapStyle(MapStyle style, boolean isRendererActive)
   {
-    // Because of the distinct behavior in auto theme, Android Auto employs its own mechanism for theme switching.
-    // For the Android Auto theme switcher, please consult the app.organicmaps.car.util.ThemeUtils module.
-    if (MwmApplication.from(mContext).getDisplayManager().isCarDisplayUsed())
-      return;
     // If rendering is not active we can mark map style, because all graphics
     // will be recreated after rendering activation.
     if (isRendererActive)
       MapStyle.set(style);
     else
       MapStyle.mark(style);
+  }
+
+  private boolean isCarDisplayUsed()
+  {
+    // Android Auto employs its own mechanism for theme switching, driving the shared core map style
+    // itself; see app.organicmaps.car.util.ThemeUtils.
+    return MwmApplication.from(mContext).getDisplayManager().isCarDisplayUsed();
   }
 }

--- a/android/app/src/main/java/app/organicmaps/util/ThemeSwitcher.java
+++ b/android/app/src/main/java/app/organicmaps/util/ThemeSwitcher.java
@@ -10,7 +10,6 @@ import androidx.annotation.UiContext;
 import androidx.appcompat.app.AppCompatDelegate;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.downloader.DownloaderStatusIcon;
-import app.organicmaps.sdk.Framework;
 import app.organicmaps.sdk.MapStyle;
 import app.organicmaps.sdk.routing.RoutingController;
 import app.organicmaps.sdk.util.Config;
@@ -88,9 +87,9 @@ public enum ThemeSwitcher
   @androidx.annotation.UiThread
   public void synchronizeMapStyle(@UiContext @NonNull Context context, boolean isRendererActive)
   {
-    var isDarkMode = ThemeUtils.isDarkTheme(context);
-    var mapStyle = calculateMapStyle(isDarkMode);
-
+    // Push the effective darkness to the core (which owns the family) and apply what it resolves.
+    MapStyle.setNightMode(ThemeUtils.isDarkTheme(context));
+    var mapStyle = MapStyle.resolveForMode();
     if (MapStyle.get() != mapStyle)
       setMapStyle(mapStyle, isRendererActive);
   }
@@ -120,21 +119,20 @@ public enum ThemeSwitcher
                                          + "and converted to either dark or light");
     }
 
+    // The AppCompat night-mode flip above recreates the activity asynchronously, so the map style
+    // would otherwise only re-sync in the following onResume. Push the darkness to the core now, so a
+    // concurrent routing-driven switch (e.g. the vehicle palette on navigation start) resolves at the
+    // right darkness immediately. SYSTEM is left to synchronizeMapStyle, which reads the settled config.
+    if (theme == Config.UiTheme.LIGHT)
+      MapStyle.setNightMode(false);
+    else if (theme == Config.UiTheme.DARK)
+      MapStyle.setNightMode(true);
+
     if (mLatestTheme != null && mLatestTheme != theme)
     {
       DownloaderStatusIcon.clearCache();
     }
     mLatestTheme = theme;
-  }
-
-  private MapStyle calculateMapStyle(boolean dark)
-  {
-    if (RoutingController.get().isVehicleNavigation())
-      return dark ? MapStyle.VehicleDark : MapStyle.VehicleClear;
-    else if (Framework.nativeIsOutdoorsLayerEnabled())
-      return dark ? MapStyle.OutdoorsDark : MapStyle.OutdoorsClear;
-    else
-      return dark ? MapStyle.Dark : MapStyle.Clear;
   }
 
   private void setMapStyle(MapStyle style, boolean isRendererActive)

--- a/android/libs/car/src/main/java/app/organicmaps/car/util/ThemeUtils.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/util/ThemeUtils.java
@@ -9,7 +9,6 @@ import androidx.annotation.UiThread;
 import androidx.car.app.CarContext;
 import app.organicmaps.car.R;
 import app.organicmaps.sdk.MapStyle;
-import app.organicmaps.sdk.routing.RoutingController;
 import app.organicmaps.sdk.util.Config;
 
 public final class ThemeUtils
@@ -60,12 +59,9 @@ public final class ThemeUtils
     final ThemeMode newThemeMode =
         oldThemeMode == ThemeMode.AUTO ? (context.isDarkMode() ? ThemeMode.NIGHT : ThemeMode.LIGHT) : oldThemeMode;
 
-    MapStyle newMapStyle;
-    if (newThemeMode == ThemeMode.NIGHT)
-      newMapStyle = RoutingController.get().isVehicleNavigation() ? MapStyle.VehicleDark : MapStyle.Dark;
-    else
-      newMapStyle = RoutingController.get().isVehicleNavigation() ? MapStyle.VehicleClear : MapStyle.Clear;
-
+    // Push the effective darkness to the core (which owns the family) and apply what it resolves.
+    MapStyle.setNightMode(newThemeMode == ThemeMode.NIGHT);
+    final MapStyle newMapStyle = MapStyle.resolveForMode();
     if (MapStyle.get() != newMapStyle)
       MapStyle.set(newMapStyle);
   }

--- a/android/libs/car/src/main/java/app/organicmaps/car/util/ThemeUtils.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/util/ThemeUtils.java
@@ -9,7 +9,6 @@ import androidx.annotation.UiThread;
 import androidx.car.app.CarContext;
 import app.organicmaps.car.R;
 import app.organicmaps.sdk.MapStyle;
-import app.organicmaps.sdk.routing.RoutingController;
 import app.organicmaps.sdk.util.Config;
 
 public final class ThemeUtils
@@ -60,12 +59,9 @@ public final class ThemeUtils
     final ThemeMode newThemeMode =
         oldThemeMode == ThemeMode.AUTO ? (context.isDarkMode() ? ThemeMode.NIGHT : ThemeMode.LIGHT) : oldThemeMode;
 
-    MapStyle newMapStyle;
-    if (newThemeMode == ThemeMode.NIGHT)
-      newMapStyle = RoutingController.get().isVehicleNavigation() ? MapStyle.VehicleDark : MapStyle.Dark;
-    else
-      newMapStyle = RoutingController.get().isVehicleNavigation() ? MapStyle.VehicleClear : MapStyle.Clear;
-
+    // Push the effective darkness to the core (which owns the family) and apply what it resolves.
+    MapStyle.setNightMode(newThemeMode == ThemeMode.NIGHT);
+    final MapStyle newMapStyle = MapStyle.resolveForMode();
     if (MapStyle.get() == newMapStyle)
       return;
 

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/MapStyle.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/MapStyle.cpp
@@ -24,4 +24,14 @@ JNIEXPORT void Java_app_organicmaps_sdk_MapStyle_nativeMark(JNIEnv *, jclass, ji
   if (val != g_framework->GetMapStyle())
     g_framework->MarkMapStyle(val);
 }
+
+JNIEXPORT jint Java_app_organicmaps_sdk_MapStyle_nativeResolveForMode(JNIEnv *, jclass)
+{
+  return static_cast<jint>(g_framework->NativeFramework()->ResolveMapStyleForMode());
+}
+
+JNIEXPORT void Java_app_organicmaps_sdk_MapStyle_nativeSetNightMode(JNIEnv *, jclass, jboolean nightMode)
+{
+  g_framework->NativeFramework()->SetNightMode(nightMode);
+}
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/MapStyle.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/MapStyle.java
@@ -38,6 +38,25 @@ public enum MapStyle
     nativeMark(mapStyle.value);
   }
 
+  /**
+   * Stores the platform's light/dark choice in the core, which combines it with the active family
+   * (vehicle / outdoors / default) to resolve the concrete map style. Storing only, no apply.
+   */
+  public static void setNightMode(boolean nightMode)
+  {
+    nativeSetNightMode(nightMode);
+  }
+
+  /**
+   * Resolves the map style for the current routing/outdoors mode. Both the family (vehicle / outdoors
+   * / default) and the darkness come from the core; push the latter via {@link #setNightMode}.
+   */
+  @NonNull
+  public static MapStyle resolveForMode()
+  {
+    return valueOf(nativeResolveForMode());
+  }
+
   @NonNull
   public static MapStyle valueOf(int value)
   {
@@ -56,4 +75,8 @@ public enum MapStyle
   private static native int nativeGet();
 
   private static native void nativeMark(int mapStyle);
+
+  private static native int nativeResolveForMode();
+
+  private static native void nativeSetNightMode(boolean nightMode);
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
@@ -586,11 +586,6 @@ public class RoutingController
     return mState == State.NAVIGATION;
   }
 
-  public boolean isVehicleNavigation()
-  {
-    return isNavigating() && isVehicleRouterType();
-  }
-
   public boolean isBuilding()
   {
     return mState == State.PREPARE && mBuildState == BuildState.BUILDING;

--- a/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
@@ -618,11 +618,6 @@ public class RoutingController
     return mState == State.NAVIGATION;
   }
 
-  public boolean isVehicleNavigation()
-  {
-    return isNavigating() && isVehicleRouterType();
-  }
-
   public boolean isBuilding()
   {
     return mState == State.PREPARE && mBuildState == BuildState.BUILDING;

--- a/iphone/CoreApi/CoreApi/Common/MWMTypes.h
+++ b/iphone/CoreApi/CoreApi/Common/MWMTypes.h
@@ -18,13 +18,7 @@ typedef NS_ENUM(NSUInteger, MWMPlacement) {
   MWMPlacementBottom
 } NS_SWIFT_NAME(Placement);
 
-typedef NS_ENUM(NSUInteger, MWMTheme) {
-  MWMThemeDay,
-  MWMThemeNight,
-  MWMThemeVehicleDay,
-  MWMThemeVehicleNight,
-  MWMThemeAuto
-};
+typedef NS_ENUM(NSUInteger, MWMTheme) { MWMThemeDay, MWMThemeNight, MWMThemeAuto };
 
 typedef NS_ENUM(NSUInteger, MWMFileType) {
   MWMFileTypeKml,

--- a/iphone/CoreApi/CoreApi/Common/MWMTypes.h
+++ b/iphone/CoreApi/CoreApi/Common/MWMTypes.h
@@ -27,8 +27,6 @@ typedef NS_ENUM(NSUInteger, MWMPlacement) {
 typedef NS_ENUM(NSUInteger, MWMTheme) {
   MWMThemeDay,
   MWMThemeNight,
-  MWMThemeVehicleDay,
-  MWMThemeVehicleNight,
   MWMThemeAuto
 };
 

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
@@ -51,30 +51,11 @@ static Framework::ProductsPopupCloseReason ConvertProductPopupCloseReasonToCore(
 
 + (void)setTheme:(MWMTheme)theme
 {
-  auto & f = GetFramework();
-
-  auto const style = f.GetMapStyle();
-  auto const isOutdoor = ^BOOL(MapStyle style) {
-    switch (style)
-    {
-    case MapStyleOutdoorsLight:
-    case MapStyleOutdoorsDark: return YES;
-    default: return NO;
-    }
-  }(style);
-  auto const newStyle = ^MapStyle(MWMTheme theme) {
-    switch (theme)
-    {
-    case MWMThemeDay: return isOutdoor ? MapStyleOutdoorsLight : MapStyleDefaultLight;
-    case MWMThemeVehicleDay: return MapStyleVehicleLight;
-    case MWMThemeNight: return isOutdoor ? MapStyleOutdoorsDark : MapStyleDefaultDark;
-    case MWMThemeVehicleNight: return MapStyleVehicleDark;
-    case MWMThemeAuto: NSAssert(NO, @"Invalid theme"); return MapStyleDefaultLight;
-    }
-  }(theme);
-
-  if (style != newStyle)
-    f.SetMapStyle(newStyle);
+  // The map style family (vehicle / outdoors / default) is resolved by the core; pass only darkness.
+  // Auto must be resolved to Day/Night by the caller (ThemeManager) before reaching here.
+  NSAssert(theme != MWMThemeAuto, @"Auto theme must be resolved to Day/Night before applying");
+  bool const dark = theme == MWMThemeNight || theme == MWMThemeVehicleNight;
+  GetFramework().ApplyMapStyleForMode(dark);
 }
 
 + (MWMDayTime)daytimeAtLocation:(CLLocation *)location

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
@@ -54,7 +54,7 @@ static Framework::ProductsPopupCloseReason ConvertProductPopupCloseReasonToCore(
   // The map style family (vehicle / outdoors / default) is resolved by the core; pass only darkness.
   // Auto must be resolved to Day/Night by the caller (ThemeManager) before reaching here.
   NSAssert(theme != MWMThemeAuto, @"Auto theme must be resolved to Day/Night before applying");
-  bool const dark = theme == MWMThemeNight || theme == MWMThemeVehicleNight;
+  bool const dark = theme == MWMThemeNight;
   GetFramework().ApplyMapStyleForMode(dark);
 }
 

--- a/iphone/CoreApi/CoreApi/Traffic/MWMMapOverlayManager.mm
+++ b/iphone/CoreApi/CoreApi/Traffic/MWMMapOverlayManager.mm
@@ -208,6 +208,9 @@ static NSString * didChangeMapOverlay = @"didChangeMapOverlay";
 + (void)setOutdoorEnabled:(BOOL)enable
 {
   auto & f = GetFramework();
+  // Persist the layer flag (like the other overlays) so the core can resolve the base map-style
+  // family. iOS historically encoded outdoors only in the MapStyle below.
+  f.SaveOutdoorsEnabled(enable);
   switch (f.GetMapStyle())
   {
   case MapStyleDefaultLight:

--- a/iphone/CoreApi/CoreApi/Traffic/MWMMapOverlayManager.mm
+++ b/iphone/CoreApi/CoreApi/Traffic/MWMMapOverlayManager.mm
@@ -131,12 +131,7 @@ static NSString * didChangeMapOverlay = @"didChangeMapOverlay";
 
 + (MWMMapOverlayOutdoorState)outdoorState
 {
-  switch (GetFramework().GetMapStyle())
-  {
-  case MapStyleOutdoorsLight:
-  case MapStyleOutdoorsDark: return MWMMapOverlayOutdoorStateEnabled;
-  default: return MWMMapOverlayOutdoorStateDisabled;
-  }
+  return Framework::LoadOutdoorsEnabled() ? MWMMapOverlayOutdoorStateEnabled : MWMMapOverlayOutdoorStateDisabled;
 }
 
 + (MWMMapOverlayHikingState)hikingState
@@ -208,19 +203,10 @@ static NSString * didChangeMapOverlay = @"didChangeMapOverlay";
 + (void)setOutdoorEnabled:(BOOL)enable
 {
   auto & f = GetFramework();
-  // Persist the layer flag (like the other overlays) so the core can resolve the base map-style
-  // family. iOS historically encoded outdoors only in the MapStyle below.
+  // Persist the layer flag (like the other overlays) and let the core resolve the base map-style
+  // family from it, at the current night mode.
   f.SaveOutdoorsEnabled(enable);
-  switch (f.GetMapStyle())
-  {
-  case MapStyleDefaultLight:
-  case MapStyleVehicleLight:
-  case MapStyleOutdoorsLight: f.SetMapStyle(enable ? MapStyleOutdoorsLight : MapStyleDefaultLight); break;
-  case MapStyleDefaultDark:
-  case MapStyleVehicleDark:
-  case MapStyleOutdoorsDark: f.SetMapStyle(enable ? MapStyleOutdoorsDark : MapStyleDefaultDark); break;
-  default: break;
-  }
+  f.ApplyMapStyleForMode();
 
   // TODO: - Observing for the selected/deselected state of the Outdoor style should be implemented not by
   // NSNotificationCenter but the same way as for IsoLines with 'GetFramework().GetIsolinesManager().SetStateListener'.

--- a/iphone/Maps/Core/Theme/Core/ThemeManager.swift
+++ b/iphone/Maps/Core/Theme/Core/ThemeManager.swift
@@ -29,8 +29,8 @@ final class ThemeManager: NSObject {
     // and outdoors-layer state; here we resolve only light vs dark.
     let actualTheme: MWMTheme = { theme in
       switch theme {
-      case .day, .vehicleDay: return .day
-      case .night, .vehicleNight: return .night
+      case .day: return .day
+      case .night: return .night
       case .auto: return UIScreen.main.traitCollection.userInterfaceStyle == .dark ? .night : .day
       @unknown default:
         fatalError()
@@ -66,10 +66,8 @@ final class ThemeManager: NSObject {
   private func updateSystemUserInterfaceStyle(_ theme: MWMTheme) {
     let userInterfaceStyle: UIUserInterfaceStyle = { theme in
       switch theme {
-      case .day: fallthrough
-      case .vehicleDay: return .light
-      case .night: fallthrough
-      case .vehicleNight: return .dark
+      case .day: return .light
+      case .night: return .dark
       case .auto: return .unspecified
       @unknown default:
         fatalError()

--- a/iphone/Maps/Core/Theme/Core/ThemeManager.swift
+++ b/iphone/Maps/Core/Theme/Core/ThemeManager.swift
@@ -25,23 +25,19 @@ final class ThemeManager: NSObject {
 
     updateSystemUserInterfaceStyle(effectivePreference)
 
+    // The map style family (vehicle / outdoors / default) is resolved by the core from the routing
+    // and outdoors-layer state; here we resolve only light vs dark.
     let actualTheme: MWMTheme = { theme in
-      let isVehicleRouting = MWMRouter.isRoutingActive() && (MWMRouter.type() == .vehicle)
       switch theme {
-      case .day: fallthrough
-      case .vehicleDay: return isVehicleRouting ? .vehicleDay : .day
-      case .night: fallthrough
-      case .vehicleNight: return isVehicleRouting ? .vehicleNight : .night
-      case .auto:
-        let isDarkModeEnabled = UIScreen.main.traitCollection.userInterfaceStyle == .dark
-        guard isVehicleRouting else { return isDarkModeEnabled ? .night : .day }
-        return isDarkModeEnabled ? .vehicleNight : .vehicleDay
+      case .day, .vehicleDay: return .day
+      case .night, .vehicleNight: return .night
+      case .auto: return UIScreen.main.traitCollection.userInterfaceStyle == .dark ? .night : .day
       @unknown default:
         fatalError()
       }
     }(effectivePreference)
 
-    let newNightMode = actualTheme == .night || actualTheme == .vehicleNight
+    let newNightMode = actualTheme == .night
 
     FrameworkHelper.setTheme(actualTheme)
 

--- a/iphone/Maps/UI/Settings/Appearance/AppearanceSettingsInteractor.swift
+++ b/iphone/Maps/UI/Settings/Appearance/AppearanceSettingsInteractor.swift
@@ -8,7 +8,7 @@ final class AppearanceSettingsInteractor {
   }
 
   func loadSettings() {
-    present(AppearanceSettingsState(theme: settings.theme().settingsTheme),
+    present(AppearanceSettingsState(theme: settings.theme()),
             animatingDifferences: false)
   }
 

--- a/iphone/Maps/UI/Settings/Appearance/AppearanceSettingsModels.swift
+++ b/iphone/Maps/UI/Settings/Appearance/AppearanceSettingsModels.swift
@@ -4,14 +4,6 @@ enum AppearanceSettingsSection: String {
 
 extension MWMTheme {
   static let settingsOptions: [MWMTheme] = [.auto, .night, .day]
-
-  var settingsTheme: MWMTheme {
-    switch self {
-    case .vehicleDay: return .day
-    case .vehicleNight: return .night
-    default: return self
-    }
-  }
 }
 
 struct AppearanceSettingsState {

--- a/iphone/Maps/UI/Settings/Root/RootSettingsModels.swift
+++ b/iphone/Maps/UI/Settings/Root/RootSettingsModels.swift
@@ -117,8 +117,8 @@ extension Placement {
 extension MWMTheme {
   var title: String {
     switch self {
-    case .vehicleDay, .day: return L("pref_appearance_light")
-    case .vehicleNight, .night: return L("pref_appearance_dark")
+    case .day: return L("pref_appearance_light")
+    case .night: return L("pref_appearance_dark")
     case .auto: return L("auto")
     @unknown default: return ""
     }

--- a/iphone/Maps/UI/Settings/Root/RootSettingsModels.swift
+++ b/iphone/Maps/UI/Settings/Root/RootSettingsModels.swift
@@ -119,8 +119,8 @@ extension Placement {
 extension MWMTheme {
   var title: String {
     switch self {
-    case .vehicleDay, .day: return L("pref_appearance_light")
-    case .vehicleNight, .night: return L("pref_appearance_dark")
+    case .day: return L("pref_appearance_light")
+    case .night: return L("pref_appearance_dark")
     case .auto: return L("auto")
     @unknown default: return ""
     }

--- a/libs/indexer/indexer_tests/CMakeLists.txt
+++ b/libs/indexer/indexer_tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SRC
   features_vector_test.cpp
   index_builder_test.cpp
   interval_index_test.cpp
+  map_style_tests.cpp
   metadata_serdes_tests.cpp
   mwm_set_test.cpp
   postcodes_matcher_tests.cpp

--- a/libs/indexer/indexer_tests/CMakeLists.txt
+++ b/libs/indexer/indexer_tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SRC
   features_vector_test.cpp
   index_builder_test.cpp
   interval_index_test.cpp
+  map_style_tests.cpp
   metadata_serdes_tests.cpp
   mwm_set_test.cpp
   postcodes_matcher_tests.cpp

--- a/libs/indexer/indexer_tests/map_style_tests.cpp
+++ b/libs/indexer/indexer_tests/map_style_tests.cpp
@@ -1,0 +1,70 @@
+#include "testing/testing.hpp"
+
+#include "indexer/map_style.hpp"
+
+#include <optional>
+
+namespace map_style_tests
+{
+UNIT_TEST(GetMapStyleForFamily)
+{
+  TEST_EQUAL(GetMapStyleForFamily(MapStyleFamily::Default, false /* dark */), MapStyleDefaultLight, ());
+  TEST_EQUAL(GetMapStyleForFamily(MapStyleFamily::Default, true), MapStyleDefaultDark, ());
+
+  TEST_EQUAL(GetMapStyleForFamily(MapStyleFamily::Vehicle, false), MapStyleVehicleLight, ());
+  TEST_EQUAL(GetMapStyleForFamily(MapStyleFamily::Vehicle, true), MapStyleVehicleDark, ());
+
+  TEST_EQUAL(GetMapStyleForFamily(MapStyleFamily::Outdoors, false), MapStyleOutdoorsLight, ());
+  TEST_EQUAL(GetMapStyleForFamily(MapStyleFamily::Outdoors, true), MapStyleOutdoorsDark, ());
+}
+
+UNIT_TEST(SelectMapStyleFamily)
+{
+  // Priority, highest first: Vehicle (while following) > Outdoors (layer flag) > Default.
+  TEST_EQUAL(SelectMapStyleFamily(true /* vehicleFollowing */, false /* outdoors */), MapStyleFamily::Vehicle, ());
+  TEST_EQUAL(SelectMapStyleFamily(true, true), MapStyleFamily::Vehicle, ());  // Vehicle outranks Outdoors.
+  TEST_EQUAL(SelectMapStyleFamily(false, true), MapStyleFamily::Outdoors, ());
+  TEST_EQUAL(SelectMapStyleFamily(false, false), MapStyleFamily::Default, ());
+}
+
+UNIT_TEST(NormalizeStartupMapStyle)
+{
+  // Vehicle is transient: with no active route at launch it collapses to the base family at the same
+  // darkness. Flag absent + non-Outdoors style => Default, nothing to persist.
+  {
+    auto const s = NormalizeStartupMapStyle(MapStyleVehicleDark, std::nullopt);
+    TEST_EQUAL(s.style, MapStyleDefaultDark, ());
+    TEST(!s.outdoorsEnabled, ());
+    TEST(!s.persistOutdoorsFlag, ());
+  }
+  // Flag explicitly true collapses Vehicle to the Outdoors base; nothing to persist (already stored).
+  {
+    auto const s = NormalizeStartupMapStyle(MapStyleVehicleLight, std::optional<bool>(true));
+    TEST_EQUAL(s.style, MapStyleOutdoorsLight, ());
+    TEST(s.outdoorsEnabled, ());
+    TEST(!s.persistOutdoorsFlag, ());
+  }
+  // Legacy iOS persisted only the Outdoors style (flag absent): derive the flag and persist it.
+  {
+    auto const s = NormalizeStartupMapStyle(MapStyleOutdoorsDark, std::nullopt);
+    TEST_EQUAL(s.style, MapStyleOutdoorsDark, ());
+    TEST(s.outdoorsEnabled, ());
+    TEST(s.persistOutdoorsFlag, ());
+  }
+  // Explicit false is authoritative even under an inconsistent Outdoors style (e.g. a crash after
+  // saving false but before applying Default): collapse to Default, do not re-enable Outdoors.
+  {
+    auto const s = NormalizeStartupMapStyle(MapStyleOutdoorsLight, std::optional<bool>(false));
+    TEST_EQUAL(s.style, MapStyleDefaultLight, ());
+    TEST(!s.outdoorsEnabled, ());
+    TEST(!s.persistOutdoorsFlag, ());
+  }
+  // Default style + explicit outdoors flag => Outdoors (the previously-unhandled legacy Qt state).
+  {
+    auto const s = NormalizeStartupMapStyle(MapStyleDefaultDark, std::optional<bool>(true));
+    TEST_EQUAL(s.style, MapStyleOutdoorsDark, ());
+    TEST(s.outdoorsEnabled, ());
+    TEST(!s.persistOutdoorsFlag, ());
+  }
+}
+}  // namespace map_style_tests

--- a/libs/indexer/map_style.cpp
+++ b/libs/indexer/map_style.cpp
@@ -46,6 +46,17 @@ std::string DebugPrint(MapStyle mapStyle)
   return MapStyleToString(mapStyle);
 }
 
+std::string DebugPrint(MapStyleFamily family)
+{
+  switch (family)
+  {
+  case MapStyleFamily::Default: return "Default";
+  case MapStyleFamily::Vehicle: return "Vehicle";
+  case MapStyleFamily::Outdoors: return "Outdoors";
+  }
+  return "Unknown MapStyleFamily";
+}
+
 bool MapStyleIsDark(MapStyle mapStyle)
 {
   for (auto const darkStyle : {MapStyleDefaultDark, MapStyleVehicleDark, MapStyleOutdoorsDark})
@@ -80,4 +91,42 @@ MapStyle GetLightMapStyleVariant(MapStyle mapStyle)
   case MapStyleOutdoorsDark: return MapStyleOutdoorsLight;
   default: CHECK(false, ()); return MapStyleDefaultLight;
   }
+}
+
+MapStyle GetMapStyleForFamily(MapStyleFamily family, bool dark)
+{
+  switch (family)
+  {
+  case MapStyleFamily::Default: return dark ? MapStyleDefaultDark : MapStyleDefaultLight;
+  case MapStyleFamily::Vehicle: return dark ? MapStyleVehicleDark : MapStyleVehicleLight;
+  case MapStyleFamily::Outdoors: return dark ? MapStyleOutdoorsDark : MapStyleOutdoorsLight;
+  }
+  CHECK(false, ("Unhandled MapStyleFamily", static_cast<int>(family)));
+  return dark ? MapStyleDefaultDark : MapStyleDefaultLight;
+}
+
+bool IsOutdoorsStyle(MapStyle mapStyle)
+{
+  return mapStyle == MapStyleOutdoorsLight || mapStyle == MapStyleOutdoorsDark;
+}
+
+MapStyleFamily SelectMapStyleFamily(bool vehicleFollowing, bool outdoorsEnabled)
+{
+  // Priority, highest first. A new higher-priority family (e.g. Satellite) prepends its own branch.
+  if (vehicleFollowing)
+    return MapStyleFamily::Vehicle;
+  if (outdoorsEnabled)
+    return MapStyleFamily::Outdoors;
+  return MapStyleFamily::Default;
+}
+
+StartupMapStyle NormalizeStartupMapStyle(MapStyle persisted, std::optional<bool> persistedOutdoorsEnabled)
+{
+  // The stored flag is authoritative; only a legacy Outdoors-only persistence (flag absent) derives it
+  // from the style. Persist only that derived value, so an explicit stored value is never overwritten.
+  bool const outdoorsEnabled = persistedOutdoorsEnabled.value_or(IsOutdoorsStyle(persisted));
+  bool const persistFlag = !persistedOutdoorsEnabled.has_value() && outdoorsEnabled;
+  // No active route at launch, so no Vehicle family: pick the base family at the persisted darkness.
+  auto const family = SelectMapStyleFamily(false /* vehicleFollowing */, outdoorsEnabled);
+  return {GetMapStyleForFamily(family, MapStyleIsDark(persisted)), outdoorsEnabled, persistFlag};
 }

--- a/libs/indexer/map_style.cpp
+++ b/libs/indexer/map_style.cpp
@@ -65,34 +65,6 @@ bool MapStyleIsDark(MapStyle mapStyle)
   return false;
 }
 
-MapStyle GetDarkMapStyleVariant(MapStyle mapStyle)
-{
-  if (MapStyleIsDark(mapStyle) || mapStyle == MapStyleMerged)
-    return mapStyle;
-
-  switch (mapStyle)
-  {
-  case MapStyleDefaultLight: return MapStyleDefaultDark;
-  case MapStyleVehicleLight: return MapStyleVehicleDark;
-  case MapStyleOutdoorsLight: return MapStyleOutdoorsDark;
-  default: CHECK(false, ()); return MapStyleDefaultDark;
-  }
-}
-
-MapStyle GetLightMapStyleVariant(MapStyle mapStyle)
-{
-  if (!MapStyleIsDark(mapStyle))
-    return mapStyle;
-
-  switch (mapStyle)
-  {
-  case MapStyleDefaultDark: return MapStyleDefaultLight;
-  case MapStyleVehicleDark: return MapStyleVehicleLight;
-  case MapStyleOutdoorsDark: return MapStyleOutdoorsLight;
-  default: CHECK(false, ()); return MapStyleDefaultLight;
-  }
-}
-
 MapStyle GetMapStyleForFamily(MapStyleFamily family, bool dark)
 {
   switch (family)

--- a/libs/indexer/map_style.hpp
+++ b/libs/indexer/map_style.hpp
@@ -34,8 +34,6 @@ extern std::string MapStyleToString(MapStyle mapStyle);
 extern std::string DebugPrint(MapStyle mapStyle);
 extern std::string DebugPrint(MapStyleFamily family);
 extern bool MapStyleIsDark(MapStyle mapStyle);
-extern MapStyle GetDarkMapStyleVariant(MapStyle mapStyle);
-extern MapStyle GetLightMapStyleVariant(MapStyle mapStyle);
 // Concrete map style for the given family at the given darkness.
 extern MapStyle GetMapStyleForFamily(MapStyleFamily family, bool dark);
 // True for the Outdoors-family styles.

--- a/libs/indexer/map_style.hpp
+++ b/libs/indexer/map_style.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 
 enum MapStyle
@@ -17,11 +18,43 @@ enum MapStyle
   MapStyleCount
 };
 
+// A map style "family": the variant selected by the current usage mode, orthogonal to light/dark.
+// Extend this enum to introduce a new family.
+enum class MapStyleFamily
+{
+  Default,
+  Vehicle,
+  Outdoors,
+};
+
 extern MapStyle const kDefaultMapStyle;
 
 extern MapStyle MapStyleFromSettings(std::string const & str);
 extern std::string MapStyleToString(MapStyle mapStyle);
 extern std::string DebugPrint(MapStyle mapStyle);
+extern std::string DebugPrint(MapStyleFamily family);
 extern bool MapStyleIsDark(MapStyle mapStyle);
 extern MapStyle GetDarkMapStyleVariant(MapStyle mapStyle);
 extern MapStyle GetLightMapStyleVariant(MapStyle mapStyle);
+// Concrete map style for the given family at the given darkness.
+extern MapStyle GetMapStyleForFamily(MapStyleFamily family, bool dark);
+// True for the Outdoors-family styles.
+extern bool IsOutdoorsStyle(MapStyle mapStyle);
+
+// Chooses the live-mode family by priority, highest first: Vehicle while following a vehicle route,
+// then Outdoors when the layer flag is set, else Default. Takes pre-resolved booleans so it carries
+// no routing/layer dependencies and is directly unit-testable; a higher-priority family (e.g. a
+// future Satellite layer) adds an argument and a leading branch.
+extern MapStyleFamily SelectMapStyleFamily(bool vehicleFollowing, bool outdoorsEnabled);
+
+// Normalizes a persisted style at startup. There is no active route at launch, so a transient
+// navigation (Vehicle) style collapses to the base family — Outdoors when the layer flag is set,
+// else Default — at the persisted darkness. Presence-aware: the outdoors flag is authoritative when
+// stored; only a legacy Outdoors-only persistence (flag absent) seeds it from the style.
+struct StartupMapStyle
+{
+  MapStyle style;
+  bool outdoorsEnabled;
+  bool persistOutdoorsFlag;  // true only when the flag was absent and a value was derived to persist
+};
+extern StartupMapStyle NormalizeStartupMapStyle(MapStyle persisted, std::optional<bool> persistedOutdoorsEnabled);

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -346,6 +346,14 @@ Framework::Framework(FrameworkParams const & params, bool loadMaps)
   std::string mapStyleStr;
   if (settings::Get(kMapStyleKey, mapStyleStr))
     mapStyle = MapStyleFromSettings(mapStyleStr);
+  // A persisted Vehicle style is a transient navigation override applied only while following.
+  // There is no active route at startup, so collapse it to the base family (Outdoors/Default per
+  // the layer flag) at the same darkness.
+  if (mapStyle == MapStyleVehicleLight || mapStyle == MapStyleVehicleDark)
+  {
+    auto const baseFamily = LoadOutdoorsEnabled() ? MapStyleFamily::Outdoors : MapStyleFamily::Default;
+    mapStyle = GetMapStyleForFamily(baseFamily, MapStyleIsDark(mapStyle));
+  }
   GetStyleReader().SetCurrentStyle(mapStyle);
   df::LoadTransitColors();
 

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -347,6 +347,14 @@ Framework::Framework(FrameworkParams const & params, bool loadMaps)
   std::string mapStyleStr;
   if (settings::Get(kMapStyleKey, mapStyleStr))
     mapStyle = MapStyleFromSettings(mapStyleStr);
+  // A persisted Vehicle style is a transient navigation override applied only while following.
+  // There is no active route at startup, so collapse it to the base family (Outdoors/Default per
+  // the layer flag) at the same darkness.
+  if (mapStyle == MapStyleVehicleLight || mapStyle == MapStyleVehicleDark)
+  {
+    auto const baseFamily = LoadOutdoorsEnabled() ? MapStyleFamily::Outdoors : MapStyleFamily::Default;
+    mapStyle = GetMapStyleForFamily(baseFamily, MapStyleIsDark(mapStyle));
+  }
   GetStyleReader().SetCurrentStyle(mapStyle);
   df::LoadTransitColors();
 

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -71,6 +71,7 @@
 #include "std/target_os.hpp"
 
 #include <algorithm>
+#include <optional>
 
 using namespace location;
 using namespace routing;
@@ -346,15 +347,18 @@ Framework::Framework(FrameworkParams const & params, bool loadMaps)
   std::string mapStyleStr;
   if (settings::Get(kMapStyleKey, mapStyleStr))
     mapStyle = MapStyleFromSettings(mapStyleStr);
-  // A persisted Vehicle style is a transient navigation override applied only while following.
-  // There is no active route at startup, so collapse it to the base family (Outdoors/Default per
-  // the layer flag) at the same darkness.
-  if (mapStyle == MapStyleVehicleLight || mapStyle == MapStyleVehicleDark)
-  {
-    auto const baseFamily = LoadOutdoorsEnabled() ? MapStyleFamily::Outdoors : MapStyleFamily::Default;
-    mapStyle = GetMapStyleForFamily(baseFamily, MapStyleIsDark(mapStyle));
-  }
+  // Normalize the persisted style against the outdoors flag: with no active route at launch a
+  // transient Vehicle style collapses to the base family. Presence-aware, so a legacy Outdoors-only
+  // persistence (flag absent) seeds the flag without clobbering an explicitly stored value.
+  std::optional<bool> persistedOutdoors;
+  if (bool enabled; settings::Get(kOutdoorsEnabledKey, enabled))
+    persistedOutdoors = enabled;
+  auto const startup = NormalizeStartupMapStyle(mapStyle, persistedOutdoors);
+  if (startup.persistOutdoorsFlag)
+    SaveOutdoorsEnabled(startup.outdoorsEnabled);
+  mapStyle = startup.style;
   GetStyleReader().SetCurrentStyle(mapStyle);
+  m_nightMode = MapStyleIsDark(mapStyle);
   df::LoadTransitColors();
 
   // Init strings bundle.
@@ -1991,6 +1995,9 @@ void Framework::MarkMapStyle(MapStyle mapStyle)
     mapStyleStr = MapStyleToString(mapStyle);
   }
   settings::Set(kMapStyleKey, mapStyleStr);
+  // Keep the night mode in sync with the active style's darkness so ResolveMapStyleForMode() stays
+  // correct after any direct style change (debug commands, SDK MapStyle.set/mark).
+  m_nightMode = MapStyleIsDark(mapStyle);
   // Make sure the new style's family is resident before switching (a no-op once it is loaded, so
   // light<->dark stays zero-IO); drape worker threads observe the switch only via UpdateMapStyle.
   classificator::EnsureStyleLoaded(mapStyle);
@@ -2005,6 +2012,31 @@ void Framework::SetMapStyle(MapStyle mapStyle)
   InvalidateUserMarks();
   UpdateBookmarksTextPlacement();
   UpdateMinBuildingsTapZoom();
+}
+
+void Framework::SetNightMode(bool nightMode)
+{
+  m_nightMode = nightMode;
+}
+
+MapStyle Framework::ResolveMapStyleForMode() const
+{
+  auto const & rm = GetRoutingManager();
+  bool const vehicleFollowing = rm.IsRoutingFollowing() && rm.GetRouter() == routing::RouterType::Vehicle;
+  return GetMapStyleForFamily(SelectMapStyleFamily(vehicleFollowing, LoadOutdoorsEnabled()), m_nightMode);
+}
+
+void Framework::ApplyMapStyleForMode()
+{
+  auto const style = ResolveMapStyleForMode();
+  if (style != GetMapStyle())
+    SetMapStyle(style);
+}
+
+void Framework::ApplyMapStyleForMode(bool nightMode)
+{
+  SetNightMode(nightMode);
+  ApplyMapStyleForMode();
 }
 
 MapStyle Framework::GetMapStyle() const
@@ -3789,6 +3821,11 @@ std::vector<MwmSet::MwmId> Framework::GetMwmsByRect(m2::RectD const & rect, bool
 // RoutingManager::Delegate
 void Framework::OnRouteFollow(routing::RouterType type)
 {
+  // Following just started with m_isFollowing already final. The session-state callback can miss this:
+  // when a preview location update already advanced the session to OnRoute, EnableFollowMode re-issues
+  // SetState(OnRoute) — a no-op that emits no callback — so resolve the (now Vehicle) family here.
+  ApplyMapStyleForMode();
+
   bool const isPedestrianRoute = type == RouterType::Pedestrian;
   bool const enableAutoZoom = isPedestrianRoute ? false : LoadAutoZoom();
   int const scale = isPedestrianRoute ? scales::GetPedestrianNavigationScale() : scales::GetNavigationScale();
@@ -3807,6 +3844,14 @@ void Framework::OnRouteFollow(routing::RouterType type)
   // |isArrowGlued| parameter fully corresponds to |m_matchRoute| in RoutingSettings.
   // For pedestrian and bicycle modes, use compass heading when stopped (isArrowGlued = false).
   m_drapeEngine->FollowRoute(scale, scale3d, enableAutoZoom, !(isPedestrianRoute || isBicycleRoute) /* isArrowGlued */);
+}
+
+// RoutingManager::Delegate
+void Framework::OnRoutingSessionStateChanged()
+{
+  // Entered or left active navigation; re-resolve the map style family at the night mode the
+  // platform last supplied.
+  ApplyMapStyleForMode();
 }
 
 // RoutingManager::Delegate

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -69,6 +69,7 @@
 #include "std/target_os.hpp"
 
 #include <algorithm>
+#include <optional>
 
 using namespace location;
 using namespace routing;
@@ -347,15 +348,18 @@ Framework::Framework(FrameworkParams const & params, bool loadMaps)
   std::string mapStyleStr;
   if (settings::Get(kMapStyleKey, mapStyleStr))
     mapStyle = MapStyleFromSettings(mapStyleStr);
-  // A persisted Vehicle style is a transient navigation override applied only while following.
-  // There is no active route at startup, so collapse it to the base family (Outdoors/Default per
-  // the layer flag) at the same darkness.
-  if (mapStyle == MapStyleVehicleLight || mapStyle == MapStyleVehicleDark)
-  {
-    auto const baseFamily = LoadOutdoorsEnabled() ? MapStyleFamily::Outdoors : MapStyleFamily::Default;
-    mapStyle = GetMapStyleForFamily(baseFamily, MapStyleIsDark(mapStyle));
-  }
+  // Normalize the persisted style against the outdoors flag: with no active route at launch a
+  // transient Vehicle style collapses to the base family. Presence-aware, so a legacy Outdoors-only
+  // persistence (flag absent) seeds the flag without clobbering an explicitly stored value.
+  std::optional<bool> persistedOutdoors;
+  if (bool enabled; settings::Get(kOutdoorsEnabledKey, enabled))
+    persistedOutdoors = enabled;
+  auto const startup = NormalizeStartupMapStyle(mapStyle, persistedOutdoors);
+  if (startup.persistOutdoorsFlag)
+    SaveOutdoorsEnabled(startup.outdoorsEnabled);
+  mapStyle = startup.style;
   GetStyleReader().SetCurrentStyle(mapStyle);
+  m_nightMode = MapStyleIsDark(mapStyle);
   df::LoadTransitColors();
 
   // Init strings bundle.
@@ -2076,6 +2080,9 @@ void Framework::MarkMapStyle(MapStyle mapStyle)
     mapStyleStr = MapStyleToString(mapStyle);
   }
   settings::Set(kMapStyleKey, mapStyleStr);
+  // Keep the night mode in sync with the active style's darkness so ResolveMapStyleForMode() stays
+  // correct after any direct style change (debug commands, SDK MapStyle.set/mark).
+  m_nightMode = MapStyleIsDark(mapStyle);
   // Make sure the new style's family is resident before switching (a no-op once it is loaded, so
   // light<->dark stays zero-IO); drape worker threads observe the switch only via UpdateMapStyle.
   classificator::EnsureStyleLoaded(mapStyle);
@@ -2090,6 +2097,31 @@ void Framework::SetMapStyle(MapStyle mapStyle)
   InvalidateUserMarks();
   UpdateBookmarksTextPlacement();
   UpdateMinBuildingsTapZoom();
+}
+
+void Framework::SetNightMode(bool nightMode)
+{
+  m_nightMode = nightMode;
+}
+
+MapStyle Framework::ResolveMapStyleForMode() const
+{
+  auto const & rm = GetRoutingManager();
+  bool const vehicleFollowing = rm.IsRoutingFollowing() && rm.GetRouter() == routing::RouterType::Vehicle;
+  return GetMapStyleForFamily(SelectMapStyleFamily(vehicleFollowing, LoadOutdoorsEnabled()), m_nightMode);
+}
+
+void Framework::ApplyMapStyleForMode()
+{
+  auto const style = ResolveMapStyleForMode();
+  if (style != GetMapStyle())
+    SetMapStyle(style);
+}
+
+void Framework::ApplyMapStyleForMode(bool nightMode)
+{
+  SetNightMode(nightMode);
+  ApplyMapStyleForMode();
 }
 
 MapStyle Framework::GetMapStyle() const
@@ -3865,6 +3897,11 @@ std::vector<MwmSet::MwmId> Framework::GetMwmsByRect(m2::RectD const & rect, bool
 // RoutingManager::Delegate
 void Framework::OnRouteFollow(routing::RouterType type)
 {
+  // Following just started with m_isFollowing already final. The session-state callback can miss this:
+  // when a preview location update already advanced the session to OnRoute, EnableFollowMode re-issues
+  // SetState(OnRoute) — a no-op that emits no callback — so resolve the (now Vehicle) family here.
+  ApplyMapStyleForMode();
+
   bool const isPedestrianRoute = type == RouterType::Pedestrian;
   bool const enableAutoZoom = isPedestrianRoute ? false : LoadAutoZoom();
   int const scale = isPedestrianRoute ? scales::GetPedestrianNavigationScale() : scales::GetNavigationScale();
@@ -3883,6 +3920,14 @@ void Framework::OnRouteFollow(routing::RouterType type)
   // |isArrowGlued| parameter fully corresponds to |m_matchRoute| in RoutingSettings.
   // For pedestrian and bicycle modes, use compass heading when stopped (isArrowGlued = false).
   m_drapeEngine->FollowRoute(scale, scale3d, enableAutoZoom, !(isPedestrianRoute || isBicycleRoute) /* isArrowGlued */);
+}
+
+// RoutingManager::Delegate
+void Framework::OnRoutingSessionStateChanged()
+{
+  // Entered or left active navigation; re-resolve the map style family at the night mode the
+  // platform last supplied.
+  ApplyMapStyleForMode();
 }
 
 // RoutingManager::Delegate

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -457,6 +457,19 @@ public:
   void SetMapStyle(MapStyle mapStyle);
   void MarkMapStyle(MapStyle mapStyle);
   MapStyle GetMapStyle() const;
+  // Stores the platform's light/dark choice. The core combines it with the active family to pick the
+  // concrete MapStyle; routing/outdoors switches then resolve at this darkness without the platform
+  // re-supplying it. Storing only, no apply (Android applies via its own renderer-aware mark/set).
+  void SetNightMode(bool nightMode);
+  // Concrete style for the current mode: the active family at the stored night mode. Family priority:
+  // Vehicle (while following) > Outdoors (layer flag) > Default. Resolve only, no apply — platforms
+  // with a custom apply path (e.g. Android's renderer-aware mark/set) use this directly.
+  MapStyle ResolveMapStyleForMode() const;
+  // Resolves (see above) and applies it immediately if it changed.
+  void ApplyMapStyleForMode();
+  // Stores the night mode (see SetNightMode) and applies. For platforms whose theme path supplies
+  // darkness with an immediate apply (iOS, Qt).
+  void ApplyMapStyleForMode(bool nightMode);
 
   void SetupMeasurementSystem();
 
@@ -784,6 +797,7 @@ public:
 protected:
   /// RoutingManager::Delegate
   void OnRouteFollow(routing::RouterType type) override;
+  void OnRoutingSessionStateChanged() override;
   void InitRouting();
 
 public:
@@ -804,6 +818,9 @@ private:
   settings::UsageStats m_usageStats;
 
   bool m_showDownloadedRegions = false;
+
+  // Platform-supplied light/dark choice; see SetNightMode. Seeded from the persisted style at startup.
+  bool m_nightMode = false;
 
 public:
   power_management::PowerManager & GetPowerManager() { return m_powerManager; }

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -466,6 +466,19 @@ public:
   void SetMapStyle(MapStyle mapStyle);
   void MarkMapStyle(MapStyle mapStyle);
   MapStyle GetMapStyle() const;
+  // Stores the platform's light/dark choice. The core combines it with the active family to pick the
+  // concrete MapStyle; routing/outdoors switches then resolve at this darkness without the platform
+  // re-supplying it. Storing only, no apply (Android applies via its own renderer-aware mark/set).
+  void SetNightMode(bool nightMode);
+  // Concrete style for the current mode: the active family at the stored night mode. Family priority:
+  // Vehicle (while following) > Outdoors (layer flag) > Default. Resolve only, no apply — platforms
+  // with a custom apply path (e.g. Android's renderer-aware mark/set) use this directly.
+  MapStyle ResolveMapStyleForMode() const;
+  // Resolves (see above) and applies it immediately if it changed.
+  void ApplyMapStyleForMode();
+  // Stores the night mode (see SetNightMode) and applies. For platforms whose theme path supplies
+  // darkness with an immediate apply (iOS, Qt).
+  void ApplyMapStyleForMode(bool nightMode);
 
   void SetupMeasurementSystem();
 
@@ -803,6 +816,7 @@ public:
 protected:
   /// RoutingManager::Delegate
   void OnRouteFollow(routing::RouterType type) override;
+  void OnRoutingSessionStateChanged() override;
   void InitRouting();
 
 public:
@@ -823,6 +837,9 @@ private:
   settings::UsageStats m_usageStats;
 
   bool m_showDownloadedRegions = false;
+
+  // Platform-supplied light/dark choice; see SetNightMode. Seeded from the persisted style at startup.
+  bool m_nightMode = false;
 
 public:
   power_management::PowerManager & GetPowerManager() { return m_powerManager; }

--- a/libs/map/map_tests/CMakeLists.txt
+++ b/libs/map/map_tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SRC
   gps_track_storage_test.cpp
   gps_track_test.cpp
   kmz_unarchive_test.cpp
+  map_style_resolve_tests.cpp
   mwm_url_tests.cpp
   power_manager_tests.cpp
   road_warning_tests.cpp

--- a/libs/map/map_tests/map_style_resolve_tests.cpp
+++ b/libs/map/map_tests/map_style_resolve_tests.cpp
@@ -1,0 +1,49 @@
+#include "testing/testing.hpp"
+
+#include "map/framework.hpp"
+
+#include "indexer/map_style.hpp"
+
+namespace map_style_resolve_tests
+{
+// Framework wiring for ResolveMapStyleForMode(): it feeds the live night mode and outdoors flag into
+// the pure SelectMapStyleFamily/GetMapStyleForFamily (unit-tested in indexer_tests). With no active
+// route it picks the base family at the stored darkness. The Vehicle-while-following branch needs a
+// calculated route and is not exercised here.
+UNIT_TEST(Framework_ResolveMapStyleForMode_BaseFamilies)
+{
+  Framework framework(FrameworkParams(false /* m_enableDiffs */));
+  TEST(!framework.GetRoutingManager().IsRoutingFollowing(), ("No active route at construction"));
+
+  Framework::SaveOutdoorsEnabled(false);
+  framework.SetNightMode(false);
+  TEST_EQUAL(framework.ResolveMapStyleForMode(), MapStyleDefaultLight, ());
+  framework.SetNightMode(true);
+  TEST_EQUAL(framework.ResolveMapStyleForMode(), MapStyleDefaultDark, ());
+
+  Framework::SaveOutdoorsEnabled(true);
+  framework.SetNightMode(false);
+  TEST_EQUAL(framework.ResolveMapStyleForMode(), MapStyleOutdoorsLight, ());
+  framework.SetNightMode(true);
+  TEST_EQUAL(framework.ResolveMapStyleForMode(), MapStyleOutdoorsDark, ());
+
+  Framework::SaveOutdoorsEnabled(false);  // Restore the global default for other tests.
+}
+
+// A direct style change (debug commands, SDK MapStyle.set/mark) must keep m_nightMode in sync, so a
+// subsequent routing/outdoors resolve does not reverse the user's darkness.
+UNIT_TEST(Framework_MarkMapStyleSyncsNightMode)
+{
+  Framework framework(FrameworkParams(false /* m_enableDiffs */));
+  Framework::SaveOutdoorsEnabled(false);
+
+  framework.SetNightMode(false);
+  framework.MarkMapStyle(MapStyleDefaultDark);  // Direct dark style while the night mode was light.
+  TEST_EQUAL(framework.ResolveMapStyleForMode(), MapStyleDefaultDark, ("resolve must keep the darkness"));
+
+  framework.MarkMapStyle(MapStyleDefaultLight);
+  TEST_EQUAL(framework.ResolveMapStyleForMode(), MapStyleDefaultLight, ());
+
+  framework.MarkMapStyle(kDefaultMapStyle);  // Restore for other tests.
+}
+}  // namespace map_style_resolve_tests

--- a/libs/map/routing_manager.cpp
+++ b/libs/map/routing_manager.cpp
@@ -401,6 +401,13 @@ RoutingManager::RoutingManager(Callbacks && callbacks, Delegate & delegate)
         m_routeSpeedCamsClearCallback();
     });
   });
+
+  m_routingSession.SetChangeSessionStateCallback([this](SessionState, SessionState)
+  {
+    // IsFollowing() is updated by the session right after this callback returns, so defer the
+    // map-style resolution to the next GUI loop where the navigation state is final.
+    GetPlatform().RunTask(Platform::Thread::Gui, [this]() { m_delegate.OnRoutingSessionStateChanged(); });
+  });
 }
 
 void RoutingManager::SetBookmarkManager(BookmarkManager * bmManager)

--- a/libs/map/routing_manager.hpp
+++ b/libs/map/routing_manager.hpp
@@ -64,6 +64,9 @@ public:
   {
   public:
     virtual void OnRouteFollow(routing::RouterType type) = 0;
+    // Called on the GUI thread after the routing session state changed, so the map style can be
+    // re-resolved for the new navigation state.
+    virtual void OnRoutingSessionStateChanged() {}
     virtual ~Delegate() = default;
   };
 

--- a/libs/routing/routing_tests/routing_session_test.cpp
+++ b/libs/routing/routing_tests/routing_session_test.cpp
@@ -530,6 +530,53 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRoutePercentTest
   TEST(checkTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route checking timeout."));
 }
 
+// Regression for the map-style-on-navigation trigger. When a preview location update has already
+// advanced the session to OnRoute, EnableFollowMode() re-issues SetState(OnRoute) — a no-op that
+// fires no state-change callback — while turning following on. The vehicle map style must therefore
+// be applied from the follow hook (Framework::OnRouteFollow), not derived from that callback.
+UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, EnableFollowModeFromOnRouteFiresNoStateCallback)
+{
+  TimedSignal buildSignal;
+  GetPlatform().RunTask(Platform::Thread::Gui, [&buildSignal, this]()
+  {
+    InitRoutingSession();
+    size_t counter = 0;
+    m_session->SetRouter(make_unique<DummyRouter>(counter), nullptr);
+    m_session->SetRoutingCallbacks([&buildSignal](RoutesResult const &, RouterResultCode) {
+      buildSignal.Signal();
+    }, nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */);
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), RouterDelegate::kNoTimeout);
+  });
+  TEST(buildSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
+
+  TimedSignal checkSignal;
+  GetPlatform().RunTask(Platform::Thread::Gui, [&checkSignal, this]()
+  {
+    // Advance to OnRoute via location updates without enabling following (route preview).
+    location::GpsInfo info;
+    info.m_horizontalAccuracy = 0.01;
+    info.m_verticalAccuracy = 0.01;
+    info.m_longitude = 0.;
+    info.m_latitude = 1.;
+    m_session->OnLocationPositionChanged(info);
+    info.m_latitude = 2.;
+    m_session->OnLocationPositionChanged(info);
+    TEST(m_session->IsOnRoute(), ("A preview location update advances the session to OnRoute."));
+    TEST(!m_session->IsFollowing(), ("Following is not enabled yet."));
+
+    // From OnRoute, EnableFollowMode() turns following on, but its SetState(OnRoute) is a no-op that
+    // emits no callback. The map-style switch therefore cannot rely on the session-state callback.
+    size_t callbackCount = 0;
+    m_session->SetChangeSessionStateCallback([&callbackCount](SessionState, SessionState) { ++callbackCount; });
+    TEST(m_session->EnableFollowMode(), ());
+    TEST(m_session->IsFollowing(), ());
+    TEST_EQUAL(callbackCount, 0, ("EnableFollowMode from OnRoute must not fire a state-change callback."));
+    m_session->SetChangeSessionStateCallback(nullptr);
+    checkSignal.Signal();
+  });
+  TEST(checkSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route checking timeout."));
+}
+
 UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingError)
 {
   vector<m2::PointD> const kRoute = {{0.0, 0.001}, {0.0, 0.002}, {0.0, 0.003}, {0.0, 0.004}};

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -143,12 +143,7 @@ void DrawWidget::PrepareShutdown()
 {
   auto & routingManager = m_framework.GetRoutingManager();
   if (routingManager.IsRoutingActive() && routingManager.IsRoutingFollowing())
-  {
     routingManager.SaveRoutePoints();
-
-    auto style = m_framework.GetMapStyle();
-    m_framework.MarkMapStyle(MapStyleIsDark(style) ? MapStyle::MapStyleDefaultDark : MapStyle::MapStyleDefaultLight);
-  }
 }
 
 void DrawWidget::UpdateAfterSettingsChanged()
@@ -618,22 +613,13 @@ void DrawWidget::FollowRoute()
   if (!points.front().m_isMyPosition && !points.back().m_isMyPosition)
     return;
   if (routingManager.IsRoutingActive() && !routingManager.IsRoutingFollowing())
-  {
     routingManager.FollowRoute();
-    SetMapStyleToVehicle();
-  }
 }
 
 void DrawWidget::ClearRoute()
 {
   auto & routingManager = m_framework.GetRoutingManager();
-
-  bool const wasActive = routingManager.IsRoutingActive() && routingManager.IsRoutingFollowing();
   routingManager.CloseRouting(true /* remove route points */);
-
-  if (wasActive)
-    SetMapStyleToDefault();
-
   m_turnsVisualizer.ClearTurns(m_framework.GetDrapeApi());
 }
 
@@ -712,24 +698,6 @@ void DrawWidget::SetRuler(bool enabled)
 void DrawWidget::RefreshDrawingRules()
 {
   SetMapStyle(MapStyleDefaultLight);
-}
-
-void DrawWidget::SetMapStyleToDefault()
-{
-  auto const style = m_framework.GetMapStyle();
-  SetMapStyle(MapStyleIsDark(style) ? MapStyle::MapStyleDefaultDark : MapStyle::MapStyleDefaultLight);
-}
-
-void DrawWidget::SetMapStyleToVehicle()
-{
-  auto const style = m_framework.GetMapStyle();
-  SetMapStyle(MapStyleIsDark(style) ? MapStyle::MapStyleVehicleDark : MapStyle::MapStyleVehicleLight);
-}
-
-void DrawWidget::SetMapStyleToOutdoors()
-{
-  auto const style = m_framework.GetMapStyle();
-  SetMapStyle(MapStyleIsDark(style) ? MapStyle::MapStyleOutdoorsDark : MapStyle::MapStyleOutdoorsLight);
 }
 
 m2::PointD DrawWidget::P2G(m2::PointD const & pt) const

--- a/qt/draw_widget.hpp
+++ b/qt/draw_widget.hpp
@@ -79,9 +79,6 @@ public:
   void EditPlace(FeatureID const & featureId);
 
   void RefreshDrawingRules();
-  void SetMapStyleToDefault();
-  void SetMapStyleToVehicle();
-  void SetMapStyleToOutdoors();
 
 protected:
   /// @name Overriden from MapWidget.

--- a/qt/mainwindow.cpp
+++ b/qt/mainwindow.cpp
@@ -925,10 +925,7 @@ void MainWindow::SetLayerEnabled(LayerType type, bool enable)
     break;
   case OUTDOORS:
     frm.SaveOutdoorsEnabled(enable);
-    if (enable)
-      m_pDrawWidget->SetMapStyleToOutdoors();
-    else
-      m_pDrawWidget->SetMapStyleToDefault();
+    frm.ApplyMapStyleForMode();
     break;
   case HIKING: frm.SetHikingEnabled(enable); break;
   case CYCLING: frm.SetCyclingEnabled(enable); break;

--- a/qt/preferences_dialog.cpp
+++ b/qt/preferences_dialog.cpp
@@ -192,11 +192,10 @@ PreferencesDialog::PreferencesDialog(QWidget * parent, Framework & framework)
       auto const mode = static_cast<NightMode>(i);
       SetNightModeSetting(mode);
 
-      auto const currStyle = framework.GetMapStyle();
       switch (mode)
       {
-      case NightMode::Off: framework.SetMapStyle(GetLightMapStyleVariant(currStyle)); break;
-      case NightMode::On: framework.SetMapStyle(GetDarkMapStyleVariant(currStyle)); break;
+      case NightMode::Off: framework.ApplyMapStyleForMode(false /* dark */); break;
+      case NightMode::On: framework.ApplyMapStyleForMode(true /* dark */); break;
       case NightMode::System: qt::common::ApplySystemNightMode(framework); break;
       }
     });

--- a/qt/qt_common/helpers.cpp
+++ b/qt/qt_common/helpers.cpp
@@ -6,8 +6,6 @@
 #include "platform/location.hpp"
 #include "platform/style_utils.hpp"
 
-#include "indexer/map_style.hpp"
-
 #include "base/logging.hpp"
 
 #include <QtCore/QDateTime>

--- a/qt/qt_common/helpers.cpp
+++ b/qt/qt_common/helpers.cpp
@@ -129,11 +129,7 @@ void ApplySystemNightMode(Framework & framework)
   if (style_utils::GetNightModeSetting() != style_utils::NightMode::System)
     return;
 
-  auto const currentStyle = framework.GetMapStyle();
-  auto const useDark = IsSystemInDarkMode();
-  auto const desiredStyle = useDark ? GetDarkMapStyleVariant(currentStyle) : GetLightMapStyleVariant(currentStyle);
-  if (desiredStyle != currentStyle)
-    framework.SetMapStyle(desiredStyle);
+  framework.ApplyMapStyleForMode(IsSystemInDarkMode());
 }
 
 }  // namespace qt::common


### PR DESCRIPTION
## What and why

Each platform (iOS, Android, Android Auto, Qt) independently mapped the "current mode"
to a concrete `MapStyle`, combining the usage **family** (vehicle while navigating /
outdoors layer / default) with **light/dark**. The logic was duplicated four times and
had diverged — with several latent bugs (see *Behavioral fixes*).

This PR moves the family decision into the C++ core. The core now switches the map style
on routing session-state changes; each platform supplies only its light/dark choice,
which the core stores as a "night mode" and combines with the active family.

...and it should be easy to add/switch new map styles.

**Ownership after this change:** the core owns the family; the platform owns darkness.

## Key changes

- **indexer:** new `MapStyleFamily` enum and `GetMapStyleForFamily(family, dark)`.
- **map/Framework:**
  - `SetNightMode(bool)` stores the platform's light/dark choice (seeded from the
    persisted style at startup); `ResolveMapStyleForMode()` / `ApplyMapStyleForMode()`
    resolve and apply it; `ApplyMapStyleForMode(dark)` stores-and-applies.
  - `RoutingSession::ChangeSessionStateCallback` re-resolves the family on every
    session-state change (GUI-deferred so it reads the settled `IsFollowing()`; a
    `GetMapStyle()` guard makes redundant fires no-ops, so reroutes don't flicker).
  - Startup migration: collapse a persisted **Vehicle** style to its base family (no
    active route at launch); reconcile a persisted **Outdoors** style with the layer flag.
- **Platforms:** iOS, Qt, Android, and Android Auto drop their per-platform resolution
  and call the core. Android keeps its renderer-aware (Vulkan) `mark`/`set` apply path.
- **Cleanups:** removed `MWMThemeVehicleDay/Night` (iOS), `GetDark/LightMapStyleVariant`
  (indexer), and the Qt `SetMapStyleTo{Default,Vehicle,Outdoors}` helpers.

## Behavioral fixes

- **iOS:** the vehicle palette now reliably applies when vehicle navigation starts
  (previously it depended on an unrelated theme refresh happening mid-navigation), and
  only while *following* a vehicle route — it no longer flips during route preview.
- **Qt:** the vehicle palette no longer applies to bicycle/pedestrian routes (it was
  applied unconditionally on follow).
- **Android:** with auto-dark navigation, the map no longer briefly shows the wrong
  darkness on navigation start/stop — `ThemeSwitcher.setTheme` pushes the night mode to
  the core synchronously, before the asynchronous activity recreate.
- **Android Auto:** now honors the outdoors layer.

## How it was tested

- New unit test `GetMapStyleForFamily` (`indexer_tests`) — passing.
- Built the C++ `map` library and the Qt `desktop` app; compiled the Android Java
  (`:app` + `:sdk` + `:libs:car`). iOS was **not** built locally.
- Suggested manual checks (light + dark, auto/system theme, both orientations):
  - light/dark and auto/system theme switching;
  - outdoors layer on/off;
  - start/stop **vehicle** vs **bicycle/pedestrian** navigation (palette only changes for
    vehicle);
  - Android auto-dark-navigation start/stop (no wrong-darkness flash);
  - Android Auto and iOS CarPlay light/dark and navigation.

## Notes

- No new cross-layer dependencies: `MapStyleFamily` lives in `indexer`; the stored night
  mode lives in `map`/`Framework`.
- Possible follow-up (not in this PR): extract `ResolveMapStyleForMode` and the startup
  migration into pure helpers in `indexer` for direct unit testing (incl. a regression
  guard that bicycle/pedestrian following does not select the vehicle family).

Related #2360
