### PR TITLE
[android][wear] Sync navigation state via Wear Data Layer

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -244,6 +244,7 @@ dependencies {
   implementation project(':libs:googleassistant')
   implementation project(':libs:routing')
   implementation project(':libs:utils')
+  implementation project(':libs:wear-protocol')
 
   implementation project(':sdk')
   implementation project(':sdk:car')
@@ -257,6 +258,7 @@ dependencies {
   googleImplementation project(':sdk:location:gms:google')
   huaweiImplementation project(':sdk:location:gms:google')
   fdroidImplementation project(':sdk:location:gms:foss')
+  googleImplementation libs.google.gms.wearable
 
   coreLibraryDesugaring libs.android.tools.desugaring
 

--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -119,6 +119,8 @@ import app.organicmaps.util.Utils;
 import app.organicmaps.util.WindowInsetUtils.BaselinePaddingInsetsListener;
 import app.organicmaps.util.bottomsheet.MenuBottomSheetFragment;
 import app.organicmaps.util.bottomsheet.MenuBottomSheetItem;
+import app.organicmaps.wear.PhoneWearNavigationStatePublisher;
+import app.organicmaps.wear.protocol.WearNavigationState;
 import app.organicmaps.widget.placepage.PlacePageController;
 import app.organicmaps.widget.placepage.PlacePageViewModel;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
@@ -226,6 +228,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       restoreRoutingUI(MapButtonsController.LayoutMode.navigation);
     else if (RoutingController.get().hasSavedRoute())
       RoutingController.get().restoreRoute();
+    publishCurrentWearNavigationState();
     if (mSearchPageViewModel.getSearchEnabled().getValue() == null && mSearchPageViewModel.isSearchPersistedActive())
     {
       mSearchPageViewModel.setSearchPageLastState(mSearchPageViewModel.getPersistedSheetState());
@@ -1248,6 +1251,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onNavigationCancelled()
   {
+    PhoneWearNavigationStatePublisher.publish(this, WearNavigationState.normal());
     closeFloatingToolbarsAndPanels();
     ThemeSwitcher.INSTANCE.synchronizeApplicationTheme();
     ThemeSwitcher.INSTANCE.synchronizeMapStyle(this, mMapController.isRenderingActive());
@@ -1270,9 +1274,17 @@ public class MwmActivity extends BaseMwmFragmentActivity
     refreshLightStatusBar();
   }
 
+  private void publishCurrentWearNavigationState()
+  {
+    WearNavigationState state =
+        RoutingController.get().isNavigating() ? WearNavigationState.navigation() : WearNavigationState.normal();
+    PhoneWearNavigationStatePublisher.publish(this, state);
+  }
+
   @Override
   public void onNavigationStarted()
   {
+    PhoneWearNavigationStatePublisher.publish(this, WearNavigationState.navigation());
     closeFloatingToolbarsAndPanels();
     ThemeSwitcher.INSTANCE.synchronizeApplicationTheme();
     ThemeSwitcher.INSTANCE.synchronizeMapStyle(this, mMapController.isRenderingActive());
@@ -1310,6 +1322,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onResetToPlanningState()
   {
+    PhoneWearNavigationStatePublisher.publish(this, WearNavigationState.normal());
     closeFloatingToolbarsAndPanels();
     ThemeSwitcher.INSTANCE.synchronizeApplicationTheme();
     ThemeSwitcher.INSTANCE.synchronizeMapStyle(this, mMapController.isRenderingActive());

--- a/android/app/src/main/java/app/organicmaps/wear/PhoneWearNavigationStatePublisher.java
+++ b/android/app/src/main/java/app/organicmaps/wear/PhoneWearNavigationStatePublisher.java
@@ -1,0 +1,99 @@
+package app.organicmaps.wear;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+import app.organicmaps.BuildConfig;
+import app.organicmaps.sdk.util.log.Logger;
+import app.organicmaps.wear.protocol.WearNavigationData;
+import app.organicmaps.wear.protocol.WearNavigationState;
+import app.organicmaps.wear.protocol.WearNavigationStateCodec;
+import java.lang.reflect.Method;
+
+public final class PhoneWearNavigationStatePublisher
+{
+  private static final String TAG = PhoneWearNavigationStatePublisher.class.getSimpleName();
+  private static final String GOOGLE_FLAVOR = "google";
+  private static final PublisherDelegate sDelegate = createDelegate();
+
+  public static void publish(@NonNull Context context, @NonNull WearNavigationState state)
+  {
+    sDelegate.publish(context.getApplicationContext(), state);
+  }
+
+  @NonNull
+  private static PublisherDelegate createDelegate()
+  {
+    if (!BuildConfig.FLAVOR.equals(GOOGLE_FLAVOR))
+      return new NoopPublisherDelegate();
+
+    try
+    {
+      return new ReflectiveWearPublisherDelegate();
+    }
+    catch (ReflectiveOperationException | LinkageError e)
+    {
+      Logger.w(TAG, "Wear Data Layer is not available", e);
+      return new NoopPublisherDelegate();
+    }
+  }
+
+  private interface PublisherDelegate
+  {
+    void publish(@NonNull Context context, @NonNull WearNavigationState state);
+  }
+
+  private static final class NoopPublisherDelegate implements PublisherDelegate
+  {
+    @Override
+    public void publish(@NonNull Context context, @NonNull WearNavigationState state)
+    {}
+  }
+
+  private static final class ReflectiveWearPublisherDelegate implements PublisherDelegate
+  {
+    @NonNull
+    private final Method mCreatePutDataRequest;
+    @NonNull
+    private final Method mSetData;
+    @NonNull
+    private final Method mSetUrgent;
+    @NonNull
+    private final Method mGetDataClient;
+    @NonNull
+    private final Method mPutDataItem;
+
+    ReflectiveWearPublisherDelegate() throws ReflectiveOperationException
+    {
+      Class<?> putDataRequestClass = Class.forName("com.google.android.gms.wearable.PutDataRequest");
+      Class<?> wearableClass = Class.forName("com.google.android.gms.wearable.Wearable");
+      Class<?> dataClientClass = Class.forName("com.google.android.gms.wearable.DataClient");
+
+      mCreatePutDataRequest = putDataRequestClass.getMethod("create", String.class);
+      mSetData = putDataRequestClass.getMethod("setData", byte[].class);
+      mSetUrgent = putDataRequestClass.getMethod("setUrgent");
+      mGetDataClient = wearableClass.getMethod("getDataClient", Context.class);
+      mPutDataItem = dataClientClass.getMethod("putDataItem", putDataRequestClass);
+    }
+
+    @Override
+    public void publish(@NonNull Context context, @NonNull WearNavigationState state)
+    {
+      try
+      {
+        byte[] payload = WearNavigationStateCodec.encode(state);
+        Object request = mCreatePutDataRequest.invoke(null, WearNavigationData.PATH_NAVIGATION_STATE);
+        mSetData.invoke(request, (Object) payload);
+        mSetUrgent.invoke(request);
+
+        Object dataClient = mGetDataClient.invoke(null, context);
+        mPutDataItem.invoke(dataClient, request);
+      }
+      catch (ReflectiveOperationException | LinkageError e)
+      {
+        Logger.w(TAG, "Failed to publish Wear navigation state", e);
+      }
+    }
+  }
+
+  private PhoneWearNavigationStatePublisher() {}
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ google-firebase-crashlytics = "3.0.6"
 google-firebase-appdistribution = "5.2.0"
 google-gms-location = "21.3.0"
 google-gms-services = "4.4.4"
+google-gms-wearable = "19.0.0"
 google-material = "1.13.0"
 
 huawei-plugin = "1.5.0"
@@ -83,6 +84,7 @@ google-firebase-crashlytics = { module = "com.google.firebase:firebase-crashlyti
 google-firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-ndk" }
 
 google-gms-location = { module = "com.google.android.gms:play-services-location", version.ref = "google-gms-location" }
+google-gms-wearable = { module = "com.google.android.gms:play-services-wearable", version.ref = "google-gms-wearable" }
 google-material = { module = "com.google.android.material:material", version.ref = "google-material" }
 
 ktlint-cli = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint" }

--- a/android/libs/wear-protocol/src/main/java/app/organicmaps/wear/protocol/WearNavigationData.java
+++ b/android/libs/wear-protocol/src/main/java/app/organicmaps/wear/protocol/WearNavigationData.java
@@ -1,0 +1,11 @@
+package app.organicmaps.wear.protocol;
+
+public final class WearNavigationData
+{
+  public static final String PATH_NAVIGATION_STATE = "/organicmaps/navigation/state";
+  public static final int VERSION = 1;
+
+  public static final String KEY_VERSION = "version";
+  public static final String KEY_MODE = "mode";
+  private WearNavigationData() {}
+}

--- a/android/libs/wear-protocol/src/main/java/app/organicmaps/wear/protocol/WearNavigationState.java
+++ b/android/libs/wear-protocol/src/main/java/app/organicmaps/wear/protocol/WearNavigationState.java
@@ -14,6 +14,11 @@ public final class WearNavigationState
     return new WearNavigationState(WearNavigationMode.NORMAL);
   }
 
+  public static WearNavigationState navigation()
+  {
+    return new WearNavigationState(WearNavigationMode.NAVIGATION);
+  }
+
   public WearNavigationMode getMode()
   {
     return mMode;

--- a/android/libs/wear-protocol/src/main/java/app/organicmaps/wear/protocol/WearNavigationStateCodec.java
+++ b/android/libs/wear-protocol/src/main/java/app/organicmaps/wear/protocol/WearNavigationStateCodec.java
@@ -1,0 +1,45 @@
+package app.organicmaps.wear.protocol;
+
+import java.nio.charset.StandardCharsets;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public final class WearNavigationStateCodec
+{
+  public static byte[] encode(WearNavigationState state)
+  {
+    JSONObject json = new JSONObject();
+    try
+    {
+      json.put(WearNavigationData.KEY_VERSION, WearNavigationData.VERSION);
+      json.put(WearNavigationData.KEY_MODE, state.getMode().name());
+    }
+    catch (JSONException e)
+    {
+      throw new IllegalStateException("Failed to encode Wear navigation state", e);
+    }
+    return json.toString().getBytes(StandardCharsets.UTF_8);
+  }
+
+  public static WearNavigationState decode(byte[] payload)
+  {
+    if (payload == null || payload.length == 0)
+      return null;
+
+    try
+    {
+      JSONObject json = new JSONObject(new String(payload, StandardCharsets.UTF_8));
+      if (json.optInt(WearNavigationData.KEY_VERSION) != WearNavigationData.VERSION)
+        return null;
+
+      WearNavigationMode mode = WearNavigationMode.valueOf(json.getString(WearNavigationData.KEY_MODE));
+      return new WearNavigationState(mode);
+    }
+    catch (IllegalArgumentException | JSONException e)
+    {
+      return null;
+    }
+  }
+
+  private WearNavigationStateCodec() {}
+}

--- a/android/wear/build.gradle
+++ b/android/wear/build.gradle
@@ -36,4 +36,5 @@ android {
 dependencies {
     implementation project(':libs:branding')
     implementation project(':libs:wear-protocol')
+    implementation libs.google.gms.wearable
 }

--- a/android/wear/src/main/java/app/organicmaps/wear/MainActivity.java
+++ b/android/wear/src/main/java/app/organicmaps/wear/MainActivity.java
@@ -1,21 +1,28 @@
 package app.organicmaps.wear;
-
 import android.app.Activity;
 import android.os.Bundle;
 import android.view.Gravity;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-
+import app.organicmaps.wear.protocol.WearNavigationData;
+import app.organicmaps.wear.protocol.WearNavigationMode;
 import app.organicmaps.wear.protocol.WearNavigationState;
+import app.organicmaps.wear.protocol.WearNavigationStateCodec;
+import com.google.android.gms.wearable.DataClient;
+import com.google.android.gms.wearable.DataEvent;
+import com.google.android.gms.wearable.DataEventBuffer;
+import com.google.android.gms.wearable.DataItem;
+import com.google.android.gms.wearable.DataItemBuffer;
+import com.google.android.gms.wearable.Wearable;
 
-public final class MainActivity extends Activity
+public final class MainActivity extends Activity implements DataClient.OnDataChangedListener
 {
+  private TextView mSubtitle;
+
   @Override
   protected void onCreate(Bundle savedInstanceState)
   {
     super.onCreate(savedInstanceState);
-
-    WearNavigationState state = WearNavigationState.normal();
 
     LinearLayout layout = new LinearLayout(this);
     layout.setGravity(Gravity.CENTER);
@@ -28,14 +35,85 @@ public final class MainActivity extends Activity
     title.setText(R.string.app_name);
     title.setTextSize(18);
 
-    TextView subtitle = new TextView(this);
-    subtitle.setGravity(Gravity.CENTER);
-    subtitle.setText(R.string.wear_no_navigation_message);
-    subtitle.setTextSize(14);
+    mSubtitle = new TextView(this);
+    mSubtitle.setGravity(Gravity.CENTER);
+    mSubtitle.setTextSize(14);
 
     layout.addView(title);
-    layout.addView(subtitle);
+    layout.addView(mSubtitle);
 
     setContentView(layout);
+    render(WearNavigationState.normal());
+  }
+
+  @Override
+  protected void onStart()
+  {
+    super.onStart();
+    // Phase 1 keeps Wear sync foreground-only: read the latest state on start and listen while visible.
+    DataClient dataClient = Wearable.getDataClient(this);
+    dataClient.addListener(this);
+    dataClient.getDataItems().addOnSuccessListener(this::updateFromDataItems);
+  }
+
+  @Override
+  protected void onStop()
+  {
+    Wearable.getDataClient(this).removeListener(this);
+    super.onStop();
+  }
+
+  @Override
+  public void onDataChanged(DataEventBuffer dataEvents)
+  {
+    try
+    {
+      for (DataEvent event : dataEvents)
+      {
+        if (event.getType() != DataEvent.TYPE_CHANGED)
+          continue;
+
+        updateFromDataItem(event.getDataItem());
+      }
+    }
+    finally
+    {
+      dataEvents.release();
+    }
+  }
+
+  private void updateFromDataItems(DataItemBuffer dataItems)
+  {
+    try
+    {
+      for (DataItem item : dataItems)
+        updateFromDataItem(item);
+    }
+    finally
+    {
+      dataItems.release();
+    }
+  }
+
+  private void updateFromDataItem(DataItem item)
+  {
+    if (!WearNavigationData.PATH_NAVIGATION_STATE.equals(item.getUri().getPath()))
+      return;
+
+    WearNavigationState state = WearNavigationStateCodec.decode(item.getData());
+    if (state != null)
+      render(state);
+  }
+
+  private void render(WearNavigationState state)
+  {
+    mSubtitle.setText(getMessageResId(state));
+  }
+
+  private int getMessageResId(WearNavigationState state)
+  {
+    if (state.getMode() == WearNavigationMode.NAVIGATION)
+      return R.string.wear_navigation_active_message;
+    return R.string.wear_no_navigation_message;
   }
 }

--- a/android/wear/src/main/res/values/wear_strings.xml
+++ b/android/wear/src/main/res/values/wear_strings.xml
@@ -4,4 +4,6 @@
     <!-- SECTION: gps strings -->
     <!-- Displayed in the Wear OS app when no navigation is active on the phone. -->
     <string name="wear_no_navigation_message">Open Organic Maps on your phone to start navigation.</string>
+    <!-- Displayed in the Wear OS app when navigation is active on the phone. -->
+    <string name="wear_navigation_active_message">Navigation is active on your phone.</string>
 </resources>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -44613,3 +44613,8 @@ zh-Hant = 網格
 comment = Displayed in the Wear OS app when no navigation is active on the phone.
 tags = android-wear
 en = Open Organic Maps on your phone to start navigation.
+
+[wear_navigation_active_message]
+comment = Displayed in the Wear OS app when navigation is active on the phone.
+tags = android-wear
+en = Navigation is active on your phone.

--- a/tools/hooks/format-config.bash
+++ b/tools/hooks/format-config.bash
@@ -15,8 +15,10 @@ CLANG_FORMAT_TARGETS=(
   "android/libs/googleassistant/src|*.java"
   "android/libs/routing/src|*.java"
   "android/libs/utils/src|*.java"
+  "android/libs/wear-protocol/src|*.java"
   "android/sdk/car/src|*.java"
   "android/sdk/src|*.java"
+  "android/wear/src|*.java"
   "android/sdk/widgets/lanes/src|*.java"
   "android/sdk/widgets/speedlimit/src|*.java"
   # Android – C++


### PR DESCRIPTION
This adds the next incremental Wear OS step after the shell:

- publishes NORMAL / NAVIGATION state from the phone app;
- keeps the phone as the source of truth;
- uses the Wear Data Layer for phone → watch state sync;
- updates the Wear UI between idle and navigation-active states;
- keeps the protocol module free of Google Play Services APIs;
- keeps the watch read-only, with no commands or turn-by-turn details yet.

Tested locally:
- :wear:assembleGoogleDebug
- :wear:lintGoogleDebug
- :app:assembleGoogleDebug
- :app:assembleFdroidDebug
- :app:assembleWebDebug
- lintAllModules