### PR TITLE
[android] Show route build progress as START button fill

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -16,9 +16,7 @@ import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
 import android.text.style.TypefaceSpan;
 import android.view.View;
-import android.widget.Button;
 import android.widget.ImageView;
-import android.widget.ProgressBar;
 import android.widget.ScrollView;
 import android.widget.TextView;
 import androidx.annotation.IdRes;
@@ -44,6 +42,7 @@ import app.organicmaps.sdk.util.StringUtils;
 import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
+import app.organicmaps.widget.RoutingProgressButton;
 import app.organicmaps.widget.recycler.DotDividerItemDecoration;
 import app.organicmaps.widget.recycler.MultilineLayoutManager;
 import java.util.LinkedList;
@@ -74,9 +73,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
   @NonNull
   private final TextView mError;
   @NonNull
-  private final Button mStart;
-  @NonNull
-  private final ProgressBar mStartProgress;
+  private final RoutingProgressButton mStart;
   @NonNull
   private final View mAltitudeChart;
   @NonNull
@@ -132,8 +129,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
     View transitTime = chartPanel.findViewById(R.id.transit_time);
     TextView rulerTime = chartPanel.findViewById(R.id.time_ruler);
     TextView error = (TextView) getViewById(activity, frame, R.id.error);
-    Button start = (Button) getViewById(activity, frame, R.id.start);
-    ProgressBar startProgress = (ProgressBar) getViewById(activity, frame, R.id.start_progress);
+    RoutingProgressButton start = (RoutingProgressButton) getViewById(activity, frame, R.id.start);
     View altitudeChart = chartPanel.findViewById(R.id.altitude_chart);
     TextView time = chartPanel.findViewById(R.id.time);
     TextView timeVehicle = chartPanel.findViewById(R.id.time_vehicle);
@@ -142,8 +138,8 @@ final class RoutingBottomMenuController implements View.OnClickListener
     View actionFrame = getViewById(activity, frame, R.id.routing_action_frame);
     View saveButton = getViewById(activity, frame, R.id.btn__save);
     return new RoutingBottomMenuController(activity, chartPanel, timeElevationLine, transitTime, rulerTime, error,
-                                           start, startProgress, altitudeChart, time, altitudeDifference, timeVehicle,
-                                           arrival, actionFrame, saveButton, headerAdapter, listener);
+                                           start, altitudeChart, time, altitudeDifference, timeVehicle, arrival,
+                                           actionFrame, saveButton, headerAdapter, listener);
   }
 
   @NonNull
