### PR TITLE
[cmake] Add CMakePresets.json and adopt it in CI and docs

### DIFF
--- a/.github/problem-matchers/gcc.json
+++ b/.github/problem-matchers/gcc.json
@@ -1,0 +1,18 @@
+{
+  "//": "Surfaces gcc/clang diagnostics as inline GitHub annotations. Registered via ::add-matcher:: from the CMake workflow. Matches: file:line:col: [fatal ]warning|error: message",
+  "problemMatcher": [
+    {
+      "owner": "gcc-clang",
+      "pattern": [
+        {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/build-cmake-mac.yaml
+++ b/.github/workflows/build-cmake-mac.yaml
@@ -59,13 +59,13 @@ jobs:
           key: ${{ github.workflow }}-${{ matrix.cmake-build-type }}
 
       - name: Generate Xcode project with CMake
+        # The ci-xcode preset sets the Xcode generator, the build-xcode dir and
+        # -g1. Xcode is multi-config, so the build type is chosen per build/test
+        # step below, not here.
         run: |
-          cmake . -B ${{ env.BUILD_DIR }} -G Xcode \
-            -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} \
+          cmake --preset ci-xcode \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_C_FLAGS=-g1 \
-            -DCMAKE_CXX_FLAGS=-g1
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build all targets
         working-directory: ${{ env.BUILD_DIR }}
@@ -79,25 +79,18 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
 
+      # The omim-test label filter and the exclude list live in CMakePresets.json
+      # (test preset "ci-xcode"). Excluded suites and why:
+      #   drape_tests, drape_frontend_tests, shaders_tests - need offscreen GL, run separately
+      #   generator_integration_tests - https://github.com/organicmaps/organicmaps/issues/225
+      #   opening_hours_integration_tests - https://github.com/organicmaps/organicmaps/issues/219
+      #   opening_hours_supported_features_tests - https://github.com/organicmaps/organicmaps/issues/219
+      #   routing_integration_tests - https://github.com/organicmaps/organicmaps/issues/221
+      #   world_feed_integration_tests - https://github.com/organicmaps/organicmaps/issues/215
       - name: Run tests
-        working-directory: ${{ env.BUILD_DIR }}
-        env:
-          # drape_tests, drape_frontend_tests, shaders_tests - require offscreen rendering, run separately.
-          # generator_integration_tests - https://github.com/organicmaps/organicmaps/issues/225
-          # opening_hours_integration_tests - https://github.com/organicmaps/organicmaps/issues/219
-          # opening_hours_supported_features_tests - https://github.com/organicmaps/organicmaps/issues/219
-          # routing_integration_tests - https://github.com/organicmaps/organicmaps/issues/221
-          # world_feed_integration_tests - https://github.com/organicmaps/organicmaps/issues/215
-          CTEST_EXCLUDE_REGEX: "drape_tests|drape_frontend_tests|generator_integration_tests|opening_hours_integration_tests|opening_hours_supported_features_tests|routing_benchmarks|routing_integration_tests|routing_quality_tests|search_quality_tests|storage_integration_tests|shaders_tests|world_feed_integration_tests"
-        run: |
-          ctest -j$(sysctl -n hw.logicalcpu) -C ${{ matrix.cmake-build-type }} \
-            -L "omim-test" -E "$CTEST_EXCLUDE_REGEX" --output-on-failure
+        run: ctest --preset ci-xcode -C ${{ matrix.cmake-build-type }} -j$(sysctl -n hw.logicalcpu)
 
       # Run drape tests separately. They require offscreen rendering support.
+      # The "ci-drape-xcode" test preset sets QT_QPA_PLATFORM=offscreen.
       - name: Run drape tests
-        working-directory: ${{ env.BUILD_DIR }}
-        env:
-          QT_QPA_PLATFORM: "offscreen"
-        run: |
-          ctest -C ${{ matrix.cmake-build-type }} \
-            -R "drape_tests|drape_frontend_tests|shaders_tests" --verbose
+        run: ctest --preset ci-drape-xcode -C ${{ matrix.cmake-build-type }} --verbose

--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -32,6 +32,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -143,6 +146,10 @@ jobs:
           cmake --preset ci \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} \
             -DCMAKE_UNITY_BUILD=${UNITY_BUILD}
+
+      # Surface gcc/clang warnings and errors as inline annotations on the PR diff.
+      - name: Enable inline compiler annotations
+        run: echo "::add-matcher::.github/problem-matchers/gcc.json"
 
       - name: Compile
         run: cmake --build --preset ci

--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -70,7 +70,6 @@ jobs:
     runs-on: ${{ matrix.environment.os }}
 
     env:
-      BUILD_DIR: build
       DEVELOPER_DIR: ${{ matrix.environment.developer-dir }}
 
     steps:
@@ -141,15 +140,12 @@ jobs:
           CMAKE_CXX_COMPILER_LAUNCHER: ccache
           UNITY_BUILD: ${{ matrix.environment.unity || 'ON' }}
         run: |
-          cmake . -B ${{ env.BUILD_DIR }} -G Ninja \
+          cmake --preset ci \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} \
-            -DCMAKE_C_FLAGS=-g1 \
-            -DCMAKE_CXX_FLAGS=-g1 \
             -DCMAKE_UNITY_BUILD=${UNITY_BUILD}
 
       - name: Compile
-        working-directory: ${{ env.BUILD_DIR }}
-        run: ninja
+        run: cmake --build --preset ci
 
       - name: Prepare testing environment (Linux)
         if: ${{ runner.os == 'Linux' }}
@@ -164,24 +160,21 @@ jobs:
           sudo locale-gen ru_RU.UTF-8
           sudo update-locale
 
+      # The omim-test label filter and the exclude list live in CMakePresets.json
+      # (test preset "ci"). Excluded suites and why:
+      #   drape_tests, drape_frontend_tests, shaders_tests - need offscreen GL, run in the next step
+      #   generator_integration_tests - https://github.com/organicmaps/organicmaps/issues/225
+      #   opening_hours_integration_tests - https://github.com/organicmaps/organicmaps/issues/219
+      #   opening_hours_supported_features_tests - https://github.com/organicmaps/organicmaps/issues/219
+      #   routing_integration_tests - https://github.com/organicmaps/organicmaps/issues/221
+      #   world_feed_integration_tests - https://github.com/organicmaps/organicmaps/issues/215
       - name: Run tests
         if: ${{ matrix.environment.run-tests != 'OFF' }}
-        working-directory: ${{ env.BUILD_DIR }}
-        env:
-          # drape_tests, drape_frontend_tests, shaders_tests - see next step
-          # generator_integration_tests - https://github.com/organicmaps/organicmaps/issues/225
-          # opening_hours_integration_tests - https://github.com/organicmaps/organicmaps/issues/219
-          # opening_hours_supported_features_tests - https://github.com/organicmaps/organicmaps/issues/219
-          # routing_integration_tests - https://github.com/organicmaps/organicmaps/issues/221
-          # world_feed_integration_tests - https://github.com/organicmaps/organicmaps/issues/215
-          CTEST_EXCLUDE_REGEX: "drape_tests|drape_frontend_tests|generator_integration_tests|opening_hours_integration_tests|opening_hours_supported_features_tests|routing_benchmarks|routing_integration_tests|routing_quality_tests|search_quality_tests|storage_integration_tests|shaders_tests|world_feed_integration_tests"
-        run: ctest -j$(nproc --all) -L "omim-test" -E "$CTEST_EXCLUDE_REGEX" --output-on-failure
+        run: ctest --preset ci -j$(nproc --all)
 
       # Run drape tests separately. They require offscreen rendering support.
-      # Setting QT_QPA_PLATFORM to "offscreen" breaks network tests on macOS.
+      # The "ci-drape" test preset sets QT_QPA_PLATFORM=offscreen; setting it
+      # globally breaks network tests on macOS.
       - name: Run drape tests
         if: ${{ matrix.environment.run-tests != 'OFF' }}
-        working-directory: ${{ env.BUILD_DIR }}
-        env:
-          QT_QPA_PLATFORM: "offscreen"
-        run: ctest -R "drape_tests|drape_frontend_tests|shaders_tests" --verbose
+        run: ctest --preset ci-drape --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,8 @@ iphone/Maps/app.omaps/
 /cmake-build-*
 build/
 /build*/
+# Per-developer CMake preset overrides (CMakePresets.json is committed).
+CMakeUserPresets.json
 
 qt/res/Info.plist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,14 +94,18 @@ std::string DebugPrint(MyType const & t);
 - Follow the instructions in [docs/INSTALL.md](docs/INSTALL.md)
 
 ## Build on desktop
-1. CMake configure: `cmake -B build-$YOUR_NAME -S . -DCMAKE_BUILD_TYPE=Debug -GNinja` for debug configuration
+1. CMake configure: `cmake --preset debug -B build-$YOUR_NAME` for debug configuration
+   - the `debug` preset (in `CMakePresets.json`) sets Ninja + `CMAKE_BUILD_TYPE=Debug`; `-B` overrides the preset's build dir so each agent gets its own `build-$YOUR_NAME` and they don't clobber each other
    - if configure fails, repeat with `--fresh` option to clear CMake cache
 2. Build: `cmake --build build-$YOUR_NAME` to build all targets
    or specify `--target target_name` to build a specific target (e.g., `desktop` for the main app)
 3. To run tests:
 ```bash
-# Exclude some tests that are not relevant for most contributors.
-ctest -j --test-dir build-$YOUR_NAME --stop-on-failure --output-on-failure -E "drape_tests|generator_integration_tests|opening_hours_integration_tests|opening_hours_supported_features_tests|routing_benchmarks|routing_integration_tests|routing_quality_tests|search_quality_tests|storage_integration_tests|shaders_tests|world_feed_integration_tests"
+# Mirrors the default CMake test preset while keeping the per-agent build dir.
+CTEST_EXCLUDE_REGEX="drape_tests|drape_frontend_tests|generator_integration_tests|opening_hours_integration_tests|opening_hours_supported_features_tests|routing_benchmarks|routing_integration_tests|routing_quality_tests|search_quality_tests|storage_integration_tests|shaders_tests|world_feed_integration_tests"
+ctest -j --test-dir build-$YOUR_NAME --stop-on-failure --output-on-failure -L "omim-test" -E "$CTEST_EXCLUDE_REGEX"
+# Rendering tests need offscreen GL and are run separately.
+QT_QPA_PLATFORM=offscreen ctest --test-dir build-$YOUR_NAME --stop-on-failure --output-on-failure -R "drape_tests|drape_frontend_tests|shaders_tests"
 # Run only a specific test:
 ctest -j --test-dir build-$YOUR_NAME --stop-on-failure --output-on-failure -R test_name
 ```

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,211 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 22,
+    "patch": 1
+  },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}"
+    },
+    {
+      "name": "ci-flags",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_FLAGS": "-g1",
+        "CMAKE_CXX_FLAGS": "-g1"
+      }
+    },
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "description": "Single-config Debug build (Ninja). Output in build/debug.",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release",
+      "description": "Single-config Release build (Ninja). Output in build/release.",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "relwithdebinfo",
+      "displayName": "RelWithDebInfo",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "debug-no-unity",
+      "displayName": "Debug, no Unity build",
+      "description": "Debug with Unity batching off (lower peak memory, slower build).",
+      "inherits": "debug",
+      "cacheVariables": {
+        "CMAKE_UNITY_BUILD": "OFF"
+      }
+    },
+    {
+      "name": "coverage",
+      "displayName": "Debug + coverage",
+      "description": "Debug build instrumented for a gcovr coverage report (target omim_coverage).",
+      "inherits": "debug",
+      "cacheVariables": {
+        "COVERAGE_REPORT": "ON",
+        "CMAKE_C_FLAGS": "-g1",
+        "CMAKE_CXX_FLAGS": "-g1"
+      }
+    },
+    {
+      "name": "xcode",
+      "displayName": "Xcode (multi-config)",
+      "description": "Xcode generator. Needed for dev_sandbox + Metal shader development on macOS.",
+      "generator": "Xcode",
+      "binaryDir": "${sourceDir}/build/xcode",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ci",
+      "displayName": "CI (Ninja)",
+      "description": "Mirrors the Ninja CI leg: flat build/ dir, -g1 debug info. Pass -DCMAKE_BUILD_TYPE on top.",
+      "inherits": [
+        "base",
+        "ci-flags"
+      ],
+      "binaryDir": "${sourceDir}/build"
+    },
+    {
+      "name": "ci-xcode",
+      "displayName": "CI (Xcode)",
+      "description": "Mirrors the Xcode CI leg. Multi-config: choose Debug/Release at build/test time.",
+      "inherits": [
+        "xcode",
+        "ci-flags"
+      ],
+      "binaryDir": "${sourceDir}/build-xcode"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "relwithdebinfo",
+      "configurePreset": "relwithdebinfo"
+    },
+    {
+      "name": "debug-no-unity",
+      "configurePreset": "debug-no-unity"
+    },
+    {
+      "name": "coverage",
+      "configurePreset": "coverage"
+    },
+    {
+      "name": "ci",
+      "configurePreset": "ci"
+    },
+    {
+      "name": "xcode",
+      "configurePreset": "xcode",
+      "configuration": "Debug"
+    },
+    {
+      "name": "ci-xcode",
+      "configurePreset": "ci-xcode",
+      "configuration": "Debug"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "omim-tests",
+      "hidden": true,
+      "output": {
+        "outputOnFailure": true
+      },
+      "filter": {
+        "include": {
+          "label": "omim-test"
+        },
+        "exclude": {
+          "name": "drape_tests|drape_frontend_tests|generator_integration_tests|opening_hours_integration_tests|opening_hours_supported_features_tests|routing_benchmarks|routing_integration_tests|routing_quality_tests|search_quality_tests|storage_integration_tests|shaders_tests|world_feed_integration_tests"
+        }
+      }
+    },
+    {
+      "name": "drape-tests",
+      "hidden": true,
+      "description": "Rendering tests that need offscreen GL; run separately from the main suite.",
+      "environment": {
+        "QT_QPA_PLATFORM": "offscreen"
+      },
+      "output": {
+        "outputOnFailure": true
+      },
+      "filter": {
+        "include": {
+          "name": "drape_tests|drape_frontend_tests|shaders_tests"
+        }
+      }
+    },
+    {
+      "name": "debug",
+      "inherits": "omim-tests",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "inherits": "omim-tests",
+      "configurePreset": "release"
+    },
+    {
+      "name": "coverage",
+      "inherits": "omim-tests",
+      "configurePreset": "coverage"
+    },
+    {
+      "name": "drape-debug",
+      "inherits": "drape-tests",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "ci",
+      "inherits": "omim-tests",
+      "configurePreset": "ci"
+    },
+    {
+      "name": "ci-drape",
+      "inherits": "drape-tests",
+      "configurePreset": "ci"
+    },
+    {
+      "name": "ci-xcode",
+      "inherits": "omim-tests",
+      "configurePreset": "ci-xcode"
+    },
+    {
+      "name": "ci-drape-xcode",
+      "inherits": "drape-tests",
+      "configurePreset": "ci-xcode"
+    }
+  ]
+}

