### PR TITLE
[android] Updated search peak min height

### DIFF
--- a/android/app/src/main/java/app/organicmaps/search/SearchFragment.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchFragment.java
@@ -222,12 +222,7 @@ public class SearchFragment extends Fragment implements SearchListener, Categori
     if (mAppBar == null)
       return;
 
-    mAppBar.post(() -> {
-      int height = mAppBar.getHeight();
-      if (!mToolbarController.hasQuery() && mTabFrame.getVisibility() == View.VISIBLE)
-        height += mTabFrame.getHeight();
-      mSearchViewModel.setToolbarHeight(height);
-    });
+    mAppBar.post(() -> mSearchViewModel.setToolbarHeight(mAppBar.getHeight()));
   }
 
   private void updateResultsPlaceholder()

--- a/android/app/src/main/java/app/organicmaps/search/SearchFragmentController.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchFragmentController.java
@@ -43,7 +43,7 @@ public class SearchFragmentController extends Fragment implements SearchFragment
         {
           mViewModel.setHiddenByPlacePage(true);
           mViewModel.setSearchPageLastState(mBottomSheetBehavior.getState());
-          mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+          hideSearchSheet();
         }
       }
       else
@@ -54,7 +54,7 @@ public class SearchFragmentController extends Fragment implements SearchFragment
         if (searchEnabled != null && searchEnabled && lastState != null && lastState != BottomSheetBehavior.STATE_HIDDEN
             && mViewModel.isHiddenByPlacePage())
         {
-          mBottomSheetBehavior.setState(lastState);
+          showSearchSheet(lastState);
           mViewModel.setHiddenByPlacePage(false);
         }
       }
@@ -79,14 +79,14 @@ public class SearchFragmentController extends Fragment implements SearchFragment
         Integer lastState = mViewModel.getSearchPageLastState().getValue();
         if (lastState != null && lastState != BottomSheetBehavior.STATE_HIDDEN)
         {
-          mBottomSheetBehavior.setState(lastState);
+          showSearchSheet(lastState);
         }
         else if (mBottomSheetBehavior.getState() == BottomSheetBehavior.STATE_HIDDEN)
-          mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+          showSearchSheet(BottomSheetBehavior.STATE_EXPANDED);
       }
       else
       {
-        mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+        hideSearchSheet();
       }
     }
   };
@@ -170,7 +170,7 @@ public class SearchFragmentController extends Fragment implements SearchFragment
         return false;
       if (mBottomSheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED
           || mBottomSheetBehavior.getState() == BottomSheetBehavior.STATE_HALF_EXPANDED)
-        mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+        showSearchSheet(BottomSheetBehavior.STATE_COLLAPSED);
       return false;
     }
   };
@@ -198,10 +198,8 @@ public class SearchFragmentController extends Fragment implements SearchFragment
     mSearchPageContainer = view.findViewById(R.id.search_page_container);
     mTouchSlop = ViewConfiguration.get(requireContext()).getScaledTouchSlop();
 
