### PR TITLE
[android] Auto-close color picker on preset tap

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/colorpicker/ColorPickerFragment.kt
+++ b/android/app/src/main/java/app/organicmaps/widget/colorpicker/ColorPickerFragment.kt
@@ -300,6 +300,7 @@ class ColorPickerFragment : BottomSheetDialogFragment() {
                 )
                 setOnClickListener {
                     viewModel.selectPreset(i)
+                    dismiss()
                 }
                 setOnLongClickListener { v ->
                     showDeletePresetPopup(v, i)


### PR DESCRIPTION
## Summary                                                                                                        
                                                                                                                  
- Tapping a preset circle in the color picker's bottom row now dismisses the picker immediately, restoring the pre-unification behaviour of the old bookmark picker.                          
- Grid, Spectrum, Sliders and the "+" (add preset) button keep the picker open — those flows are exploratory or additive, so auto-closing would hurt them.                                                                                   
- One-line change in `ColorPickerFragment.rebuildPresetViews()`.                                                  
                                                                  
  Fixes the UX regression reported in #13056