### PR TITLE
[ios] Fix route points collection jumping while reordering

### DIFF
--- a/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointCollectionViewCell.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointCollectionViewCell.swift
@@ -1,6 +1,4 @@
 final class RoutePointCollectionViewCell: UICollectionViewCell {
-  static let minimumHeight: CGFloat = 44
-
   enum CellType {
     case point(PointViewModel)
     case addPoint
@@ -17,14 +15,16 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
   }
 
   private enum Constants {
+    static let fontStyle = FontStyleSheet.semibold14
+    static let minimumHeight: CGFloat = 44
+    static let titleNumberOfLines: Int = 2
+    static let verticalInset: CGFloat = 8
     static let logoSize: CGFloat = 28
     static let logoImageLeadingInset: CGFloat = 12
     static let reorderButtonSize: CGFloat = 24
     static let closeButtonSize: CGFloat = 24
     static let horizontalSpacing: CGFloat = 12
     static let horizontalSpacingSmall: CGFloat = 5
-    static let verticalInset: CGFloat = 8
-    static let accessibilityVerticalInset: CGFloat = 12
   }
 
   private let logoImageView = UIImageView()
@@ -39,14 +39,6 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
   }()
 
   private var didTapClose: (() -> Void)?
-  private var textStackViewTopConstraint: NSLayoutConstraint!
-  private var textStackViewBottomConstraint: NSLayoutConstraint!
-
-  private var verticalInset: CGFloat {
-    traitCollection.preferredContentSizeCategory.isAccessibilityCategory
-      ? Constants.accessibilityVerticalInset
-      : Constants.verticalInset
-  }
 
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -60,12 +52,6 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
     }
   }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    guard previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory else { return }
-    updateVerticalInsets()
-  }
-
   @available(*, unavailable)
   required init?(coder _: NSCoder) {
     fatalError("init(coder:) has not been implemented")
@@ -75,13 +61,13 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
     contentView.clipsToBounds = false
 
     contentBackgroundView.setStyle(.pressBackground)
-    contentBackgroundView.layer.setCornerRadius(.buttonDefault)
+    contentBackgroundView.layer.setCornerRadius(.buttonDefaultBig)
     contentBackgroundView.clipsToBounds = false
 
     logoImageView.contentMode = .scaleAspectFill
     logoImageView.clipsToBounds = true
 
-    titleLabel.numberOfLines = 0
+    titleLabel.numberOfLines = Constants.titleNumberOfLines
 
     textStackView.axis = .vertical
     textStackView.alignment = .leading
@@ -108,16 +94,11 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
     reorderButton.translatesAutoresizingMaskIntoConstraints = false
     closeButton.translatesAutoresizingMaskIntoConstraints = false
 
-    textStackViewTopConstraint = textStackView.topAnchor.constraint(greaterThanOrEqualTo: contentBackgroundView.topAnchor)
-    textStackViewBottomConstraint = textStackView.bottomAnchor.constraint(lessThanOrEqualTo: contentBackgroundView.bottomAnchor)
-    updateVerticalInsets()
-
     NSLayoutConstraint.activate([
       contentBackgroundView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
       contentBackgroundView.topAnchor.constraint(equalTo: contentView.topAnchor),
       contentBackgroundView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
       contentBackgroundView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-      contentBackgroundView.heightAnchor.constraint(greaterThanOrEqualToConstant: Self.minimumHeight),
 
       logoImageView.leadingAnchor.constraint(equalTo: contentBackgroundView.leadingAnchor, constant: Constants.logoImageLeadingInset),
       logoImageView.centerYAnchor.constraint(equalTo: contentBackgroundView.centerYAnchor),
@@ -125,10 +106,8 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
       logoImageView.heightAnchor.constraint(equalToConstant: Constants.logoSize),
 
       textStackView.leadingAnchor.constraint(equalTo: logoImageView.trailingAnchor, constant: Constants.horizontalSpacing),
-      textStackViewTopConstraint,
       textStackView.centerYAnchor.constraint(equalTo: contentBackgroundView.centerYAnchor),
       textStackView.trailingAnchor.constraint(lessThanOrEqualTo: closeButton.leadingAnchor, constant: -Constants.horizontalSpacing),
-      textStackViewBottomConstraint,
 
       closeButton.trailingAnchor.constraint(equalTo: reorderButton.leadingAnchor, constant: -Constants.horizontalSpacingSmall),
       closeButton.centerYAnchor.constraint(equalTo: contentBackgroundView.centerYAnchor),
@@ -142,30 +121,6 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
     ])
   }
 
