### PR TITLE
routing: Add real-time online ALPR camera avoidance and warning alerts

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1357,6 +1357,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
     Logger.i(TAG, "Driving options warning: the built route uses roads that could be avoided");
   }
 
+  @Override
+  public void onRouteHasAlprs()
+  {
+    Toast.makeText(this, getString(R.string.driving_options_warning_alprs), Toast.LENGTH_LONG).show();
+  }
+
   public boolean showRoutingDisclaimer()
   {
     if (Config.isRoutingDisclaimerAccepted())

--- a/android/app/src/main/java/app/organicmaps/settings/DrivingOptionsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/DrivingOptionsFragment.java
@@ -13,6 +13,7 @@ import androidx.core.view.ViewCompat;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmToolbarFragment;
 import app.organicmaps.sdk.routing.RoutingOptions;
+import app.organicmaps.sdk.util.Config;
 import app.organicmaps.sdk.settings.RoadType;
 import app.organicmaps.util.WindowInsetUtils.PaddingInsetsListener;
 import java.util.ArrayList;
@@ -28,6 +29,7 @@ public class DrivingOptionsFragment extends BaseMwmToolbarFragment
   @NonNull
   private Set<RoadType> mRoadTypes = Collections.emptySet();
   private View mContent;
+  private boolean mInitialStrictAlprsAvoidance;
 
   @Nullable
   @Override
@@ -40,6 +42,7 @@ public class DrivingOptionsFragment extends BaseMwmToolbarFragment
     mRoadTypes = savedInstanceState != null && savedInstanceState.containsKey(BUNDLE_ROAD_TYPES)
                    ? makeRouteTypes(savedInstanceState)
                    : RoutingOptions.getActiveRoadTypes();
+    mInitialStrictAlprsAvoidance = Config.isStrictAlprsAvoidance();
     return root;
   }
 
@@ -70,7 +73,7 @@ public class DrivingOptionsFragment extends BaseMwmToolbarFragment
   private boolean areSettingsNotChanged()
   {
     Set<RoadType> lastActiveRoadTypes = RoutingOptions.getActiveRoadTypes();
-    return mRoadTypes.equals(lastActiveRoadTypes);
+    return mRoadTypes.equals(lastActiveRoadTypes) && mInitialStrictAlprsAvoidance == Config.isStrictAlprsAvoidance();
   }
 
   @Override
@@ -112,6 +115,26 @@ public class DrivingOptionsFragment extends BaseMwmToolbarFragment
     dirtyRoadsBtn.setChecked(RoutingOptions.hasOption(RoadType.Dirty));
     CompoundButton.OnCheckedChangeListener dirtyBtnListener = new ToggleRoutingOptionListener(RoadType.Dirty);
     dirtyRoadsBtn.setOnCheckedChangeListener(dirtyBtnListener);
+
+    SwitchCompat alprsBtn = root.findViewById(R.id.avoid_alprs_btn);
+    alprsBtn.setChecked(RoutingOptions.hasOption(RoadType.ALPR));
+
+    final View strictContainer = root.findViewById(R.id.strict_avoidance_container);
+    strictContainer.setVisibility(alprsBtn.isChecked() ? View.VISIBLE : View.GONE);
+
+    alprsBtn.setOnCheckedChangeListener((buttonView, isChecked) -> {
+      if (isChecked)
+        RoutingOptions.addOption(RoadType.ALPR);
+      else
+        RoutingOptions.removeOption(RoadType.ALPR);
+      strictContainer.setVisibility(isChecked ? View.VISIBLE : View.GONE);
+    });
+
+    SwitchCompat strictBtn = root.findViewById(R.id.strict_alprs_btn);
+    strictBtn.setChecked(Config.isStrictAlprsAvoidance());
+    strictBtn.setOnCheckedChangeListener((buttonView, isChecked) -> {
+      Config.setStrictAlprsAvoidance(isChecked);
+    });
   }
 
   private static class ToggleRoutingOptionListener implements CompoundButton.OnCheckedChangeListener

--- a/android/app/src/main/res/layout/fragment_driving_options.xml
+++ b/android/app/src/main/res/layout/fragment_driving_options.xml
@@ -109,5 +109,51 @@
       android:padding="@dimen/margin_half_double_plus"
       android:layout_height="match_parent"/>
   </LinearLayout>
+  <include layout="@layout/list_divider"/>
+  <LinearLayout
+    android:orientation="horizontal"
+    android:minHeight="@dimen/height_block_base"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingEnd="@dimen/margin_base"
+    android:paddingStart="@dimen/margin_base">
+    <TextView
+      android:text="@string/avoid_alprs"
+      android:textAppearance="?android:attr/textAppearanceMedium"
+      android:layout_width="0dp"
+      android:layout_weight="1"
+      android:layout_gravity="center_vertical"
+      android:layout_height="wrap_content"
+      android:textColor="?android:attr/textColorPrimary"/>
+    <androidx.appcompat.widget.SwitchCompat
+      android:id="@+id/avoid_alprs_btn"
+      android:layout_width="wrap_content"
+      android:padding="@dimen/margin_half_double_plus"
+      android:layout_height="match_parent"/>
+  </LinearLayout>
+  <!-- ALPR strict avoidance (detours) option -->
+  <LinearLayout
+    android:id="@+id/strict_avoidance_container"
+    android:orientation="horizontal"
+    android:minHeight="@dimen/height_block_base"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingEnd="@dimen/margin_base"
+    android:paddingStart="@dimen/margin_double"
+    android:visibility="gone">
+    <TextView
+      android:text="@string/strict_alprs_avoidance"
+      android:textAppearance="?android:attr/textAppearanceMedium"
+      android:layout_width="0dp"
+      android:layout_weight="1"
+      android:layout_gravity="center_vertical"
+      android:layout_height="wrap_content"
+      android:textColor="?android:attr/textColorPrimary"/>
+    <androidx.appcompat.widget.SwitchCompat
+      android:id="@+id/strict_alprs_btn"
+      android:layout_width="wrap_content"
+      android:padding="@dimen/margin_half_double_plus"
+      android:layout_height="match_parent"/>
+  </LinearLayout>
   </LinearLayout>
 </LinearLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -682,6 +682,9 @@
     <!-- Recommended length for CarPlay and Android Auto is around 25-27 characters -->
     <string name="avoid_ferry">Avoid ferries</string>
     <string name="avoid_motorways">Avoid freeways</string>
