### PR TITLE
[strings] use 运营方 instead of 操作员 as the Chinese translation of "operator"

### DIFF
--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -20035,8 +20035,8 @@ th = ตัวดำเนินการ
 tr = İşletici
 uk = Оператор
 vi = Toán tử
-zh-Hans = 操作员
-zh-Hant = 操作員
+zh-Hans = 运营方
+zh-Hant = 運營方
 
 [operator]
 comment = To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…
@@ -20090,8 +20090,8 @@ th = ตัวดำเนินการ: %@
 tr = İşletici: %@
 uk = Оператор: %@
 vi = Toán tử: %@
-zh-Hans = 操作员: %@
-zh-Hant = 操作員: %@
+zh-Hans = 运营方: %@
+zh-Hant = 運營方: %@
 
 [editor_category_unsuitable_title]
 tags = android-app,apple-maps


### PR DESCRIPTION
use 运营方 instead of 操作员 as the Chinese translation of "operator" because 操作员 can only refer to one person who operates some equipment, while in OSM it usually refers to some company or a group of people maintaining an amenity, where 运营方 suits more. 

运营方 can also refer to one person, so it is a more common word choice.

Thanks.