-  private func updateVerticalInsets() {
-    textStackViewTopConstraint?.constant = verticalInset
-    textStackViewBottomConstraint?.constant = -verticalInset
-  }
-
-  override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
-    let attributes = layoutAttributes.copy() as! UICollectionViewLayoutAttributes
-    let width = attributes.size.width > 0 ? attributes.size.width : superview?.bounds.width ?? 0
-    guard width > 0 else { return super.preferredLayoutAttributesFitting(layoutAttributes) }
-
-    contentView.bounds.size.width = width
-    contentView.setNeedsLayout()
-    contentView.layoutIfNeeded()
-
-    let targetSize = CGSize(width: width, height: UIView.layoutFittingCompressedSize.height)
-    let size = contentView.systemLayoutSizeFitting(
-      targetSize,
-      withHorizontalFittingPriority: .required,
-      verticalFittingPriority: .fittingSizeLevel
-    )
-    attributes.size = CGSize(width: width, height: max(Self.minimumHeight, ceil(size.height)))
-    return attributes
-  }
-
   func configure(with viewModel: CellType) {
     switch viewModel {
     case .point(let viewModel):
@@ -173,7 +128,7 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
       logoImageView.image = viewModel.image
       logoImageView.setStyleAndApply(.black)
       didTapClose = viewModel.onCloseHandler
-      titleLabel.setFontStyleAndApply(.semibold14, color: viewModel.isPlaceholder ? .blackSecondary : .blackPrimary)
+      titleLabel.setFontStyleAndApply(Constants.fontStyle, color: viewModel.isPlaceholder ? .blackSecondary : .blackPrimary)
       closeButton.isHidden = !viewModel.showCloseButton
       reorderButton.isHidden = false
       contentBackgroundView.layer.maskedCorners = viewModel.maskedCorners
@@ -182,7 +137,7 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
       titleLabel.text = L("placepage_add_stop")
       logoImageView.image = UIImage(resource: .icAddButton)
       logoImageView.setStyleAndApply(.blue)
-      titleLabel.setFontStyleAndApply(.semibold14, color: .linkBlue)
+      titleLabel.setFontStyleAndApply(Constants.fontStyle, color: .linkBlue)
       closeButton.isHidden = true
       reorderButton.isHidden = true
       contentBackgroundView.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
@@ -193,5 +148,10 @@ final class RoutePointCollectionViewCell: UICollectionViewCell {
   @objc
   private func didTapCloseButton() {
     didTapClose?()
+  }
+
+  static func height() -> CGFloat {
+    let titleHeight = Constants.fontStyle.font.dynamic.lineHeight * CGFloat(Constants.titleNumberOfLines)
+    return max(Constants.minimumHeight, ceil(titleHeight + Constants.verticalInset * 2))
   }
 }

--- a/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointsView.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/RoutePreview/RoutePoints/RoutePointsView.swift
@@ -1,6 +1,5 @@
 final class RoutePointsView: UIView {
   private enum Constants {
-    static let estimatedCellHeight = RoutePointCollectionViewCell.minimumHeight
     static var bottomContentInset: CGFloat {
       let bottomActionBartHeight = RouteActionsBottomMenuView.Constants.height +
         RouteActionsBottomMenuView.Constants.insets.top +
@@ -33,13 +32,8 @@ final class RoutePointsView: UIView {
 
   func viewWillTransition(to _: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     coordinator.animate(alongsideTransition: { _ in
-      self.updateEstimatedItemSize()
+      self.collectionView.collectionViewLayout.invalidateLayout()
     }, completion: nil)
-  }
-
-  override func layoutSubviews() {
-    super.layoutSubviews()
-    updateEstimatedItemSize()
   }
 
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -57,8 +51,6 @@ final class RoutePointsView: UIView {
   private func setupView() {
     let layout = UICollectionViewFlowLayout()
     layout.scrollDirection = .vertical
-    layout.minimumLineSpacing = 0
-    layout.estimatedItemSize = CGSize(width: UIScreen.main.bounds.width, height: Constants.estimatedCellHeight)
     collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
     collectionView.backgroundColor = .clear
     collectionView.dragInteractionEnabled = true
@@ -83,17 +75,6 @@ final class RoutePointsView: UIView {
     ])
   }
 
-  private func updateEstimatedItemSize() {
-    guard let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout else { return }
-    let width = collectionView.bounds.width
-    guard width > 0 else { return }
-
-    let estimatedItemSize = CGSize(width: width, height: Constants.estimatedCellHeight)
-    guard layout.estimatedItemSize != estimatedItemSize else { return }
-    layout.estimatedItemSize = estimatedItemSize
-    layout.invalidateLayout()
-  }
-
   private func configure(_ cell: RoutePointCollectionViewCell, at indexPath: IndexPath) {
     switch indexPath.item {
     case routePoints.count:
@@ -112,7 +93,6 @@ final class RoutePointsView: UIView {
     guard self.routePoints != routePoints else { return }
     self.routePoints = routePoints
     collectionView.reloadData()
-    collectionView.collectionViewLayout.invalidateLayout()
   }
 }
 
@@ -144,6 +124,18 @@ extension RoutePointsView: UICollectionViewDataSource, UICollectionViewDelegate 
     default:
       interactor?.process(.selectRoutePoint(routePoints[indexPath.item]))
     }
+  }
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension RoutePointsView: UICollectionViewDelegateFlowLayout {
+  func collectionView(_ collectionView: UICollectionView, layout _: UICollectionViewLayout, sizeForItemAt _: IndexPath) -> CGSize {
+    CGSize(width: collectionView.bounds.width, height: RoutePointCollectionViewCell.height())
+  }
+
+  func collectionView(_: UICollectionView, layout _: UICollectionViewLayout, minimumLineSpacingForSectionAt _: Int) -> CGFloat {
+    0
   }
 }
 


### PR DESCRIPTION
During the latest dynamic font accessibility implementation, the route point cell autosizing behavior was significantly changed, causing excessive layout invalidation and UI glitches during cell reordering.

This PR fixes the issue by partially reverting to the previous behavior when the cell height is limited by the font line height and the number of lines is capped at 2. This is sufficient for displaying the point description without significantly increasing the cell height when using large fonts in accessibility settings.

https://github.com/user-attachments/assets/6613a4fd-d546-44d1-b3f6-825f1a485019

<img width="340" height="739" alt="image" src="https://github.com/user-attachments/assets/8d142c4f-3809-4da2-9ebb-72eafb78a8f1" /> <img width="340" height="739" alt="image" src="https://github.com/user-attachments/assets/b7cbe1ad-8510-4776-93f9-c359343e5afc" />
