### PR TITLE
[android] Show route building progress as-is from core

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -345,8 +345,7 @@ final class RoutingBottomMenuController
 
   void setBuildProgress(int progress)
   {
-    if (progress > mStart.getBuildProgress())
-      mStart.setBuildProgress(progress);
+    mStart.setBuildProgress(progress);
   }
 
   // Explicit reset covers the rebuild-during-build case where setStartState(BUILDING) early-returns


### PR DESCRIPTION
The progress bar filled to 99% on the first (Normal) route, then froze for the entire alternative-route pass and only snapped to 100% on completion.

The C++ core computes the two routes sequentially, each reporting an independent 0..99% ramp with no cross-phase scaling. The Android side gated updates behind a monotonic check (progress > current), so every value of the second pass was dropped and the bar appeared stuck.

Pass the core progress through as-is: the bar now resets and sweeps a second time during the alternative-route calculation, so its duration is visible instead of frozen.