### PR TITLE
[github] Save CI caches only on master to stop cache eviction

### DIFF
--- a/.github/workflows/android-check.yaml
+++ b/.github/workflows/android-check.yaml
@@ -83,9 +83,10 @@ jobs:
           - flavor: FdroidDebug
             arch: arm32
     # Cancels previous jobs if the same branch or PR was updated again.
+    # Only cancel PR runs: master runs must finish to populate the shared ccache.
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.flavor }}-${{ github.event.pull_request.number || github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
     steps:
       - name: Install build tools and dependencies
@@ -120,6 +121,9 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ matrix.flavor }}
+          # Restore-only on PRs: master populates the shared cache, PRs read it.
+          # Avoids overflowing the 10GB repo limit, which evicts master's caches.
+          save: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Compile ${{ matrix.flavor }}
         shell: bash

--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -27,9 +27,10 @@ on:
       - xcode/**
 
 # Cancels previous jobs if the same branch or PR was updated again.
+# Only cancel PR runs: master runs must finish to populate the shared ccache.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -125,6 +126,12 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ matrix.environment.os }}-${{ matrix.environment.cc }}-${{ matrix.environment.unity }}-${{ matrix.cmake-build-type }}
+          # No Unity compiles every TU separately, so its cache needs more room
+          # than the 500M default (max-size is a ceiling, not a reservation).
+          max-size: ${{ matrix.environment.unity == 'OFF' && '2G' || '1G' }}
+          # Restore-only on PRs: master populates the shared cache, PRs read it.
+          # Avoids overflowing the 10GB repo limit, which evicts master's caches.
+          save: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Configure cmake
         env:

--- a/.github/workflows/ios-check.yaml
+++ b/.github/workflows/ios-check.yaml
@@ -47,9 +47,10 @@ jobs:
       matrix:
         buildType: [Debug, Release]
     # Cancels previous jobs if the same branch or PR was updated again.
+    # Only cancel PR runs: master runs must finish to populate the shared cache.
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.buildType }}-${{ github.event.pull_request.number || github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     permissions:
       contents: read
       actions: write  # To delete unnecessary cache.
@@ -85,7 +86,12 @@ jobs:
         with:
           key: xcode-cache-deriveddata-${{ github.workflow }}-${{ matrix.buildType }}-${{ github.sha }}
           restore-keys: xcode-cache-deriveddata-${{ github.workflow }}-${{ matrix.buildType }}
-          delete-used-deriveddata-cache: true
+          # Restore-only on PRs: master populates the shared cache, PRs read it.
+          # Avoids overflowing the 10GB repo limit, which evicts master's caches.
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
+          # Only master may delete its used cache; otherwise a PR would delete
+          # the master DerivedData it just restored from (via restore-keys).
+          delete-used-deriveddata-cache: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Build and Run Tests (Debug)
         if: matrix.buildType == 'Debug'


### PR DESCRIPTION
## Problem

GitHub enforces a **10 GB per-repository Actions cache limit, shared across all workflows**. The repo currently sits at **~11.5 GB / 31 caches** (CMake ccache + iOS DerivedData + Android ccache), so GitHub continuously evicts least-recently-used entries.

Because every PR job also *writes* its caches, each active PR adds ~3–4 GB. Master's caches — written once per push, then idle — get evicted before PR builds can read them, so PR jobs restore nothing and compile cold:

- The **No Unity Debug** job is hit hardest: **~40 min cold** (and often cancelled) vs **~13 min** with a warm cache.
- Even the regular unity jobs were getting **0% ccache hits** ("No cache found") on PRs.

Two extra leaks made it worse:
- `ios-check` ran `delete-used-deriveddata-cache: true` on PRs too, so a PR **deleted the master DerivedData it had just restored from**.
- The No Unity ccache exceeds the 500 MB default `max-size`, so it evicts its own objects mid-build (116 self-cleanups in a single run) — never fully caching even when warm.

## Fix

Make **master the sole cache writer; PRs restore-only** — the standard ccache-on-Actions pattern that keeps the shared cache warm and well under the limit.

- `build-cmake`, `android-check`: ccache-action saves only on master (`save:`).
- `ios-check`: xcode-cache is read-only on PRs (`cache-read-only:`); only master prunes its own cache.
- `build-cmake`: raise ccache `max-size` to `2G` for No Unity (`1G` for the rest). `max-size` is a ceiling, so smaller jobs still save only what they use.
- Don't cancel in-progress **master** runs — they must finish to populate caches (PR runs are still cancelled on update).

Steady-state footprint drops to **~6.5 GB**, comfortably under the 10 GB limit, so every PR restores a warm cache.

## Testing

- `actionlint` passes on all three workflows; the conditional expressions were verified across `push` / `pull_request` / `workflow_dispatch` events.
- Full effect lands after merge + one master run repopulates caches under the new config; subsequent PR builds should restore warm (No Unity ~13 min instead of ~40 min).