### PR TITLE
[android] Show expanded opening hours from today; simplify adapter API

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
@@ -24,9 +24,9 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
 
   public PlaceOpeningHoursAdapter() {}
 
-  public void setTimetables(Timetable[] timetables, int firstDayOfWeek, int currentDayOfWeek)
+  public void setTimetables(Timetable[] timetables, int currentDayOfWeek)
   {
-    final List<Integer> weekDays = buildWeekByFirstDay(firstDayOfWeek);
+    final List<Integer> weekDays = buildWeekByFirstDay(currentDayOfWeek);
     final List<WeekScheduleData> scheduleData = new ArrayList<>();
 
     // Timetables array contains only working days. We need to fill non-working gaps.

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageOpeningHoursFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageOpeningHoursFragment.java
@@ -10,7 +10,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
-import androidx.core.text.util.LocalePreferences;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
@@ -27,10 +26,8 @@ import app.organicmaps.widget.placepage.PlacePageUtils;
 import app.organicmaps.widget.placepage.PlacePageViewModel;
 import java.text.DateFormat;
 import java.text.DateFormatSymbols;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.List;
 
 public class PlacePageOpeningHoursFragment extends Fragment implements Observer<MapObject>
 {
@@ -139,27 +136,10 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
       {
         UiUtils.show(mFullWeekOpeningHours);
         int currentDayOfWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        mOpeningHoursAdapter.setTimetables(timetables, getFirstDayOfWeek(), currentDayOfWeek);
+        mOpeningHoursAdapter.setTimetables(timetables, currentDayOfWeek);
         enableDropdownContent();
       }
     }
-  }
-
-  private int getFirstDayOfWeek()
-  {
-    final List<String> stringDayList =
-        Arrays.asList(LocalePreferences.FirstDayOfWeek.SUNDAY, LocalePreferences.FirstDayOfWeek.MONDAY,
-                      LocalePreferences.FirstDayOfWeek.TUESDAY, LocalePreferences.FirstDayOfWeek.WEDNESDAY,
-                      LocalePreferences.FirstDayOfWeek.THURSDAY, LocalePreferences.FirstDayOfWeek.FRIDAY,
-                      LocalePreferences.FirstDayOfWeek.SATURDAY);
-
-    int dayIndex = stringDayList.indexOf(LocalePreferences.getFirstDayOfWeek());
-    if (dayIndex == -1)
-    {
-      return 1; // LocalePreferences.getFirstDayOfWeek() returned default
-    }
-
-    return dayIndex + 1;
   }
 
   private void expandOpeningHours()

--- a/android/app/src/test/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapterTest.java
+++ b/android/app/src/test/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapterTest.java
@@ -70,38 +70,6 @@ public class PlaceOpeningHoursAdapterTest
   }
 
   @Test
-  public void test_single_closed_day_sunday() throws IllegalAccessException
-  {
-    // opening_hours = "Mo-Fr 09:00-18:00; Sa 12:00-14:00"
-    Timetable[] timetables = new Timetable[2];
-    timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(18, 0, true)),
-                                  new Timespan[0], false, new int[] {2, 3, 4, 5, 6});
-
-    timetables[1] = new Timetable(new Timespan(new HoursMinutes(12, 0, true), new HoursMinutes(14, 0, true)),
-                                  new Timespan[0], false, new int[] {7});
-
-    adapter.setTimetables(timetables, Calendar.SUNDAY, Calendar.MONDAY);
-
-    /* Expected parsed schedule:
-     *  0 - Su, closed
-     *  1 - Mo-Fr, open
-     *  2 - Sa, open
-     * */
-
-    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
-    assertNotNull(schedule);
-    assertEquals(3, schedule.size());
-    assertTrue(schedule.get(0).isClosed);
-    assertEquals(schedule.get(0).startWeekDay, 1);
-    assertEquals(schedule.get(0).endWeekDay, 1);
-    assertFalse(schedule.get(1).isClosed);
-    assertFalse(schedule.get(2).isClosed);
-    assertFalse(schedule.get(0).isBold);
-    assertTrue(schedule.get(1).isBold);
-    assertFalse(schedule.get(2).isBold);
-  }
-
-  @Test
   public void test_single_closed_day_monday() throws IllegalAccessException
   {
     // opening_hours = "Mo-Fr 09:00-18:00; Sa 12:00-14:00"
@@ -112,12 +80,12 @@ public class PlaceOpeningHoursAdapterTest
     timetables[1] = new Timetable(new Timespan(new HoursMinutes(12, 0, true), new HoursMinutes(14, 0, true)),
                                   new Timespan[0], false, new int[] {7});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY, Calendar.MONDAY);
