### PR TITLE
[drape] Abandon in-flight GL frame when rendering is disabled

### DIFF
--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -1842,6 +1842,15 @@ void FrontendRenderer::RenderFrame()
   m_frameData.m_framesFast += static_cast<uint64_t>(!isActiveFrameForScene);
 #endif
 
+  // Rendering may have been disabled (e.g. the app is going to the background) after we passed the guard before
+  // BeginRendering and already started the frame. Abandon it before the expensive RenderScene + Present, which can
+  // stall for seconds while the surface is being torn down and would block the UI thread waiting in
+  // Framework::DetachSurface. Restricted to OpenGL ES: there BeginRendering/EndRendering are no-ops, so an early
+  // return needs no frame-scope balancing. Vulkan already guards its in-flight frame inside BeginRendering/Present
+  // (present-availability flag + fence timeouts) and forbids ending a frame without an active render pass.
+  if (m_apiVersion == dp::ApiVersion::OpenGLES3 && !IsRenderingEnabled())
+    return;
+
   RenderScene(modelView, isActiveFrameForScene);
 
   if (m_renderInjectionHandler)


### PR DESCRIPTION
## What
Skip the rest of an already-started OpenGL ES render frame once rendering has
been disabled, before the expensive RenderScene + Present.

## Why
ANR: surfaceDestroyed -> nativeDetachSurface -> Framework::DetachSurface
synchronously waits (BaseRenderer::SetRenderingEnabled(false)) for the render
thread to finish its current frame. An in-flight frame that already passed the
pre-BeginRendering guard doigrywaet RenderScene + eglSwapBuffers on a surface
being torn down and blocks the UI thread >5s. ANR trace shows the frontend
thread inside RenderFrame -> PrepareScene while the main thread waits in
DetachSurface.

https://play.google.com/console/u/0/developers/8084273541548442467/app/4972992444534608608/vitals/crashes/3c6ed6df8656844525dd81f812bbb7cd/details?days=28&versionCode=26062903&isUserPerceived=true