### PR TITLE
[routing] Remove unnecessary directions where going straight is obvious

### DIFF
--- a/libs/routing/routing_integration_tests/turn_test.cpp
+++ b/libs/routing/routing_integration_tests/turn_test.cpp
@@ -812,6 +812,39 @@ UNIT_TEST(USA_Tampa_TurnTest)
       {CarDirection::TurnSlightRight, CarDirection::TurnRight});
 }
 
+// Test on no turn generation at a driveway junction while the route follows a residential road
+// which gently curves there. The only alternative is a driveway (two highway classes below),
+// so no direction should be given. See https://github.com/organicmaps/organicmaps/issues/13152
+UNIT_TEST(USA_Connecticut_WestHartford_NoTurnAtDriveway_TurnTest)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Car),
+                                                               mercator::FromLatLon(41.780262, -72.943726), {0., 0.},
+                                                               mercator::FromLatLon(41.778837, -72.937728));
+
+  Route const & route = *routeResult.first;
+  RouterResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
+}
+
+// Control test for the previous one: a real turn from Vineyard Road to a same-class
+// residential road (Deer Field Trace) a few hundred meters to the west must be kept.
+UNIT_TEST(USA_Connecticut_WestHartford_TurnToDeerField_TurnTest)
+{
+  TRouteResult const routeResult = integration::CalculateRoute(integration::GetVehicleComponents(VehicleType::Car),
+                                                               mercator::FromLatLon(41.780262, -72.943726), {0., 0.},
+                                                               mercator::FromLatLon(41.7800312, -72.9419313));
+
+  Route const & route = *routeResult.first;
+  RouterResultCode const result = routeResult.second;
+
+  TEST_EQUAL(result, RouterResultCode::NoError, ());
+  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
+  integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
+      {CarDirection::TurnSlightLeft, CarDirection::TurnLeft});
+}
+
 // Test on go straight direction if it's possible to go through a roundabout.
 UNIT_TEST(Russia_Moscow_Minskia1_TurnTest)
 {

--- a/libs/routing/routing_tests/turns_generator_test.cpp
+++ b/libs/routing/routing_tests/turns_generator_test.cpp
@@ -230,6 +230,43 @@ UNIT_TEST(TestCheckUTurnOnRoute)
   TEST_EQUAL(CheckUTurnOnRoute(resultTest, 3 /* outgoingSegmentIndex */, NumMwmIds(), vehicleSettings, turn3), 0, ());
 }
 