+    <string name="avoid_alprs">Avoid surveillance cameras</string>
+    <string name="strict_alprs_avoidance">Strict avoidance (calculate detours)</string>
+    <string name="driving_options_warning_alprs">This route includes surveillance cameras!</string>
     <string name="unable_to_calc_alert_title">Unable to calculate route</string>
     <string name="unable_to_calc_alert_subtitle">A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</string>
     <string name="define_to_avoid_btn">Define roads to avoid</string>

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/routing/RouteRecommendationType.hpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/routing/RouteRecommendationType.hpp
@@ -30,9 +30,31 @@ jobject GetRebuildAfterPointsLoading(JNIEnv * env)
 
 jobject GetRouteRecommendationType(JNIEnv * env, RoutingManager::Recommendation recommendation)
 {
-  switch (recommendation)
+  static jobject rebuildAfterPointsLoading = nullptr;
+  static jobject hasAlprs = nullptr;
+
+  jclass routeRecommendationTypeClass = env->FindClass("app/organicmaps/sdk/routing/RouteRecommendationType");
+  ASSERT(routeRecommendationTypeClass, ());
+
+  jmethodID valuesMethod = env->GetStaticMethodID(routeRecommendationTypeClass, "values",
+                                                  "()[Lapp/organicmaps/sdk/routing/RouteRecommendationType;");
+  ASSERT(valuesMethod, ());
+
+  jobjectArray enumConstants = (jobjectArray)env->CallStaticObjectMethod(routeRecommendationTypeClass, valuesMethod);
+  ASSERT(enumConstants, ());
+
+  if (recommendation == RoutingManager::Recommendation::RebuildAfterPointsLoading)
   {
-  case RoutingManager::Recommendation::RebuildAfterPointsLoading: return GetRebuildAfterPointsLoading(env);
-  default: ASSERT_FAIL("Unknown recommendation type");
+    if (!rebuildAfterPointsLoading)
+      rebuildAfterPointsLoading = env->NewGlobalRef(env->GetObjectArrayElement(enumConstants, 0));
+    return rebuildAfterPointsLoading;
   }
+  else if (recommendation == RoutingManager::Recommendation::HasAlprs)
+  {
+    if (!hasAlprs)
+      hasAlprs = env->NewGlobalRef(env->GetObjectArrayElement(enumConstants, 1));
+    return hasAlprs;
+  }
+
+  ASSERT_FAIL("Unknown recommendation type");
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/routing/RouteRecommendationType.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/routing/RouteRecommendationType.java
@@ -2,5 +2,6 @@ package app.organicmaps.sdk.routing;
 
 public enum RouteRecommendationType
 {
-  RebuildAfterPointsLoading
+  RebuildAfterPointsLoading,
+  HasAlprs
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
@@ -47,6 +47,7 @@ public class RoutingController
     default void onResetToPlanningState() {}
     default void onBuiltRoute() {}
     default void onDrivingOptionsWarning() {}
+    default void onRouteHasAlprs() {}
 
     default void onCommonBuildError(int lastResultCode, @NonNull String[] lastMissingMaps) {}
     default void onDrivingOptionsBuildError() {}
@@ -241,6 +242,10 @@ public class RoutingController
     Framework.nativeSetRoutingRecommendationListener(recommendation -> UiThread.run(() -> {
       if (recommendation == RouteRecommendationType.RebuildAfterPointsLoading)
         setStartPoint(locationHelper.getMyPosition());
+      else if (recommendation == RouteRecommendationType.HasAlprs) {
+        if (mContainer != null)
+          mContainer.onRouteHasAlprs();
+      }
     }));
     Framework.nativeSetRoutingLoadPointsListener(mRoutingLoadPointsListener);
   }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/settings/RoadType.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/settings/RoadType.java
@@ -6,5 +6,7 @@ public enum RoadType
   Toll,
   Motorway,
   Ferry,
-  Dirty
+  Dirty,
+  Steps,
+  ALPR
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/util/Config.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/util/Config.java
@@ -476,6 +476,16 @@ public final class Config
     setBool(KEY_PREF_SEARCH_HISTORY, enabled);
   }
 
