### PR TITLE
[map] Attach OSM notes to map selection, not feature center

### DIFF
--- a/libs/indexer/editable_map_object.cpp
+++ b/libs/indexer/editable_map_object.cpp
@@ -164,6 +164,12 @@ void EditableMapObject::SetEditableProperties(osm::EditableProperties const & pr
   m_editableProperties = props;
 }
 
+void EditableMapObject::SetFromFeatureType(FeatureType & ft)
+{
+  MapObject::SetFromFeatureType(ft);
+  m_selectionPoint.reset();
+}
+
 void EditableMapObject::SetName(std::string_view name, int8_t langCode)
 {
   m_name.Add(langCode, name);

--- a/libs/indexer/editable_map_object.hpp
+++ b/libs/indexer/editable_map_object.hpp
@@ -8,6 +8,7 @@
 #include "indexer/map_object.hpp"
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -89,6 +90,7 @@ public:
 
   void SetEditableProperties(osm::EditableProperties const & props);
   //  void SetFeatureID(FeatureID const & fid);
+  void SetFromFeatureType(FeatureType & ft);
   void SetName(FeatureNames names) { m_name = std::move(names); }
   void SetName(std::string_view name, int8_t langCode);
   void SetMercator(m2::PointD const & center);
@@ -100,6 +102,11 @@ public:
   void SetNearbyStreets(std::vector<LocalizedStreet> && streets);
   void SetHouseNumber(std::string const & houseNumber);
   void SetPostcode(std::string const & postcode);
+
+  // User interaction point used for editor notes when it differs from the feature center.
+  // Present only for user-selected non-point features.
+  std::optional<m2::PointD> const & GetSelectionPoint() const { return m_selectionPoint; }
+  void SetSelectionPoint(m2::PointD const & pt) { m_selectionPoint = pt; }
 
   static bool IsValidMetadata(MetadataID type, std::string const & value);
   void SetMetadata(MetadataID type, std::string value);
@@ -153,6 +160,7 @@ private:
   LocalizedStreet m_street;
   std::vector<LocalizedStreet> m_nearbyStreets;
   EditableProperties m_editableProperties;
+  std::optional<m2::PointD> m_selectionPoint;
   osm::EditJournal m_journal;
 };
 }  // namespace osm

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -3492,6 +3492,20 @@ bool Framework::GetEditableMapObject(FeatureID const & fid, osm::EditableMapObje
 
   emo = {};
   emo.SetFromFeatureType(*ft);
+
+  if (HasPlacePageInfo())
+  {
+    auto const & info = GetCurrentPlacePageInfo();
+    auto const & buildInfo = info.GetBuildInfo();
+    // In explicit feature selections (for example, tapping a road label), the place page keeps the
+    // feature center. The original user tap is still the location that the note should report.
+    if (info.GetID() == fid && buildInfo.m_source == place_page::BuildInfo::Source::User &&
+        info.GetGeomType() != feature::GeomType::Point)
+    {
+      emo.SetSelectionPoint(buildInfo.m_mercator);
+    }
+  }
+
   auto const & editor = osm::Editor::Instance();
   emo.SetEditableProperties(editor.GetEditableProperties(*ft));
 
@@ -3678,20 +3692,11 @@ bool Framework::RollBackChanges(FeatureID const & fid)
   return rolledBack;
 }
 