@@ -155,8 +151,8 @@ final class RoutingBottomMenuController implements View.OnClickListener
 
   private RoutingBottomMenuController(@NonNull Activity context, @NonNull View altitudeChartFrame,
                                       @NonNull View timeElevationLine, @NonNull View transitTime,
-                                      @NonNull TextView rulerTime, @NonNull TextView error, @NonNull Button start,
-                                      @NonNull ProgressBar startProgress, @NonNull View altitudeChart,
+                                      @NonNull TextView rulerTime, @NonNull TextView error,
+                                      @NonNull RoutingProgressButton start, @NonNull View altitudeChart,
                                       @NonNull TextView time, @NonNull TextView altitudeDifference,
                                       @NonNull TextView timeVehicle, @Nullable TextView arrival,
                                       @NonNull View actionFrame, @NonNull View saveButton,
@@ -170,7 +166,6 @@ final class RoutingBottomMenuController implements View.OnClickListener
     mTimeRuler = rulerTime;
     mError = error;
     mStart = start;
-    mStartProgress = startProgress;
     mAltitudeChart = altitudeChart;
     mRouteElevationChartController = new RouteElevationChartController(mAltitudeChart);
     mRouteElevationChartController.setListener(new RouteElevationChartController.ElevationSelectionListener() {
@@ -397,17 +392,16 @@ final class RoutingBottomMenuController implements View.OnClickListener
   {
     if (state == mStartState)
       return;
+    mStart.setBuildProgress(0);
     mStartState = state;
-    UiUtils.showIf(state == StartState.BUILDING, mStartProgress);
     mStart.setEnabled(state == StartState.ENABLED);
-    // Reserve extra right padding while the spinner is visible so the centered label shifts
-    // left and does not slide under the spinner.
-    final Resources res = mContext.getResources();
-    int paddingEnd = res.getDimensionPixelSize(R.dimen.margin_base);
-    if (state == StartState.BUILDING)
-      paddingEnd += res.getDimensionPixelSize(R.dimen.routing_start_btn_spinner_reserve);
-    mStart.setPaddingRelative(mStart.getPaddingStart(), mStart.getPaddingTop(), paddingEnd, mStart.getPaddingBottom());
     notifyVisibilityChanged();
+  }
+
+  void setBuildProgress(int progress)
+  {
+    if (progress > mStart.getBuildProgress())
+      mStart.setBuildProgress(progress);
   }
 
   private void showError(@NonNull String message)

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingPlanFragment.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingPlanFragment.java
@@ -80,7 +80,7 @@ public class RoutingPlanFragment extends Fragment implements View.OnLayoutChange
   private final Observer<int[]> mBuildProgressObserver = progress ->
   {
     if (progress != null)
-      updateBuildProgress(ROUTERS[progress[1]]);
+      updateBuildProgress(progress[0], ROUTERS[progress[1]]);
   };
   private final Observer<Integer> mDrivingOptionsCountObserver = this::updateBadgeCount;
   private final Observer<Void> mDrivingOptionsErrorObserver = e -> onDrivingOptionsBuildError();
@@ -401,7 +401,7 @@ public class RoutingPlanFragment extends Fragment implements View.OnLayoutChange
     }
   }
 
-  private void updateBuildProgress(@NonNull Router router)
+  private void updateBuildProgress(int progress, @NonNull Router router)
   {
     if (getView() == null)
       return;
@@ -410,9 +410,12 @@ public class RoutingPlanFragment extends Fragment implements View.OnLayoutChange
     updateProgressLabels();
     final RoutingController controller = RoutingController.get();
     if (controller.isBuilding())
+    {
       mRoutingBottomMenuController.setStartState(RoutingBottomMenuController.StartState.BUILDING);
+      mRoutingBottomMenuController.setBuildProgress(progress);
+    }
     else if (!controller.isBuilt())
-      // ERROR / NONE / cancelled: clear the spinner that BUILDING left behind.
+      // ERROR / NONE / cancelled: clear the progress fill that BUILDING left behind.
       mRoutingBottomMenuController.setStartState(RoutingBottomMenuController.StartState.DISABLED);
   }
 

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingPlanViewModel.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingPlanViewModel.java
@@ -79,7 +79,8 @@ public class RoutingPlanViewModel extends ViewModel
     mMenuUpdateTrigger.setValue(current == null ? 1 : current + 1);
   }
 
-  // This is a workaround to update the progress and will be removed when the routing types are made segmented buttons
+  // Value layout: {progress, routerOrdinal}. Observers use routerOrdinal to look up the
+  // Router enum and reflect the currently-building router in the tab selector.
   public LiveData<int[]> getBuildProgress()
   {
     return mBuildProgress;

--- a/android/app/src/main/java/app/organicmaps/widget/RoutingProgressButton.kt
+++ b/android/app/src/main/java/app/organicmaps/widget/RoutingProgressButton.kt
@@ -1,0 +1,45 @@
+package app.organicmaps.widget
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatButton
+import androidx.core.content.ContextCompat
+import app.organicmaps.R
+
+class RoutingProgressButton @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = android.R.attr.buttonStyle,
+) : AppCompatButton(context, attrs, defStyleAttr) {
+
+    private val fillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+        color = ContextCompat.getColor(context, R.color.button_accent_normal)
+    }
+
+    init {
+        clipToOutline = true
+    }
+
+    var buildProgress: Int = 0
+        set(value) {
+            val clamped = value.coerceIn(0, 100)
+            if (clamped == field) return
+            field = clamped
+            invalidate()
+        }
+
+    override fun onDraw(canvas: Canvas) {
+        if (buildProgress > 0) {
+            val fillWidth = width * buildProgress / 100f
+            if (layoutDirection == LAYOUT_DIRECTION_RTL) {
+                canvas.drawRect(width - fillWidth, 0f, width.toFloat(), height.toFloat(), fillPaint)
+            } else {
+                canvas.drawRect(0f, 0f, fillWidth, height.toFloat(), fillPaint)
+            }
+        }
+        super.onDraw(canvas)
+    }
+}