-    int actionBarSize = (int) getResources().getDimension(
+    mMinCollapsedPeekHeight = (int) getResources().getDimension(
         ThemeUtils.getResource(requireContext(), androidx.appcompat.R.attr.actionBarSize));
-    int tabsHeight = getResources().getDimensionPixelSize(R.dimen.tabs_height);
-    mMinCollapsedPeekHeight = actionBarSize + tabsHeight;
 
     float topRadius = getResources().getDimension(R.dimen.bottom_sheet_corner_radius);
     int surface = MaterialColors.getColor(mSearchPageContainer, com.google.android.material.R.attr.colorSurface);
@@ -240,7 +238,7 @@ public class SearchFragmentController extends Fragment implements SearchFragment
       updateExpandedOffset();
       if (imeVisible && mViewModel.getSearchEnabled().getValue() != null && mViewModel.getSearchEnabled().getValue()
           && !mViewModel.isHiddenByPlacePage())
-        mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+        showSearchSheet(BottomSheetBehavior.STATE_EXPANDED);
       Insets horizontalInsets =
           insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
       searchBottomContainer.setPadding(horizontalInsets.left, searchBottomContainer.getPaddingTop(),
@@ -358,7 +356,7 @@ public class SearchFragmentController extends Fragment implements SearchFragment
 
     if (mBottomSheetBehavior.getState() != BottomSheetBehavior.STATE_HIDDEN)
     {
-      mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+      hideSearchSheet();
       return true;
     }
     return false;
@@ -367,12 +365,29 @@ public class SearchFragmentController extends Fragment implements SearchFragment
   @Override
   public void onSearchClicked()
   {
-    mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_HALF_EXPANDED);
+    showSearchSheet(BottomSheetBehavior.STATE_HALF_EXPANDED);
   }
 
   @Override
   public void closeSearch()
   {
+    hideSearchSheet();
+  }
+
+  // The sheet is kept non-hideable while visible so a swipe can't dismiss it. Re-enable hideable here so
+  // this programmatic close is the only path to STATE_HIDDEN (setState(HIDDEN) is rejected when !hideable).
+  private void hideSearchSheet()
+  {
+    mBottomSheetBehavior.setHideable(true);
     mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+  }
+
+  // Order matters: setState() must run before setHideable(false). Disabling hideable while the sheet is
+  // still at STATE_HIDDEN would make Material immediately force STATE_COLLAPSED. hideable=false then locks
+  // the sheet so only hideSearchSheet() can close it.
+  private void showSearchSheet(@BottomSheetBehavior.State int state)
+  {
+    mBottomSheetBehavior.setState(state);
+    mBottomSheetBehavior.setHideable(false);
   }
 }

--- a/android/app/src/main/res/layout/toolbar_search_controls_sheet.xml
+++ b/android/app/src/main/res/layout/toolbar_search_controls_sheet.xml
@@ -23,7 +23,8 @@
     android:paddingHorizontal="@dimen/margin_half"
     android:layout_marginStart="@dimen/margin_base"
     android:layout_marginEnd="@dimen/margin_half"
-    android:layout_marginVertical="@dimen/margin_base">
+    android:layout_marginTop="@dimen/margin_half_plus"
+    android:layout_marginBottom="@dimen/margin_quarter_plus">
     <ImageView
       android:id="@+id/back"
       android:layout_width="@dimen/place_page_icon_size"
@@ -91,6 +92,8 @@
     android:layout_height="@dimen/place_page_icon_size"
     android:padding="0dp"
     android:layout_marginEnd="@dimen/margin_half"
+    android:layout_marginTop="@dimen/margin_half_plus"
+    android:layout_marginBottom="@dimen/margin_quarter_plus"
     android:layout_gravity="center_vertical"
     android:layout_weight="0"
     android:background="?attr/selectableItemBackgroundBorderless"

--- a/android/app/src/main/res/layout/toolbar_search_controls_sheet.xml
+++ b/android/app/src/main/res/layout/toolbar_search_controls_sheet.xml
@@ -23,8 +23,8 @@
     android:paddingHorizontal="@dimen/margin_half"
     android:layout_marginStart="@dimen/margin_base"
     android:layout_marginEnd="@dimen/margin_half"
-    android:layout_marginTop="@dimen/margin_half_plus"
-    android:layout_marginBottom="@dimen/margin_quarter_plus">
+    android:layout_marginTop="@dimen/margin_base"
+    android:layout_marginBottom="@dimen/margin_half_plus">
     <ImageView
       android:id="@+id/back"
       android:layout_width="@dimen/place_page_icon_size"
@@ -92,8 +92,8 @@
     android:layout_height="@dimen/place_page_icon_size"
     android:padding="0dp"
     android:layout_marginEnd="@dimen/margin_half"