+// GetPointForTurn() must not overshoot its limits on sparse geometry: when one long geometry
+// edge crosses the time limit, a point on this edge at the limit is expected instead of its
+// far end. Otherwise the turn angle gets the road curvature accumulated far from the junction.
+// See https://github.com/organicmaps/organicmaps/issues/13152
+UNIT_TEST(GetPointForTurnOnSparseGeometry)
+{
+  // For HighwayClass::LivingStreet (20 km/h) the 3 seconds limit of GetPointForTurn()
+  // is reached in 20 / 3.6 * 3 ~= 16.67 meters.
+  double constexpr kExpectedDistM = 20.0 / 3.6 * 3.0;
+  double constexpr kEpsM = 0.2;
+
+  m2::PointD const junction = mercator::FromLatLon(0.0, 0.0);
+
+  TUnpackedPathSegments pathSegments(2, LoadedPathSegment());
+  pathSegments[0].m_highwayClass = ftypes::HighwayClass::LivingStreet;
+  pathSegments[0].m_path = {
+      {mercator::GetSmPoint(junction, -105.0, 0.0), 0}, {mercator::GetSmPoint(junction, -5.0, 0.0), 0}, {junction, 0}};
+  pathSegments[1].m_highwayClass = ftypes::HighwayClass::LivingStreet;
+  pathSegments[1].m_path = {
+      {junction, 0}, {mercator::GetSmPoint(junction, 5.0, 0.0), 0}, {mercator::GetSmPoint(junction, 105.0, 0.0), 0}};
+
+  RoutingResultTest resultTest(pathSegments);
+  RoutingSettings const vehicleSettings = GetRoutingSettings(VehicleType::Car);
+
+  // Forward: a 5 m edge, then a 100 m edge which overshoots the limit.
+  m2::PointD const outgoingPoint =
+      GetPointForTurn(resultTest, 1 /* outgoingSegmentIndex */, NumMwmIds(), vehicleSettings.m_maxOutgoingPointsCount,
+                      vehicleSettings.m_minOutgoingDistMeters, true /* forward */);
+  TEST_ALMOST_EQUAL_ABS(mercator::DistanceOnEarth(junction, outgoingPoint), kExpectedDistM, kEpsM, ());
+
+  // Backward: the same, in the ingoing direction.
+  m2::PointD const ingoingPoint =
+      GetPointForTurn(resultTest, 1 /* outgoingSegmentIndex */, NumMwmIds(), vehicleSettings.m_maxIngoingPointsCount,
+                      vehicleSettings.m_minIngoingDistMeters, false /* forward */);
+  TEST_ALMOST_EQUAL_ABS(mercator::DistanceOnEarth(junction, ingoingPoint), kExpectedDistM, kEpsM, ());
+}
+
 UNIT_TEST(GetNextRoutePointIndex)
 {
   TUnpackedPathSegments pathSegments(2, LoadedPathSegment());

--- a/libs/routing/turns_generator.cpp
+++ b/libs/routing/turns_generator.cpp
@@ -85,7 +85,7 @@ m2::PointD GetPointForTurn(IRoutingResult const & result, size_t outgoingSegment
 
   while (GetNextRoutePointIndex(result, index, numMwmIds, forward, nextIndex))
   {
-    m2::PointD nextPoint = GetPointByIndex(segments, nextIndex);
+    m2::PointD const nextPoint = GetPointByIndex(segments, nextIndex);
 
     // At start and finish there are two edges with zero length.
     // This function should not be called for the start (|outgoingSegmentIndex| == 0).
@@ -93,11 +93,28 @@ m2::PointD GetPointForTurn(IRoutingResult const & result, size_t outgoingSegment
     if (point == nextPoint && outgoingSegmentIndex + 1 == segments.size())
       return nextPoint;
 
-    double distanceMeters = mercator::DistanceOnEarth(point, nextPoint);
-    curDistanceMeters += distanceMeters;
-    curTimeSeconds += CalcEstimatedTimeToPass(distanceMeters, segments[nextIndex.m_segmentIndex].m_highwayClass);
+    double const distanceMeters = mercator::DistanceOnEarth(point, nextPoint);
+    double const timeSeconds =
+        CalcEstimatedTimeToPass(distanceMeters, segments[nextIndex.m_segmentIndex].m_highwayClass);
 
-    if (curTimeSeconds > kMaxTimeSeconds || ++count >= maxPointsCount || curDistanceMeters > maxDistMeters)
+    // If the next geometry edge overshoots the time or the distance limit, a point on this edge
+    // at the limit is taken. Otherwise on sparse geometry one long edge could move the result
+    // tens of meters past the limits, and the turn angle would get the road curvature
+    // accumulated far from the junction. See https://github.com/organicmaps/organicmaps/issues/13152
+    if (curTimeSeconds + timeSeconds > kMaxTimeSeconds || curDistanceMeters + distanceMeters > maxDistMeters)
+    {
+      double share = 1.0;
+      if (timeSeconds > 0.0)
+        share = std::min(share, (kMaxTimeSeconds - curTimeSeconds) / timeSeconds);
+      if (distanceMeters > 0.0)
+        share = std::min(share, (maxDistMeters - curDistanceMeters) / distanceMeters);
+      return point + (nextPoint - point) * share;
+    }
+
+    curDistanceMeters += distanceMeters;
+    curTimeSeconds += timeSeconds;
+
+    if (++count >= maxPointsCount)
       return nextPoint;
 
     point = nextPoint;


### PR DESCRIPTION
GetPointForTurn() checked its time and distance limits only after consuming a whole geometry edge and returned that edge's far end. On sparse geometry (e.g. long TIGER-imported edges) a single edge could move the ingoing/outgoing reference point tens of meters past the limits (86 m instead of the intended ~17 m on a residential road), so the turn angle accumulated road curvature far from the junction. A gentle bend next to a driveway was then classified as TurnLeft, which disabled the highway-class based discarding of negligible turn candidates.

Now a point on the overshooting edge at the limit is taken instead, so the turn angle reflects the geometry around the junction.

Fixes: #13152