+    adapter.setTimetables(timetables, Calendar.MONDAY);
 
-    /* Expected parsed schedule:
-     *  0 - Mo-Fr, open
-     *  1 - Sa, open
-     *  2 - Su, closed
+    /* Expected parsed schedule (today = Mo):
+     *  0 - Mo-Fr, open, bold
+     *  1 - Sa,    open
+     *  2 - Su,    closed
      * */
 
     List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
@@ -134,7 +102,7 @@ public class PlaceOpeningHoursAdapterTest
   }
 
   @Test
-  public void test_multiple_closed_day_monday() throws IllegalAccessException
+  public void test_multiple_closed_day_thursday() throws IllegalAccessException
   {
     // opening_hours = "Mo 09:00-18:00; We 10:00-18:00; Fr 11:00-18:00"
     Timetable[] timetables = new Timetable[3];
@@ -147,111 +115,64 @@ public class PlaceOpeningHoursAdapterTest
     timetables[2] = new Timetable(new Timespan(new HoursMinutes(11, 0, true), new HoursMinutes(18, 0, true)),
                                   new Timespan[0], false, new int[] {6});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY, Calendar.THURSDAY);
+    adapter.setTimetables(timetables, Calendar.THURSDAY);
 
-    /* Expected parsed schedule:
-     *  0 - Mo, open
-     *  1 - Tu, closed
-     *  2 - We, open
-     *  3 - Th, closed
-     *  4 - Fr, open
-     *  5 - Sa-Su, closed
+    /* Expected parsed schedule (today = Th):
+     *  0 - Th,    closed, bold
+     *  1 - Fr,    open
+     *  2 - Sa-Su, closed
+     *  3 - Mo,    open
+     *  4 - Tu,    closed
+     *  5 - We,    open
      * */
 
     List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
     assertNotNull(schedule);
     assertEquals(6, schedule.size());
-    assertFalse(schedule.get(0).isClosed); //     Mo - open
-    assertTrue(schedule.get(1).isClosed); //     Tu - closed
-    assertFalse(schedule.get(2).isClosed); //     We - open
-    assertTrue(schedule.get(3).isClosed); //     Th - closed
-    assertFalse(schedule.get(4).isClosed); //     Fr - open
-    assertTrue(schedule.get(5).isClosed); // Sa, Su - closed
-    assertEquals(schedule.get(5).startWeekDay, 7);
-    assertEquals(schedule.get(5).endWeekDay, 1);
-    assertFalse(schedule.get(0).isBold);
+    assertTrue(schedule.get(0).isClosed); //  Th    - closed
+    assertFalse(schedule.get(1).isClosed); // Fr    - open
+    assertTrue(schedule.get(2).isClosed); //  Sa-Su - closed
+    assertFalse(schedule.get(3).isClosed); // Mo    - open
+    assertTrue(schedule.get(4).isClosed); //  Tu    - closed
+    assertFalse(schedule.get(5).isClosed); // We    - open
+    assertEquals(schedule.get(2).startWeekDay, 7);
+    assertEquals(schedule.get(2).endWeekDay, 1);
+    assertTrue(schedule.get(0).isBold);
     assertFalse(schedule.get(1).isBold);
-    assertFalse(schedule.get(2).isBold);
-    assertTrue(schedule.get(3).isBold);
-    assertFalse(schedule.get(4).isBold);
-    assertFalse(schedule.get(5).isBold);
-  }
-
-  @Test
-  public void test_multiple_closed_day_sunday() throws IllegalAccessException
-  {
-    // opening_hours = "Mo 09:00-18:00; We 10:00-18:00; Fr 11:00-18:00"
-    Timetable[] timetables = new Timetable[3];
-    timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(18, 0, true)),
-                                  new Timespan[0], false, new int[] {2});
-
-    timetables[1] = new Timetable(new Timespan(new HoursMinutes(10, 0, true), new HoursMinutes(18, 0, true)),
-                                  new Timespan[0], false, new int[] {4});
-
-    timetables[2] = new Timetable(new Timespan(new HoursMinutes(11, 0, true), new HoursMinutes(18, 0, true)),
-                                  new Timespan[0], false, new int[] {6});
-
-    adapter.setTimetables(timetables, Calendar.SUNDAY, Calendar.MONDAY);
-
-    /* Expected parsed schedule:
-     *  0 - Su, closed
-     *  1 - Mo, open
-     *  2 - Tu, closed
-     *  3 - We, open
-     *  4 - Th, closed
-     *  5 - Fr, open
-     *  6 - Sa, closed
-     * */
-
-    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
-    assertNotNull(schedule);
-    assertEquals(7, schedule.size());
-    assertTrue(schedule.get(0).isClosed); // Su - closed
-    assertFalse(schedule.get(1).isClosed); // Mo - open
-    assertTrue(schedule.get(2).isClosed); // Tu - closed
-    assertFalse(schedule.get(3).isClosed); // We - open
-    assertTrue(schedule.get(4).isClosed); // Th - closed
-    assertFalse(schedule.get(5).isClosed); // Fr - open
-    assertTrue(schedule.get(6).isClosed); // Sa - closed
-    assertEquals(schedule.get(6).startWeekDay, 7);
-    assertEquals(schedule.get(6).endWeekDay, 7);
-    assertFalse(schedule.get(0).isBold);
-    assertTrue(schedule.get(1).isBold);
     assertFalse(schedule.get(2).isBold);
     assertFalse(schedule.get(3).isBold);
     assertFalse(schedule.get(4).isBold);
     assertFalse(schedule.get(5).isBold);
