### PR TITLE
[android] Fix NPE in color picker long-press on Android 5.0

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/colorpicker/ColorPickerFragment.kt
+++ b/android/app/src/main/java/app/organicmaps/widget/colorpicker/ColorPickerFragment.kt
@@ -367,6 +367,8 @@ class ColorPickerFragment : BottomSheetDialogFragment() {
         val marginHalf = resources.getDimensionPixelSize(R.dimen.margin_half)
 
         val label = TextView(ctx).apply {
+            // Workaround for Android 5.0 NPE in TextView.checkForRelayout via PopupWindow.setLayoutDirectionFromAnchor.
+            layoutParams = ViewGroup.LayoutParams(WRAP_CONTENT, WRAP_CONTENT)
             text = getString(R.string.delete)
             setTextColor(Color.RED)
             setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)


### PR DESCRIPTION
## What                                                                                                         

  Fix a crash when long-pressing a color swatch in the bookmark/track color                                         
  picker on Android 5.0 (Lollipop, API 21–22).
                                                                                                                    
  ## Why                                                                                                          
                                                                                                                    
  User reported (with logcat) that long-pressing a color in                                                         
  `ColorPickerFragment` crashes the app on a Lenovo TAB 2 A8-50LC running
  Android 5.0.2. Stack trace:                                                                                       
                                                                                                                    
  java.lang.NullPointerException: Attempt to read from field                                                        
    'int android.view.ViewGroup$LayoutParams.width' on a null object reference                                      
      at android.widget.TextView.checkForRelayout(TextView.java:6811)                                               
      at android.widget.TextView.onRtlPropertiesChanged(TextView.java:8916)
      at android.view.View.resolvePadding(View.java:13245)                                                          
      at android.view.View.resolveRtlPropertiesIfNeeded(View.java:12996)                                          
      at android.view.View.setLayoutDirection(View.java:6853)                                                       
      at android.widget.PopupWindow.setLayoutDirectionFromAnchor(PopupWindow.java:1065)                           
      at android.widget.PopupWindow.invokePopup(PopupWindow.java:1057)                                              
      at android.widget.PopupWindow.showAsDropDown(PopupWindow.java:962)                                          
      at app.organicmaps.widget.colorpicker.ColorPickerFragment                                                     
          .showDeletePresetPopup(ColorPickerFragment.kt:398)  