-    android:layout_marginTop="@dimen/margin_half_plus"
-    android:layout_marginBottom="@dimen/margin_quarter_plus"
+    android:layout_marginTop="@dimen/margin_base"
+    android:layout_marginBottom="@dimen/margin_half_plus"
     android:layout_gravity="center_vertical"
     android:layout_weight="0"
     android:background="?attr/selectableItemBackgroundBorderless"

--- a/android/sdk/src/main/java/app/organicmaps/sdk/Map.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/Map.java
@@ -361,8 +361,11 @@ public final class Map
 
   private void updateRulerOffset(final Context context, int offsetX, int offsetY)
   {
+    // Raise the ruler a bit above the bottom edge so it stays visible over the search bar in compact mode.
+    final int additionalOffset = Utils.dimen(context, R.dimen.ruler_additional_offset);
     nativeSetupWidget(WIDGET_RULER, Utils.dimen(context, R.dimen.margin_ruler) + offsetX,
-                      mHeight - Utils.dimen(context, R.dimen.margin_ruler) - offsetY, ANCHOR_LEFT_BOTTOM);
+                      mHeight - Utils.dimen(context, R.dimen.margin_ruler) - offsetY - additionalOffset,
+                      ANCHOR_LEFT_BOTTOM);
     if (mSurfaceCreated)
       nativeApplyWidgets();
   }

--- a/android/sdk/src/main/res/values/dimens.xml
+++ b/android/sdk/src/main/res/values/dimens.xml
@@ -8,4 +8,5 @@
   <dimen name="margin_compass">24dp</dimen>
   <dimen name="margin_compass_top">26dp</dimen>
   <dimen name="margin_ruler">10dp</dimen>
+  <dimen name="ruler_additional_offset">8dp</dimen>
 </resources>


### PR DESCRIPTION
## What

Rework the search bottom sheet's collapsed (compact) state and keep the map
ruler visible above it:

- **Collapsed state now shows only the input field.** The peek-height floor no
  longer adds the tab-bar height, and the toolbar-height measurement no longer
  conditionally adds the tabs — so the collapsed height is constant regardless
  of whether a query is entered.
- **Swipe-down can no longer dismiss search.** The sheet is kept non-hideable
  while visible, so a downward swipe from the collapsed state just settles
  instead of closing. Closing is only possible via the ✕ (close) button (and the
  existing back / place-page paths).
- **The map ruler is raised slightly** so it stays visible above the compact
  search bar, mirroring the iOS change in #13131.

## Why

The collapsed sheet was taller than needed (input field + tabs) and could be
accidentally dismissed with a swipe, which conflicted with the ✕ button being
the intended close affordance. With the sheet lowered, the ruler sat flush under
it; a small vertical offset keeps the ruler legible.

Related: #13125

## How

- `SearchFragmentController`: symmetric `showSearchSheet(state)` /
  `hideSearchSheet()` helpers assert `hideable` explicitly at every transition
  (`hideable=false` while visible, briefly `true` only for the programmatic
  close). All close paths route through `hideSearchSheet()`, keeping it the
  single path to `STATE_HIDDEN`. Peek-height floor reduced to `actionBarSize`.
- `SearchFragment`: `updatePeekHeight()` always reports the app-bar height.
- `toolbar_search_controls_sheet.xml`: tighter vertical margins lower the
  collapsed row; the close icon gets matching margins to stay vertically aligned
  with the input field.
- `Map.updateRulerOffset` + `ruler_additional_offset` (8dp): a Y-only offset that
  raises the ruler above the bottom edge (leaves the copyright/attribution
  untouched, same as the iOS PR).

<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/ed1c04f1-8e03-4d3c-95dc-56089fafddb2" />
<img width="2553" height="1209" alt="image" src="https://github.com/user-attachments/assets/d16eacd6-1798-4d10-8a64-a0d26b476cdb" />
<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/6ff5fcd9-3268-47d5-91a9-aeee8cbc9ace" />
<img width="2553" height="1209" alt="image" src="https://github.com/user-attachments/assets/a1da6d7c-fce8-413f-bef7-fcc0fb059a87" />