-    assertFalse(schedule.get(6).isBold);
   }
 
   @Test
   public void test_multiple_closed_days_2_monday() throws IllegalAccessException
   {
-    // opening_hours = "Mo 09:00-18:00; We 10:00-18:00; Fr 11:00-18:00"
+    // opening_hours = "Mo,We,Fr 09:00-18:00"
     Timetable[] timetables = new Timetable[1];
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(18, 0, true)),
                                   new Timespan[0], false, new int[] {2, 4, 6});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY, Calendar.MONDAY);
+    adapter.setTimetables(timetables, Calendar.MONDAY);
 
-    /* Expected parsed schedule:
-     *  0 - Mo, open
-     *  1 - Tu, closed
-     *  2 - We, open
-     *  3 - Th, closed
-     *  4 - Fr, open
+    /* Expected parsed schedule (today = Mo):
+     *  0 - Mo,    open, bold
+     *  1 - Tu,    closed
+     *  2 - We,    open
+     *  3 - Th,    closed
+     *  4 - Fr,    open
      *  5 - Sa-Su, closed
      * */
 
     List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
     assertNotNull(schedule);
     assertEquals(6, schedule.size());
-    assertFalse(schedule.get(0).isClosed); //     Mo - open
-    assertTrue(schedule.get(1).isClosed); //     Tu - closed
-    assertFalse(schedule.get(2).isClosed); //     We - open
-    assertTrue(schedule.get(3).isClosed); //     Th - closed
-    assertFalse(schedule.get(4).isClosed); //     Fr - open
-    assertTrue(schedule.get(5).isClosed); // Sa, Su - closed
+    assertFalse(schedule.get(0).isClosed); // Mo    - open
+    assertTrue(schedule.get(1).isClosed); //  Tu    - closed
+    assertFalse(schedule.get(2).isClosed); // We    - open
+    assertTrue(schedule.get(3).isClosed); //  Th    - closed
+    assertFalse(schedule.get(4).isClosed); // Fr    - open
+    assertTrue(schedule.get(5).isClosed); //  Sa-Su - closed
     assertEquals(schedule.get(5).startWeekDay, 7);
     assertEquals(schedule.get(5).endWeekDay, 1);
     assertTrue(schedule.get(0).isBold);
@@ -265,15 +186,15 @@ public class PlaceOpeningHoursAdapterTest
   @Test
   public void test_multiple_closed_days_2_sunday() throws IllegalAccessException
   {
-    // opening_hours = "Mo 09:00-18:00; We 10:00-18:00; Fr 11:00-18:00"
+    // opening_hours = "Mo,We,Fr 09:00-18:00"
     Timetable[] timetables = new Timetable[1];
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(18, 0, true)),
                                   new Timespan[0], false, new int[] {2, 4, 6});
 
-    adapter.setTimetables(timetables, Calendar.SUNDAY, Calendar.SUNDAY);
+    adapter.setTimetables(timetables, Calendar.SUNDAY);
 
