### PR TITLE
[android] Fix route plan panel not collapsing over the map

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -16,7 +16,6 @@ import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
 import android.text.style.TypefaceSpan;
 import android.view.View;
-import android.widget.ScrollView;
 import android.widget.TextView;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
@@ -283,8 +282,6 @@ final class RoutingBottomMenuController
     UiUtils.show(transit_time, mTransitRecyclerView);
     mTransitAdapter.setItems(info.getTransitSteps());
 
-    scrollToBottom(mTransitRecyclerView);
-
     TextView totalTimeView = mAltitudeChartFrame.findViewById(R.id.total_time);
     totalTimeView.setText(Utils.formatRoutingTime(mContext, info.getTotalTime(), R.dimen.text_size_routing_number));
     View dotView = mAltitudeChartFrame.findViewById(R.id.dot);
@@ -308,8 +305,6 @@ final class RoutingBottomMenuController
     {
       UiUtils.show(mTransitRecyclerView);
       mTransitAdapter.setItems(pointsToRulerSteps(points));
-
-      scrollToBottom(mTransitRecyclerView);
     }
     else
       UiUtils.hide(mTransitRecyclerView); // Show only distance between start and finish
@@ -453,14 +448,6 @@ final class RoutingBottomMenuController
       String arrivalTime = Utils.formatArrivalTime(rinfo.totalTimeInSeconds);
       mArrival.setText(arrivalTime);
     }
-  }
-
-  // Scroll RecyclerView to bottom using parent ScrollView.
-  private static void scrollToBottom(RecyclerView rv)
-  {
-    final ScrollView parentScroll = (ScrollView) rv.getParent();
-    if (parentScroll != null)
-      parentScroll.postDelayed(() -> parentScroll.fullScroll(ScrollView.FOCUS_DOWN), 100);
   }
 
   @NonNull

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingPlanFragment.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingPlanFragment.java
@@ -41,6 +41,7 @@ public class RoutingPlanFragment extends Fragment implements View.OnLayoutChange
 
   private RoutingPlanViewModel mViewModel;
   private View mChartPanel;
+  private View mTransitStepsView;
   private ChartHeaderAdapter mChartHeaderAdapter;
   private View mDrivingOptionsBtn;
   private View mFrame;
@@ -120,10 +121,11 @@ public class RoutingPlanFragment extends Fragment implements View.OnLayoutChange
 
     mRoutingBottomMenuController =
         RoutingBottomMenuController.newInstance(requireActivity(), mFrame, mChartPanel, mChartHeaderAdapter, this);
-    mRoutingBottomMenuController.setVisibilityChangedCallback(this::updateMapButtonsOffset);
+    mRoutingBottomMenuController.setVisibilityChangedCallback(this::updateSheetLayout);
     mRoutingRoot = view.findViewById(R.id.routing_root);
     mRoutingBottomContainer = view.findViewById(R.id.routing_bottom_container);
 
+    mTransitStepsView = mChartPanel.findViewById(R.id.transit_recycler_view);
     mDrivingOptionsBadge = mChartPanel.findViewById(R.id.driving_options_badge);
     mDrivingOptionsBtn = mChartPanel.findViewById(R.id.driving_options_btn_img);
     mDrivingOptionsBtn.setOnClickListener(
@@ -267,18 +269,28 @@ public class RoutingPlanFragment extends Fragment implements View.OnLayoutChange
     }
   }
 
