### PR TITLE
[transit] Restore subway layer after closing a transit route preview

### DIFF
--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1517,7 +1517,16 @@ void Framework::HideRouteTransitIfNeeded()
     return;
 
   m_drapeEngine->HideRouteTransit();
-  m_drapeEngine->EnableTransitScheme(false);
+
+  // Keep the user's subway/transit-scheme layer visible after previewing a route. The layer
+  // returns on its own: the render gate stays enabled and the real-MwmId scheme data was never
+  // wiped (the route lives under the sentinel MwmId{}), so the frontend re-collects the scheme
+  // overlays once the route data is gone. Disabling here would clear the builder instead;
+  // Invalidate() is only a safety refresh in case the viewport's MWMs changed during the preview.
+  if (m_transitManager.IsSchemeMode())
+    m_transitManager.Invalidate();
+  else
+    m_drapeEngine->EnableTransitScheme(false);
 }
 
 void Framework::UpdateViewport(search::Results const & results)

--- a/libs/map/transit/transit_reader.hpp
+++ b/libs/map/transit/transit_reader.hpp
@@ -107,6 +107,7 @@ public:
   bool GetTransitDisplayInfo(TransitDisplayInfos & transitDisplayInfos);
 
   void EnableTransitSchemeMode(bool enable);
+  bool IsSchemeMode() const { return m_isSchemeMode; }
   void BlockTransitSchemeMode(bool isBlocked);
   void UpdateViewport(ScreenBase const & screen);
 


### PR DESCRIPTION
## What

Fixes the subway/transit-scheme layer disappearing from the map after opening and closing a public-transport route preview, while the layers menu still shows the layer as enabled.

Fixes #13089
Refs #12943 — fixes part I (the Metro layer disappearing); part II (font-size changes not propagating to the Metro layer until it's toggled) is untouched and stays open.

## Why

The layer is gated by two separate flags that got out of sync:
- `TransitReadManager::m_isSchemeMode` — the user's persisted setting (also what the layers UI reads);
- `FrontendRenderer::m_transitSchemeEnabled` — the drape render gate.

`Framework::ShowRouteTransit` flips the render gate directly, and `HideRouteTransitIfNeeded` used to flip it back off unconditionally on close — clearing all transit data via `EnableTransitScheme(false)` even when the user had the layer enabled. The setting stayed on, so the UI and the map disagreed.

## Fix

`HideRouteTransitIfNeeded` now only disables the scheme when the user has not enabled it; otherwise it refreshes the network via `TransitReadManager::Invalidate()` — the same restore path used by `BlockTransitSchemeMode(false)` after navigation. Added a small `TransitReadManager::IsSchemeMode()` accessor. Core-only change, so it fixes Android, iOS and Qt at once.

## Testing

Built the `map` target (`cmake --build … --target map`) — compiles clean.
Manual, on a region with a metro network (e.g. Berlin):
- Enable Metro → open a stop's route preview → close it → the metro network reappears and the layer stays lit. ✅
- Regression: with Metro off, open/close a route → the network stays hidden. ✅
- Regression: run and finish a full transit navigation with Metro on → the network is restored. ✅