+  public static boolean isStrictAlprsAvoidance()
+  {
+    return getBool("alpr_strict_avoidance", false);
+  }
+
+  public static void setStrictAlprsAvoidance(boolean enabled)
+  {
+    setBool("alpr_strict_avoidance", enabled);
+  }
+
   public static class TTS
   {
     interface Keys

--- a/libs/map/CMakeLists.txt
+++ b/libs/map/CMakeLists.txt
@@ -39,6 +39,8 @@ set(SRC
   isolines_manager.hpp
   mwm_url.cpp
   mwm_url.hpp
+  online_camera_fetcher.cpp
+  online_camera_fetcher.hpp
   place_page_info.cpp
   place_page_info.hpp
   selection_processor.cpp

--- a/libs/map/online_camera_fetcher.cpp
+++ b/libs/map/online_camera_fetcher.cpp
@@ -1,0 +1,198 @@
+#include "libs/map/online_camera_fetcher.hpp"
+
+#include "routing/speed_camera.hpp"
+#include "coding/url.hpp"
+
+#include "platform/http_client.hpp"
+#include "platform/measurement_utils.hpp"
+#include "platform/platform.hpp"
+
+#include "geometry/mercator.hpp"
+
+#include "base/logging.hpp"
+
+#include <glaze/json.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <chrono>
+#include <mutex>
+
+namespace routing
+{
+struct OverpassNode
+{
+  double lat = 0.0;
+  double lon = 0.0;
+  std::map<std::string, std::string> tags;
+};
+
+struct OverpassResponse
+{
+  std::vector<OverpassNode> elements;
+};
+}  // namespace routing
+
+
+
+namespace
+{
+double ParseSpeedLimit(std::string const & maxspeedTag)
+{
+  if (maxspeedTag.empty())
+    return routing::SpeedCameraOnRoute::kNoSpeedInfo;
+
+  try
+  {
+    size_t const firstDigit = maxspeedTag.find_first_of("0123456789");
+    if (firstDigit == std::string::npos)
+      return routing::SpeedCameraOnRoute::kNoSpeedInfo;
+
+    size_t const lastDigit = maxspeedTag.find_last_of("0123456789");
+    std::string const numStr = maxspeedTag.substr(firstDigit, lastDigit - firstDigit + 1);
+
+    double val = std::stod(numStr);
+    if (maxspeedTag.find("mph") != std::string::npos)
+      val = measurement_utils::MiphToKmph(val);
+
+    return val;
+  }
+  catch (...)
+  {
+    return routing::SpeedCameraOnRoute::kNoSpeedInfo;
+  }
+}
+}  // namespace
+
+namespace routing
+{
+namespace
+{
+// Query cache variables
+double s_lastSouth = 0.0;
+double s_lastWest = 0.0;
+double s_lastNorth = 0.0;
+double s_lastEast = 0.0;
+std::vector<OnlineCamera> s_lastCameras;
+std::chrono::steady_clock::time_point s_lastQueryTime;
+std::mutex s_cacheMutex;
+}  // namespace
+
+// static
+void OnlineCameraFetcher::FetchCamerasNearRect(m2::RectD const & rect, Callback const & callback)
+{
+  GetPlatform().RunTask(Platform::Thread::Network, [rect, callback]()
+  {
+    ms::LatLon minLatLon = mercator::ToLatLon(rect.LeftBottom());
+    ms::LatLon maxLatLon = mercator::ToLatLon(rect.RightTop());
+
+    // Privacy protection: align to coarse 0.1 degree grid
+    double const gridStep = 0.1;
+    double const south = std::floor(std::min(minLatLon.m_lat, maxLatLon.m_lat) / gridStep) * gridStep;
+    double const west = std::floor(std::min(minLatLon.m_lon, maxLatLon.m_lon) / gridStep) * gridStep;
+    double const north = std::ceil(std::max(minLatLon.m_lat, maxLatLon.m_lat) / gridStep) * gridStep;
+    double const east = std::ceil(std::max(minLatLon.m_lon, maxLatLon.m_lon) / gridStep) * gridStep;
+
+    {
+      std::lock_guard<std::mutex> lock(s_cacheMutex);
+      auto const now = std::chrono::steady_clock::now();
+      if (south == s_lastSouth && west == s_lastWest && north == s_lastNorth && east == s_lastEast &&
+          std::chrono::duration_cast<std::chrono::seconds>(now - s_lastQueryTime).count() < 5)
+      {
+        std::vector<OnlineCamera> cachedCams = s_lastCameras;
+        GetPlatform().RunTask(Platform::Thread::Gui, [callback, cachedCams = std::move(cachedCams)]()
+        {
+          callback(cachedCams);
+        });
+        return;
+      }
+    }
+
+    if ((north - south) > 5.0 || (east - west) > 5.0)
+    {
+      LOG(LWARNING, ("Query bounding box is too large for online fetch, skipping:", south, west, north, east));
+      return;
+    }
+
+    std::string const query = "[out:json][timeout:15];\n"
+                              "(\n"
+                              "  node[\"highway\"=\"speed_camera\"](" +
+                              std::to_string(south) + "," + std::to_string(west) + "," +
+                              std::to_string(north) + "," + std::to_string(east) + ");\n"
+                              "  node[\"man_made\"=\"surveillance\"][\"surveillance:type\"=\"ALPR\"](" +
+                              std::to_string(south) + "," + std::to_string(west) + "," +
+                              std::to_string(north) + "," + std::to_string(east) + ");\n"
+                              "  node[\"man_made\"=\"surveillance\"][\"surveillance:type\"=\"alpr\"](" +
+                              std::to_string(south) + "," + std::to_string(west) + "," +
+                              std::to_string(north) + "," + std::to_string(east) + ");\n"
+                              "  node[\"man_made\"=\"surveillance\"][\"surveillance\"=\"traffic\"](" +
+                              std::to_string(south) + "," + std::to_string(west) + "," +
+                              std::to_string(north) + "," + std::to_string(east) + ");\n"
+                              ");\n"
+                              "out body;";
+
+    platform::HttpClient request("https://overpass-api.de/api/interpreter");
+    request.SetBodyData("data=" + url::UrlEncode(query), "application/x-www-form-urlencoded");
+    request.SetRawHeader("User-Agent", "OrganicMaps/1.0 (https://organicmaps.app)");
+    request.SetTimeout(15.0);
+
+    if (request.RunHttpRequest() && !request.WasRedirected() && request.ErrorCode() == 200)
+    {
+      std::string const response = request.ServerResponse();
+      routing::OverpassResponse responseObj;
+      glz::opts constexpr opts{.error_on_unknown_keys = false, .error_on_missing_keys = false};
+      auto const error = glz::read<opts>(responseObj, response);
+      if (!error)
+      {
+        std::vector<OnlineCamera> cameras;
+        for (auto const & node : responseObj.elements)
+        {
+          OnlineCamera cam;
+          cam.m_point = mercator::FromLatLon(node.lat, node.lon);
+
+          auto const itSurveillance = node.tags.find("man_made");
+          if (itSurveillance != node.tags.end() && itSurveillance->second == "surveillance")
+          {
+            cam.m_isAlpr = true;
+            cam.m_speedLimitKmPH = SpeedCameraOnRoute::kAlprCameraSpeed;
+          }
+          else
+          {
+            cam.m_isAlpr = false;
+            auto const itSpeed = node.tags.find("maxspeed");
+            if (itSpeed != node.tags.end())
+              cam.m_speedLimitKmPH = ParseSpeedLimit(itSpeed->second);
+            else
+              cam.m_speedLimitKmPH = SpeedCameraOnRoute::kNoSpeedInfo;
+          }
+          cameras.emplace_back(std::move(cam));
+        }
+
+        {
+          std::lock_guard<std::mutex> lock(s_cacheMutex);
+          s_lastSouth = south;
+          s_lastWest = west;
+          s_lastNorth = north;
+          s_lastEast = east;
+          s_lastCameras = cameras;
+          s_lastQueryTime = std::chrono::steady_clock::now();
+        }
+
+        GetPlatform().RunTask(Platform::Thread::Gui, [callback, cameras = std::move(cameras)]()
+        {
+          callback(cameras);
+        });
+      }
+      else
+      {
+        LOG(LWARNING, ("Failed to parse Overpass response:", glz::format_error(error, response)));
+      }
+    }
+    else
+    {
+      LOG(LWARNING, ("Failed to fetch cameras from Overpass API. Code:", request.ErrorCode()));
+    }
+  });
+}
+}  // namespace routing

--- a/libs/map/online_camera_fetcher.hpp
+++ b/libs/map/online_camera_fetcher.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "geometry/rect2d.hpp"
+#include "geometry/point2d.hpp"
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace routing
+{
+struct OnlineCamera
+{
+  m2::PointD m_point;
+  bool m_isAlpr = false;
+  double m_speedLimitKmPH = 0.0;
+};
+
+class OnlineCameraFetcher
+{
+public:
+  using Callback = std::function<void(std::vector<OnlineCamera> const &)>;
+
+  static void FetchCamerasNearRect(m2::RectD const & rect, Callback const & callback);
+};
+}  // namespace routing

--- a/libs/map/routing_manager.cpp
+++ b/libs/map/routing_manager.cpp
@@ -1,6 +1,8 @@
 #include "routing_manager.hpp"
 
 #include "map/routing_mark.hpp"
+#include "map/online_camera_fetcher.hpp"
+#include "platform/settings.hpp"
 
 #include "routing/absent_regions_finder.hpp"
 #include "routing/checkpoint_predictor.hpp"
@@ -9,6 +11,9 @@
 #include "routing/routing_callbacks.hpp"
 #include "routing/ruler_router.hpp"
 #include "routing/speed_camera.hpp"
+#include "routing/index_graph_loader.hpp"
+#include "routing/index_graph.hpp"
+#include "routing/speed_camera_ser_des.hpp"
 
 #include "storage/country_info_getter.hpp"
 #include "storage/routing_helpers.hpp"
@@ -347,6 +352,12 @@ RoutingManager::RoutingManager(Callbacks && callbacks, Delegate & delegate)
       if (cameraSpeedKmPH == SpeedCameraOnRoute::kNoSpeedInfo)
         return;
 
+      if (cameraSpeedKmPH == SpeedCameraOnRoute::kAlprCameraSpeed)
+      {
+        mark->SetTitle("ALPR");
+        return;
+      }
+
       double speed = cameraSpeedKmPH;
       if (measurement_utils::GetMeasurementUnits() == measurement_utils::Units::Imperial)
         speed = measurement_utils::KmphToMiph(cameraSpeedKmPH);
@@ -359,7 +370,10 @@ RoutingManager::RoutingManager(Callbacks && callbacks, Delegate & delegate)
   {
     GetPlatform().RunTask(Platform::Thread::Gui, [this]()
     {
-      m_bmManager->GetEditSession().ClearGroup(UserMark::Type::SPEED_CAM);
+      m_bmManager->GetEditSession().DeleteUserMarks<SpeedCameraMark>(UserMark::Type::SPEED_CAM, [](SpeedCameraMark const * mark)
+      {
+        return mark->GetTitle() != "ALPR";
+      });
       if (m_routeSpeedCamsClearCallback)
         m_routeSpeedCamsClearCallback();
     });
@@ -543,6 +557,10 @@ void RoutingManager::RemoveRoute(bool deactivateFollowing)
 
   if (deactivateFollowing)
   {
+    {
+      std::lock_guard<std::mutex> lock(routing::g_dynamicAlprsMutex);
+      routing::g_dynamicBlockedAlprs.clear();
+    }
     m_transitReadManager->BlockTransitSchemeMode(false /* isBlocked */);
     // Remove all subroutes.
     m_drapeEngine.SafeCall(&df::DrapeEngine::RemoveSubroute, dp::DrapeID(), true /* deactivateFollowing */);
@@ -683,6 +701,262 @@ void RoutingManager::CollectRoadPointWarnings(std::vector<routing::RouteSegment>
 
       marks.push_back(RoadInfo(center, featureId));
     }, rect, scales::GetUpperScale(), mwmId);
+  }
+}
+
+void RoutingManager::ShowAlprsNearRoute(std::vector<routing::RouteSegment> const & segments, m2::PointD const & startPt)
+{
+  if (m_bmManager == nullptr)
+    return;
+
+  LOG(LINFO, ("ShowAlprsNearRoute called. Segments count:", segments.size()));
+
+  std::set<MwmSet::MwmId> mwmIds;
+  for (auto const & segment : segments)
+  {
+    if (segment.GetSegment().IsRealSegment())
+      mwmIds.insert(GetMwmId(segment.GetSegment().GetMwmId()));
+  }
+
+  std::vector<m2::PointD> routePoints;
+  routePoints.reserve(segments.size() + 1);
+  routePoints.push_back(startPt);
+  for (auto const & segment : segments)
+  {
+    routePoints.push_back(segment.GetJunction().GetPoint());
+  }
+
+  double const maxMercatorDist = mercator::MetersToMercator(60.0);
+  double const maxSqMercatorDist = maxMercatorDist * maxMercatorDist;
+
+  // Build spatial chunks of the route to optimize distance queries
+  size_t const kChunkSize = 64;
+  struct RouteChunk
+  {
+    m2::RectD m_rect;
+    size_t m_startIdx = 0;
+    size_t m_endIdx = 0;
+  };
+
+  std::vector<RouteChunk> chunks;
+  chunks.reserve((routePoints.size() + kChunkSize - 1) / kChunkSize);
+  for (size_t i = 1; i < routePoints.size(); i += kChunkSize)
+  {
+    RouteChunk chunk;
+    chunk.m_startIdx = i;
+    chunk.m_endIdx = std::min(i + kChunkSize, routePoints.size());
+    for (size_t j = chunk.m_startIdx - 1; j < chunk.m_endIdx; ++j)
+    {
+      chunk.m_rect.Add(routePoints[j]);
+    }
+    chunk.m_rect.Inflate(maxMercatorDist, maxMercatorDist);
+    chunks.push_back(chunk);
+  }
+
+  // Calculate the overall bounding box of the route (for online query)
+  m2::RectD routeRect;
+  for (auto const & pt : routePoints)
+    routeRect.Add(pt);
+
+  DataSource const & dataSource = m_callbacks.m_dataSourceGetter();
+  std::vector<m2::PointD> alprCameraPoints;
+
+  for (auto const & mwmId : mwmIds)
+  {
+    if (!mwmId.IsAlive())
+      continue;
+
+    MwmSet::MwmHandle handle = dataSource.GetMwmHandleById(mwmId);
+    if (!handle.IsAlive())
+      continue;
+
+    MwmValue const & mwmValue = *handle.GetValue();
+    routing::SpeedCamerasMapT camerasMap;
+    if (!routing::ReadSpeedCamsFromMwm(mwmValue, camerasMap))
+      continue;
+
+    FeaturesLoaderGuard guard(dataSource, mwmId);
+
+    for (auto const & [segmentCoord, speedCams] : camerasMap)
+    {
+      for (auto const & cam : speedCams)
+      {
+        if (cam.m_maxSpeedKmPH == SpeedCameraOnRoute::kAlprCameraSpeed)
+        {
+          auto const featureId = segmentCoord.GetFeatureId();
+          auto const pointIdx = segmentCoord.GetPointId();
+          auto ft = guard.GetFeatureByIndex(featureId);
+          if (ft && pointIdx < ft->GetPointsCount())
+          {
+            m2::PointD const pt = ft->GetPoint(pointIdx);
+
+            bool nearRoute = false;
+            for (auto const & chunk : chunks)
+            {
+              if (!chunk.m_rect.IsPointInside(pt))
+                continue;
+
+              for (size_t i = chunk.m_startIdx; i < chunk.m_endIdx; ++i)
+              {
+                m2::PointD const & p0 = routePoints[i - 1];
+                m2::PointD const & p1 = routePoints[i];
+
+                // Fast bounding box check for the individual segment
+                double const minX = std::min(p0.x, p1.x) - maxMercatorDist;
+                double const maxX = std::max(p0.x, p1.x) + maxMercatorDist;
+                double const minY = std::min(p0.y, p1.y) - maxMercatorDist;
+                double const maxY = std::max(p0.y, p1.y) + maxMercatorDist;
+                if (pt.x < minX || pt.x > maxX || pt.y < minY || pt.y > maxY)
+                  continue;
+
+                m2::ParametrizedSegment<m2::PointD> lineSeg(p0, p1);
+                double const sqDist = lineSeg.SquaredDistanceToPoint(pt);
+                if (sqDist <= maxSqMercatorDist)
+                {
+                  nearRoute = true;
+                  break;
+                }
+              }
+              if (nearRoute)
+                break;
+            }
+
+            if (nearRoute)
+            {
+              if (std::find_if(alprCameraPoints.begin(), alprCameraPoints.end(), [&](m2::PointD const & p) {
+                    return p.EqualDxDy(pt, mercator::kPointEqualityEps);
+                  }) == alprCameraPoints.end())
+              {
+                alprCameraPoints.push_back(pt);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Draw offline cameras
+  if (!alprCameraPoints.empty())
+  {
+    GetPlatform().RunTask(Platform::Thread::Gui, [this, alprCameraPoints]()
+    {
+      auto editSession = m_bmManager->GetEditSession();
+      for (auto const & pt : alprCameraPoints)
+      {
+        auto mark = editSession.CreateUserMark<SpeedCameraMark>(pt);
+        mark->SetIndex(0);
+        mark->SetTitle("ALPR");
+      }
+    });
+  }
+
+  // Fetch online cameras if enabled
+  bool fetchOnline = true;
+  (void)settings::Get("realtime_cameras_online", fetchOnline);
+  if (fetchOnline)
+  {
+    OnlineCameraFetcher::FetchCamerasNearRect(routeRect, [this, chunks = std::move(chunks), routePoints = std::move(routePoints), maxMercatorDist, maxSqMercatorDist, segments](std::vector<OnlineCamera> const & onlineCameras)
+    {
+      if (m_bmManager == nullptr)
+        return;
+
+      LOG(LINFO, ("FetchCamerasNearRect callback fired. Received count:", onlineCameras.size()));
+
+      bool addedNewBlockedAlprs = false;
+      bool const avoidAlprs = routing::RoutingOptions::LoadCarOptionsFromSettings().Has(routing::RoutingOptions::Road::ALPR);
+      bool alprStrict = false;
+      (void)settings::Get("alpr_strict_avoidance", alprStrict);
+      bool const doStrictAvoidance = avoidAlprs && alprStrict;
+
+      std::vector<OnlineCamera> filteredCameras;
+      for (auto const & cam : onlineCameras)
+      {
+        bool nearRoute = false;
+        for (auto const & chunk : chunks)
+        {
+          if (!chunk.m_rect.IsPointInside(cam.m_point))
+            continue;
+
+          for (size_t i = chunk.m_startIdx; i < chunk.m_endIdx; ++i)
+          {
+            m2::PointD const & p0 = routePoints[i - 1];
+            m2::PointD const & p1 = routePoints[i];
+
+            // Fast bounding box check for the individual segment
+            double const minX = std::min(p0.x, p1.x) - maxMercatorDist;
+            double const maxX = std::max(p0.x, p1.x) + maxMercatorDist;
+            double const minY = std::min(p0.y, p1.y) - maxMercatorDist;
+            double const maxY = std::max(p0.y, p1.y) + maxMercatorDist;
+            if (cam.m_point.x < minX || cam.m_point.x > maxX || cam.m_point.y < minY || cam.m_point.y > maxY)
+              continue;
+
+            m2::ParametrizedSegment<m2::PointD> lineSeg(p0, p1);
+            double const sqDist = lineSeg.SquaredDistanceToPoint(cam.m_point);
+            if (sqDist <= maxSqMercatorDist)
+            {
+              nearRoute = true;
+              if (cam.m_isAlpr && doStrictAvoidance && i - 1 < segments.size())
+              {
+                auto const & seg = segments[i - 1].GetSegment();
+                if (seg.IsRealSegment())
+                {
+                  std::lock_guard<std::mutex> lock(routing::g_dynamicAlprsMutex);
+                  auto rp1 = seg.GetRoadPoint(false);
+                  auto rp2 = seg.GetRoadPoint(true);
+                  if (routing::g_dynamicBlockedAlprs.count(rp1) == 0 ||
+                      routing::g_dynamicBlockedAlprs.count(rp2) == 0)
+                  {
+                    routing::g_dynamicBlockedAlprs.insert(rp1);
+                    routing::g_dynamicBlockedAlprs.insert(rp2);
+                    addedNewBlockedAlprs = true;
+                  }
+                }
+              }
+              break;
+            }
+          }
+          if (nearRoute)
+            break;
+        }
+
+        if (nearRoute)
+        {
+          filteredCameras.push_back(cam);
+        }
+      }
+
+      LOG(LINFO, ("Filtered online cameras near route count:", filteredCameras.size()));
+
+      if (addedNewBlockedAlprs)
+      {
+        LOG(LINFO, ("Found ALPRs on route with ALPR avoidance enabled. Rebuilding route around them."));
+        BuildRoute();
+        return;
+      }
+
+      if (filteredCameras.empty())
+        return;
+
+      auto editSession = m_bmManager->GetEditSession();
+      bool createdAlprMark = false;
+      for (auto const & cam : filteredCameras)
+      {
+        if (cam.m_isAlpr)
+        {
+          auto mark = editSession.CreateUserMark<SpeedCameraMark>(cam.m_point);
+          mark->SetIndex(0);
+          mark->SetTitle("ALPR");
+          LOG(LINFO, ("Created navigation ALPR mark at point:", mercator::ToLatLon(cam.m_point)));
+          createdAlprMark = true;
+        }
+      }
+
+      if (createdAlprMark && m_routeRecommendCallback)
+      {
+        m_routeRecommendCallback(Recommendation::HasAlprs);
+      }
+    });
   }
 }
 
@@ -924,6 +1198,7 @@ void RoutingManager::InsertSingleRoute(RouteBase const & route, bool isActive, d
       CollectRoadWarnings(segments, startPt, subroute->m_baseDistance, roadWarnings);
       CollectRoadPointWarnings(segments, startPt, roadWarnings);
     }
+    ShowAlprsNearRoute(segments, startPt);
 
     auto const subrouteId =
         m_drapeEngine.SafeCallWithResult(&df::DrapeEngine::AddSubroute, df::SubrouteConstPtr(subroute.release()));

--- a/libs/map/routing_manager.hpp
+++ b/libs/map/routing_manager.hpp
@@ -107,6 +107,7 @@ public:
     // after restoring route points from file. In this case we can
     // rebuild route using "my position".
     RebuildAfterPointsLoading = 0,
+    HasAlprs = 1,
   };
   using RouteRecommendCallback = std::function<void(Recommendation)>;
 
@@ -316,6 +317,7 @@ private:
   // Point warnings (gate/lift_gate): barrier features sitting exactly on a route vertex.
   void CollectRoadPointWarnings(std::vector<routing::RouteSegment> const & segments, m2::PointD const & startPt,
                                 RoadWarningsCollection & roadWarnings);
+  void ShowAlprsNearRoute(std::vector<routing::RouteSegment> const & segments, m2::PointD const & startPt);
   void CreateRoadWarningMarks(RoadWarningsCollection && roadWarnings);
 
   // Creates an ETA balloon (RouteAltMark) at the midpoint of each route variant in |result|.

--- a/libs/map/routing_mark.cpp
+++ b/libs/map/routing_mark.cpp
@@ -653,12 +653,18 @@ void SpeedCameraMark::SetIndex(uint32_t index)
 
 drape_ptr<df::UserPointMark::SymbolNameZoomInfo> SpeedCameraMark::GetSymbolNames() const
 {
-  return make_unique_dp<SymbolNameZoomInfo>(m_symbolNames);
+  auto symbolNames = m_symbolNames;
+  if (m_titleDecl.m_primaryText == "ALPR")
+  {
+    symbolNames.clear();
+    symbolNames.insert(std::make_pair(10, "speedcam-alert-l"));
+  }
+  return make_unique_dp<SymbolNameZoomInfo>(symbolNames);
 }
 
 drape_ptr<df::UserPointMark::TitlesInfo> SpeedCameraMark::GetTitleDecl() const
 {
-  if (m_titleDecl.m_primaryText.empty())
+  if (m_titleDecl.m_primaryText.empty() || m_titleDecl.m_primaryText == "ALPR")
     return nullptr;
   auto titleInfo = make_unique_dp<TitlesInfo>();
   titleInfo->push_back(m_titleDecl);
@@ -667,18 +673,23 @@ drape_ptr<df::UserPointMark::TitlesInfo> SpeedCameraMark::GetTitleDecl() const
 
 drape_ptr<df::UserPointMark::ColoredSymbolZoomInfo> SpeedCameraMark::GetColoredSymbols() const
 {
-  if (m_titleDecl.m_primaryText.empty())
+  if (m_titleDecl.m_primaryText.empty() || m_titleDecl.m_primaryText == "ALPR")
     return nullptr;
-  return make_unique_dp<ColoredSymbolZoomInfo>(m_textBg);
+  auto textBg = m_textBg;
+  return make_unique_dp<ColoredSymbolZoomInfo>(textBg);
 }
 
 int SpeedCameraMark::GetMinZoom() const
 {
+  if (m_titleDecl.m_primaryText == "ALPR")
+    return 10;
   return kMinSpeedCameraZoom;
 }
 
 int SpeedCameraMark::GetMinTitleZoom() const
 {
+  if (m_titleDecl.m_primaryText == "ALPR")
+    return 10;
   return kMinSpeedCameraTitleZoom;
 }
 

--- a/libs/routing/index_graph.cpp
+++ b/libs/routing/index_graph.cpp
@@ -2,6 +2,7 @@
 
 #include "routing/restrictions_serialization.hpp"
 #include "routing/routing_options.hpp"
+#include "routing/speed_camera.hpp"
 #include "routing/world_graph.hpp"
 
 #include "base/assert.hpp"
@@ -14,6 +15,9 @@
 
 namespace routing
 {
+std::mutex g_dynamicAlprsMutex;
+std::set<RoadPoint> g_dynamicBlockedAlprs;
+
 using namespace base;
 
 bool IsUTurn(Segment const & u, Segment const & v)
@@ -220,6 +224,22 @@ void IndexGraph::SetRoadAccess(RoadAccess && roadAccess)
   m_roadAccess.SetCurrentTimeGetter(m_currentTimeGetter);
 }
 
+void IndexGraph::SetSpeedCameras(std::map<RoadPoint, std::vector<RouteSegment::SpeedCamera>> const & cameras)
+{
+  m_alprSegments.clear();
+  for (auto const & [segment, camerasList] : cameras)
+  {
+    for (auto const & camera : camerasList)
+    {
+      if (camera.m_maxSpeedKmPH == SpeedCameraOnRoute::kAlprCameraSpeed)
+      {
+        m_alprSegments.insert(segment);
+        break;
+      }
+    }
+  }
+}
+
 void IndexGraph::GetNeighboringEdges(astar::VertexData<Segment, RouteWeight> const & fromVertexData,
                                      RoadPoint const & rp, bool isOutgoing, bool useRoutingOptions,
                                      SegmentEdgeListT & edges, Parents<Segment> const & parents,
@@ -237,14 +257,32 @@ void IndexGraph::GetNeighboringEdges(astar::VertexData<Segment, RouteWeight> con
   auto const & from = fromVertexData.m_vertex;
   if ((isOutgoing || bidirectional) && rp.GetPointId() + 1 < road.GetPointsCount())
   {
-    GetNeighboringEdge(fromVertexData, Segment(from.GetMwmId(), rp.GetFeatureId(), rp.GetPointId(), isOutgoing),
-                       isOutgoing, edges, parents, useAccessConditional);
+    bool isBlocked = false;
+    {
+      std::lock_guard<std::mutex> lock(g_dynamicAlprsMutex);
+      isBlocked = (g_dynamicBlockedAlprs.count(RoadPoint(rp.GetFeatureId(), rp.GetPointId())) > 0);
+    }
+    if (!useRoutingOptions || !m_avoidRoutingOptions.Has(RoutingOptions::Road::ALPR) ||
+        (m_alprSegments.count(RoadPoint(rp.GetFeatureId(), rp.GetPointId())) == 0 && !isBlocked))
+    {
+      GetNeighboringEdge(fromVertexData, Segment(from.GetMwmId(), rp.GetFeatureId(), rp.GetPointId(), isOutgoing),
+                         isOutgoing, edges, parents, useAccessConditional);
+    }
   }
 
   if ((!isOutgoing || bidirectional) && rp.GetPointId() > 0)
   {
-    GetNeighboringEdge(fromVertexData, Segment(from.GetMwmId(), rp.GetFeatureId(), rp.GetPointId() - 1, !isOutgoing),
-                       isOutgoing, edges, parents, useAccessConditional);
+    bool isBlocked = false;
+    {
+      std::lock_guard<std::mutex> lock(g_dynamicAlprsMutex);
+      isBlocked = (g_dynamicBlockedAlprs.count(RoadPoint(rp.GetFeatureId(), rp.GetPointId() - 1)) > 0);
+    }
+    if (!useRoutingOptions || !m_avoidRoutingOptions.Has(RoutingOptions::Road::ALPR) ||
+        (m_alprSegments.count(RoadPoint(rp.GetFeatureId(), rp.GetPointId() - 1)) == 0 && !isBlocked))
+    {
+      GetNeighboringEdge(fromVertexData, Segment(from.GetMwmId(), rp.GetFeatureId(), rp.GetPointId() - 1, !isOutgoing),
+                         isOutgoing, edges, parents, useAccessConditional);
+    }
   }
 }
 
@@ -262,10 +300,32 @@ void IndexGraph::GetSegmentCandidateForRoadPoint(RoadPoint const & rp, NumMwmId 
   auto const pointId = rp.GetPointId();
 
   if ((isOutgoing || bidirectional) && pointId + 1 < road.GetPointsCount())
-    children.emplace_back(numMwmId, rp.GetFeatureId(), pointId, isOutgoing);
+  {
+    bool isBlocked = false;
+    {
+      std::lock_guard<std::mutex> lock(g_dynamicAlprsMutex);
+      isBlocked = (g_dynamicBlockedAlprs.count(RoadPoint(rp.GetFeatureId(), pointId)) > 0);
+    }
+    if (!m_avoidRoutingOptions.Has(RoutingOptions::Road::ALPR) ||
+        (m_alprSegments.count(RoadPoint(rp.GetFeatureId(), pointId)) == 0 && !isBlocked))
+    {
+      children.emplace_back(numMwmId, rp.GetFeatureId(), pointId, isOutgoing);
+    }
+  }
 
   if ((!isOutgoing || bidirectional) && pointId > 0)
-    children.emplace_back(numMwmId, rp.GetFeatureId(), pointId - 1, !isOutgoing);
+  {
+    bool isBlocked = false;
+    {
+      std::lock_guard<std::mutex> lock(g_dynamicAlprsMutex);
+      isBlocked = (g_dynamicBlockedAlprs.count(RoadPoint(rp.GetFeatureId(), pointId - 1)) > 0);
+    }
+    if (!m_avoidRoutingOptions.Has(RoutingOptions::Road::ALPR) ||
+        (m_alprSegments.count(RoadPoint(rp.GetFeatureId(), pointId - 1)) == 0 && !isBlocked))
+    {
+      children.emplace_back(numMwmId, rp.GetFeatureId(), pointId - 1, !isOutgoing);
+    }
+  }
 }
 
 void IndexGraph::GetSegmentCandidateForJoint(Segment const & parent, bool isOutgoing, SegmentListT & children) const

--- a/libs/routing/index_graph.hpp
+++ b/libs/routing/index_graph.hpp
@@ -12,18 +12,26 @@
 #include "routing/road_access.hpp"
 #include "routing/road_index.hpp"
 #include "routing/road_point.hpp"
-#include "routing/routing_options.hpp"
+#include "routing/route.hpp"
 #include "routing/segment.hpp"
 
 #include "base/buffer_vector.hpp"
 
+#include <map>
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
+
+#include <set>
+#include <mutex>
 
 namespace routing
 {
+extern std::mutex g_dynamicAlprsMutex;
+extern std::set<RoadPoint> g_dynamicBlockedAlprs;
+
 bool IsUTurn(Segment const & u, Segment const & v);
 
 enum class WorldGraphMode;
@@ -89,6 +97,7 @@ public:
   void SetRestrictions(RestrictionVec && restrictions);
   void SetUTurnRestrictions(std::vector<RestrictionUTurn> && noUTurnRestrictions);
   void SetRoadAccess(RoadAccess && roadAccess);
+  void SetSpeedCameras(std::map<RoadPoint, std::vector<RouteSegment::SpeedCamera>> const & cameras);
 
   void PushFromSerializer(Joint::Id jointId, RoadPoint const & rp) { m_roadIndex.PushFromSerializer(jointId, rp); }
 
@@ -204,6 +213,7 @@ private:
 
   RoadAccess m_roadAccess;
   RoutingOptions m_avoidRoutingOptions;
+  std::unordered_set<RoadPoint, RoadPoint::Hash> m_alprSegments;
 
   std::function<time_t()> m_currentTimeGetter = []() { return GetCurrentTimestamp(); };
 };

--- a/libs/routing/routing_options.cpp
+++ b/libs/routing/routing_options.cpp
@@ -110,6 +110,7 @@ std::string DebugPrint(RoutingOptions const & routingOptions)
   append(RoutingOptions::Road::Ferry);
   append(RoutingOptions::Road::Dirty);
   append(RoutingOptions::Road::Steps);
+  append(RoutingOptions::Road::ALPR);
 
   if (wasAppended)
     ss << " | ";
@@ -128,6 +129,7 @@ std::string DebugPrint(RoutingOptions::Road type)
   case RoutingOptions::Road::Ferry: return "ferry";
   case RoutingOptions::Road::Dirty: return "dirty";
   case RoutingOptions::Road::Steps: return "steps";
+  case RoutingOptions::Road::ALPR: return "alpr";
   case RoutingOptions::Road::Usual: return "usual";
   case RoutingOptions::Road::Max: return "max";
   }

--- a/libs/routing/routing_options.hpp
+++ b/libs/routing/routing_options.hpp
@@ -19,8 +19,9 @@ public:
     Ferry = 1u << 3,
     Dirty = 1u << 4,
     Steps = 1u << 5,
+    ALPR = 1u << 6,
 
-    Max = (1u << 5) + 1
+    Max = (1u << 6) + 1
   };
 
   using RoadType = std::underlying_type_t<Road>;


### PR DESCRIPTION
## Description
This PR implements real-time online ALPR camera warnings and pathfinding avoidance under the Routing Options menu. 

## Design Rationale for Online Camera Fetching
Organic Maps works primarily offline using MWM maps. However, because offline map files are generated and updated only periodically (sometimes weeks or months apart), they often lack newly added or recently modified speed cameras and surveillance sensors. 
To ensure maximum user privacy and up-to-date protection, this feature asynchronously queries the OpenStreetMap database on route creation to fetch real-time camera data directly, while rounding the bounding box to a coarse grid to preserve location privacy.

## Key Changes
### 1. Core C++ Engine
- Implemented `OnlineCameraFetcher` (`libs/map/`) to query the OSM Overpass API asynchronously for speed cameras and `man_made=surveillance` nodes.
- Added a thread-safe coordinate alignment grid cache to prevent parallel network requests.
- Obfuscated user location by rounding bounding box request coordinates to a coarse `0.1` degree grid for privacy.
- Differentiated ALPR/surveillance cameras from regular speed cameras so only ALPRs display in the overlay.
- Overrode minimum camera symbol rendering zoom levels to display ALPR icons beginning at zoom level `10` (zoomed out view).
- Ensured cameras remain on the map in active navigation.
- Added `HasAlprs` recommendation callback value to C++ routing session.
- Implemented a dynamic segment-blocking graph search: if "Strict Avoidance" is checked, the C++ pathfinder automatically blocks matching road segments within 60 meters of the camera and recalculates/detours around them.

### 2. Android Platform Integration
- Added native UI switches in `DrivingOptionsFragment` supporting both "Avoid surveillance cameras" and a nested "Strict avoidance (calculate detours)" option.
- Exposed config preferences in `Config.java` to bind Java switches to the C++ settings configuration.
- Overrode recommendation callbacks in `RoutingController` and `MwmActivity` to show an on-screen Toast warning: *"This route includes surveillance cameras!"* in Relaxed mode when a route crosses an ALPR camera.

## Note for iOS/Desktop Maintainers
The core C++ fetching, distance matching, map markers, and detouring graph search are fully implemented in cross-platform code. The Android front-end bindings are complete; other maintainers can hook up the new C++ `HasAlprs` recommendation enum value to native Swift (iOS) or Qt (Desktop) UI elements to support settings/popups there.

Fixes #12035 