-void Framework::CreateNote(osm::MapObject const & mapObject, osm::Editor::NoteProblemType const type,
+void Framework::CreateNote(osm::EditableMapObject const & mapObject, osm::Editor::NoteProblemType const type,
                            std::string const & note)
 {
-  // MapObject::GetLatLon() returns the feature's geometric center, which for lines and areas
-  // (roads, forests, etc.) can be far from where the user actually pointed. The place page keeps the
-  // real map selection (tap) point, so use it when it refers to the same feature, posting the note
-  // where the user reported the problem.
-  auto noteLatLon = mapObject.GetLatLon();
-  if (mapObject.GetID().IsValid() && HasPlacePageInfo())
-  {
-    auto const & ppInfo = GetCurrentPlacePageInfo();
-    if (ppInfo.GetID() == mapObject.GetID())
-      noteLatLon = ppInfo.GetLatLon();
-  }
+  auto const & selection = mapObject.GetSelectionPoint();
+  auto const noteLatLon = selection ? mercator::ToLatLon(*selection) : mapObject.GetLatLon();
 
   osm::Editor::Instance().CreateNote(noteLatLon, mapObject.GetID(), mapObject.GetTypes(), mapObject.GetDefaultName(),
                                      type, note);

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -3681,8 +3681,20 @@ bool Framework::RollBackChanges(FeatureID const & fid)
 void Framework::CreateNote(osm::MapObject const & mapObject, osm::Editor::NoteProblemType const type,
                            std::string const & note)
 {
-  osm::Editor::Instance().CreateNote(mapObject.GetLatLon(), mapObject.GetID(), mapObject.GetTypes(),
-                                     mapObject.GetDefaultName(), type, note);
+  // MapObject::GetLatLon() returns the feature's geometric center, which for lines and areas
+  // (roads, forests, etc.) can be far from where the user actually pointed. The place page keeps the
+  // real map selection (tap) point, so use it when it refers to the same feature, posting the note
+  // where the user reported the problem.
+  auto noteLatLon = mapObject.GetLatLon();
+  if (mapObject.GetID().IsValid() && HasPlacePageInfo())
+  {
+    auto const & ppInfo = GetCurrentPlacePageInfo();
+    if (ppInfo.GetID() == mapObject.GetID())
+      noteLatLon = ppInfo.GetLatLon();
+  }
+
+  osm::Editor::Instance().CreateNote(noteLatLon, mapObject.GetID(), mapObject.GetTypes(), mapObject.GetDefaultName(),
+                                     type, note);
   if (type == osm::Editor::NoteProblemType::PlaceDoesNotExist)
     DeactivateMapSelection();
 }

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -791,7 +791,8 @@ public:
   void DeleteFeature(FeatureID const & fid);
   osm::NewFeatureCategories GetEditorCategories() const;
   bool RollBackChanges(FeatureID const & fid);
-  void CreateNote(osm::MapObject const & mapObject, osm::Editor::NoteProblemType const type, std::string const & note);
+  void CreateNote(osm::EditableMapObject const & mapObject, osm::Editor::NoteProblemType const type,
+                  std::string const & note);
 
 private:
   settings::UsageStats m_usageStats;

--- a/libs/map/map_tests/CMakeLists.txt
+++ b/libs/map/map_tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SRC
   check_mwms.cpp
   coordinate_formats_tests.cpp
   countries_names_tests.cpp
+  editor_notes_tests.cpp
   extrapolator_tests.cpp
   feature_getters_tests.cpp
   gps_track_collection_test.cpp
@@ -30,5 +31,6 @@ target_link_libraries(${PROJECT_NAME}
   PRIVATE
     search_tests_support
     generator_tests_support
+    platform_tests_support
     map
 )

--- a/libs/map/map_tests/editor_notes_tests.cpp
+++ b/libs/map/map_tests/editor_notes_tests.cpp
@@ -25,9 +25,6 @@
 #include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"
 
-#include <string>
-#include <utility>
-
 namespace editor_notes_tests
 {
 using namespace generator::tests_support;
@@ -35,72 +32,95 @@ using platform::LocalCountryFile;
 using platform::tests_support::ScopedFile;
 
 // https://github.com/organicmaps/organicmaps/issues/11170
-// A note created via "Edit place" on a line/area feature must be attached to the user's actual map
-// selection (tap) point, not to the feature's geometric center (which for a road or forest can be
-// far from where the problem was reported).
+// A note created via "Edit place" on a line/area feature must be attached to the user's map
+// selection (tap) point, not to the feature's geometric center, which for a road or forest can be
+// far from where the problem was reported.
 UNIT_TEST(EditorNotes_UseSelectionPointNotFeatureCenter)
 {
-  // The selection point is copied verbatim, so it must match the tap exactly. Coordinates read back
-  // from the mwm are quantized and notes round-trip through XML, hence the looser tolerance for those.
-  double constexpr kExactEps = 1e-7;
-  double constexpr kGeomEps = 1e-4;
-
-  // A straight horizontal road; its polyline center is the midpoint (0.5, 0).
-  m2::PointD const roadCenter(0.5, 0.0);
-
-  // Construct the framework first: it loads the classificator required to build test features.
   Framework frm({} /* params */, false /* loadMaps */);
   df::VisualParams::Init(1.0, 1024);
 
-  std::string const kCountryName = "EditorNotesLand";
-  LocalCountryFile localFile(GetPlatform().WritableDir(), platform::CountryFile(kCountryName), 0 /* version */);
-  platform::CountryIndexes::DeleteFromDisk(localFile);
-  localFile.DeleteFromDisk(MapFileType::Map);
-
+  // A straight horizontal road; its geometric center is the midpoint (0.5, 0).
+  LocalCountryFile country(GetPlatform().WritableDir(), platform::CountryFile("EditorNotesLand"), 0 /* version */);
+  platform::CountryIndexes::DeleteFromDisk(country);
+  country.DeleteFromDisk(MapFileType::Map);
   {
-    TestMwmBuilder builder(localFile, feature::DataHeader::MapType::Country);
+    TestMwmBuilder builder(country, feature::DataHeader::MapType::Country);
     builder.Add(TestStreet({{0.0, 0.0}, {1.0, 0.0}}, "Test Road", "en"));
   }
-
-  auto const regResult = frm.RegisterMap(localFile);
-  TEST_EQUAL(regResult.second, MwmSet::RegResult::Success, ());
+  TEST_EQUAL(frm.RegisterMap(country).second, MwmSet::RegResult::Success, ());
 
   // Tap on the road far from its center, as if reporting a problem at that exact spot.
   m2::PointD const tapPoint(0.9, 0.0);
-  {
-    place_page::BuildInfo bi;
-    bi.m_source = place_page::BuildInfo::Source::User;
-    bi.m_mercator = tapPoint;
-    frm.BuildAndSetPlacePageInfo(bi);
-  }
+  place_page::BuildInfo bi;
+  bi.m_source = place_page::BuildInfo::Source::User;
+  bi.m_mercator = tapPoint;
+  frm.BuildAndSetPlacePageInfo(bi);
 
-  TEST(frm.HasPlacePageInfo(), ());
   auto const & info = frm.GetCurrentPlacePageInfo();
-  TEST(info.GetID().IsValid(), ("The road should be selected by the tap."));
-  // The selection keeps the tap point, not the road center.
-  TEST(info.GetMercator().EqualDxDy(tapPoint, kExactEps), (info.GetMercator(), tapPoint));
+  TEST(info.GetID().IsValid(), ("The tap must select the road."));
+  // The selection keeps the tap point verbatim, not the road center.
+  TEST_ALMOST_EQUAL_ABS(info.GetMercator(), tapPoint, 1e-7, ());
 
-  // The editable map object (what the note used before the fix) carries the road center,
-  // which is far away from the tap point.
-  osm::EditableMapObject emo;
-  TEST(frm.GetEditableMapObject(info.GetID(), emo), ());
-  TEST(emo.GetMercator().EqualDxDy(roadCenter, kGeomEps), (emo.GetMercator(), roadCenter));
-  TEST(!emo.GetMercator().EqualDxDy(tapPoint, kGeomEps), (emo.GetMercator()));
-
-  // Create a note and verify it is attached to the tap point, not the road center.
   ScopedFile const notesFile("test_editor_notes.xml", ScopedFile::Mode::DoNotCreate);
   osm::Editor::Instance().SetNotesForTesting(notesFile.GetFullPath());
 
+  osm::EditableMapObject emo;
+  TEST(frm.GetEditableMapObject(info.GetID(), emo), ());
   frm.CreateNote(emo, osm::Editor::NoteProblemType::General, "Obstacle on the road");
 
   editor::Notes const notes(notesFile.GetFullPath());
-  auto const & stored = notes.GetNotesForTests();
-  TEST_EQUAL(stored.size(), 1, ());
-  TEST(stored.front().m_point.EqualDxDy(mercator::ToLatLon(tapPoint), kGeomEps),
-       (stored.front().m_point, mercator::ToLatLon(tapPoint)));
-  TEST(!stored.front().m_point.EqualDxDy(mercator::ToLatLon(roadCenter), kGeomEps), (stored.front().m_point));
+  TEST_EQUAL(notes.GetNotesForTests().size(), 1, ());
+  // Looser tolerance: the note round-trips through XML.
+  TEST_ALMOST_EQUAL_ABS(notes.GetNotesForTests().front().m_point, mercator::ToLatLon(tapPoint), 1e-4, ());
 
-  platform::CountryIndexes::DeleteFromDisk(localFile);
-  localFile.DeleteFromDisk(MapFileType::Map);
+  platform::CountryIndexes::DeleteFromDisk(country);
+  country.DeleteFromDisk(MapFileType::Map);
+}
+
+UNIT_TEST(EditorNotes_UseSelectionPointForExplicitFeatureTap)
+{
+  Framework frm({} /* params */, false /* loadMaps */);
+  df::VisualParams::Init(1.0, 1024);
+
+  LocalCountryFile country(GetPlatform().WritableDir(), platform::CountryFile("EditorNotesExplicitLand"),
+                           0 /* version */);
+  platform::CountryIndexes::DeleteFromDisk(country);
+  country.DeleteFromDisk(MapFileType::Map);
+  {
+    TestMwmBuilder builder(country, feature::DataHeader::MapType::Country);
+    builder.Add(TestStreet({{0.0, 0.0}, {1.0, 0.0}}, "Test Road", "en"));
+  }
+  TEST_EQUAL(frm.RegisterMap(country).second, MwmSet::RegResult::Success, ());
+
+  m2::PointD const tapPoint(0.9, 0.0);
+  auto const roadId = frm.GetFeatureAtPoint(tapPoint);
+  TEST(roadId.IsValid(), ("The tap must resolve the test road."));
+
+  place_page::BuildInfo bi;
+  bi.m_source = place_page::BuildInfo::Source::User;
+  bi.m_mercator = tapPoint;
+  bi.m_featureId = roadId;
+  frm.BuildAndSetPlacePageInfo(bi);
+
+  auto const & info = frm.GetCurrentPlacePageInfo();
+  TEST_EQUAL(info.GetID(), roadId, ());
+  TEST_EQUAL(info.GetGeomType(), feature::GeomType::Line, ());
+  TEST_NOT_EQUAL(info.GetMercator(), tapPoint,
+                 ("Explicit feature selection keeps the feature center in the place page."));
+
+  ScopedFile const notesFile("test_editor_notes_explicit.xml", ScopedFile::Mode::DoNotCreate);
+  osm::Editor::Instance().SetNotesForTesting(notesFile.GetFullPath());
+
+  osm::EditableMapObject emo;
+  TEST(frm.GetEditableMapObject(info.GetID(), emo), ());
+  frm.CreateNote(emo, osm::Editor::NoteProblemType::General, "Obstacle on the road");
+
+  editor::Notes const notes(notesFile.GetFullPath());
+  TEST_EQUAL(notes.GetNotesForTests().size(), 1, ());
+  TEST_ALMOST_EQUAL_ABS(notes.GetNotesForTests().front().m_point, mercator::ToLatLon(tapPoint), 1e-4, ());
+
+  platform::CountryIndexes::DeleteFromDisk(country);
+  country.DeleteFromDisk(MapFileType::Map);
 }
 }  // namespace editor_notes_tests

--- a/libs/map/map_tests/editor_notes_tests.cpp
+++ b/libs/map/map_tests/editor_notes_tests.cpp
@@ -1,0 +1,106 @@
+#include "testing/testing.hpp"
+
+#include "generator/generator_tests_support/test_feature.hpp"
+#include "generator/generator_tests_support/test_mwm_builder.hpp"
+
+#include "map/framework.hpp"
+#include "map/place_page_info.hpp"
+
+#include "drape_frontend/visual_params.hpp"
+
+#include "editor/editor_notes.hpp"
+#include "editor/osm_editor.hpp"
+
+#include "indexer/data_header.hpp"
+#include "indexer/editable_map_object.hpp"
+#include "indexer/mwm_set.hpp"
+
+#include "platform/country_defines.hpp"
+#include "platform/local_country_file.hpp"
+#include "platform/local_country_file_utils.hpp"
+#include "platform/platform.hpp"
+#include "platform/platform_tests_support/scoped_file.hpp"
+
+#include "geometry/latlon.hpp"
+#include "geometry/mercator.hpp"
+#include "geometry/point2d.hpp"
+
+#include <string>
+#include <utility>
+
+namespace editor_notes_tests
+{
+using namespace generator::tests_support;
+using platform::LocalCountryFile;
+using platform::tests_support::ScopedFile;
+
+// https://github.com/organicmaps/organicmaps/issues/11170
+// A note created via "Edit place" on a line/area feature must be attached to the user's actual map
+// selection (tap) point, not to the feature's geometric center (which for a road or forest can be
+// far from where the problem was reported).
+UNIT_TEST(EditorNotes_UseSelectionPointNotFeatureCenter)
+{
+  // The selection point is copied verbatim, so it must match the tap exactly. Coordinates read back
+  // from the mwm are quantized and notes round-trip through XML, hence the looser tolerance for those.
+  double constexpr kExactEps = 1e-7;
+  double constexpr kGeomEps = 1e-4;
+
+  // A straight horizontal road; its polyline center is the midpoint (0.5, 0).
+  m2::PointD const roadCenter(0.5, 0.0);
+
+  // Construct the framework first: it loads the classificator required to build test features.
+  Framework frm({} /* params */, false /* loadMaps */);
+  df::VisualParams::Init(1.0, 1024);
+
+  std::string const kCountryName = "EditorNotesLand";
+  LocalCountryFile localFile(GetPlatform().WritableDir(), platform::CountryFile(kCountryName), 0 /* version */);
+  platform::CountryIndexes::DeleteFromDisk(localFile);
+  localFile.DeleteFromDisk(MapFileType::Map);
+
+  {
+    TestMwmBuilder builder(localFile, feature::DataHeader::MapType::Country);
+    builder.Add(TestStreet({{0.0, 0.0}, {1.0, 0.0}}, "Test Road", "en"));
+  }
+
+  auto const regResult = frm.RegisterMap(localFile);
+  TEST_EQUAL(regResult.second, MwmSet::RegResult::Success, ());
+
+  // Tap on the road far from its center, as if reporting a problem at that exact spot.
+  m2::PointD const tapPoint(0.9, 0.0);
+  {
+    place_page::BuildInfo bi;
+    bi.m_source = place_page::BuildInfo::Source::User;
+    bi.m_mercator = tapPoint;
+    frm.BuildAndSetPlacePageInfo(bi);
+  }
+
+  TEST(frm.HasPlacePageInfo(), ());
+  auto const & info = frm.GetCurrentPlacePageInfo();
+  TEST(info.GetID().IsValid(), ("The road should be selected by the tap."));
+  // The selection keeps the tap point, not the road center.
+  TEST(info.GetMercator().EqualDxDy(tapPoint, kExactEps), (info.GetMercator(), tapPoint));
+
+  // The editable map object (what the note used before the fix) carries the road center,
+  // which is far away from the tap point.
+  osm::EditableMapObject emo;
+  TEST(frm.GetEditableMapObject(info.GetID(), emo), ());
+  TEST(emo.GetMercator().EqualDxDy(roadCenter, kGeomEps), (emo.GetMercator(), roadCenter));
+  TEST(!emo.GetMercator().EqualDxDy(tapPoint, kGeomEps), (emo.GetMercator()));
+
+  // Create a note and verify it is attached to the tap point, not the road center.
+  ScopedFile const notesFile("test_editor_notes.xml", ScopedFile::Mode::DoNotCreate);
+  osm::Editor::Instance().SetNotesForTesting(notesFile.GetFullPath());
+
+  frm.CreateNote(emo, osm::Editor::NoteProblemType::General, "Obstacle on the road");
+
+  editor::Notes const notes(notesFile.GetFullPath());
+  auto const & stored = notes.GetNotesForTests();
+  TEST_EQUAL(stored.size(), 1, ());
+  TEST(stored.front().m_point.EqualDxDy(mercator::ToLatLon(tapPoint), kGeomEps),
+       (stored.front().m_point, mercator::ToLatLon(tapPoint)));
+  TEST(!stored.front().m_point.EqualDxDy(mercator::ToLatLon(roadCenter), kGeomEps), (stored.front().m_point));
+
+  platform::CountryIndexes::DeleteFromDisk(localFile);
+  localFile.DeleteFromDisk(MapFileType::Map);
+}
+}  // namespace editor_notes_tests


### PR DESCRIPTION
When reporting a problem via "Edit place" on a line or area feature (road, forest, etc.), the note was posted at the feature's geometric center rather than where the user tapped, resulting in the reported location being lost. Post the note at the place page selection (tap) point when it refers to the same feature.

Fixes: #11170