--- a/android/app/src/main/res/layout-land/routing_bottom_sheet.xml
+++ b/android/app/src/main/res/layout-land/routing_bottom_sheet.xml
@@ -99,34 +99,7 @@
               app:srcCompat="@drawable/icon_save" />
           </LinearLayout>
 
-          <FrameLayout
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_margin="@dimen/margin_eighth"
-            android:layout_marginEnd="@dimen/margin_base"
-            android:layout_weight="1">
-
-            <Button
-              android:id="@+id/start"
-              style="@style/MwmWidget.Button.Primary"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:text="@string/p2p_start"
-              android:textColor="@color/start_button_text" />
-
-            <com.google.android.material.progressindicator.CircularProgressIndicator
-              android:id="@+id/start_progress"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_gravity="center_vertical|end"
-              android:layout_marginEnd="@dimen/margin_base"
-              android:indeterminate="true"
-              android:visibility="gone"
-              app:indicatorColor="@color/start_button_text"
-              app:indicatorSize="20dp"
-              app:trackThickness="2dp"
-              tools:visibility="visible" />
-          </FrameLayout>
+          <include layout="@layout/routing_start_button" />
         </LinearLayout>
 
       </FrameLayout>

--- a/android/app/src/main/res/layout/routing_bottom_sheet.xml
+++ b/android/app/src/main/res/layout/routing_bottom_sheet.xml
@@ -99,34 +99,7 @@
               app:srcCompat="@drawable/icon_save" />
           </LinearLayout>
 
-          <FrameLayout
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_margin="@dimen/margin_eighth"
-            android:layout_marginEnd="@dimen/margin_base"
-            android:layout_weight="1">
-
-            <Button
-              android:id="@+id/start"
-              style="@style/MwmWidget.Button.Primary"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:text="@string/p2p_start"
-              android:textColor="@color/start_button_text" />
-
-            <com.google.android.material.progressindicator.CircularProgressIndicator
-              android:id="@+id/start_progress"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_gravity="center_vertical|end"
-              android:layout_marginEnd="@dimen/margin_base"
-              android:indeterminate="true"
-              android:visibility="gone"
-              app:indicatorColor="@color/start_button_text"
-              app:indicatorSize="20dp"
-              app:trackThickness="2dp"
-              tools:visibility="visible" />
-          </FrameLayout>
+          <include layout="@layout/routing_start_button" />
         </LinearLayout>
 
       </FrameLayout>

--- a/android/app/src/main/res/layout/routing_start_button.xml
+++ b/android/app/src/main/res/layout/routing_start_button.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<app.organicmaps.widget.RoutingProgressButton
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/start"
+  style="@style/MwmWidget.Button.Primary"
+  android:layout_width="0dp"
+  android:layout_height="match_parent"
+  android:layout_margin="@dimen/margin_eighth"
+  android:layout_marginEnd="@dimen/margin_base"
+  android:layout_weight="1"
+  android:text="@string/p2p_start"
+  android:textColor="@color/start_button_text" />

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -115,7 +115,6 @@
   <dimen name="track_recorder_status_top_margin">64dp</dimen>
   <dimen name="routing_margin_peek_height">35dp</dimen>
   <dimen name="routing_toolbar_pill_padding">4dp</dimen>
-  <dimen name="routing_start_btn_spinner_reserve">40dp</dimen>
   <dimen name="routing_toolbar_cell_height">40dp</dimen>
   <dimen name="routing_toolbar_pill_corner_radius">24dp</dimen>
   <dimen name="routing_toolbar_cell_radius">20dp</dimen>


### PR DESCRIPTION
## Summary

  - Route build progress is now shown as a horizontal fill on the START button instead of an indeterminate spinner, giving the user visible feedback on how close the route is to being ready.

https://github.com/user-attachments/assets/e4385eda-ea92-4538-a554-df20916b39e4