-  public void updateMapButtonsOffset()
+  public void updateSheetLayout()
   {
     if (mFrame.getTop() == 0)
       return;
-    // mChartPanel lives inside the route list (ConcatAdapter header), so it reports a real height once the
-    // RecyclerView has measured its first pass. Falling back to 0 keeps peek-height sensible on early calls.
-    final int chartHeight = mChartPanel.getHeight();
-    final int newPeekHeight =
-        mRoutingTypesContainer.getHeight() + chartHeight + mBottomButtonsMaxHeight + mPeekHeightMargins;
-    mSheetBehavior.setPeekHeight(newPeekHeight);
+    updateSheetHeights();
     final int newDistanceTop = mFrame.getTop();
     mViewModel.setRoutingBottomDistanceToTop(newDistanceTop);
+  }
+
+  private void updateSheetHeights()
+  {
+    final View parent = (View) mFrame.getParent();
+    final int parentHeight = parent == null ? 0 : parent.getHeight();
+    if (parentHeight > 0)
+      mSheetBehavior.setMaxHeight(parentHeight);
+    // Peek excludes the scrollable steps/list: it ends at the steps' top (or the full header when there are
+    // none), while setMaxHeight caps a long list to scroll inside the sheet instead of covering the map.
+    final boolean stepsVisible = mTransitStepsView.getVisibility() == View.VISIBLE;
+    final int chartHeader = stepsVisible ? mTransitStepsView.getTop() : mChartPanel.getHeight();
+    final int peekHeight =
+        mRoutingTypesContainer.getHeight() + chartHeader + mBottomButtonsMaxHeight + mPeekHeightMargins;
+    mSheetBehavior.setPeekHeight(peekHeight);
   }
 
   private void setupRouterButtons()
@@ -395,7 +407,7 @@ public class RoutingPlanFragment extends Fragment implements View.OnLayoutChange
   public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight,
                              int oldBottom)
   {
-    updateMapButtonsOffset();
+    updateSheetLayout();
   }
 
   @Override

--- a/android/app/src/main/res/layout/altitude_chart_panel.xml
+++ b/android/app/src/main/res/layout/altitude_chart_panel.xml
@@ -11,6 +11,7 @@
   android:orientation="vertical"
   android:paddingStart="@dimen/altitude_chart_container_padding_left"
   android:paddingEnd="@dimen/altitude_chart_container_padding_left"
+  android:paddingBottom="@dimen/margin_half_plus"
   tools:showIn="@layout/routing_bottom_sheet">
 
   <LinearLayout
@@ -166,23 +167,12 @@
 
   </LinearLayout>
 
-  <ScrollView
+  <androidx.recyclerview.widget.RecyclerView
+    android:id="@+id/transit_recycler_view"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_marginTop="12dp"
-    android:scrollbarAlwaysDrawVerticalTrack="true"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintHeight_max="150dp"
-    app:layout_constraintHorizontal_bias="0.0"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/total_time">
-
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/transit_recycler_view"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:visibility="gone"
-      tools:visibility="visible" />
-  </ScrollView>
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/margin_half_plus"
+    android:visibility="gone"
+    tools:visibility="visible" />
 
 </LinearLayout>


### PR DESCRIPTION
## What
Make the route planning bottom sheet behave predictably:
- It no longer grows to cover the whole map — capped at the screen height, taller routes scroll inside the sheet.
- Collapsed (peek) state shows only the header (transport selector, ETA/distance, elevation chart); the waypoint list and transit/ruler steps are revealed by expanding.
- Dragging the panel (grabber or list) reliably collapses/expands it again.

## Why
On long routes (many stops, transit/ruler steps) the panel filled the screen and couldn't be collapsed, so the map was unusable while building a route.

Root cause of the broken drag: a vertical `ScrollView` (transit/ruler steps)nested inside the route list `RecyclerView` — a nested scroller inside a scroller breaks `BottomSheetBehavior`'s drag-to-collapse. Removed it; Also removed `scrollToBottom` (it relied on that `ScrollView`); auto-scrolling steps to the last item is no longer applicable with the new layout.

<img width="1209" height="2553" alt="image" src="https://github.com/user-attachments/assets/47b486ba-2dd8-4f04-beca-2add7616a2cd" />

https://github.com/user-attachments/assets/b1e3d8df-efb7-4964-8f78-396f76222ad6

