### PR TITLE
[ios] Add OM to the `Open With` in Files

### DIFF
--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -53,6 +53,21 @@ static FileType convertFileTypeToCore(MWMFileType fileType)
   }
 }
 
+static void DeleteTemporaryBookmarksFile(std::string const & filePath)
+{
+  NSError * error;
+  NSString * path = [NSString stringWithUTF8String:filePath.c_str()];
+  if ([[NSFileManager defaultManager] removeItemAtPath:path error:&error])
+  {
+    LOG(LINFO, ("Temporary bookmarks file is deleted:", filePath));
+    [[NSFileManager defaultManager] removeItemAtPath:path.stringByDeletingLastPathComponent error:nil];
+  }
+  else
+  {
+    LOG(LWARNING, ("Failed to delete temporary bookmarks file:", filePath, error));
+  }
+}
+
 @interface MWMBookmarksManager ()
 
 @property(nonatomic, readonly) BookmarkManager & bm;
@@ -131,6 +146,8 @@ static FileType convertFileTypeToCore(MWMFileType fileType)
         if ([observer respondsToSelector:@selector(onBookmarksFileLoadSuccess)])
           [observer onBookmarksFileLoadSuccess];
       }];
+      if (isTemporaryFile)
+        DeleteTemporaryBookmarksFile(filePath);
     };
   }
   {
@@ -142,6 +159,8 @@ static FileType convertFileTypeToCore(MWMFileType fileType)
         if ([observer respondsToSelector:@selector(onBookmarksFileLoadError)])
           [observer onBookmarksFileLoadError];
       }];
+      if (isTemporaryFile)
+        DeleteTemporaryBookmarksFile(filePath);
     };
   }
   self.bm.SetAsyncLoadingCallbacks(std::move(bookmarkCallbacks));

--- a/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.h
+++ b/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.h
@@ -17,7 +17,8 @@ typedef NS_ENUM(NSUInteger, DeeplinkUrlType) {
 
 + (DeeplinkUrlType)parseAndSetApiURL:(NSURL *)url;
 + (void)executeMapApiRequest;
-+ (void)addBookmarksFile:(NSURL *)url;
++ (void)addBookmarksFile:(NSURL *)url isTemporaryFile:(BOOL)isTemporaryFile;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.mm
+++ b/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.mm
@@ -33,10 +33,9 @@ static inline DeeplinkUrlType deeplinkUrlType(url_scheme::ParsedMapApi::UrlType 
   GetFramework().ExecuteMapApiRequest();
 }
 
-+ (void)addBookmarksFile:(NSURL *)url
++ (void)addBookmarksFile:(NSURL *)url isTemporaryFile:(BOOL)isTemporaryFile
 {
-  // iOS doesn't create temporary files on import at least in Safari and Files.
-  GetFramework().AddBookmarksFile(url.path.UTF8String, false /* isTemporaryFile */);
+  GetFramework().AddBookmarksFile(url.path.UTF8String, isTemporaryFile);
 }
 
 @end

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
@@ -275,7 +275,7 @@ using namespace osm_auth_ios;
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
 {
   NSLog(@"application:openURL: %@ options: %@", url, options);
-  return [DeepLinkHandler.shared applicationDidOpenUrl:url];
+  return [DeepLinkHandler.shared applicationDidOpenUrl:url options:options];
 }
 
 - (void)showMap

--- a/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
+++ b/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
@@ -16,10 +16,14 @@
     }
   }
 
-  func applicationDidOpenUrl(_ url: URL) -> Bool {
+  func applicationDidOpenUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
     // File reading should be processed synchronously to avoid permission issues (the Files app will close the file for reading when the application:openURL:options returns).
     if url.isFileURL {
-      return handleFileImport(url: url)
+      // UIApplication.openURL options are deprecated for scene-based apps. When scenes are adopted,
+      // handle UIApplication.OpenURLOptionsKey.openInPlace via the scene URL context instead.
+      // https://developer.apple.com/documentation/uikit/uiapplication/openurloptionskey/openinplace?language=objc
+      let openInPlace = options[.openInPlace] as? Bool ?? false
+      return handleFileImport(url: url, openInPlace: openInPlace)
     }
 
     // On the cold start, isLaunchedByDeeplink is set and handleDeepLink() call is delayed
@@ -68,18 +72,49 @@
     return false
   }
 
-  private func handleFileImport(url: URL) -> Bool {
-    LOG(.info, "handleFileImport: \(url)")
+  private func handleFileImport(url: URL, openInPlace: Bool) -> Bool {
+    LOG(.info, "handleFileImport: \(url), openInPlace: \(openInPlace)")
+    guard openInPlace else {
+      DeepLinkParser.addBookmarksFile(url, isTemporaryFile: true)
+      reset()
+      return true
+    }
+
+    let shouldStopAccessing = url.startAccessingSecurityScopedResource()
+    defer {
+      if shouldStopAccessing {
+        url.stopAccessingSecurityScopedResource()
+      }
+    }
+
     let fileCoordinator = NSFileCoordinator()
     var error: NSError?
+    var copyError: Error?
     fileCoordinator.coordinate(readingItemAt: url, options: [], error: &error) { fileURL in
-      DeepLinkParser.addBookmarksFile(fileURL)
+      do {
+        try DeepLinkParser.addBookmarksFile(copyFileToTemporaryDirectory(fileURL), isTemporaryFile: true)
+      } catch {
+        copyError = error
+      }
     }
     if let error {
       LOG(.error, "Failed to read file: \(error)")
     }
+    if let copyError {
+      LOG(.error, "Failed to copy file for import: \(copyError)")
+    }
     reset()
-    return true
+    return error == nil && copyError == nil
+  }
+
+  private func copyFileToTemporaryDirectory(_ url: URL) throws -> URL {
+    let temporaryDirectory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("FileImports/\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+
+    let localCopyURL = temporaryDirectory.appendingPathComponent(url.lastPathComponent)
+    try FileManager.default.copyItem(at: url, to: localCopyURL)
+    return localCopyURL
   }
 
   private func handleDeepLink(url: URL) -> Bool {

--- a/iphone/Maps/OMaps.plist
+++ b/iphone/Maps/OMaps.plist
@@ -140,7 +140,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
-	<false/>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
This PR enables Organic Maps to appear in the Files “Open With” menu for supported bookmark/track formats and makes that import path safe.

What changed:
- Enables opening documents in place in the app plist.
- Passes `openInPlace` from `application:openURL:options:` into `DeepLinkHandler`.
- Copies open-in-place files into the app temp directory under `FileImports` before starting async bookmark import.
- Keeps the existing non-open-in-place import path unchanged.
- Passes `isTemporaryFile` through the iOS bridge and deletes owned temp copies after import success or failure.

Why:
Bookmark import runs asynchronously on the file thread. With open-in-place URLs, iOS may pass a path to the original document from Files, iCloud Drive, or another document provider. That path may stop being readable after `application:openURL:options:` returns, so Organic Maps now creates its own temporary copy before handing the file to the async core importer.

https://github.com/user-attachments/assets/743072d3-0edf-4f0c-a9e3-a379ea12cbcf