-    /* Expected parsed schedule:
-     *  0 - Su, closed
+    /* Expected parsed schedule (today = Su):
+     *  0 - Su, closed, bold
      *  1 - Mo, open
      *  2 - Tu, closed
      *  3 - We, open
@@ -300,40 +221,7 @@ public class PlaceOpeningHoursAdapterTest
     assertFalse(schedule.get(3).isBold);
     assertFalse(schedule.get(4).isBold);
     assertFalse(schedule.get(5).isBold);
-    assertFalse(schedule.get(5).isBold);
-  }
-
-  @Test
-  public void test_open_weekend_sunday() throws IllegalAccessException
-  {
-    // opening_hours = "Sa-Su 9:00-24:00"
-    Timetable[] timetables = new Timetable[1];
-    timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
-                                  new Timespan[0], false, new int[] {1, 7});
-
-    adapter.setTimetables(timetables, Calendar.SUNDAY, Calendar.MONDAY);
-
-    /* Expected parsed schedule:
-     *  0 - Su, open
-     *  1 - Mo-Fr, closed
-     *  2 - Sa, open
-     * */
-
-    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
-    assertNotNull(schedule);
-    assertEquals(3, schedule.size());
-    assertFalse(schedule.get(0).isClosed); // Su - open
-    assertTrue(schedule.get(1).isClosed); // Mo-Fr - closed
-    assertFalse(schedule.get(2).isClosed); // Sa - open
-    assertEquals(schedule.get(0).startWeekDay, 1);
-    assertEquals(schedule.get(0).endWeekDay, 1);
-    assertEquals(schedule.get(1).startWeekDay, 2);
-    assertEquals(schedule.get(1).endWeekDay, 6);
-    assertEquals(schedule.get(2).startWeekDay, 7);
-    assertEquals(schedule.get(2).endWeekDay, 7);
-    assertFalse(schedule.get(0).isBold);
-    assertTrue(schedule.get(1).isBold);
-    assertFalse(schedule.get(2).isBold);
+    assertFalse(schedule.get(6).isBold);
   }
 
   @Test
@@ -344,48 +232,85 @@ public class PlaceOpeningHoursAdapterTest
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
                                   new Timespan[0], false, new int[] {1, 7});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY, Calendar.SUNDAY);
+    adapter.setTimetables(timetables, Calendar.MONDAY);
 
-    /* Expected parsed schedule:
-     *  0 - Mo-Fr, closed
+    /* Expected parsed schedule (today = Mo):
+     *  0 - Mo-Fr, closed, bold
      *  1 - Sa-Su, open
      * */
 
     List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
     assertNotNull(schedule);
     assertEquals(2, schedule.size());
-    assertTrue(schedule.get(0).isClosed); // Mo-Fr - closed
+    assertTrue(schedule.get(0).isClosed); //  Mo-Fr - closed
     assertFalse(schedule.get(1).isClosed); // Sa-Su - open
+    assertEquals(schedule.get(0).startWeekDay, 2);
+    assertEquals(schedule.get(0).endWeekDay, 6);
     assertEquals(schedule.get(1).startWeekDay, 7);
     assertEquals(schedule.get(1).endWeekDay, 1);
-    assertFalse(schedule.get(0).isBold);
-    assertTrue(schedule.get(1).isBold);
+    assertTrue(schedule.get(0).isBold);
+    assertFalse(schedule.get(1).isBold);
   }
 
   @Test
-  public void test_bold_weekend_monday() throws IllegalAccessException
+  public void test_open_weekend_sunday() throws IllegalAccessException
   {
     // opening_hours = "Sa-Su 9:00-24:00"
     Timetable[] timetables = new Timetable[1];
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
                                   new Timespan[0], false, new int[] {1, 7});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY, Calendar.SATURDAY);
+    adapter.setTimetables(timetables, Calendar.SUNDAY);
 
-    /* Expected parsed schedule:
-     *  0 - Mo-Fr, closed
-     *  1 - Sa-Su, open
+    /* Expected parsed schedule (today = Su):
+     *  0 - Su,    open, bold
+     *  1 - Mo-Fr, closed
+     *  2 - Sa,    open
+     * */
+
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    assertNotNull(schedule);
+    assertEquals(3, schedule.size());
+    assertFalse(schedule.get(0).isClosed); // Su    - open
+    assertTrue(schedule.get(1).isClosed); //  Mo-Fr - closed
+    assertFalse(schedule.get(2).isClosed); // Sa    - open
+    assertEquals(schedule.get(0).startWeekDay, 1);
+    assertEquals(schedule.get(0).endWeekDay, 1);
+    assertEquals(schedule.get(1).startWeekDay, 2);
+    assertEquals(schedule.get(1).endWeekDay, 6);
+    assertEquals(schedule.get(2).startWeekDay, 7);
+    assertEquals(schedule.get(2).endWeekDay, 7);
+    assertTrue(schedule.get(0).isBold);
+    assertFalse(schedule.get(1).isBold);
+    assertFalse(schedule.get(2).isBold);
+  }
+
+  @Test
+  public void test_open_weekend_saturday() throws IllegalAccessException
+  {
+    // opening_hours = "Sa-Su 9:00-24:00" — exercises wrap-around bold on group start=7 end=1
+    Timetable[] timetables = new Timetable[1];
+    timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
+                                  new Timespan[0], false, new int[] {1, 7});
+
+    adapter.setTimetables(timetables, Calendar.SATURDAY);
+
+    /* Expected parsed schedule (today = Sa):
+     *  0 - Sa-Su, open, bold (wrap start=7 end=1)
+     *  1 - Mo-Fr, closed
      * */
 
     List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
     assertNotNull(schedule);
     assertEquals(2, schedule.size());
