### PR TITLE
[android] Unify bottom-sheet corners and stop place page from overlapping the status bar

### DIFF
--- a/android/app/src/main/java/app/organicmaps/search/SearchFragmentController.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchFragmentController.java
@@ -3,7 +3,6 @@ package app.organicmaps.search;
 import android.annotation.SuppressLint;
 import android.graphics.Outline;
 import android.os.Bundle;
-import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -204,7 +203,7 @@ public class SearchFragmentController extends Fragment implements SearchFragment
     int tabsHeight = getResources().getDimensionPixelSize(R.dimen.tabs_height);
     mMinCollapsedPeekHeight = actionBarSize + tabsHeight;
 
-    float topRadius = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 30, getResources().getDisplayMetrics());
+    float topRadius = getResources().getDimension(R.dimen.bottom_sheet_corner_radius);
     int surface = MaterialColors.getColor(mSearchPageContainer, com.google.android.material.R.attr.colorSurface);
     mSearchPageContainer.setBackgroundColor(surface);
     mSearchPageContainer.setOutlineProvider(new ViewOutlineProvider() {

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
@@ -6,11 +6,13 @@ import android.app.Dialog;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.graphics.Outline;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewOutlineProvider;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.graphics.Insets;
@@ -43,7 +45,6 @@ import app.organicmaps.util.bottomsheet.MenuBottomSheetFragment;
 import app.organicmaps.util.bottomsheet.MenuBottomSheetItem;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.android.material.shape.MaterialShapeDrawable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -60,7 +61,6 @@ public class PlacePageController
   private BottomSheetBehavior<View> mPlacePageBehavior;
   private NestedScrollView mPlacePage;
   private ViewGroup mPlacePageContainer;
-  private View mPlacePageStatusBarBackground;
   private ViewGroup mCoordinator;
   private int mViewportMinHeight;
   private int mButtonsHeight;
@@ -80,59 +80,10 @@ public class PlacePageController
   // Enabled after the sheet reaches COLLAPSED; prevents dismiss during initial open animation.
   private boolean mEasyDismissEnabled;
   private int mDistanceToTop;
-  private float mPlacePageCornerRadius;
 
   private ValueAnimator mCustomPeekHeightAnimator;
   private PlacePageListener mPlacePageListener;
   private Dialog mAlertDialog;
-
-  private final Observer<Integer> mPlacePageDistanceToTopObserver = distanceToTop ->
-  {
-    if (mCurrentWindowInsets == null)
-      return;
-
-    final int topInset = mCurrentWindowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
-    if (mCoordinator.getHeight() - mPlacePageContainer.getHeight() < topInset)
-    {
-      final int animationStartHeight = topInset * 3;
-      int newHeight = 0;
-      if (distanceToTop < animationStartHeight)
-        newHeight = Math.min(topInset * (animationStartHeight - distanceToTop) / 100, topInset);
-      if (newHeight > 0)
-      {
-        mPlacePageStatusBarBackground.setTranslationY(distanceToTop - newHeight);
-        if (!UiUtils.isVisible(mPlacePageStatusBarBackground))
-          onScreenFilled();
-      }
-      else if (UiUtils.isVisible(mPlacePageStatusBarBackground))
-        onScreenUnfilled();
-    }
-  };
-
-  private void onScreenFilled()
-  {
-    UiUtils.show(mPlacePageStatusBarBackground);
-    // LiveData observer fires before the layout pass that creates MaterialShapeDrawable.
-    if (mPlacePage.getBackground() instanceof MaterialShapeDrawable bg)
-    {
-      mPlacePageCornerRadius = bg.getTopLeftCornerResolvedSize();
-      bg.setCornerSize(0);
-    }
-  }
-
-  private void onScreenUnfilled()
-  {
-    UiUtils.hide(mPlacePageStatusBarBackground);
-    // LiveData observer fires before the layout pass that creates MaterialShapeDrawable.
-    if (mPlacePage.getBackground() instanceof MaterialShapeDrawable bg)
-    {
-      // onScreenUnfilled can fire before any onScreenFilled cached the radius (sheet-state
-      // callback / layout listener), so seed it here on first run.
-      if (mPlacePageCornerRadius == 0f)
-        mPlacePageCornerRadius = bg.getTopLeftCornerResolvedSize();
-      bg.setCornerSize(mPlacePageCornerRadius);
-    }
-  }
 
   private final BottomSheetBehavior.BottomSheetCallback mDefaultBottomSheetCallback =
       new BottomSheetBehavior.BottomSheetCallback() {
@@ -149,9 +100,6 @@ public class PlacePageController
             mEasyDismissEnabled = false;
           else if (PlacePageUtils.isCollapsedState(newState))
             mEasyDismissEnabled = true;
-
-          if (!PlacePageUtils.isExpandedState(newState))
-            onScreenUnfilled();
 
           if (PlacePageUtils.isHiddenState(newState))
           {
@@ -197,7 +145,6 @@ public class PlacePageController
     mPlacePage = view.findViewById(R.id.placepage);
     mPlacePageContainer = view.findViewById(R.id.placepage_container);
     mPlacePageBehavior = BottomSheetBehavior.from(mPlacePage);
-    mPlacePageStatusBarBackground = view.findViewById(R.id.place_page_status_bar_background);
 
     mShouldCollapse = true;
 
@@ -205,57 +152,28 @@ public class PlacePageController
     mPlacePageBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
     mPlacePageBehavior.setFitToContents(true);
     mPlacePageBehavior.setSkipCollapsed(false);
+    // Clip to outline so top corners stay rounded regardless of BottomSheetBehavior shape
+    // animations. Extending the rect past the bottom hides the bottom corner rounding.
+    final int topRadius = res.getDimensionPixelSize(R.dimen.bottom_sheet_corner_radius);
+    mPlacePage.setOutlineProvider(new ViewOutlineProvider() {
+      @Override
+      public void getOutline(@NonNull View v, @NonNull Outline outline)
+      {
+        outline.setRoundRect(0, 0, v.getWidth(), v.getHeight() + topRadius, topRadius);
+      }
+    });
+    mPlacePage.setClipToOutline(true);
 
     UiUtils.bringViewToFrontOf(view.findViewById(R.id.pp_buttons_fragment), mPlacePage);
     mViewModel = new ViewModelProvider(requireActivity()).get(PlacePageViewModel.class);
-    // place page status bar background
+
     ViewCompat.setOnApplyWindowInsetsListener(mPlacePage, (v, windowInsets) -> {
       mCurrentWindowInsets = windowInsets;
-      final Insets insets = mCurrentWindowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-      final ViewGroup.MarginLayoutParams layoutParams =
-          (ViewGroup.MarginLayoutParams) mPlacePageStatusBarBackground.getLayoutParams();
-      // Layout calculations are heavy so we compute them once then move the view from behind the place page to the
-      // status bar
-      boolean needsUpdate = layoutParams.height != insets.top || layoutParams.width != mPlacePage.getWidth()
-                         || layoutParams.leftMargin != insets.left || layoutParams.rightMargin != insets.right;
-      if (needsUpdate)
-      {
-        layoutParams.height = insets.top;
-        layoutParams.width = mPlacePage.getWidth();
-        layoutParams.setMargins(insets.left, 0, insets.right, 0);
-        mPlacePageStatusBarBackground.setLayoutParams(layoutParams);
-      }
       return windowInsets;
     });
 
-    mPlacePageContainer.addOnLayoutChangeListener(
-        (v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
-          final int newHeight = bottom - top;
-          final int oldHeight = oldBottom - oldTop;
-          if (newHeight >= oldHeight)
-            return;
-          if (mCurrentWindowInsets == null || !UiUtils.isVisible(mPlacePageStatusBarBackground))
-            return;
-          final int topInset = mCurrentWindowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
-          if (mCoordinator.getHeight() - newHeight >= topInset)
-            onScreenUnfilled();
-        });
-
     ViewCompat.requestApplyInsets(mPlacePage);
     mPlacePage.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
-      // This callback may be called before insets are updated when resuming the app
-      if (mCurrentWindowInsets == null)
-        return;
-
-      // Reserve the status bar and any display cutout, matching the status-bar fill check above. With
-      // displayCutout() alone the inset is 0 on non-cutout devices, so the "fills the screen" branch
-      // would never trip and the screen-filled correction would be skipped.
-      final int topInset =
-          mCurrentWindowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout())
-              .top;
-      if (mPlacePage.getHeight() >= mCoordinator.getHeight() - topInset)
-        mPlacePageDistanceToTopObserver.onChanged(oldTop);
-
       if (top != oldTop)
       {
         mDistanceToTop = oldTop;
@@ -369,14 +287,6 @@ public class PlacePageController
     // Set the maximum height of the place page to prevent jumps when new data results in BIGGER content
     // It does not take into account the navigation bar height so we need to add it manually
     mPlacePageBehavior.setMaxHeight(maxHeight);
-    final int availableHeight = mCoordinator.getHeight() - topInsets;
-    // Add bottom padding when content requires scrolling in landscape to prevent
-    // the last elements from being cut off by the navigation bar
-    final boolean isLandscape = getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
-    final boolean needsBottomInset = isLandscape && (minHeight + insets.bottom > availableHeight);
-    final int bottomPadding = needsBottomInset ? insets.bottom : 0;
-    if (mPlacePageContainer.getPaddingBottom() != bottomPadding)
-      mPlacePageContainer.setPadding(0, 0, 0, bottomPadding);
     mPlacePageRoot.setPadding(0, topInsets, 0, 0);
     if (mPpBottomContainer != null
         && (mPpBottomContainer.getPaddingLeft() != insets.left || mPpBottomContainer.getPaddingRight() != insets.right))
@@ -470,8 +380,9 @@ public class PlacePageController
     {
       peekHeight += plusDetailsContainer.getHeight();
     }
-    return Math.min(peekHeight + (isLandscape ? bottomInsets : 0),
-                    (mCoordinator.getHeight() - (mPlacePageStatusBarBackground.getHeight())));
+    final int topInset =
+        (mCurrentWindowInsets != null) ? mCurrentWindowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).top : 0;
+    return Math.min(peekHeight + (isLandscape ? bottomInsets : 0), mCoordinator.getHeight() - topInset);
   }
 
   @Override
@@ -480,7 +391,6 @@ public class PlacePageController
     mPreviewHeight = previewHeight;
     mFrameHeight = frameHeight;
     mViewModel.setPlacePageWidth(mPlacePage.getWidth());
-    mPlacePageStatusBarBackground.getLayoutParams().width = mPlacePage.getWidth();
     // Make sure to update the peek height on the UI thread to prevent weird animation jumps
     // TODO(AB): Investigate if this post is still necessary.
     mPlacePage.post(() -> {
@@ -824,7 +734,6 @@ public class PlacePageController
     super.onStart();
     mPlacePageBehavior.addBottomSheetCallback(mDefaultBottomSheetCallback);
     mViewModel.getMapObject().observe(requireActivity(), this);
-    mViewModel.getPlacePageDistanceToTop().observe(requireActivity(), mPlacePageDistanceToTopObserver);
   }
 
   @Override
@@ -852,7 +761,6 @@ public class PlacePageController
     super.onStop();
     mPlacePageBehavior.removeBottomSheetCallback(mDefaultBottomSheetCallback);
     mViewModel.getMapObject().removeObserver(this);
-    mViewModel.getPlacePageDistanceToTop().removeObserver(mPlacePageDistanceToTopObserver);
   }
 
   public interface PlacePageListener

--- a/android/app/src/main/res/layout-land/place_page_container_fragment.xml
+++ b/android/app/src/main/res/layout-land/place_page_container_fragment.xml
@@ -6,15 +6,6 @@
   android:id="@+id/pp_root"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
-  <View
-    android:id="@+id/place_page_status_bar_background"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:visibility="gone"
-    app:layout_constraintBottom_toTopOf="parent"
-    app:layout_constraintEnd_toStartOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
   <FrameLayout
     android:id="@+id/pp_bottom_container"
     android:layout_width="0dp"
@@ -29,6 +20,7 @@
       <androidx.core.widget.NestedScrollView
         android:id="@+id/placepage"
         style="@style/MwmWidget.BottomSheet.Rounded"
+        android:background="?cardBackground"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:elevation="0dp"

--- a/android/app/src/main/res/layout/place_page_container_fragment.xml
+++ b/android/app/src/main/res/layout/place_page_container_fragment.xml
@@ -6,17 +6,6 @@
   android:layout_height="match_parent"
   android:id="@+id/pp_root">
 
-  <View
-    android:id="@+id/place_page_status_bar_background"
-    android:layout_width="0dp"
-    android:layout_height="0dp"
-    android:layout_gravity="center_horizontal|top"
-    android:background="?ppBackground"
-    android:visibility="gone"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent"/>
-
   <FrameLayout
     android:id="@+id/pp_bottom_container"
     android:layout_width="@dimen/bottom_sheet_widths"
@@ -30,7 +19,8 @@
 
       <androidx.core.widget.NestedScrollView
         android:id="@+id/placepage"
-        style="?attr/bottomSheetStyle"
+        style="@style/MwmWidget.BottomSheet.Rounded"
+        android:background="?cardBackground"
         android:elevation="0dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -87,6 +87,7 @@
   <dimen name="corner_radius_small">8dp</dimen>
   <dimen name="corner_radius_medium">14dp</dimen>
   <dimen name="corner_radius_large">20dp</dimen>
+  <dimen name="bottom_sheet_corner_radius">24dp</dimen>
 
   <!-- map widgets -->
   <dimen name="viewport_min_height">100dp</dimen>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -152,6 +152,10 @@
     <item name="cornerSize">@dimen/corner_radius_large</item>
   </style>
 
+  <style name="ShapeAppearance.App.BottomSheet" parent="ShapeAppearance.Material3.LargeComponent">
+    <item name="cornerSize">@dimen/bottom_sheet_corner_radius</item>
+  </style>
+
   <style name="MwmWidget.ToolbarStyle" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar">
     <item name="android:background">?colorPrimary</item>
     <item name="android:displayOptions">homeAsUp|showTitle</item>
@@ -383,7 +387,7 @@
     <item name="backgroundTint">?cardBackground</item>
     <item name="paddingBottomSystemWindowInsets">true</item>
     <item name="paddingTopSystemWindowInsets">true</item>
-    <item name="shapeAppearance">?attr/shapeAppearanceLargeComponent</item>
+    <item name="shapeAppearance">@style/ShapeAppearance.App.BottomSheet</item>
   </style>
 
   <style name="FAB" parent="Widget.MaterialComponents.ExtendedFloatingActionButton">


### PR DESCRIPTION
## Summary                                                                                                                
  - Place page no longer overlaps the status bar and keeps its rounded                                                      
    top corners at full expansion — matching the search and routing                                                         
    cards.                                                                                                                
  - Replaces the custom status-bar tint backdrop and Material corner
    flattening with `ViewOutlineProvider` + `setClipToOutline` (the same
    pattern used by the search card).                                                                                       
  - Introduces a shared `bottom_sheet_corner_radius` (24dp) used by the
    place page, search, and routing cards.

<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/3e883d23-175f-4388-862f-ef6328795a05" />
<img width="2553" height="1209" alt="image" src="https://github.com/user-attachments/assets/7ffc9a20-57c1-492d-bbd5-a7c7c78bd48f" />
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/ae9697ec-595f-4d50-9f92-c620e0b5861f" />
