### PR TITLE
[android] Apply search history toggle without app restart

### DIFF
--- a/android/app/src/main/java/app/organicmaps/search/SearchCategoriesFragment.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchCategoriesFragment.java
@@ -3,7 +3,6 @@ package app.organicmaps.search;
 import android.os.Bundle;
 import android.view.View;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmRecyclerFragment;

--- a/android/app/src/main/java/app/organicmaps/search/SearchFragment.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchFragment.java
@@ -2,7 +2,6 @@ package app.organicmaps.search;
 
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.location.Location;
 import android.os.Bundle;
 import android.os.Handler;
@@ -53,7 +52,6 @@ public class SearchFragment extends Fragment implements SearchListener, Categori
 {
   @NonNull
   private final List<HiddenCommand> mHiddenCommands = new ArrayList<>();
-  private final List<RecyclerView> mAttachedRecyclers = new ArrayList<>();
   private final LastPosition mLastPosition = new LastPosition();
   private SearchFragmentListener mSearchFragmentListener;
   private View mResultsFrame;
@@ -341,10 +339,6 @@ public class SearchFragment extends Fragment implements SearchListener, Categori
 
     mSearchViewModel.getSearchPageLastState().observe(getViewLifecycleOwner(), mBottomSheetStateObserver);
 
-    if (Config.isSearchHistoryEnabled())
-      mTabLayout.setVisibility(View.VISIBLE);
-    else
-      mTabLayout.setVisibility(View.GONE);
     mAppBar = root.findViewById(R.id.app_bar);
 
     updateFrames();
@@ -358,11 +352,27 @@ public class SearchFragment extends Fragment implements SearchListener, Categori
 
   private void setupTabsIfNeeded()
   {
-    if (mTabAdapter != null || getView() == null)
+    if (getView() == null)
       return;
 
+    final boolean historyEnabled = Config.isSearchHistoryEnabled();
+    if (mTabAdapter != null)
+    {
+      if (mTabAdapter.isHistoryEnabled() == historyEnabled)
+        return;
+      mPager.clearOnPageChangeListeners();
+      mTabAdapter.destroy();
+      mTabAdapter = null;
+      // The nested-scrolling snapshot is keyed by (hasQuery, activeTab); the rebuilt pager reuses
+      // those indices, so drop it or syncNestedScrollingState() would short-circuit and skip
+      // re-enabling the new tab's RecyclerView.
+      mNestedScrollingSyncedHasQuery = null;
+      mNestedScrollingSyncedActiveTab = null;
+    }
+    UiUtils.showIf(historyEnabled, mTabLayout);
+
     final ViewPager pager = mPager;
-    final TabAdapter tabAdapter = new TabAdapter(getChildFragmentManager(), pager, mTabLayout);
+    final TabAdapter tabAdapter = new TabAdapter(getChildFragmentManager(), pager, mTabLayout, historyEnabled);
     mTabAdapter = tabAdapter;
     pager.setOffscreenPageLimit(tabAdapter.getCount());
     pager.addOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
@@ -372,11 +382,6 @@ public class SearchFragment extends Fragment implements SearchListener, Categori
         updateNestedScrollingForTab(tabAdapter, position);
       }
     });