-    assertTrue(schedule.get(0).isClosed); // Mo-Fr - closed
-    assertFalse(schedule.get(1).isClosed); // Sa-Su - open
-    assertEquals(schedule.get(1).startWeekDay, 7);
-    assertEquals(schedule.get(1).endWeekDay, 1);
-    assertFalse(schedule.get(0).isBold);
-    assertTrue(schedule.get(1).isBold);
+    assertFalse(schedule.get(0).isClosed); // Sa-Su - open
+    assertTrue(schedule.get(1).isClosed); //  Mo-Fr - closed
+    assertEquals(schedule.get(0).startWeekDay, 7);
+    assertEquals(schedule.get(0).endWeekDay, 1);
+    assertEquals(schedule.get(1).startWeekDay, 2);
+    assertEquals(schedule.get(1).endWeekDay, 6);
+    assertTrue(schedule.get(0).isBold);
+    assertFalse(schedule.get(1).isBold);
   }
 
   @Test
@@ -396,18 +321,43 @@ public class PlaceOpeningHoursAdapterTest
     timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(24, 0, true)),
                                   new Timespan[0], false, new int[] {1, 2, 3, 4, 5, 6, 7});
 
-    adapter.setTimetables(timetables, Calendar.MONDAY, Calendar.FRIDAY);
+    adapter.setTimetables(timetables, Calendar.FRIDAY);
 
-    /* Expected parsed schedule:
-     *  0 - Mo-Su, open
+    /* Expected parsed schedule (today = Fr):
+     *  0 - Fr-Th, open, bold (wrap start=6 end=5)
      * */
 
     List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
     assertNotNull(schedule);
     assertEquals(1, schedule.size());
-    assertFalse(schedule.get(0).isClosed); // Mo-Su - open
-    assertEquals(schedule.get(0).startWeekDay, 2);
-    assertEquals(schedule.get(0).endWeekDay, 1);
+    assertFalse(schedule.get(0).isClosed); // Fr-Th - open
+    assertEquals(schedule.get(0).startWeekDay, 6);
+    assertEquals(schedule.get(0).endWeekDay, 5);
     assertTrue(schedule.get(0).isBold);
+  }
+
+  @Test
+  public void test_expanded_week_starts_today() throws IllegalAccessException
+  {
+    // Today = Thursday(5); expected week order Th..We, with today (Thursday) first and bold,
+    // and the remaining six days collapsed into one closed group.
+    Timetable[] timetables = new Timetable[1];
+    timetables[0] = new Timetable(new Timespan(new HoursMinutes(9, 0, true), new HoursMinutes(18, 0, true)),
+                                  new Timespan[0], false, new int[] {Calendar.THURSDAY}); // open only today
+
+    adapter.setTimetables(timetables, Calendar.THURSDAY);
+
+    List<WeekScheduleData> schedule = (List<WeekScheduleData>) mWeekScheduleField.get(adapter);
+    assertNotNull(schedule);
+    assertEquals(2, schedule.size());
+    WeekScheduleData today = schedule.get(0); // today is first
+    assertEquals(Calendar.THURSDAY, today.startWeekDay);
+    assertEquals(Calendar.THURSDAY, today.endWeekDay);
+    assertFalse(today.isClosed);
+    assertTrue(today.isBold);
+    assertEquals(Calendar.FRIDAY, schedule.get(1).startWeekDay); // rest of the week is closed
+    assertEquals(Calendar.WEDNESDAY, schedule.get(1).endWeekDay);
+    assertTrue(schedule.get(1).isClosed);
+    assertFalse(schedule.get(1).isBold);
   }
 }


### PR DESCRIPTION
Show the expanded weekly schedule starting from today: today is the first row and bold, right below the collapsed "today" preview. Replaces the locale-first-day ordering, which is no longer used. Also drops the now redundant `firstDayOfWeek` parameter from `PlaceOpeningHoursAdapter.setTimetables()` and rewrites the affected tests accordingly.

Tuesday:
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/38e4b800-8858-4a18-8401-94c5597bea36" />

Sunday:
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/f97aa234-cb76-4258-9c36-9eed4a6c758c" />


@strider-dunadan please test and review. Related to https://github.com/organicmaps/organicmaps/pull/12077/