### PR TITLE
[routing] Drop inter-field TTS spaces for Chinese, like Japanese

### DIFF
--- a/libs/routing/routing_tests/turns_tts_text_tests.cpp
+++ b/libs/routing/routing_tests/turns_tts_text_tests.cpp
@@ -191,6 +191,36 @@ UNIT_TEST(GetTtsStreetTextTest)
       "you_have_reached_the_destination":"到着。"
       })";
 
+  // Chinese (incl. Cantonese) is written without spaces between words, so the "then" and
+  // distance separators must be omitted, just like for Japanese.
+  string const zhHansShortJson =
+      R"({
+      "in_300_meters":"在三百米后",
+      "in_500_meters":"在五百米后",
+      "then":"然后",
+      "onto":"进入",
+      "make_a_right_turn":"右转。",
+      "make_a_left_turn":"左转。",
+      "make_a_right_turn_street":"NULL",
+      "make_a_left_turn_street":"NULL",
+      "dist_direction_onto_street":"%1$s%2$s%3$s%4$s",
+      "you_have_reached_the_destination":"您已到达目的地。"
+      })";
+
+  string const yueShortJson =
+      R"({
+      "in_300_meters":"喺三百米後",
+      "in_500_meters":"喺五百米後",
+      "then":"跟住",
+      "onto":"入",
+      "make_a_right_turn":"轉右。",
+      "make_a_left_turn":"轉左。",
+      "make_a_right_turn_street":"NULL",
+      "make_a_left_turn_street":"NULL",
+      "dist_direction_onto_street":"%1$s%2$s%3$s%4$s",
+      "you_have_reached_the_destination":"你已經到咗目的地。"
+      })";
+
   string const faShortJson =
       R"({
       "in_300_meters":"ﺩﺭ ﺲﯿﺻﺩ ﻢﺗﺮﯾ",
@@ -272,6 +302,24 @@ UNIT_TEST(GetTtsStreetTextTest)
   TEST_EQUAL(getTtsText.GetTurnNotification(notification2), "三百メートル先左折し Main Street に入ります", ());
   TEST_EQUAL(getTtsText.GetTurnNotification(notification3), "三百メートル先左折です。", ());
   TEST_EQUAL(getTtsText.GetTurnNotification(notification4), "その先左折です。", ());
+
+  // No inter-field spaces for Chinese, neither in the street, distance nor "then" notifications.
+  getTtsText.ForTestingSetLocaleWithJson(zhHansShortJson, "zh-Hans");
+  TEST_EQUAL(getTtsText.GetTurnNotification(notification1), "在五百米后右转进入Main Street", ());
+  TEST_EQUAL(getTtsText.GetTurnNotification(notification2), "在三百米后左转进入Main Street", ());
+  TEST_EQUAL(getTtsText.GetTurnNotification(notification3), "在三百米后左转。", ());
+  TEST_EQUAL(getTtsText.GetTurnNotification(notification4), "然后左转。", ());
+
+  getTtsText.ForTestingSetLocaleWithJson(yueShortJson, "yue");
+  TEST_EQUAL(getTtsText.GetTurnNotification(notification1), "喺五百米後轉右入Main Street", ());
+  TEST_EQUAL(getTtsText.GetTurnNotification(notification2), "喺三百米後轉左入Main Street", ());
+  TEST_EQUAL(getTtsText.GetTurnNotification(notification3), "喺三百米後轉左。", ());
+  TEST_EQUAL(getTtsText.GetTurnNotification(notification4), "跟住轉左。", ());
+
+  // Regional Cantonese variants (yue-HK, yue-MO) must be treated like "yue".
+  getTtsText.ForTestingSetLocaleWithJson(yueShortJson, "yue-HK");
+  TEST_EQUAL(getTtsText.GetTurnNotification(notification3), "喺三百米後轉左。", ());
+  TEST_EQUAL(getTtsText.GetTurnNotification(notification4), "跟住轉左。", ());
 
   getTtsText.ForTestingSetLocaleWithJson(faShortJson, "fa");
   TEST_EQUAL(getTtsText.GetTurnNotification(notification1), "ﺩﺭ ﭖﺎﻨﺻﺩ ﻢﺗﺮﯾ ﺐﻫ ﺭﺎﺴﺗ ﺐﭙﯿﭽﯾﺩ ﺐﻫ Main Street", ());

--- a/libs/routing/turns_tts_text.cpp
+++ b/libs/routing/turns_tts_text.cpp
@@ -37,6 +37,13 @@ std::string DistToTextId(TIter begin, TIter end, uint32_t dist)
 
   return it->second;
 }
+
+// Japanese and Chinese (including Cantonese, e.g. "yue-HK") are written without spaces
+// between words, so their turn notifications are concatenated without inter-field spaces.
+bool IsSpacelessLanguage(std::string const & locale)
+{
+  return locale == "ja" || locale.starts_with("zh") || locale.starts_with("yue");
+}
 }  //  namespace
 
 void GetTtsText::SetLocale(std::string const & locale)
@@ -124,7 +131,7 @@ std::string GetTtsText::GetTurnNotification(Notification const & notification) c
   {
     // add "then" and space only if needed, for appropriate languages
     thenStr = GetTextByIdTrimmed("then");
-    if (localeKey != "ja")
+    if (!IsSpacelessLanguage(localeKey))
       thenStr.push_back(' ');
   }
 
@@ -236,7 +243,7 @@ std::string GetTtsText::GetTurnNotification(Notification const & notification) c
   if (!distStr.empty())
   {
     // add distance and/or space only if needed, for appropriate languages
-    if (localeKey != "ja")
+    if (!IsSpacelessLanguage(localeKey))
       out = thenStr + distStr + " " + dirStr;
     else
       out = thenStr + distStr + dirStr;


### PR DESCRIPTION
The "then" separator and the non-street distance notification only skipped the inter-field space for "ja", so Chinese turn notifications still got a stray space there even though the dist_direction_onto_street format strings already concatenate without spaces. Treat Chinese (zh-Hans/zh-Hant) and Cantonese (yue, incl. regional yue-HK/yue-MO) the same as Japanese, since none of these scripts separate words with spaces.

Follow-up for #13020