--- a/cmake/OmimOptions.cmake
+++ b/cmake/OmimOptions.cmake
@@ -1,4 +1,5 @@
-if (NOT CMAKE_BUILD_TYPE)
+get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if (NOT _is_multi_config AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif ()
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -237,19 +237,30 @@ Running X Server is also required to run `generate_symbols.sh` script when you c
 
 ### Building
 
-To build a desktop app:
+The recommended way to configure and build is with [CMake presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html),
+run from the repository root. List configure/build/test presets with
+`cmake --list-presets=all`; list only test presets with `ctest --list-presets`.
+
+To configure and build the desktop app in Debug (binaries go into `build/debug`):
+
 ```bash
-tools/unix/build_omim.sh -r desktop
+cmake --preset debug
+cmake --build --preset debug --target desktop
 ```
 
-The output binary will go into `../omim-build-release`.
+Use `--preset release` for an optimized build (binaries in `build/release`). Other
+presets include `relwithdebinfo`, `debug-no-unity` (disables Unity batching for
+lower peak memory), `coverage`, and `xcode` (macOS only; generates an Xcode
+project, needed for `dev_sandbox` and Metal shader development).
 
-Check `tools/unix/build_omim.sh -h` for more build options, e.g. to build a debug version.
+Besides _desktop_ there are other targets like _generator_tool_; pass them to
+`--target`, or omit `--target` to build everything.
 
-Besides _desktop_ there are other targets like _generator_tool_, to see a full list execute:
+Alternatively, the `tools/unix/build_omim.sh` wrapper builds into
+`../omim-build-<buildtype>` (run with `-h` for options, `-d`/`-r` for Debug/Release):
 
 ```bash
-tools/unix/build_omim.sh -d help
+tools/unix/build_omim.sh -r desktop
 ```
 
 #### Build issues
@@ -262,42 +273,50 @@ tools/unix/build_omim.sh -d help
 
 ### Running
 
-The generated binaries appear in `../omim-build-<buildtype>`.
+A preset build puts binaries in `build/<preset>` (e.g. `build/release`); the
+`build_omim.sh` wrapper uses `../omim-build-<buildtype>` instead.
 
-A desktop app binary is `OMaps`. To run e.g. a release version:
+A desktop app binary is `OMaps`. To run e.g. a release version built with the
+`release` preset:
 
 _Linux:_
 
 ```bash
-../omim-build-release/OMaps
+build/release/OMaps
 ```
 
 _macOS:_
 
 ```bash
-../omim-build-release/OMaps.app/Contents/MacOS/OMaps
+build/release/OMaps.app/Contents/MacOS/OMaps
 ```
 
 ### Testing
 
-Compile all unit tests in Debug mode:
+Configure and compile all unit tests in Debug mode:
 
 ```bash
-cmake . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
-cmake --build build --target all
+cmake --preset debug
+cmake --build --preset debug
 ```
 
-Run all unit tests:
+Run the unit tests (the `debug` test preset filters to the `omim-test` label and
+excludes the suites that are [known to be broken](https://github.com/organicmaps/organicmaps/issues?q=is%3Aissue+is%3Aopen+label%3ATests) on CI):
 
 ```bash
-cd build
-ctest -L "omim-test" --output-on-failure
+ctest --preset debug
+```
+
+Rendering tests need offscreen GL, so they are run via a separate preset:
+
+```bash
+ctest --preset drape-debug
 ```
 
 To run a limited set of tests, use `-R <regex>` flag. To exclude some tests, use `-E <regex>` flag:
 
 ```bash
-cd build
+cd build/debug
 ctest -R "base_tests|coding_tests" --output-on-failure
 ctest -L "omim-test" -E "base_tests|coding_tests" --output-on-failure
 ```
@@ -339,19 +358,17 @@ brew install llvm
 
 Steps to generate coverage report:
 
-1. Configure cmake with `-DCOVERAGE_REPORT=ON` flag:
+1. Configure with the `coverage` preset (enables `COVERAGE_REPORT`):
    ```bash
-   cmake . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug \
-           -DCMAKE_CXX_FLAGS=-g1 -DCOVERAGE_REPORT=ON
+   cmake --preset coverage
    ```
-2. Compile unit tests.
-3. Run unit tests.
+2. Compile unit tests: `cmake --build --preset coverage`.
+3. Run unit tests: `ctest --preset coverage`.
 4. Run coverage report generation:
    ```bash
-   cd build
-   cmake --build . --target omim_coverage
+   cmake --build --preset coverage --target omim_coverage
    ```
-5. Report can be found in the `build/coverage_report` folder.
+5. Report can be found in the `build/coverage/coverage_report` folder.
 
 ### Debug commands
 
@@ -373,7 +390,7 @@ There are also other commands for turning on/off isolines, anti-aliasing, etc. C
 To make the desktop app display maps in a different language add a `-lang` option, e.g. for the Russian language:
 
 ```bash
-../omim-build-release/OMaps -lang ru
+build/release/OMaps -lang ru
 ```
 
 By default `OMaps` expects a repository's `data` folder to be present in the current working directory, add a `-data_path` option to override it.
@@ -609,7 +626,7 @@ Android Studio has issues in parsing the C++ part of the project, please let us 
 - [Xcode](https://developer.apple.com/xcode/)
 - [CLion](https://www.jetbrains.com/clion/)
 
-For Xcode it is required to run `cmake . -g Xcode` to generate project files, while CLion and QT Creator can import CMakeLists.txt.
+For Xcode, run `cmake --preset xcode` to generate the project (`build/xcode/omim.xcodeproj`); CLion and Qt Creator read `CMakePresets.json` directly (pick the `debug` preset).
 
 #### Enable Vulkan Validation
 


### PR DESCRIPTION
Introduce CMakePresets.json with configure/build/test presets so the desktop, CI, and IDE build invocations share one canonical source instead of the several divergent commands previously spread across docs, CI, and build_omim.sh.

Presets:
- debug (default), release, relwithdebinfo, debug-no-unity, coverage
- xcode (multi-config, macOS only) for dev_sandbox + Metal development
- ci / ci-xcode backing the two CMake CI workflows

The long CTest exclude regex and the offscreen-GL drape setup are now defined once in the test presets instead of being duplicated in both CI workflows.

CLAUDE.md keeps per-agent build dirs: `cmake --preset debug -B build-$YOUR_NAME` overrides the preset's binaryDir so concurrent agents don't clobber each other.

Presets serve desktop, CI and IDEs only; the Android Gradle externalNativeBuild and the iOS xcodeproj build do not consume CMakePresets.json and are unchanged.

Closes #12940

CC @bam80 