### PR TITLE
[drape] Skip GPU frame when rendering is being disabled.

### DIFF
--- a/libs/drape/drape_routine.hpp
+++ b/libs/drape/drape_routine.hpp
@@ -8,7 +8,6 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
-#include <unordered_set>
 #include <vector>
 
 namespace dp
@@ -26,21 +25,16 @@ public:
       if (m_isFinished)
         return;
 
-      DrapeRoutine::Instance().Wait(m_id);
+      DrapeRoutine::Instance().Wait(m_isFinished);
     }
 
   private:
     friend class DrapeRoutine;
 
-    explicit Result(uint64_t id) : m_id(id), m_isFinished(false) {}
+    Result() : m_isFinished(false) {}
 
-    uint64_t Finish()
-    {
-      m_isFinished = true;
-      return m_id;
-    }
+    void Finish() { m_isFinished = true; }
 
-    uint64_t const m_id;
     std::atomic<bool> m_isFinished;
   };
 
@@ -53,11 +47,12 @@ public:
   template <typename Task>
   static ResultPtr Run(Task && t)
   {
-    ResultPtr result(new Result(Instance().GetNextId()));
+    ResultPtr result(new Result());
     auto const pushResult = Instance().m_workerThread.Push([result, t = std::forward<Task>(t)]() mutable
     {
       t();
-      Instance().Notify(result->Finish());
+      result->Finish();
+      Instance().Notify();
     });
 
     if (!pushResult.m_isSuccess)
@@ -69,12 +64,13 @@ public:
   template <typename Task>
   static ResultPtr RunDelayed(base::DelayedThreadPool::Duration const & duration, Task && t)
   {
-    ResultPtr result(new Result(Instance().GetNextId()));
+    ResultPtr result(new Result());
     auto const pushResult =
         Instance().m_workerThread.PushDelayed(duration, [result, t = std::forward<Task>(t)]() mutable
     {
       t();
-      Instance().Notify(result->Finish());
+      result->Finish();
+      Instance().Notify();
     });
 
     if (!pushResult.m_isSuccess)
@@ -87,11 +83,12 @@ public:
   template <typename Task>
   static ResultPtr RunSequential(Task && t)
   {
-    ResultPtr result(new Result(Instance().GetNextId()));
+    ResultPtr result(new Result());
     auto const pushResult = Instance().m_sequentialWorkerThread.Push([result, t = std::forward<Task>(t)]() mutable
     {
       t();
-      Instance().Notify(result->Finish());
+      result->Finish();
+      Instance().Notify();
     });
 
     if (!pushResult.m_isSuccess)
@@ -115,26 +112,16 @@ private:
 
   DrapeRoutine() : m_workerThread(2 /* threads count */) {}
 
-  uint64_t GetNextId()
+  void Notify()
   {
     std::lock_guard<std::mutex> lock(m_mutex);
-    return m_counter++;
-  }
-
-  void Notify(uint64_t id)
-  {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    m_finishedIds.insert(id);
     m_condition.notify_all();
   }
 
-  void Wait(uint64_t id)
+  void Wait(std::atomic<bool> const & isFinished)
   {
     std::unique_lock<std::mutex> lock(m_mutex);
-    if (m_finished)
-      return;
-    m_condition.wait(lock, [this, id]() { return m_finished || m_finishedIds.find(id) != m_finishedIds.end(); });
-    m_finishedIds.erase(id);
+    m_condition.wait(lock, [this, &isFinished]() { return m_finished || isFinished.load(); });
   }
 
   void FinishAll()
@@ -147,8 +134,6 @@ private:
     m_condition.notify_all();
   }
 
-  std::unordered_set<uint64_t> m_finishedIds;
-  uint64_t m_counter = 0;
   bool m_finished = false;
   std::condition_variable m_condition;
   std::mutex m_mutex;

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -1806,6 +1806,14 @@ void FrontendRenderer::RenderFrame()
   /// @todo Put ResolveZoomLevel under modelViewChanged after testing.
   ASSERT(!zoomChanged || modelViewChanged, ());
 
+  // Skip starting a new GPU frame if rendering is being disabled (e.g. the app is going to the
+  // background). SetRenderingEnabled(false) sets the flag on the UI thread and then blocks until this
+  // render thread reaches CheckRenderingEnabled(); bailing out here (before BeginRendering, so GPU frame
+  // scope stays balanced) lets that handshake complete after at most the already in-flight frame instead
+  // of waiting for a full PrepareScene + RenderScene + present. Prevents ANRs in Framework::DetachSurface.
+  if (!IsRenderingEnabled())
+    return;
+
   if (!m_context->BeginRendering())
     return;
 

--- a/libs/drape_frontend/route_renderer.cpp
+++ b/libs/drape_frontend/route_renderer.cpp
@@ -164,14 +164,14 @@ std::vector<ArrowBorders> CalculateArrowBorders(m2::RectD screenRect, double scr
   size_t constexpr kAverageArrowsCount = 10;
   std::vector<ArrowBorders> newArrowBorders;
   newArrowBorders.reserve(kAverageArrowsCount);
-  auto const & polyline = subroute->m_polyline;
+  m2::PolylineDistanceScanner<double> pointByDist(subroute->m_polyline);
 
-  auto const intersectsScreen = [&screenRect, &polyline](double startDistance, double endDistance)
+  auto const intersectsScreen = [&screenRect, &pointByDist](double startDistance, double endDistance)
   {
-    auto p1 = polyline.GetPointByDistance(startDistance);
+    auto p1 = pointByDist.GetPointByDistance(startDistance);
     if (screenRect.IsPointInside(p1))
       return true;
-    auto p2 = polyline.GetPointByDistance(endDistance);
+    auto p2 = pointByDist.GetPointByDistance(endDistance);
     if (screenRect.IsPointInside(p2))
       return true;
 
@@ -352,9 +352,10 @@ void RouteRenderer::UpdatePreview(ScreenBase const & screen)
     if (circlesCount == 0)
       circlesCount = 1;
     double const distDelta = segmentLen / circlesCount;
+    m2::PolylineDistanceScanner<double> pointByDist(polyline);
     for (double d = distDelta * 0.5; d < segmentLen; d += distDelta)
     {
-      m2::PointD const pt = AdjustPointForViewport(polyline.GetPointByDistance(d), screen);
+      m2::PointD const pt = AdjustPointForViewport(pointByDist.GetPointByDistance(d), screen);
       m2::RectD const circleRect(pt.x - radiusMercator, pt.y - radiusMercator, pt.x + radiusMercator,
                                  pt.y + radiusMercator);
       if (!screen.ClipRect().IsIntersect(circleRect))

--- a/libs/geometry/geometry_tests/polyline_tests.cpp
+++ b/libs/geometry/geometry_tests/polyline_tests.cpp
@@ -4,8 +4,6 @@
 #include "geometry/polyline2d.hpp"
 #include "geometry/rect2d.hpp"
 
-#include "base/math.hpp"
-
 #include <vector>
 
 namespace polyline_tests
@@ -37,6 +35,61 @@ UNIT_TEST(Rect_PolylineSmokeTest)
 
   poly.PopBack();
   TEST_EQUAL(poly.GetSize(), 2, ());
+}
+
+// Naive reference: rescan the polyline from the start for every query. The scanner must match it.
+m2::PointD PointByDistanceRef(m2::PolylineD const & poly, double distance)
+{
+  m2::PolylineDistanceScanner<double> scan(poly);
+  return scan.GetPointByDistance(distance);
+}
+
+UNIT_TEST(Polyline_DistanceScanner_Ascending)
+{
+  // Segment lengths: 2, 3, 3 -> total length 8.
+  m2::PolylineD const poly = {{0.0, 0.0}, {2.0, 0.0}, {2.0, 3.0}, {5.0, 3.0}};
+  TEST_ALMOST_EQUAL_ABS(poly.GetLength(), 8.0, kEps, ());
+
+  TEST_ALMOST_EQUAL_ABS(PointByDistanceRef(poly, 0), poly.GetPoint(0), kEps, ());
+  TEST_ALMOST_EQUAL_ABS(PointByDistanceRef(poly, 2), poly.GetPoint(1), kEps, ());
+  TEST_ALMOST_EQUAL_ABS(PointByDistanceRef(poly, 5), poly.GetPoint(2), kEps, ());
+  TEST_ALMOST_EQUAL_ABS(PointByDistanceRef(poly, 8), poly.GetPoint(3), kEps, ());
+
+  m2::PolylineDistanceScanner<double> scan(poly);
+  // Ascending queries, including out-of-range on both ends, exercise the fast forward path.
+  for (double d = -1.0; d <= 9.0; d += 0.1)
+    TEST_ALMOST_EQUAL_ABS(scan.GetPointByDistance(d), PointByDistanceRef(poly, d), kEps, (d));
+}
+
+UNIT_TEST(Polyline_DistanceScanner_ArbitraryOrder)
+{
+  m2::PolylineD const poly = {{0.0, 0.0}, {2.0, 0.0}, {2.0, 3.0}, {5.0, 3.0}};
+  m2::PolylineDistanceScanner<double> scan(poly);
+
+  // A shared cursor must stay correct even when queries step backwards (the restart path).
+  std::vector<double> const queries = {0.0, 5.0, 1.0, 8.0, 3.5, 2.0, 7.9, -0.5, 4.0, 2.0};
+  for (double const d : queries)
+    TEST_ALMOST_EQUAL_ABS(scan.GetPointByDistance(d), PointByDistanceRef(poly, d), kEps, (d));
+}
+
+UNIT_TEST(Polyline_DistanceScanner_Edges)
+{
+  m2::PolylineD const poly = {{0.0, 0.0}, {10.0, 0.0}};
+  m2::PolylineDistanceScanner<double> scan(poly);
+  TEST_ALMOST_EQUAL_ABS(scan.GetPointByDistance(-1.0), m2::PointD(0.0, 0.0), kEps, ());
+  TEST_ALMOST_EQUAL_ABS(scan.GetPointByDistance(0.0), m2::PointD(0.0, 0.0), kEps, ());
+  TEST_ALMOST_EQUAL_ABS(scan.GetPointByDistance(2.5), m2::PointD(2.5, 0.0), kEps, ());
+  TEST_ALMOST_EQUAL_ABS(scan.GetPointByDistance(10.0), m2::PointD(10.0, 0.0), kEps, ());
+  TEST_ALMOST_EQUAL_ABS(scan.GetPointByDistance(100.0), m2::PointD(10.0, 0.0), kEps, ());
+}
+
+UNIT_TEST(Polyline_DistanceScanner_ZeroLengthSegment)
+{
+  // A duplicate point makes a zero-length segment; the query at that distance must not divide by zero.
+  m2::PolylineD const poly = {{0.0, 0.0}, {2.0, 0.0}, {2.0, 0.0}, {4.0, 0.0}};
+  m2::PolylineDistanceScanner<double> scan(poly);
+  TEST_ALMOST_EQUAL_ABS(scan.GetPointByDistance(2.0), m2::PointD(2.0, 0.0), kEps, ());
+  TEST_ALMOST_EQUAL_ABS(scan.GetPointByDistance(3.0), m2::PointD(3.0, 0.0), kEps, ());
 }
 
 UNIT_TEST(Rect_PolylineMinDistanceTest)

--- a/libs/geometry/polyline2d.hpp
+++ b/libs/geometry/polyline2d.hpp
@@ -131,26 +131,6 @@ public:
     return m_points[idx];
   }
 
-  Point<T> GetPointByDistance(T distance) const
-  {
-    if (distance < 0)
-      return m_points.front();
-
-    T dist = 0;
-    for (size_t i = 1; i < m_points.size(); ++i)
-    {
-      T const oldDist = dist;
-      dist += m_points[i - 1].Length(m_points[i]);
-      if (distance <= dist)
-      {
-        T const t = (distance - oldDist) / (dist - oldDist);
-        return m_points[i - 1] * (1 - t) + m_points[i] * t;
-      }
-    }
-
-    return m_points.back();
-  }
-
   std::vector<Point<T>> ExtractSegment(size_t segmentIndex, bool reversed) const
   {
     if (segmentIndex + 1 >= m_points.size())
@@ -176,4 +156,49 @@ public:
 };
 
 using PolylineD = Polyline<double>;
+
+// Forward cursor that returns polyline points by distance from the beginning for a sequence of
+// (mostly) ascending distance queries. It resumes the segment walk from the previous query instead
+// of rescanning from the start, so N queries cost a single O(points + N) pass instead of O(points * N).
+// A query that steps backwards restarts the walk, so any query order stays correct (only ascending
+// order is fast). Holds a reference to the polyline: it must outlive the scanner and stay unchanged.
+template <typename T>
+class PolylineDistanceScanner
+{
+public:
+  explicit PolylineDistanceScanner(Polyline<T> const & polyline) : m_polyline(polyline) {}
+
+  Point<T> GetPointByDistance(T distance)
+  {
+    if (distance < 0)
+      return m_polyline.Front();
+
+    // A query may step backwards (e.g. slightly overlapping segments); restart the walk then.
+    if (distance < m_distAtSeg)
+    {
+      m_seg = 0;
+      m_distAtSeg = 0;
+    }
+
+    size_t const count = m_polyline.GetSize();
+    for (size_t i = m_seg + 1; i < count; ++i)
+    {
+      T const segLen = m_polyline.GetPoint(i - 1).Length(m_polyline.GetPoint(i));
+      T const nextDist = m_distAtSeg + segLen;
+      if (distance <= nextDist)
+      {
+        T const t = segLen > 0 ? (distance - m_distAtSeg) / segLen : T(0);
+        return m_polyline.GetPoint(i - 1) * (1 - t) + m_polyline.GetPoint(i) * t;
+      }
+      m_distAtSeg = nextDist;
+      m_seg = i;
+    }
+    return m_polyline.Back();
+  }
+
+private:
+  Polyline<T> const & m_polyline;
+  size_t m_seg = 0;   // segment start point index; m_distAtSeg is the distance to reach it
+  T m_distAtSeg = 0;  // accumulated distance up to m_polyline.GetPoint(m_seg)
+};
 }  // namespace m2


### PR DESCRIPTION
Finding the best fix for this problem: https://github.com/organicmaps/organicmaps/pull/12587

<details><summary>Detailed stacktrace</summary>

```
"main" tid=1 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000e2dfac  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&)+122) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x00000000008cddec  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (df::BaseRenderer::SetRenderingEnabled(bool)+147) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x00000000008debbc  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (df::DrapeEngine::SetRenderingDisabled(bool)+77) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x000000000045bd38  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (android::Framework::DetachSurface(bool)+318) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  at app.organicmaps.sdk.Map.nativeDetachSurface (Map.java)
  at app.organicmaps.sdk.Map.onSurfaceDestroyed (Map.java:232)
  at app.organicmaps.sdk.MapView$SurfaceHolderCallback.surfaceDestroyed (MapView.java:45)
  at android.view.SurfaceView.notifySurfaceDestroyed (SurfaceView.java:1991)
  at android.view.SurfaceView.updateSurface (SurfaceView.java:1159)
  at android.view.SurfaceView.onWindowVisibilityChanged (SurfaceView.java:387)
  at android.view.View.dispatchWindowVisibilityChanged (View.java:15522)
  at android.view.ViewGroup.dispatchWindowVisibilityChanged (ViewGroup.java:1629)
  at android.view.ViewGroup.dispatchWindowVisibilityChanged (ViewGroup.java:1629)
  at android.view.ViewGroup.dispatchWindowVisibilityChanged (ViewGroup.java:1629)
  at android.view.ViewRootImpl.performTraversals (ViewRootImpl.java:3104)
  at android.view.ViewRootImpl.doTraversal (ViewRootImpl.java:2584)
  at android.view.ViewRootImpl$TraversalRunnable.run (ViewRootImpl.java:9704)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1386)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1394)
  at android.view.Choreographer.doCallbacks (Choreographer.java:1013)
  at android.view.Choreographer.doFrame (Choreographer.java:911)
  at android.view.Choreographer$FrameDisplayEventReceiver.run (Choreographer.java:1366)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:211)
  at android.os.Looper.loop (Looper.java:300)
  at android.app.ActivityThread.main (ActivityThread.java:8227)
  at java.lang.reflect.Method.invoke (Native method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:580)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1028)

"FinalizerWatchdogDaemon" tid=4 Waiting
  at java.lang.Object.wait (Native method)
  at java.lang.Object.wait (Object.java:405)
  at java.lang.Object.wait (Object.java:543)
  at java.lang.Daemons$FinalizerWatchdogDaemon.sleepUntilNeeded (Daemons.java:483)
  at java.lang.Daemons$FinalizerWatchdogDaemon.runInternal (Daemons.java:463)
  at java.lang.Daemons$Daemon.run (Daemons.java:135)
  at java.lang.Thread.run (Thread.java:1572)

"FinalizerDaemon" tid=5 Waiting
  at java.lang.Object.wait (Native method)
  at java.lang.Object.wait (Object.java:405)
  at java.lang.ref.ReferenceQueue.remove (ReferenceQueue.java:207)
  at java.lang.ref.ReferenceQueue.remove (ReferenceQueue.java:228)
  at java.lang.Daemons$FinalizerDaemon.runInternal (Daemons.java:350)
  at java.lang.Daemons$Daemon.run (Daemons.java:135)
  at java.lang.Thread.run (Thread.java:1572)

"ReferenceQueueDaemon" tid=6 Waiting
  at java.lang.Object.wait (Native method)
  at java.lang.Object.wait (Object.java:405)
  at java.lang.Object.wait (Object.java:543)
  at java.lang.Daemons$ReferenceQueueDaemon.runInternal (Daemons.java:262)
  at java.lang.Daemons$Daemon.run (Daemons.java:135)
  at java.lang.Thread.run (Thread.java:1572)

"Timer-0" tid=14 Waiting
  at java.lang.Object.wait (Native method)
  at java.lang.Object.wait (Object.java:405)
  at java.lang.Object.wait (Object.java:543)
  at java.util.TimerThread.mainLoop (Timer.java:562)
  at java.util.TimerThread.run (Timer.java:540)

"Timer-1" tid=15 Waiting
  at java.lang.Object.wait (Native method)
  at java.lang.Object.wait (Object.java:405)
  at java.lang.Object.wait (Object.java:543)
  at java.util.TimerThread.mainLoop (Timer.java:562)
  at java.util.TimerThread.run (Timer.java:540)

"Signal Catcher" tid=2 Runnable
  #00  pc 0x00000000005adfd0  /apex/com.android.art/lib64/libart.so (art::DumpNativeStack+112)
  #01  pc 0x00000000005b0670  /apex/com.android.art/lib64/libart.so (art::Thread::DumpStack const+400)
  #02  pc 0x00000000005b01c0  /apex/com.android.art/lib64/libart.so (art::DumpCheckpoint::Run+292)
  #03  pc 0x00000000002f2034  /apex/com.android.art/lib64/libart.so (art::ThreadList::RunCheckpoint+2168)
  #04  pc 0x00000000005ad194  /apex/com.android.art/lib64/libart.so (art::ThreadList::Dump+212)
  #05  pc 0x00000000005acbcc  /apex/com.android.art/lib64/libart.so (art::ThreadList::DumpForSigQuit+340)
  #06  pc 0x00000000005a5178  /apex/com.android.art/lib64/libart.so (art::Runtime::DumpForSigQuit+60)
  #07  pc 0x00000000005a3270  /apex/com.android.art/lib64/libart.so (art::SignalCatcher::HandleSigQuit+576)
  #08  pc 0x0000000000473ad8  /apex/com.android.art/lib64/libart.so (art::SignalCatcher::Run+492)
  #09  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #10  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"perfetto_hprof_listener" tid=3 Native
  #00  pc 0x00000000000e5b14  /apex/com.android.runtime/lib64/bionic/libc.so (read+4)
  #01  pc 0x000000000002dfdc  /apex/com.android.art/lib64/libperfetto_hprof.so (void* std::__1::__thread_proxy[abi:nn220000]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, ArtPlugin_Initialize::$_7>>+272)
  #02  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #03  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Jit thread pool worker thread 0" tid=7 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x0000000000204394  /apex/com.android.art/lib64/libart.so (art::ConditionVariable::WaitHoldingLocks+140)
  #02  pc 0x000000000020428c  /apex/com.android.art/lib64/libart.so (art::ThreadPoolWorker::Run+228)
  #03  pc 0x000000000047592c  /apex/com.android.art/lib64/libart.so (art::ThreadPoolWorker::Callback+180)
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"HeapTaskDaemon" tid=8 Waiting
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x0000000000204394  /apex/com.android.art/lib64/libart.so (art::ConditionVariable::WaitHoldingLocks+140)
  #02  pc 0x0000000000201818  /apex/com.android.art/lib64/libart.so (art::gc::TaskProcessor::RunAllTasks+672)
  at dalvik.system.VMRuntime.runHeapTasks (Native method)
  at java.lang.Daemons$HeapTaskDaemon.runInternal (Daemons.java:766)
  at java.lang.Daemons$Daemon.run (Daemons.java:135)
  at java.lang.Thread.run (Thread.java:1572)

"binder:13299_1" tid=9 Native
  #00  pc 0x00000000000e5df4  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+4)
  #01  pc 0x0000000000097f1c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156)
  #02  pc 0x000000000005b458  /system/lib64/libbinder.so (android::IPCThreadState::talkWithDriver+280)
  #03  pc 0x000000000005b748  /system/lib64/libbinder.so (android::IPCThreadState::getAndExecuteCommand+24)
  #04  pc 0x000000000005c064  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool+68)
  #05  pc 0x000000000008bed8  /system/lib64/libbinder.so (android::PoolThread::threadLoop+24)
  #06  pc 0x0000000000013480  /system/lib64/libutils.so (android::Thread::_threadLoop+416)
  #07  pc 0x00000000000cc14c  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell+140)
  #08  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #09  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"binder:13299_2" tid=10 Native
  #00  pc 0x00000000000e5df4  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+4)
  #01  pc 0x0000000000097f1c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156)
  #02  pc 0x000000000005b458  /system/lib64/libbinder.so (android::IPCThreadState::talkWithDriver+280)
  #03  pc 0x000000000005b748  /system/lib64/libbinder.so (android::IPCThreadState::getAndExecuteCommand+24)
  #04  pc 0x000000000005c064  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool+68)
  #05  pc 0x000000000008bed8  /system/lib64/libbinder.so (android::PoolThread::threadLoop+24)
  #06  pc 0x0000000000013480  /system/lib64/libutils.so (android::Thread::_threadLoop+416)
  #07  pc 0x00000000000cc14c  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell+140)
  #08  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #09  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"binder:13299_3" tid=11 Native
  #00  pc 0x00000000000e5df4  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+4)
  #01  pc 0x0000000000097f1c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156)
  #02  pc 0x000000000005b458  /system/lib64/libbinder.so (android::IPCThreadState::talkWithDriver+280)
  #03  pc 0x000000000005b748  /system/lib64/libbinder.so (android::IPCThreadState::getAndExecuteCommand+24)
  #04  pc 0x000000000005c064  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool+68)
  #05  pc 0x000000000008bed8  /system/lib64/libbinder.so (android::PoolThread::threadLoop+24)
  #06  pc 0x0000000000013480  /system/lib64/libutils.so (android::Thread::_threadLoop+416)
  #07  pc 0x00000000000cc14c  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell+140)
  #08  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #09  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"13299-ScoutStateMachine" tid=12 Native
  #00  pc 0x00000000000e6dd8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8)
  #01  pc 0x0000000000017efc  /system/lib64/libutils.so (android::Looper::pollInner+188)
  #02  pc 0x0000000000017de0  /system/lib64/libutils.so (android::Looper::pollOnce+112)
  #03  pc 0x0000000000163c8c  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce+44)
  at android.os.MessageQueue.nativePollOnce (Native method)
  at android.os.MessageQueue.next (MessageQueue.java:341)
  at android.os.Looper.loopOnce (Looper.java:169)
  at android.os.Looper.loop (Looper.java:300)
  at android.os.HandlerThread.run (HandlerThread.java:67)

"Profile Saver" tid=13 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x0000000000204394  /apex/com.android.art/lib64/libart.so (art::ConditionVariable::WaitHoldingLocks+140)
  #02  pc 0x0000000000475eb0  /apex/com.android.art/lib64/libart.so (art::ProfileSaver::RunProfileSaverThread+464)
  #03  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #04  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"WM.task-1" tid=16 Waiting
  at jdk.internal.misc.Unsafe.park (Native method)
  at java.util.concurrent.locks.LockSupport.park (LockSupport.java:376)
  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block (AbstractQueuedSynchronizer.java:520)
  at java.util.concurrent.ForkJoinPool.unmanagedBlock (ForkJoinPool.java:3797)
  at java.util.concurrent.ForkJoinPool.managedBlock (ForkJoinPool.java:3738)
  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await (AbstractQueuedSynchronizer.java:1752)
  at java.util.concurrent.LinkedBlockingQueue.take (LinkedBlockingQueue.java:435)
  at java.util.concurrent.ThreadPoolExecutor.getTask (ThreadPoolExecutor.java:1026)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1086)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
  at java.lang.Thread.run (Thread.java:1572)

"WM.task-2" tid=17 Waiting
  at jdk.internal.misc.Unsafe.park (Native method)
  at java.util.concurrent.locks.LockSupport.park (LockSupport.java:376)
  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block (AbstractQueuedSynchronizer.java:520)
  at java.util.concurrent.ForkJoinPool.unmanagedBlock (ForkJoinPool.java:3797)
  at java.util.concurrent.ForkJoinPool.managedBlock (ForkJoinPool.java:3738)
  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await (AbstractQueuedSynchronizer.java:1752)
  at java.util.concurrent.LinkedBlockingQueue.take (LinkedBlockingQueue.java:435)
  at java.util.concurrent.ThreadPoolExecutor.getTask (ThreadPoolExecutor.java:1026)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1086)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
  at java.lang.Thread.run (Thread.java:1572)

"WM.task-3" tid=18 Waiting
  at jdk.internal.misc.Unsafe.park (Native method)
  at java.util.concurrent.locks.LockSupport.park (LockSupport.java:376)
  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block (AbstractQueuedSynchronizer.java:520)
  at java.util.concurrent.ForkJoinPool.unmanagedBlock (ForkJoinPool.java:3797)
  at java.util.concurrent.ForkJoinPool.managedBlock (ForkJoinPool.java:3738)
  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await (AbstractQueuedSynchronizer.java:1752)
  at java.util.concurrent.LinkedBlockingQueue.take (LinkedBlockingQueue.java:435)
  at java.util.concurrent.ThreadPoolExecutor.getTask (ThreadPoolExecutor.java:1026)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1086)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
  at java.lang.Thread.run (Thread.java:1572)

"WM.task-4" tid=19 Waiting
  at jdk.internal.misc.Unsafe.park (Native method)
  at java.util.concurrent.locks.LockSupport.park (LockSupport.java:376)
  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block (AbstractQueuedSynchronizer.java:520)
  at java.util.concurrent.ForkJoinPool.unmanagedBlock (ForkJoinPool.java:3797)
  at java.util.concurrent.ForkJoinPool.managedBlock (ForkJoinPool.java:3738)
  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await (AbstractQueuedSynchronizer.java:1752)
  at java.util.concurrent.LinkedBlockingQueue.take (LinkedBlockingQueue.java:435)
  at java.util.concurrent.ThreadPoolExecutor.getTask (ThreadPoolExecutor.java:1026)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1086)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
  at java.lang.Thread.run (Thread.java:1572)

"queued-work-looper" tid=20 Native
  #00  pc 0x00000000000e6dd8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8)
  #01  pc 0x0000000000017efc  /system/lib64/libutils.so (android::Looper::pollInner+188)
  #02  pc 0x0000000000017de0  /system/lib64/libutils.so (android::Looper::pollOnce+112)
  #03  pc 0x0000000000163c8c  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce+44)
  at android.os.MessageQueue.nativePollOnce (Native method)
  at android.os.MessageQueue.next (MessageQueue.java:341)
  at android.os.Looper.loopOnce (Looper.java:169)
  at android.os.Looper.loop (Looper.java:300)
  at android.os.HandlerThread.run (HandlerThread.java:67)

"GoogleApiHandler" tid=21 Native
  #00  pc 0x00000000000e6dd8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8)
  #01  pc 0x0000000000017efc  /system/lib64/libutils.so (android::Looper::pollInner+188)
  #02  pc 0x0000000000017de0  /system/lib64/libutils.so (android::Looper::pollOnce+112)
  #03  pc 0x0000000000163c8c  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce+44)
  at android.os.MessageQueue.nativePollOnce (Native method)
  at android.os.MessageQueue.next (MessageQueue.java:341)
  at android.os.Looper.loopOnce (Looper.java:169)
  at android.os.Looper.loop (Looper.java:300)
  at android.os.HandlerThread.run (HandlerThread.java:67)

"FramePolicy" tid=22 Native
  #00  pc 0x00000000000e6dd8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8)
  #01  pc 0x0000000000017efc  /system/lib64/libutils.so (android::Looper::pollInner+188)
  #02  pc 0x0000000000017de0  /system/lib64/libutils.so (android::Looper::pollOnce+112)
  #03  pc 0x0000000000163c8c  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce+44)
  at android.os.MessageQueue.nativePollOnce (Native method)
  at android.os.MessageQueue.next (MessageQueue.java:341)
  at android.os.Looper.loopOnce (Looper.java:169)
  at android.os.Looper.loop (Looper.java:300)
  at android.os.HandlerThread.run (HandlerThread.java:67)

"launch" tid=23 Native
  #00  pc 0x00000000000e6dd8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8)
  #01  pc 0x0000000000017efc  /system/lib64/libutils.so (android::Looper::pollInner+188)
  #02  pc 0x0000000000017de0  /system/lib64/libutils.so (android::Looper::pollOnce+112)
  #03  pc 0x0000000000163c8c  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce+44)
  at android.os.MessageQueue.nativePollOnce (Native method)
  at android.os.MessageQueue.next (MessageQueue.java:341)
  at android.os.Looper.loopOnce (Looper.java:169)
  at android.os.Looper.loop (Looper.java:300)
  at android.os.HandlerThread.run (HandlerThread.java:67)

"RenderThread" tid=24 Native
  #00  pc 0x00000000000e6dd8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8)
  #01  pc 0x0000000000017efc  /system/lib64/libutils.so (android::Looper::pollInner+188)
  #02  pc 0x0000000000017de0  /system/lib64/libutils.so (android::Looper::pollOnce+112)
  #03  pc 0x0000000000277e9c  /system/lib64/libhwui.so (android::uirenderer::ThreadBase::waitForWork+156)
  #04  pc 0x0000000000299294  /system/lib64/libhwui.so (android::uirenderer::renderthread::RenderThread::threadLoop+404)
  #05  pc 0x0000000000013480  /system/lib64/libutils.so (android::Thread::_threadLoop+416)
  #06  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #07  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"hwuiTask0" tid=25 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000057094  /system/lib64/libc++.so (std::__1::condition_variable::wait+20)
  #04  pc 0x000000000029cf48  /system/lib64/libhwui.so (android::uirenderer::CommonPool::workerLoop+104)
  #05  pc 0x000000000029d180  /system/lib64/libhwui.so (void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, android::uirenderer::CommonPool::CommonPool::$_0>>+192)
  #06  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #07  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"hwuiTask1" tid=26 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000057094  /system/lib64/libc++.so (std::__1::condition_variable::wait+20)
  #04  pc 0x000000000029cf48  /system/lib64/libhwui.so (android::uirenderer::CommonPool::workerLoop+104)
  #05  pc 0x000000000029d180  /system/lib64/libhwui.so (void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, android::uirenderer::CommonPool::CommonPool::$_0>>+192)
  #06  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #07  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-4" tid=27 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000e2dfac  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&)+122) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000befe94  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (base::DelayedThreadPool::ProcessTasks()+147) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bef044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::SimpleThread::ThreadFunc(std::__ndk1::function<void ()>&&)+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000bfad8c  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::function<void ()>&&), std::__ndk1::__bind<void (base::DelayedThreadPool::*)(), base::DelayedThreadPool*>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #08  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-5" tid=28 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000e2dfac  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&)+122) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000befe94  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (base::DelayedThreadPool::ProcessTasks()+147) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bef044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::SimpleThread::ThreadFunc(std::__ndk1::function<void ()>&&)+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000bfad8c  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::function<void ()>&&), std::__ndk1::__bind<void (base::DelayedThreadPool::*)(), base::DelayedThreadPool*>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #08  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-6" tid=29 Native
  #00  pc 0x0000000000089220  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+32)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fae34  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_timedwait+132)
  #03  pc 0x0000000000e2e044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::__do_timed_wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&, std::__ndk1::chrono::time_point<std::__ndk1::chrono::system_clock, std::__ndk1::chrono::duration<long long, std::__ndk1::ratio<1l, 1000000000l>>>)+127) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000befcb4  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (base::DelayedThreadPool::ProcessTasks()+106) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bef044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::SimpleThread::ThreadFunc(std::__ndk1::function<void ()>&&)+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000bfad8c  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::function<void ()>&&), std::__ndk1::__bind<void (base::DelayedThreadPool::*)(), base::DelayedThreadPool*>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #08  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-7" tid=30 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000e2dfac  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&)+122) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000bf4f08  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::__function::__func<std::__ndk1::__bind<base::DeferredTask::DeferredTask(std::__ndk1::chrono::duration<double, std::__ndk1::ratio<1l, 1l>> const&)::$_0>, std::__ndk1::allocator<std::__ndk1::__bind<base::DeferredTask::DeferredTask(std::__ndk1::chrono::duration<double, std::__ndk1::ratio<1l, 1l>> const&)::$_0>>, void ()>::operator()()+14) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bef044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::SimpleThread::ThreadFunc(std::__ndk1::function<void ()>&&)+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000bf4cdc  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::function<void ()>&&), std::__ndk1::__bind<base::DeferredTask::DeferredTask(std::__ndk1::chrono::duration<double, std::__ndk1::ratio<1l, 1l>> const&)::$_0>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #08  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-8" tid=31 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000e2dfac  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&)+122) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000bf47d0  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (ThreadedList<threads::IRoutine*>::Front(bool)+147) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bf46e8  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (base::(anonymous namespace)::PoolRoutine::Do()+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000beee00  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::(anonymous namespace)::RunRoutine(std::__ndk1::shared_ptr<threads::IRoutine>)+26) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x0000000000bfaa90  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::shared_ptr<threads::IRoutine>), std::__ndk1::shared_ptr<threads::IRoutine>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #08  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #09  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-9" tid=32 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000e2dfac  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&)+122) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x000000000060762c  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (routing::AsyncRouter::ThreadFunc()+147) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bef044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::SimpleThread::ThreadFunc(std::__ndk1::function<void ()>&&)+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000673854  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::function<void ()>&&), std::__ndk1::__bind<void (routing::AsyncRouter::*)(), routing::AsyncRouter*>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #08  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-10" tid=33 Native
  #00  pc 0x0000000000089220  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+32)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fae34  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_timedwait+132)
  #03  pc 0x0000000000e2e044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::__do_timed_wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&, std::__ndk1::chrono::time_point<std::__ndk1::chrono::system_clock, std::__ndk1::chrono::duration<long long, std::__ndk1::ratio<1l, 1000000000l>>>)+127) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x00000000004ff0dc  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (TrafficManager::WaitForRequest(std::__ndk1::vector<MwmSet::MwmId, std::__ndk1::allocator<MwmSet::MwmId>>&)+16384) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x00000000004fd6a8  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (TrafficManager::ThreadRoutine()+231) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000bef044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::SimpleThread::ThreadFunc(std::__ndk1::function<void ()>&&)+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x000000000059d398  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::function<void ()>&&), std::__ndk1::__bind<void (TrafficManager::*)(), TrafficManager*>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #08  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #09  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-11" tid=34 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000e2dfac  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&)+122) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x000000000070beb8  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (search::Engine::MainLoop(search::Engine::Context&)+147) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bef044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::SimpleThread::ThreadFunc(std::__ndk1::function<void ()>&&)+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000747160  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::function<void ()>&&), std::__ndk1::__bind<void (search::Engine::*)(search::Engine::Context&), search::Engine*, std::__ndk1::reference_wrapper<search::Engine::Context>>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #08  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-13" tid=35 Native
  #00  pc 0x0000000000089220  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+32)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fae34  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_timedwait+132)
  #03  pc 0x0000000000e2e044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::__do_timed_wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&, std::__ndk1::chrono::time_point<std::__ndk1::chrono::system_clock, std::__ndk1::chrono::duration<long long, std::__ndk1::ratio<1l, 1000000000l>>>)+127) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000befcb4  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (base::DelayedThreadPool::ProcessTasks()+106) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bef044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::SimpleThread::ThreadFunc(std::__ndk1::function<void ()>&&)+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000bfad8c  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::function<void ()>&&), std::__ndk1::__bind<void (base::DelayedThreadPool::*)(), base::DelayedThreadPool*>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #08  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-14" tid=36 Native
  #00  pc 0x0000000000089220  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+32)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fae34  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_timedwait+132)
  #03  pc 0x0000000000e2e044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::__do_timed_wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&, std::__ndk1::chrono::time_point<std::__ndk1::chrono::system_clock, std::__ndk1::chrono::duration<long long, std::__ndk1::ratio<1l, 1000000000l>>>)+127) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000befcb4  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (base::DelayedThreadPool::ProcessTasks()+106) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bef044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::SimpleThread::ThreadFunc(std::__ndk1::function<void ()>&&)+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000bfad8c  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::function<void ()>&&), std::__ndk1::__bind<void (base::DelayedThreadPool::*)(), base::DelayedThreadPool*>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #08  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-15" tid=37 Native
  #00  pc 0x0000000000089220  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+32)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fae34  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_timedwait+132)
  #03  pc 0x0000000000e2e044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::__do_timed_wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&, std::__ndk1::chrono::time_point<std::__ndk1::chrono::system_clock, std::__ndk1::chrono::duration<long long, std::__ndk1::ratio<1l, 1000000000l>>>)+127) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000befcb4  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (base::DelayedThreadPool::ProcessTasks()+106) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bef044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::SimpleThread::ThreadFunc(std::__ndk1::function<void ()>&&)+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000bfad8c  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::function<void ()>&&), std::__ndk1::__bind<void (base::DelayedThreadPool::*)(), base::DelayedThreadPool*>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #08  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-16" tid=38 Native
  #00  pc 0x0000000000089220  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+32)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fae34  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_timedwait+132)
  #03  pc 0x0000000000e2e044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::__do_timed_wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&, std::__ndk1::chrono::time_point<std::__ndk1::chrono::system_clock, std::__ndk1::chrono::duration<long long, std::__ndk1::ratio<1l, 1000000000l>>>)+127) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000befcb4  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (base::DelayedThreadPool::ProcessTasks()+106) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bef044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::SimpleThread::ThreadFunc(std::__ndk1::function<void ()>&&)+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000bfad8c  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::function<void ()>&&), std::__ndk1::__bind<void (base::DelayedThreadPool::*)(), base::DelayedThreadPool*>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #08  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-23" tid=39 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000e2dfac  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&)+122) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000bf47d0  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (ThreadedList<threads::IRoutine*>::Front(bool)+147) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bf46e8  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (base::(anonymous namespace)::PoolRoutine::Do()+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000beee00  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::(anonymous namespace)::RunRoutine(std::__ndk1::shared_ptr<threads::IRoutine>)+26) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x0000000000bfaa90  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::shared_ptr<threads::IRoutine>), std::__ndk1::shared_ptr<threads::IRoutine>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #08  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #09  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-18" tid=40 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000e2dfac  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&)+122) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000befe94  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (base::DelayedThreadPool::ProcessTasks()+147) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bef044  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::SimpleThread::ThreadFunc(std::__ndk1::function<void ()>&&)+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000bfad8c  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::function<void ()>&&), std::__ndk1::__bind<void (base::DelayedThreadPool::*)(), base::DelayedThreadPool*>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #08  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-19" tid=41 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000e2dfac  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&)+122) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x000000000083830c  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (df::MessageQueue::PopMessage(bool)+147) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000838210  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (df::MessageAcceptor::ProcessSingleMessage(bool)+12) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x00000000008cce24  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (df::BackendRenderer::RenderFrame()+764) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x00000000008ccd5c  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (df::BackendRenderer::Routine::Do()+62) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #08  pc 0x0000000000beee00  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::(anonymous namespace)::RunRoutine(std::__ndk1::shared_ptr<threads::IRoutine>)+26) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #09  pc 0x0000000000bfaa90  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::shared_ptr<threads::IRoutine>), std::__ndk1::shared_ptr<threads::IRoutine>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #10  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #11  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-20" tid=42 Native
  #00  pc 0x000000000087fee0  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (df::UserEventStream::SetFollowAndRotate(m2::Point<double> const&, m2::Point<double> const&, double, int, double, bool, bool, std::__ndk1::function<void (ref_ptr<df::Animation>)> const&, std::__ndk1::function<std::__ndk1::unique_ptr<df::Animation, std::__ndk1::default_delete<df::Animation>> (ref_ptr<df::Animation>)> const&)+76) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #01  pc 0x000000000087ef94  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (df::UserEventStream::ProcessEvents(bool&, bool&, bool&)+246) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #02  pc 0x00000000008ef63c  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (df::FrontendRenderer::RenderFrame()+2533) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #03  pc 0x00000000008f2fe8  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (df::FrontendRenderer::Routine::Do()+62) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000beee00  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::(anonymous namespace)::RunRoutine(std::__ndk1::shared_ptr<threads::IRoutine>)+26) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bfaa90  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::shared_ptr<threads::IRoutine>), std::__ndk1::shared_ptr<threads::IRoutine>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #07  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"Thread-24" tid=43 Native
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000e2dfac  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (std::__ndk1::condition_variable::wait(std::__ndk1::unique_lock<std::__ndk1::mutex>&)+122) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #04  pc 0x0000000000bf47d0  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (ThreadedList<threads::IRoutine*>::Front(bool)+147) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #05  pc 0x0000000000bf46e8  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (base::(anonymous namespace)::PoolRoutine::Do()+436) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #06  pc 0x0000000000beee00  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (threads::(anonymous namespace)::RunRoutine(std::__ndk1::shared_ptr<threads::IRoutine>)+26) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #07  pc 0x0000000000bfaa90  /data/app/~~kuc0Rl8QIDHg9ML35RO7Ug==/app.organicmaps-9XdRK4Zv1Mi5OCaq7k4T8A==/split_config.arm64_v8a.apk (void* std::__ndk1::__thread_proxy[abi:ne210000]<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::shared_ptr<threads::IRoutine>), std::__ndk1::shared_ptr<threads::IRoutine>>>(void*)+179) (BuildId: b30f4c3a064f5ae81acb9261864f7cf425abe44a)
  #08  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #09  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"binder:13299_4" tid=45 Native
  #00  pc 0x00000000000e5df4  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+4)
  #01  pc 0x0000000000097f1c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156)
  #02  pc 0x000000000005b458  /system/lib64/libbinder.so (android::IPCThreadState::talkWithDriver+280)
  #03  pc 0x000000000005b748  /system/lib64/libbinder.so (android::IPCThreadState::getAndExecuteCommand+24)
  #04  pc 0x000000000005c064  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool+68)
  #05  pc 0x000000000008bed8  /system/lib64/libbinder.so (android::PoolThread::threadLoop+24)
  #06  pc 0x0000000000013480  /system/lib64/libutils.so (android::Thread::_threadLoop+416)
  #07  pc 0x00000000000cc14c  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell+140)
  #08  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #09  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"binder:13299_5" tid=46 Native
  #00  pc 0x00000000000e5df4  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+4)
  #01  pc 0x0000000000097f1c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156)
  #02  pc 0x000000000005b458  /system/lib64/libbinder.so (android::IPCThreadState::talkWithDriver+280)
  #03  pc 0x000000000005b748  /system/lib64/libbinder.so (android::IPCThreadState::getAndExecuteCommand+24)
  #04  pc 0x000000000005c064  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool+68)
  #05  pc 0x000000000008bed8  /system/lib64/libbinder.so (android::PoolThread::threadLoop+24)
  #06  pc 0x0000000000013480  /system/lib64/libutils.so (android::Thread::_threadLoop+416)
  #07  pc 0x00000000000cc14c  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell+140)
  #08  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #09  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"AudioPortEventHandler" tid=47 Native
  #00  pc 0x00000000000e6dd8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8)
  #01  pc 0x0000000000017efc  /system/lib64/libutils.so (android::Looper::pollInner+188)
  #02  pc 0x0000000000017de0  /system/lib64/libutils.so (android::Looper::pollOnce+112)
  #03  pc 0x0000000000163c8c  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce+44)
  at android.os.MessageQueue.nativePollOnce (Native method)
  at android.os.MessageQueue.next (MessageQueue.java:341)
  at android.os.Looper.loopOnce (Looper.java:169)
  at android.os.Looper.loop (Looper.java:300)
  at android.os.HandlerThread.run (HandlerThread.java:67)

"binder:13299_6" tid=48 Native
  #00  pc 0x00000000000e5df4  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+4)
  #01  pc 0x0000000000097f1c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156)
  #02  pc 0x000000000005b458  /system/lib64/libbinder.so (android::IPCThreadState::talkWithDriver+280)
  #03  pc 0x000000000005b748  /system/lib64/libbinder.so (android::IPCThreadState::getAndExecuteCommand+24)
  #04  pc 0x000000000005c064  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool+68)
  #05  pc 0x000000000008bed8  /system/lib64/libbinder.so (android::PoolThread::threadLoop+24)
  #06  pc 0x0000000000013480  /system/lib64/libutils.so (android::Thread::_threadLoop+416)
  #07  pc 0x00000000000cc14c  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell+140)
  #08  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #09  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"ScrollPolicy" tid=49 Native
  #00  pc 0x00000000000e6dd8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8)
  #01  pc 0x0000000000017efc  /system/lib64/libutils.so (android::Looper::pollInner+188)
  #02  pc 0x0000000000017de0  /system/lib64/libutils.so (android::Looper::pollOnce+112)
  #03  pc 0x0000000000163c8c  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce+44)
  at android.os.MessageQueue.nativePollOnce (Native method)
  at android.os.MessageQueue.next (MessageQueue.java:341)
  at android.os.Looper.loopOnce (Looper.java:169)
  at android.os.Looper.loop (Looper.java:300)
  at android.os.HandlerThread.run (HandlerThread.java:67)

"binder:13299_7" tid=50 Native
  #00  pc 0x00000000000e5df4  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+4)
  #01  pc 0x0000000000097f1c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156)
  #02  pc 0x000000000005b458  /system/lib64/libbinder.so (android::IPCThreadState::talkWithDriver+280)
  #03  pc 0x000000000005b748  /system/lib64/libbinder.so (android::IPCThreadState::getAndExecuteCommand+24)
  #04  pc 0x000000000005c064  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool+68)
  #05  pc 0x000000000008bed8  /system/lib64/libbinder.so (android::PoolThread::threadLoop+24)
  #06  pc 0x0000000000013480  /system/lib64/libutils.so (android::Thread::_threadLoop+416)
  #07  pc 0x00000000000cc14c  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell+140)
  #08  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #09  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"binder:13299_8" tid=51 Native
  #00  pc 0x00000000000e5df4  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+4)
  #01  pc 0x0000000000097f1c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156)
  #02  pc 0x000000000005b458  /system/lib64/libbinder.so (android::IPCThreadState::talkWithDriver+280)
  #03  pc 0x000000000005b748  /system/lib64/libbinder.so (android::IPCThreadState::getAndExecuteCommand+24)
  #04  pc 0x000000000005c064  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool+68)
  #05  pc 0x000000000008bed8  /system/lib64/libbinder.so (android::PoolThread::threadLoop+24)
  #06  pc 0x0000000000013480  /system/lib64/libutils.so (android::Thread::_threadLoop+416)
  #07  pc 0x00000000000cc14c  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell+140)
  #08  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #09  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"AsyncTask #2" tid=52 Waiting
  at jdk.internal.misc.Unsafe.park (Native method)
  at java.util.concurrent.locks.LockSupport.park (LockSupport.java:376)
  at java.util.concurrent.LinkedTransferQueue$DualNode.await (LinkedTransferQueue.java:458)
  at java.util.concurrent.SynchronousQueue$Transferer.xferLifo (SynchronousQueue.java:194)
  at java.util.concurrent.SynchronousQueue.xfer (SynchronousQueue.java:235)
  at java.util.concurrent.SynchronousQueue.take (SynchronousQueue.java:318)
  at java.util.concurrent.ThreadPoolExecutor.getTask (ThreadPoolExecutor.java:1026)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1086)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
  at java.lang.Thread.run (Thread.java:1572)

"mali-mem-purge" tid=13334 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x00000000008708dc  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13335 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13336 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13337 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13338 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13339 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13340 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13341 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13342 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-cmar-backe" tid=13343 Unknown
  #00  pc 0x00000000000e6ed8  /apex/com.android.runtime/lib64/bionic/libc.so (__ppoll+8)
  #01  pc 0x000000000009a82c  /apex/com.android.runtime/lib64/bionic/libc.so (poll+92)
  #02  pc 0x000000000084e1cc  /vendor/lib64/egl/libGLES_mali.so
  #03  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #04  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"ged-swd" tid=13344 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000007ad8  /vendor/lib64/libged.so (ged_cond_lock+44)
  #04  pc 0x0000000000007f64  /vendor/lib64/libged.so (ged_worker_thread+112)
  #05  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #06  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"binder:13299_1" tid=13375 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x0000000000057094  /system/lib64/libc++.so (std::__1::condition_variable::wait+20)
  #04  pc 0x00000000000ac868  /system/lib64/libgui.so (android::AsyncWorker::run+136)
  #05  pc 0x00000000000acc3c  /system/lib64/libgui.so (void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void , android::AsyncWorker*>>+60)
  #06  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #07  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-mem-purge" tid=13408 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x00000000008708dc  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13409 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13410 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13411 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13412 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13413 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13414 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13415 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-utility-wo" tid=13416 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x000000000009c5a8  /apex/com.android.runtime/lib64/bionic/libc.so (sem_wait+104)
  #03  pc 0x000000000084df0c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"mali-cmar-backe" tid=13417 Unknown
  #00  pc 0x00000000000e6ed8  /apex/com.android.runtime/lib64/bionic/libc.so (__ppoll+8)
  #01  pc 0x000000000009a82c  /apex/com.android.runtime/lib64/bionic/libc.so (poll+92)
  #02  pc 0x000000000084e1cc  /vendor/lib64/egl/libGLES_mali.so
  #03  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #04  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)

"RenderThread" tid=16119 Unknown
  #00  pc 0x000000000008921c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x000000000008db00  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex+144)
  #02  pc 0x00000000000fad78  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+72)
  #03  pc 0x00000000008a7f1c  /vendor/lib64/egl/libGLES_mali.so
  #04  pc 0x00000000000fba4c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start+204)
  #05  pc 0x000000000008e5f0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)
```
</details>