-
-    final SharedPreferences preferences = MwmApplication.prefs(requireContext());
-    final int lastSelectedTabPosition = preferences.getInt(Config.KEY_PREF_LAST_SEARCHED_TAB, 0);
-    if (SearchRecents.getSize() == 0 && Config.isSearchHistoryEnabled())
-      pager.setCurrentItem(lastSelectedTabPosition);
 
     tabAdapter.setTabSelectedListener(tab -> {
       mToolbarController.deactivate();
@@ -414,6 +419,9 @@ public class SearchFragment extends Fragment implements SearchListener, Categori
     super.onResume();
     MwmApplication.from(requireContext()).getLocationHelper().addListener(mLocationListener);
 
+    if (mTabAdapter != null)
+      setupTabsIfNeeded();
+
     // onPause() stops the shimmer; if we are resuming mid-search with no results yet, restore it
     // so the results pane isn't blank until the next results callback arrives.
     if (mSearchRunning && mSearchAdapter.getItemCount() == 0 && mShimmerView != null)
@@ -442,9 +450,6 @@ public class SearchFragment extends Fragment implements SearchListener, Categori
   public void onDestroyView()
   {
     mSearchDebounceHandler.removeCallbacks(mDebouncedRunSearch);
-    for (RecyclerView v : mAttachedRecyclers)
-      v.removeOnScrollListener(mRecyclerListener);
-    mAttachedRecyclers.clear();
     SearchEngine.INSTANCE.removeListener(this);
     super.onDestroyView();
   }
@@ -640,7 +645,6 @@ public class SearchFragment extends Fragment implements SearchListener, Categori
   public void setRecyclerScrollListener(RecyclerView recycler)
   {
     recycler.addOnScrollListener(mRecyclerListener);
-    mAttachedRecyclers.add(recycler);
     if (mTabAdapter != null)
       updateNestedScrollingForTab(mTabAdapter, mPager.getCurrentItem());
   }

--- a/android/app/src/main/java/app/organicmaps/search/TabAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/search/TabAdapter.java
@@ -3,11 +3,11 @@ package app.organicmaps.search;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.SparseArray;
-import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
+import androidx.fragment.app.FragmentTransaction;
 import androidx.viewpager.widget.ViewPager;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
@@ -15,7 +15,9 @@ import app.organicmaps.sdk.util.Config;
 import app.organicmaps.util.Graphics;
 import com.google.android.material.tabs.TabLayout;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 class TabAdapter extends FragmentPagerAdapter
 {
@@ -103,40 +105,74 @@ class TabAdapter extends FragmentPagerAdapter
     }
   }
 
+  private final FragmentManager mFragmentManager;
   private final ViewPager mPager;
   private final List<Class<? extends Fragment>> mClasses = new ArrayList<>();
   private final SparseArray<Fragment> mFragments = new SparseArray<>();
   private OnTabSelectedListener mTabSelectedListener;
   private final TabLayout mTabs;
-  TabAdapter(FragmentManager fragmentManager, ViewPager pager, TabLayout tabs)
+  private final boolean mHistoryEnabled;
+  TabAdapter(FragmentManager fragmentManager, ViewPager pager, TabLayout tabs, boolean historyEnabled)
   {
     super(fragmentManager);
+    this.mFragmentManager = fragmentManager;
     this.mTabs = tabs;
+    this.mHistoryEnabled = historyEnabled;
     for (Tab tab : Tab.values())
     {
-      if (tab == tab.HISTORY && !Config.isSearchHistoryEnabled())
+      if (tab == Tab.HISTORY && !historyEnabled)
         continue;
       mClasses.add(tab.getFragmentClass());
     }
-    final List<Fragment> fragments = fragmentManager.getFragments();
-    if (fragments != null)
+    final List<Fragment> tabFragments = new ArrayList<>();
+    final Set<Class<? extends Fragment>> restoredClasses = new HashSet<>();
+    for (Fragment f : fragmentManager.getFragments())
+    {
+      if (f == null || !isTabFragment(f))
+        continue;
+      tabFragments.add(f);
+      restoredClasses.add(f.getClass());
+    }
+
+    if (restoredClasses.equals(new HashSet<>(mClasses)))
     {
       // Recollect already attached fragments
-      for (Fragment f : fragments)
-      {
-        if (f == null)
-          continue;
-
-        final int idx = mClasses.indexOf(f.getClass());
-        if (idx > -1)
-          mFragments.put(idx, f);
-      }
+      for (Fragment f : tabFragments)
+        mFragments.put(mClasses.indexOf(f.getClass()), f);
     }
+    else
+      removeFragments(tabFragments);
 
     mPager = pager;
     mPager.setAdapter(this);
-    if (mTabs.getVisibility() != View.GONE)
+    if (mHistoryEnabled)
       attachTo(tabs);
+  }
+
+  boolean isHistoryEnabled()
+  {
+    return mHistoryEnabled;
+  }
+
+  private void removeFragments(@NonNull List<Fragment> fragments)
+  {
+    if (fragments.isEmpty())
+      return;
+
+    final FragmentTransaction tx = mFragmentManager.beginTransaction();
+    for (Fragment f : fragments)
+      tx.remove(f);
+    tx.commitNowAllowingStateLoss();
+  }
+
+  private static boolean isTabFragment(@NonNull Fragment f)
+  {
+    for (Tab tab : Tab.values())
+    {
+      if (tab.getFragmentClass() == f.getClass())
+        return true;
+    }
+    return false;
   }
 
   private void attachTo(TabLayout tabs)
@@ -159,6 +195,17 @@ class TabAdapter extends FragmentPagerAdapter
   void setTabSelectedListener(OnTabSelectedListener listener)
   {
     mTabSelectedListener = listener;
+  }
+
+  void destroy()
+  {
+    mPager.setAdapter(null);
+    final List<Fragment> fragments = new ArrayList<>();
+    for (int i = 0; i < mFragments.size(); i++)
+      fragments.add(mFragments.valueAt(i));
+    mFragments.clear();
+    removeFragments(fragments);
+    mTabs.removeAllTabs();
   }
 
   @Override


### PR DESCRIPTION
## What
Toggling **Settings → Privacy → Search history** now takes effect immediately in the search bottom sheet — the History tab appears/disappears on the next open, in both directions, without restarting the app.

## How
- `SearchFragment.setupTabsIfNeeded()` now owns the tab-strip visibility  and rebuilds the pager only when the setting changed since it was built (guarded by a `mTabsHistoryEnabled` snapshot — no rebuild on ordinary opens).
- New `TabAdapter.destroy()` cleanly detaches the adapter and removes its page fragments via its own refs (avoids FragmentPagerAdapter switcher-tag collisions and the detached-fragment gap in `getFragments()`).