### PR TITLE
[ios] Update search screen compact mode

### DIFF
--- a/iphone/Maps/UI/Map/MapWidgets/MWMMapWidgets.mm
+++ b/iphone/Maps/UI/Map/MapWidgets/MWMMapWidgets.mm
@@ -79,7 +79,9 @@
   auto const vs = self.visualScale;
   auto const viewHeight = [MapViewController sharedController].mapView.height;
   auto const viewWidth = [MapViewController sharedController].mapView.width;
-  auto const rulerOffset = m2::PointF(frame.origin.x * vs, (frame.origin.y + frame.size.height - viewHeight) * vs);
+  auto const kRulerAdditionalYOffset = 12.0;
+  auto const rulerOffset =
+      m2::PointF(frame.origin.x * vs, (frame.origin.y + frame.size.height - viewHeight) * vs - kRulerAdditionalYOffset);
   auto const kCompassAdditionalYOffset = [TrackRecordingManager.shared isActive] ? 50 : 0;
   auto const compassOffset = m2::PointF((frame.origin.x + frame.size.width - viewWidth) * vs,
                                         (frame.origin.y + kCompassAdditionalYOffset) * vs);

--- a/iphone/Maps/UI/Map/MapWidgets/MWMMapWidgets.mm
+++ b/iphone/Maps/UI/Map/MapWidgets/MWMMapWidgets.mm
@@ -79,9 +79,9 @@
   auto const vs = self.visualScale;
   auto const viewHeight = [MapViewController sharedController].mapView.height;
   auto const viewWidth = [MapViewController sharedController].mapView.width;
-  auto const kRulerAdditionalYOffset = 12.0;
+  auto const kRulerAdditionalYOffset = 4.0;
   auto const rulerOffset =
-      m2::PointF(frame.origin.x * vs, (frame.origin.y + frame.size.height - viewHeight) * vs - kRulerAdditionalYOffset);
+      m2::PointF(frame.origin.x * vs, (frame.origin.y + frame.size.height - viewHeight - kRulerAdditionalYOffset) * vs);
   auto const kCompassAdditionalYOffset = [TrackRecordingManager.shared isActive] ? 50 : 0;
   auto const compassOffset = m2::PointF((frame.origin.x + frame.size.width - viewWidth) * vs,
                                         (frame.origin.y + kCompassAdditionalYOffset) * vs);

--- a/iphone/Maps/UI/Search/SearchOnMap/Presentation/SearchOnMapModalPresentationStepStrategy.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/Presentation/SearchOnMapModalPresentationStepStrategy.swift
@@ -8,9 +8,12 @@ enum SearchOnMapModalPresentationStep: Int, CaseIterable, ModalPresentationStep 
 struct SearchOnMapModalPresentationStepStrategy: ModalPresentationStepStrategy {
   private enum Constants {
     static let iPadWidth: CGFloat = 350
-    static let compactHeightOffset: CGFloat = 120
+    static let compactBaseOffset: CGFloat = 64
     static let halfScreenHeightFactorPortrait: CGFloat = 0.55
     static let topInset: CGFloat = 8
+    static func compactHeightOffset(bottomSafeAreaInset: CGFloat) -> CGFloat {
+      compactBaseOffset + max(0, bottomSafeAreaInset - topInset) // empiric value
+    }
   }
 
   typealias Step = SearchOnMapModalPresentationStep
@@ -70,7 +73,8 @@ struct SearchOnMapModalPresentationStepStrategy: ModalPresentationStepStrategy {
       case .halfScreen:
         frame.origin.y = containerSize.height * Constants.halfScreenHeightFactorPortrait
       case .compact:
-        frame.origin.y = containerSize.height - Constants.compactHeightOffset
+        frame.origin.y =
+          containerSize.height - Constants.compactHeightOffset(bottomSafeAreaInset: safeAreaInsets.bottom)
       case .hidden:
         frame.origin.y = containerSize.height
       }
@@ -81,7 +85,8 @@ struct SearchOnMapModalPresentationStepStrategy: ModalPresentationStepStrategy {
       case .expanded:
         frame.origin.y = Constants.topInset
       case .halfScreen, .compact:
-        frame.origin.y = containerSize.height - Constants.compactHeightOffset
+        frame.origin.y =
+          containerSize.height - Constants.compactHeightOffset(bottomSafeAreaInset: safeAreaInsets.bottom)
       case .hidden:
         frame.origin.y = containerSize.height
       }


### PR DESCRIPTION
Related issue: https://github.com/organicmaps/organicmaps/issues/13125

<img width="734" height="824" alt="image" src="https://github.com/user-attachments/assets/20b87ba4-3697-443d-8305-beab437196fd" />

<img width="770" height="851" alt="image" src="https://github.com/user-attachments/assets/b3237c05-f6f8-41da-b751-4de0cb1e51c3" />

___

The ruler was slightly raised up to be visible over the search bar in the compact mode.
Before / after:
<img width="352" height="782" alt="image" src="https://github.com/user-attachments/assets/0c6d98cd-ada9-47f9-bb82-0bc9e9f1dd5b" /> <img width="352" height="782" alt="image" src="https://github.com/user-attachments/assets/461b7b0b-752e-45e6-b879-b0e257cfb7ed" />
