### PR TITLE
North-up map orientation during navigation

### DIFF
--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/search/SearchEngine.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/search/SearchEngine.cpp
@@ -350,7 +350,7 @@ JNIEXPORT void Java_app_organicmaps_sdk_search_SearchEngine_nativeSelectResult(J
     return;
   // Ideally this location mode change should happen in core automatically, without specifically changing the mode.
   auto const mode = g_framework->GetMyPositionMode();
-  if (mode == location::Follow || mode == location::FollowAndRotate)
+  if (location::IsFollowingMode(mode))
     g_framework->NativeFramework()->StopLocationFollow();
   g_framework->NativeFramework()->SelectSearchResult(g_results[index], true /* animation */);
 }

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/search/SearchEngine.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/search/SearchEngine.cpp
@@ -352,7 +352,7 @@ JNIEXPORT void Java_app_organicmaps_sdk_search_SearchEngine_nativeSelectResult(J
     return;
   // Ideally this location mode change should happen in core automatically, without specifically changing the mode.
   auto const mode = g_framework->GetMyPositionMode();
-  if (mode == location::Follow || mode == location::FollowAndRotate)
+  if (location::IsFollowingMode(mode))
     g_framework->NativeFramework()->StopLocationFollow();
   g_framework->NativeFramework()->SelectSearchResult(g_results[index], true /* animation */);
 }

--- a/iphone/Maps/Core/CarPlay/Template Builders/MapTemplateBuilder.swift
+++ b/iphone/Maps/Core/CarPlay/Template Builders/MapTemplateBuilder.swift
@@ -6,6 +6,7 @@ final class MapTemplateBuilder {
     case zoomIn
     case zoomOut
     case recenter
+    case switchOrientation(MWMMyPositionMode)
   }
 
   enum BarButtonType {
@@ -108,11 +109,16 @@ final class MapTemplateBuilder {
       mapTemplate.hidesButtonsWithNavigationBar = true
       FrameworkHelper.switchMyPositionMode()
     }
+    // While the camera follows the user, this button toggles the orientation (north-up <-> heading-up):
+    // switchMyPositionMode() cycles the following camera's rotation through the core NextMode().
+    let orientationButton = buildMapButton(type: .switchOrientation(positionMode)) { _ in
+      FrameworkHelper.switchMyPositionMode()
+    }
 
     switch positionMode {
     case .follow, .followAndRotate:
       if !mapTemplate.isPanningInterfaceVisible {
-        mapTemplate.mapButtons = [panningButton, zoomInButton, zoomOutButton]
+        mapTemplate.mapButtons = [orientationButton, panningButton, zoomInButton, zoomOutButton]
       }
     case .notFollow:
       if !mapTemplate.isPanningInterfaceVisible {
@@ -164,6 +170,10 @@ final class MapTemplateBuilder {
       button.image = UIImage.btnZoomOut
     case .recenter:
       button.image = UIImage.btnGetPosition
+    case .switchOrientation(let positionMode):
+      // Reuse the phone location-button glyphs (as the recenter button reuses btnGetPosition) to
+      // show the current orientation: north-up (Follow) vs heading-up (FollowAndRotate).
+      button.image = positionMode == .follow ? UIImage.btnFollow : UIImage.btnFollowAndRotate
     }
     return button
   }

--- a/iphone/Maps/Core/Location/MWMLocationPredictor.mm
+++ b/iphone/Maps/Core/Location/MWMLocationPredictor.mm
@@ -30,7 +30,13 @@ NSUInteger constexpr kMaxPredictionCount = 20;
 
 - (void)setMyPositionMode:(MWMMyPositionMode)mode
 {
-  self.isLastPositionModeValid = (mode == MWMMyPositionModeFollowAndRotate);
+  // Predict while the camera follows the user during navigation: heading-up (FollowAndRotate) always,
+  // north-up (Follow) only while a route is being followed. Outside navigation plain Follow just
+  // centers on the user and does not need predicted intermediate fixes every 0.5 s.
+  auto const & routingManager = GetFramework().GetRoutingManager();
+  BOOL const isNavigating = routingManager.IsRoutingActive() && routingManager.IsRoutingFollowing();
+  self.isLastPositionModeValid =
+      (mode == MWMMyPositionModeFollowAndRotate || (isNavigating && mode == MWMMyPositionModeFollow));
   [self restart];
 }
 

--- a/libs/drape_frontend/drape_engine.cpp
+++ b/libs/drape_frontend/drape_engine.cpp
@@ -24,6 +24,7 @@ using namespace std::placeholders;
 namespace
 {
 std::string_view constexpr kLocationStateMode = "LastLocationStateMode";
+std::string_view constexpr kRoutingOrientation = "LastRoutingOrientation";
 std::string_view constexpr kLastEnterBackground = "LastEnterBackground";
 }  // namespace
 
@@ -70,6 +71,10 @@ DrapeEngine::DrapeEngine(Params && params)
       mode = Follow;
   }
 
+  // Use heading-up when no routing orientation has been stored.
+  MapOrientation routingOrientation = MapOrientation::HeadingUp;
+  (void)Get(kRoutingOrientation, routingOrientation);
+
   if (!Get(kLastEnterBackground, m_startBackgroundTime))
     m_startBackgroundTime = base::Timer::LocalTime();
 
@@ -88,9 +93,11 @@ DrapeEngine::DrapeEngine(Params && params)
   //  effects.push_back(PostprocessRenderer::Antialiasing);
   //}
 
-  MyPositionController::Params mpParams(mode, base::Timer::LocalTime() - m_startBackgroundTime, params.m_hints,
-                                        params.m_isRoutingActive, params.m_isAutozoomEnabled,
-                                        std::bind(&DrapeEngine::MyPositionModeChanged, this, _1, _2));
+  MyPositionController::Params mpParams(mode, routingOrientation, base::Timer::LocalTime() - m_startBackgroundTime,
+                                        params.m_hints, params.m_isRoutingActive, params.m_isAutozoomEnabled,
+                                        std::bind(&DrapeEngine::MyPositionModeChanged, this, _1, _2),
+                                        [](location::MapOrientation orientation)
+  { settings::Set(kRoutingOrientation, orientation); });
 
   FrontendRenderer::Params frParams(
       params.m_apiVersion, make_ref(m_threadCommutator), params.m_factory, make_ref(m_textureManager),

--- a/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
+++ b/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRC
   area_shape_tests.cpp
   clip_splines_builder_tests.cpp
   frame_values_tests.cpp
+  my_position_controller_tests.cpp
   navigator_test.cpp
   path_text_test.cpp
   rainbow_line_gpu_test.cpp

--- a/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
+++ b/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRC
   clip_splines_builder_tests.cpp
   frame_values_tests.cpp
   message_queue_tests.cpp
+  my_position_controller_tests.cpp
   navigator_test.cpp
   path_text_test.cpp
   rainbow_line_gpu_test.cpp

--- a/libs/drape_frontend/drape_frontend_tests/my_position_controller_tests.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/my_position_controller_tests.cpp
@@ -37,15 +37,21 @@ location::GpsInfo MakeGpsInfo(double timestamp)
 }
 
 using ModeLog = std::vector<std::pair<location::EMyPositionMode, bool>>;
+using OrientationLog = std::vector<location::MapOrientation>;
 
 df::MyPositionController::Params MakeParams(location::EMyPositionMode initMode, bool isRoutingActive,
-                                            ModeLog * modeLog = nullptr)
+                                            location::MapOrientation routingOrientation, ModeLog * modeLog = nullptr,
+                                            OrientationLog * orientationLog = nullptr)
 {
   location::TMyPositionModeChanged fn;
   if (modeLog)
     fn = [modeLog](location::EMyPositionMode mode, bool routingActive) { modeLog->emplace_back(mode, routingActive); };
-  return {initMode,        0.0 /* timeInBackground */,    df::Hints(),
-          isRoutingActive, false /* isAutozoomEnabled */, std::move(fn)};
+  location::TRoutingOrientationChanged orientationFn;
+  if (orientationLog)
+    orientationFn = [orientationLog](location::MapOrientation orientation) { orientationLog->push_back(orientation); };
+  return {initMode,      routingOrientation,      0.0 /* timeInBackground */,
+          df::Hints(),   isRoutingActive,         false /* isAutozoomEnabled */,
+          std::move(fn), std::move(orientationFn)};
 }
 
 // Records every camera request so tests can assert not only the zoom but also which
@@ -126,12 +132,14 @@ std::string DebugPrint(TestListener::Camera camera)
 class Controller
 {
 public:
-  Controller(location::EMyPositionMode initMode, bool isRoutingActive)
+  Controller(location::EMyPositionMode initMode, bool isRoutingActive,
+             location::MapOrientation routingOrientation = location::MapOrientation::HeadingUp)
   {
     df::VisualParams::Init(1.0, 1024);
     m_screen = MakeScreen();
-    m_controller = std::make_unique<df::MyPositionController>(MakeParams(initMode, isRoutingActive, &m_modeLog),
-                                                              ref_ptr<df::DrapeNotifier>());
+    m_controller = std::make_unique<df::MyPositionController>(
+        MakeParams(initMode, isRoutingActive, routingOrientation, &m_modeLog, &m_orientationLog),
+        ref_ptr<df::DrapeNotifier>());
     m_controller->SetListener(ref_ptr<df::MyPositionController::Listener>(&m_listener));
     m_controller->OnUpdateScreen(m_screen);
   }
@@ -149,6 +157,7 @@ public:
 
   TestListener m_listener;
   ModeLog m_modeLog;
+  OrientationLog m_orientationLog;
 
 private:
   ScreenBase m_screen;
@@ -261,9 +270,9 @@ UNIT_TEST(MyPositionController_NextModeWhilePendingStopsAndRestarts)
   TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
 }
 
-UNIT_TEST(MyPositionController_RoutingPendingButtonsForceFollow)
+UNIT_TEST(MyPositionController_RoutingPendingButtonsKeepOrientation)
 {
-  Controller test(location::FollowAndRotate, true /* isRoutingActive */);
+  Controller test(location::FollowAndRotate, true /* isRoutingActive */, location::MapOrientation::HeadingUp);
   TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
 
   test.NextMode();
@@ -271,11 +280,47 @@ UNIT_TEST(MyPositionController_RoutingPendingButtonsForceFollow)
   test.NextMode();
   TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
 
-  // Stopping and restarting the location search before the first fix re-arms plain
-  // Follow even during routing, losing the heading-up navigation camera.
-  /// @todo Restore the routing camera here; see the navigation orientation feature.
+  // Stopping and restarting the location search before the first fix must not lose
+  // the heading-up navigation camera, and restoring it is not an orientation choice.
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  TEST(test.m_orientationLog.empty(), ());
+}
+
+UNIT_TEST(MyPositionController_RoutingQueuedFixAfterStopKeepsOrientation)
+{
+  Controller test(location::FollowAndRotate, true /* isRoutingActive */, location::MapOrientation::HeadingUp);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollowNoPosition, ());
+
+  // A location that was already queued arrives right after the "stop location" press.
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  TEST(test.m_orientationLog.empty(), ());
+}
+
+UNIT_TEST(MyPositionController_RoutingRestoreFromLocationOffResumesFollowing)
+{
+  // Restoring into active navigation (isRoutingActive means the route is being followed) with a
+  // saved "location off" mode must resume the preferred following camera and re-arm the location
+  // search: navigation is meaningless without a position, so the map cannot stay stopped.
+  Controller test(location::NotFollowNoPosition, true /* isRoutingActive */, location::MapOrientation::NorthUp);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+
   test.OnLocationUpdate(1.0);
   TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  TEST(test.Get().IsModeHasPosition(), ());
+  TEST(test.Get().IsRouteFollowingActive(), ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_EQUAL(request.m_azimuth, 0.0, ());
+    TEST_EQUAL(request.m_pxZero, test.ScreenCenter(), ());
+  }
+  // Restoring the saved orientation is not an orientation choice.
+  TEST(test.m_orientationLog.empty(), ());
 }
 
 UNIT_TEST(MyPositionController_RoutingRecoveryRestoresHeadingUpByDefault)
@@ -310,7 +355,8 @@ UNIT_TEST(MyPositionController_ActivateRoutingDefaultsToHeadingUp)
   test.OnLocationUpdate(1.0);
   TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollow, ());
 
-  test.Get().ActivateRouting(16 /* zoomLevel */, false /* enableAutoZoom */, true /* isArrowGlued */);
+  test.Get().ActivateRouting(16 /* zoomLevel */, 17 /* zoomLevelIn3d */, false /* enableAutoZoom */,
+                             true /* isArrowGlued */);
   TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
   TEST(test.Get().IsRouteFollowingActive(), ());
   {
@@ -347,14 +393,19 @@ UNIT_TEST(MyPositionController_ActivateRoutingBeforeFirstFix)
   TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
 
   // Routing activation claims the position even though there was no fix yet.
-  test.Get().ActivateRouting(16 /* zoomLevel */, false /* enableAutoZoom */, true /* isArrowGlued */);
+  test.Get().ActivateRouting(16 /* zoomLevel */, 17 /* zoomLevelIn3d */, false /* enableAutoZoom */,
+                             true /* isArrowGlued */);
   TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
   TEST(test.Get().IsModeHasPosition(), ());
 
-  // The first fix still applies the pre-routing desired mode and drops the routing camera.
-  /// @todo Keep the routing camera here; see the navigation orientation feature.
+  // The first fix keeps the routing camera instead of the stale pre-routing desired mode.
   test.OnLocationUpdate(1.0);
-  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollow, ());
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_EQUAL(request.m_pxZero, test.RoutingCenter(), ());
+  }
 }
 
 UNIT_TEST(MyPositionController_LoseLocationWhileNotFollow)
@@ -400,7 +451,8 @@ UNIT_TEST(MyPositionController_CompassTappedResetsNorth)
 
 UNIT_TEST(MyPositionController_ModeCallbackSequence)
 {
-  Controller test(location::Follow, true /* isRoutingActive */);
+  // The saved north-up routing orientation overrides the saved mode while routing is active.
+  Controller test(location::FollowAndRotate, true /* isRoutingActive */, location::MapOrientation::NorthUp);
   test.OnLocationUpdate(1.0);
   test.Get().StopLocationFollow();
   test.NextMode();
@@ -409,8 +461,196 @@ UNIT_TEST(MyPositionController_ModeCallbackSequence)
   ModeLog const expected = {{location::PendingPosition, true},
                             {location::Follow, true},
                             {location::NotFollow, true},
-                            {location::FollowAndRotate, true},
+                            {location::Follow, true},
                             {location::Follow, false}};
   TEST_EQUAL(test.m_modeLog, expected, ());
+  TEST(test.m_orientationLog.empty(), ());
+}
+
+UNIT_TEST(MyPositionController_RoutingStartKeepsSavedNorthUp)
+{
+  Controller test(location::NotFollow, false /* isRoutingActive */, location::MapOrientation::NorthUp);
+  test.Get().EnablePerspectiveInRouting(true /* enablePerspective */);
+  test.OnLocationUpdate(1.0);
+
+  test.Get().ActivateRouting(16 /* zoomLevel */, 17 /* zoomLevelIn3d */, false /* enableAutoZoom */,
+                             true /* isArrowGlued */);
+
+  // North-up navigation starts in Follow with the 2D zoom, an explicit north azimuth
+  // and the user centered on the screen.
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  TEST(test.Get().IsRouteFollowingActive(), ());
+  TEST(!test.Get().ShouldEnablePerspectiveInRouting(), ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_EQUAL(request.m_azimuth, 0.0, ());
+    TEST_EQUAL(request.m_pxZero, test.ScreenCenter(), ());
+    TEST_EQUAL(request.m_zoomLevel, 16, ());
+  }
+  // Restoring the saved orientation is not an orientation choice.
+  TEST(test.m_orientationLog.empty(), ());
+}
+
+UNIT_TEST(MyPositionController_RoutingStartUses3dZoomForHeadingUp)
+{
+  Controller test(location::NotFollow, false /* isRoutingActive */, location::MapOrientation::HeadingUp);
+  test.Get().EnablePerspectiveInRouting(true /* enablePerspective */);
+  test.OnLocationUpdate(1.0);
+
+  test.Get().ActivateRouting(16 /* zoomLevel */, 17 /* zoomLevelIn3d */, false /* enableAutoZoom */,
+                             true /* isArrowGlued */);
+
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  TEST(test.Get().ShouldEnablePerspectiveInRouting(), ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_ALMOST_EQUAL_ABS(request.m_azimuth, math::DegToRad(45.0), kAzimuthEps, ());
+    TEST_EQUAL(request.m_pxZero, test.RoutingCenter(), ());
+    TEST_EQUAL(request.m_zoomLevel, 17, ());
+  }
+}
+
+UNIT_TEST(MyPositionController_RoutingOrientationSwitchIsExplicitAndPersisted)
+{
+  Controller test(location::FollowAndRotate, true /* isRoutingActive */, location::MapOrientation::HeadingUp);
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+
+  // The location button chooses north-up: the camera resets to north and the choice is reported.
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_EQUAL(request.m_azimuth, 0.0, ());
+    TEST_EQUAL(request.m_pxZero, test.ScreenCenter(), ());
+  }
+  OrientationLog expected = {location::MapOrientation::NorthUp};
+  TEST_EQUAL(test.m_orientationLog, expected, ());
+
+  // The next press chooses heading-up again.
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  expected.push_back(location::MapOrientation::HeadingUp);
+  TEST_EQUAL(test.m_orientationLog, expected, ());
+}
+
+UNIT_TEST(MyPositionController_RoutingCompassTapChoosesNorthUp)
+{
+  Controller test(location::FollowAndRotate, true /* isRoutingActive */, location::MapOrientation::HeadingUp);
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+
+  test.Get().OnCompassTapped();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_EQUAL(request.m_azimuth, 0.0, ());
+  }
+  OrientationLog const expected = {location::MapOrientation::NorthUp};
+  TEST_EQUAL(test.m_orientationLog, expected, ());
+}
+
+UNIT_TEST(MyPositionController_RoutingNorthUpSurvivesLocationLoss)
+{
+  Controller test(location::FollowAndRotate, true /* isRoutingActive */, location::MapOrientation::HeadingUp);
+  test.OnLocationUpdate(1.0);
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+
+  test.Get().LoseLocation();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+
+  // The recovery restores north-up with an explicit zero azimuth and the user centered.
+  test.OnLocationUpdate(2.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_EQUAL(request.m_azimuth, 0.0, ());
+    TEST_EQUAL(request.m_pxZero, test.ScreenCenter(), ());
+    TEST_EQUAL(request.m_zoomLevel, 16, ());
+  }
+  OrientationLog const expected = {location::MapOrientation::NorthUp};
+  TEST_EQUAL(test.m_orientationLog, expected, ());
+}
+
+UNIT_TEST(MyPositionController_RoutingNotFollowReturnsToPreferredNorthUp)
+{
+  Controller test(location::FollowAndRotate, true /* isRoutingActive */, location::MapOrientation::HeadingUp);
+  test.OnLocationUpdate(1.0);
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+
+  test.Get().StopLocationFollow();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollow, ());
+
+  // Recentering restores the preferred north-up orientation with a zero azimuth.
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_EQUAL(request.m_azimuth, 0.0, ());
+    TEST_EQUAL(request.m_pxZero, test.ScreenCenter(), ());
+  }
+  // Only the explicit switch to north-up was reported, not the restorations.
+  OrientationLog const expected = {location::MapOrientation::NorthUp};
+  TEST_EQUAL(test.m_orientationLog, expected, ());
+}
+
+UNIT_TEST(MyPositionController_RoutingPerspectiveIsStableThroughTransientStates)
+{
+  Controller test(location::NotFollow, false /* isRoutingActive */, location::MapOrientation::HeadingUp);
+  test.Get().EnablePerspectiveInRouting(true /* enablePerspective */);
+  test.OnLocationUpdate(1.0);
+  TEST(!test.Get().ShouldEnablePerspectiveInRouting(), ());
+
+  test.Get().ActivateRouting(16 /* zoomLevel */, 17 /* zoomLevelIn3d */, false /* enableAutoZoom */,
+                             true /* isArrowGlued */);
+  TEST(test.Get().ShouldEnablePerspectiveInRouting(), ());
+
+  // Neither a location loss, nor a manual pan, nor the recovery flattens the heading-up camera.
+  test.Get().LoseLocation();
+  TEST(test.Get().ShouldEnablePerspectiveInRouting(), ());
+  test.OnLocationUpdate(2.0);
+  TEST(test.Get().ShouldEnablePerspectiveInRouting(), ());
+  test.Get().StopLocationFollow();
+  TEST(test.Get().ShouldEnablePerspectiveInRouting(), ());
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  TEST(test.Get().ShouldEnablePerspectiveInRouting(), ());
+
+  // The 3D setting switch applies immediately.
+  test.Get().EnablePerspectiveInRouting(false /* enablePerspective */);
+  TEST(!test.Get().ShouldEnablePerspectiveInRouting(), ());
+}
+
+UNIT_TEST(MyPositionController_RoutingPerspectiveIsNeverEnabledForNorthUp)
+{
+  Controller test(location::NotFollow, false /* isRoutingActive */, location::MapOrientation::NorthUp);
+  test.Get().EnablePerspectiveInRouting(true /* enablePerspective */);
+  test.OnLocationUpdate(1.0);
+
+  test.Get().ActivateRouting(16 /* zoomLevel */, 17 /* zoomLevelIn3d */, false /* enableAutoZoom */,
+                             true /* isArrowGlued */);
+  TEST(!test.Get().ShouldEnablePerspectiveInRouting(), ());
+
+  test.Get().LoseLocation();
+  TEST(!test.Get().ShouldEnablePerspectiveInRouting(), ());
+  test.OnLocationUpdate(2.0);
+  TEST(!test.Get().ShouldEnablePerspectiveInRouting(), ());
+  test.Get().StopLocationFollow();
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  TEST(!test.Get().ShouldEnablePerspectiveInRouting(), ());
+
+  // Switching to heading-up enables the perspective again.
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  TEST(test.Get().ShouldEnablePerspectiveInRouting(), ());
 }
 }  // namespace my_position_controller_tests

--- a/libs/drape_frontend/drape_frontend_tests/my_position_controller_tests.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/my_position_controller_tests.cpp
@@ -1,0 +1,416 @@
+#include "testing/testing.hpp"
+
+#include "drape_frontend/my_position_controller.hpp"
+#include "drape_frontend/user_event_stream.hpp"
+#include "drape_frontend/visual_params.hpp"
+
+#include "geometry/screenbase.hpp"
+
+#include "base/assert.hpp"
+#include "base/math.hpp"
+
+#include <utility>
+#include <vector>
+
+namespace my_position_controller_tests
+{
+double constexpr kAzimuthEps = 1e-9;
+
+ScreenBase MakeScreen()
+{
+  ScreenBase screen;
+  screen.SetFromRects(m2::AnyRectD(m2::RectD(0.0, 0.0, 100.0, 100.0)), m2::RectD(0.0, 0.0, 1000.0, 1000.0));
+  return screen;
+}
+
+location::GpsInfo MakeGpsInfo(double timestamp)
+{
+  location::GpsInfo info;
+  info.m_source = location::EUser;
+  info.m_timestamp = timestamp;
+  info.m_latitude = 10.0;
+  info.m_longitude = 20.0;
+  info.m_horizontalAccuracy = 5.0;
+  info.m_bearing = 45.0;
+  info.m_speed = 5.0;
+  return info;
+}
+
+using ModeLog = std::vector<std::pair<location::EMyPositionMode, bool>>;
+
+df::MyPositionController::Params MakeParams(location::EMyPositionMode initMode, bool isRoutingActive,
+                                            ModeLog * modeLog = nullptr)
+{
+  location::TMyPositionModeChanged fn;
+  if (modeLog)
+    fn = [modeLog](location::EMyPositionMode mode, bool routingActive) { modeLog->emplace_back(mode, routingActive); };
+  return {initMode,        0.0 /* timeInBackground */,    df::Hints(),
+          isRoutingActive, false /* isAutozoomEnabled */, std::move(fn)};
+}
+
+// Records every camera request so tests can assert not only the zoom but also which
+// ChangeModelView() overload was used, the requested azimuth and the pixel anchor.
+class TestListener : public df::MyPositionController::Listener
+{
+public:
+  enum class Camera
+  {
+    Center,
+    Azimuth,
+    Rect,
+    FollowAndRotate,
+    AutoZoom
+  };
+
+  struct CameraRequest
+  {
+    Camera m_type;
+    double m_azimuth = 0.0;
+    m2::PointD m_pxZero = m2::PointD::Zero();
+    int m_zoomLevel = df::kDoNotChangeZoom;
+  };
+
+  void PositionChanged(m2::PointD const & /* position */, bool /* hasPosition */) override {}
+
+  void ChangeModelView(m2::PointD const & /* center */, int zoomLevel,
+                       df::TAnimationCreator const & /* parallelAnimCreator */) override
+  {
+    m_requests.push_back({Camera::Center, 0.0, m2::PointD::Zero(), zoomLevel});
+  }
+
+  void ChangeModelView(double azimuth, df::TAnimationCreator const & /* parallelAnimCreator */) override
+  {
+    m_requests.push_back({Camera::Azimuth, azimuth, m2::PointD::Zero(), df::kDoNotChangeZoom});
+  }
+
+  void ChangeModelView(m2::RectD const & /* rect */, df::TAnimationCreator const & /* parallelAnimCreator */) override
+  {
+    m_requests.push_back({Camera::Rect, 0.0, m2::PointD::Zero(), df::kDoNotChangeZoom});
+  }
+
+  void ChangeModelView(m2::PointD const & /* userPos */, double azimuth, m2::PointD const & pxZero, int zoomLevel,
+                       df::Animation::TAction const & /* onFinishAction */,
+                       df::TAnimationCreator const & /* parallelAnimCreator */) override
+  {
+    m_requests.push_back({Camera::FollowAndRotate, azimuth, pxZero, zoomLevel});
+  }
+
+  void ChangeModelView(double /* autoScale */, m2::PointD const & /* userPos */, double azimuth,
+                       m2::PointD const & pxZero, df::TAnimationCreator const & /* parallelAnimCreator */) override
+  {
+    m_requests.push_back({Camera::AutoZoom, azimuth, pxZero, df::kDoNotChangeZoom});
+  }
+
+  CameraRequest const & LastRequest() const
+  {
+    TEST(!m_requests.empty(), ());
+    return m_requests.back();
+  }
+
+  std::vector<CameraRequest> m_requests;
+};
+
+std::string DebugPrint(TestListener::Camera camera)
+{
+  switch (camera)
+  {
+  case TestListener::Camera::Center: return "Center";
+  case TestListener::Camera::Azimuth: return "Azimuth";
+  case TestListener::Camera::Rect: return "Rect";
+  case TestListener::Camera::FollowAndRotate: return "FollowAndRotate";
+  case TestListener::Camera::AutoZoom: return "AutoZoom";
+  }
+  UNREACHABLE();
+}
+
+class Controller
+{
+public:
+  Controller(location::EMyPositionMode initMode, bool isRoutingActive)
+  {
+    df::VisualParams::Init(1.0, 1024);
+    m_screen = MakeScreen();
+    m_controller = std::make_unique<df::MyPositionController>(MakeParams(initMode, isRoutingActive, &m_modeLog),
+                                                              ref_ptr<df::DrapeNotifier>());
+    m_controller->SetListener(ref_ptr<df::MyPositionController::Listener>(&m_listener));
+    m_controller->OnUpdateScreen(m_screen);
+  }
+
+  df::MyPositionController & Get() { return *m_controller; }
+  void OnLocationUpdate(double timestamp) { m_controller->OnLocationUpdate(MakeGpsInfo(timestamp), true, m_screen); }
+  void NextMode() { m_controller->NextMode(m_screen); }
+
+  m2::PointD ScreenCenter() const { return m_screen.PixelRectIn3d().Center(); }
+  m2::PointD RoutingCenter() const
+  {
+    double const offsetY = 104 * df::VisualParams::Instance().GetVisualScale();
+    return {ScreenCenter().x, m_screen.PixelRectIn3d().maxY() - offsetY};
+  }
+
+  TestListener m_listener;
+  ModeLog m_modeLog;
+
+private:
+  ScreenBase m_screen;
+  std::unique_ptr<df::MyPositionController> m_controller;
+};
+
+UNIT_TEST(MyPositionController_FirstFixAppliesDesiredInitMode)
+{
+  Controller test(location::NotFollow, false /* isRoutingActive */);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+  TEST(!test.Get().IsModeHasPosition(), ());
+
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollow, ());
+  TEST(test.Get().IsModeHasPosition(), ());
+  // NotFollow does not own the camera.
+  TEST_EQUAL(test.m_listener.m_requests.size(), 0, ());
+
+  ModeLog const expected = {{location::PendingPosition, false}, {location::NotFollow, false}};
+  TEST_EQUAL(test.m_modeLog, expected, ());
+}
+
+UNIT_TEST(MyPositionController_InitNotFollowNoPositionStaysStopped)
+{
+  Controller test(location::NotFollowNoPosition, false /* isRoutingActive */);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollowNoPosition, ());
+
+  // The location button restarts the search; the first fix then centers on the user.
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  TEST_EQUAL(test.m_listener.LastRequest().m_type, TestListener::Camera::Center, ());
+  TEST_EQUAL(test.m_listener.LastRequest().m_zoomLevel, df::kDoNotChangeZoom, ());
+}
+
+UNIT_TEST(MyPositionController_FirstFixAppliesFollowAndRotate)
+{
+  Controller test(location::FollowAndRotate, false /* isRoutingActive */);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+
+  auto const & request = test.m_listener.LastRequest();
+  TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+  TEST_ALMOST_EQUAL_ABS(request.m_azimuth, math::DegToRad(45.0), kAzimuthEps, ());
+  TEST_EQUAL(request.m_pxZero, test.ScreenCenter(), ());
+}
+
+UNIT_TEST(MyPositionController_ReacquisitionDropsRotation)
+{
+  Controller test(location::FollowAndRotate, false /* isRoutingActive */);
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+
+  test.Get().LoseLocation();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+  TEST(!test.Get().IsModeHasPosition(), ());
+
+  // Reacquisition outside routing lands in plain Follow: the rotation preference is not restored.
+  test.OnLocationUpdate(2.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  TEST_EQUAL(test.m_listener.LastRequest().m_type, TestListener::Camera::Center, ());
+}
+
+UNIT_TEST(MyPositionController_NextModeCycle)
+{
+  Controller test(location::Follow, false /* isRoutingActive */);
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+
+  // The GPS bearing made rotation available.
+  TEST(test.Get().IsRotationAvailable(), ());
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_ALMOST_EQUAL_ABS(request.m_azimuth, math::DegToRad(45.0), kAzimuthEps, ());
+    TEST_EQUAL(request.m_pxZero, test.ScreenCenter(), ());
+  }
+
+  // Switching back to Follow explicitly resets the map to north-up.
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_EQUAL(request.m_azimuth, 0.0, ());
+    TEST_EQUAL(request.m_pxZero, test.ScreenCenter(), ());
+  }
+}
+
+UNIT_TEST(MyPositionController_NextModeWhilePendingStopsAndRestarts)
+{
+  Controller test(location::NotFollow, false /* isRoutingActive */);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+
+  // Pressing the location button while waiting for a fix stops the search.
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollowNoPosition, ());
+
+  // The next press restarts it and re-arms Follow instead of the saved NotFollow.
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+}
+
+UNIT_TEST(MyPositionController_RoutingPendingButtonsForceFollow)
+{
+  Controller test(location::FollowAndRotate, true /* isRoutingActive */);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollowNoPosition, ());
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+
+  // Stopping and restarting the location search before the first fix re-arms plain
+  // Follow even during routing, losing the heading-up navigation camera.
+  /// @todo Restore the routing camera here; see the navigation orientation feature.
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+}
+
+UNIT_TEST(MyPositionController_RoutingRecoveryRestoresHeadingUpByDefault)
+{
+  Controller test(location::FollowAndRotate, true /* isRoutingActive */);
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_EQUAL(request.m_pxZero, test.RoutingCenter(), ());
+  }
+
+  test.Get().LoseLocation();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+
+  // Routing recovery restores the preferred orientation — heading-up by default here — with the routing zoom.
+  test.OnLocationUpdate(2.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_ALMOST_EQUAL_ABS(request.m_azimuth, math::DegToRad(45.0), kAzimuthEps, ());
+    TEST_EQUAL(request.m_pxZero, test.RoutingCenter(), ());
+    TEST_EQUAL(request.m_zoomLevel, 16, ());
+  }
+}
+
+UNIT_TEST(MyPositionController_ActivateRoutingDefaultsToHeadingUp)
+{
+  Controller test(location::NotFollow, false /* isRoutingActive */);
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollow, ());
+
+  test.Get().ActivateRouting(16 /* zoomLevel */, false /* enableAutoZoom */, true /* isArrowGlued */);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  TEST(test.Get().IsRouteFollowingActive(), ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_ALMOST_EQUAL_ABS(request.m_azimuth, math::DegToRad(45.0), kAzimuthEps, ());
+    TEST_EQUAL(request.m_pxZero, test.RoutingCenter(), ());
+    TEST_EQUAL(request.m_zoomLevel, 16, ());
+  }
+
+  // Panning away pauses following; the location button restores the preferred heading-up orientation.
+  test.Get().StopLocationFollow();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollow, ());
+  TEST(!test.Get().IsRouteFollowingActive(), ());
+
+  test.NextMode();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  TEST_EQUAL(test.m_listener.LastRequest().m_pxZero, test.RoutingCenter(), ());
+
+  // Finishing the route resets the camera to north-up Follow.
+  test.Get().DeactivateRouting();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_EQUAL(request.m_azimuth, 0.0, ());
+    TEST_EQUAL(request.m_pxZero, test.ScreenCenter(), ());
+  }
+}
+
+UNIT_TEST(MyPositionController_ActivateRoutingBeforeFirstFix)
+{
+  Controller test(location::NotFollow, false /* isRoutingActive */);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::PendingPosition, ());
+
+  // Routing activation claims the position even though there was no fix yet.
+  test.Get().ActivateRouting(16 /* zoomLevel */, false /* enableAutoZoom */, true /* isArrowGlued */);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+  TEST(test.Get().IsModeHasPosition(), ());
+
+  // The first fix still applies the pre-routing desired mode and drops the routing camera.
+  /// @todo Keep the routing camera here; see the navigation orientation feature.
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollow, ());
+}
+
+UNIT_TEST(MyPositionController_LoseLocationWhileNotFollow)
+{
+  Controller test(location::NotFollow, false /* isRoutingActive */);
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollow, ());
+
+  test.Get().LoseLocation();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollowNoPosition, ());
+
+  // A stray fix while stopped is accepted silently.
+  test.OnLocationUpdate(2.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::NotFollow, ());
+  TEST_EQUAL(test.m_listener.m_requests.size(), 0, ());
+}
+
+UNIT_TEST(MyPositionController_CompassTappedResetsNorth)
+{
+  Controller test(location::FollowAndRotate, false /* isRoutingActive */);
+  test.OnLocationUpdate(1.0);
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::FollowAndRotate, ());
+
+  test.Get().OnCompassTapped();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::FollowAndRotate, ());
+    TEST_EQUAL(request.m_azimuth, 0.0, ());
+    TEST_EQUAL(request.m_pxZero, test.ScreenCenter(), ());
+    TEST_EQUAL(request.m_zoomLevel, df::kDoNotChangeZoom, ());
+  }
+
+  // In Follow the compass tap only rotates the map back to north.
+  test.Get().OnCompassTapped();
+  TEST_EQUAL(test.Get().GetCurrentMode(), location::Follow, ());
+  {
+    auto const & request = test.m_listener.LastRequest();
+    TEST_EQUAL(request.m_type, TestListener::Camera::Azimuth, ());
+    TEST_EQUAL(request.m_azimuth, 0.0, ());
+  }
+}
+
+UNIT_TEST(MyPositionController_ModeCallbackSequence)
+{
+  Controller test(location::Follow, true /* isRoutingActive */);
+  test.OnLocationUpdate(1.0);
+  test.Get().StopLocationFollow();
+  test.NextMode();
+  test.Get().DeactivateRouting();
+
+  ModeLog const expected = {{location::PendingPosition, true},
+                            {location::Follow, true},
+                            {location::NotFollow, true},
+                            {location::FollowAndRotate, true},
+                            {location::Follow, false}};
+  TEST_EQUAL(test.m_modeLog, expected, ());
+}
+}  // namespace my_position_controller_tests

--- a/libs/drape_frontend/drape_frontend_tests/user_event_stream_tests.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/user_event_stream_tests.cpp
@@ -1,7 +1,7 @@
 #include "testing/testing.hpp"
 
-#include "drape_frontend/drape_frontend_tests/visual_params_fixture.hpp"
 #include "drape_frontend/user_event_stream.hpp"
+#include "drape_frontend/visual_params.hpp"
 
 #include "base/thread.hpp"
 
@@ -9,6 +9,8 @@
 #include <cstring>
 #include <functional>
 #include <list>
+#include <string>
+#include <vector>
 
 namespace user_event_stream_test
 {
@@ -25,6 +27,7 @@ public:
   explicit UserEventStreamTest(bool filtrateTouches) : m_filtrate(filtrateTouches)
   {
     m_stream.SetTestBridge(std::bind(&UserEventStreamTest::TestBridge, this, _1));
+    m_stream.SetListener(ref_ptr<df::UserEventStream::Listener>(this));
   }
 
   void OnTap(m2::PointD const & pt, bool isLong) override {}
@@ -43,7 +46,8 @@ public:
   void CorrectGlobalScalePoint(m2::PointD & pt) const override {}
   void OnScaleEnded() override {}
   void OnTouchMapAction(df::TouchEvent::ETouchType touchType, bool isMapTouch) override {}
-  void OnAnimatedScaleEnded() override {}
+  void OnAnimatedScaleStarted() override { m_animatedScaleLog.push_back("started"); }
+  void OnAnimatedScaleEnded() override { m_animatedScaleLog.push_back("ended"); }
   bool OnNewVisibleViewport(m2::RectD const & oldViewport, m2::RectD const & newViewport, bool needOffset,
                             m2::PointD & gOffset) override
   {
@@ -72,6 +76,20 @@ public:
                                                          nullptr /* parallelAnimCreator */));
   }
 
+  void AddScale(double factor, m2::PointD const & pxPoint, bool isAnim)
+  {
+    m_stream.AddEvent(make_unique_dp<df::ScaleEvent>(factor, pxPoint, isAnim));
+  }
+
+  void AddFollowAndRotate(m2::PointD const & userPos, m2::PointD const & pixelZero, int preferredZoomLevel)
+  {
+    m_stream.AddEvent(make_unique_dp<df::FollowAndRotateEvent>(
+        userPos, pixelZero, 0.0 /* azimuth */, preferredZoomLevel, true /* isAnim */, nullptr /* onFinishAction */,
+        nullptr /* parallelAnimCreator */));
+  }
+
+  std::vector<std::string> const & AnimatedScaleLog() const { return m_animatedScaleLog; }
+
   ScreenBase const & GetScreen() const { return m_stream.GetCurrentScreen(); }
 
   void AddExpectation(char const * action) { m_expectation.push_back(action); }
@@ -93,10 +111,30 @@ private:
   }
 
 private:
+  // UserEventStream's constructor reads the drag threshold from VisualParams, so the params must be
+  // initialized before m_stream is constructed. This member is declared first to guarantee that
+  // order, which also lets a single test run in isolation (--filter) without another test having
+  // initialized VisualParams first.
+  struct VisualParamsInitializer
+  {
+    VisualParamsInitializer() { df::VisualParams::Init(1.0 /* visualScale */, 1024 /* tileSize */); }
+  };
+  VisualParamsInitializer m_visualParamsInitializer;
   df::UserEventStream m_stream;
   std::list<char const *> m_expectation;
+  std::vector<std::string> m_animatedScaleLog;
   bool m_filtrate;
 };
+
+// The animation system is a process-wide singleton: complete all pending animations so their
+// callbacks cannot leak into another test. Advance() only drains the front block of the animation
+// chain, so loop until the whole chain is empty.
+void FinishAllAnimations()
+{
+  auto & animationSystem = df::AnimationSystem::Instance();
+  while (animationSystem.HasAnimations())
+    animationSystem.Advance(1000.0 /* elapsedSeconds */);
+}
 
 int touchTimeStamp = 1;
 
@@ -244,6 +282,65 @@ UNIT_CLASS_TEST(VisualParamsFixture, SetCenter_AlignsToVisibleViewportCenter)
     TEST(std::fabs(pixelPos.y - viewportCenter.y) < kEps,
          (pixelPos.y, "expected", viewportCenter.y, "trackVisibleViewport", trackVisibleViewport));
   }
+}
+
+UNIT_TEST(AnimatedScale_CallbacksOrder)
+{
+  FinishAllAnimations();
+
+  UserEventStreamTest test(false);
+  test.AddResizeEvent(1000, 1000);
+  test.SetRect(m2::RectD(-250.0, -250.0, 250.0, 250.0));
+  test.RunTest();
+  TEST(test.AnimatedScaleLog().empty(), ());
+
+  // An accepted animated scale reports the start before running the animation...
+  test.AddScale(2.0 /* factor */, m2::PointD(500.0, 500.0), true /* isAnim */);
+  test.RunTest();
+  TEST_EQUAL(test.AnimatedScaleLog().front(), "started", ());
+
+  // ...and the end on its completion.
+  FinishAllAnimations();
+  std::vector<std::string> const expected = {"started", "ended"};
+  TEST_EQUAL(test.AnimatedScaleLog(), expected, ());
+}
+
+UNIT_TEST(AnimatedScale_RejectedScaleReportsNothing)
+{
+  FinishAllAnimations();
+
+  UserEventStreamTest test(false);
+  // Set up the screen exactly at zoom 9, so that the follow animation below changes
+  // the scale over a short distance and cannot become a "pretty" move animation.
+  test.AddResizeEvent(1000, 1000);
+  double const halfScreen = 500.0 * df::GetScreenScale(9);
+  test.SetRect(m2::RectD(-halfScreen, -halfScreen, halfScreen, halfScreen));
+  test.RunTest();
+
+  // A follow animation with a pixel offset is in flight: the animated scale must be
+  // rejected without reporting the start or the end.
+  test.AddFollowAndRotate(m2::PointD(0.0, 0.0), m2::PointD(500.0, 900.0), 8 /* preferredZoomLevel */);
+  test.AddScale(2.0 /* factor */, m2::PointD(500.0, 500.0), true /* isAnim */);
+  test.RunTest();
+  TEST(test.AnimatedScaleLog().empty(), ());
+
+  FinishAllAnimations();
+  TEST(test.AnimatedScaleLog().empty(), ());
+}
+
+UNIT_TEST(AnimatedScale_NotAnimatedScaleEndsInstantly)
+{
+  FinishAllAnimations();
+
+  UserEventStreamTest test(false);
+  test.AddResizeEvent(1000, 1000);
+  test.SetRect(m2::RectD(-250.0, -250.0, 250.0, 250.0));
+  test.RunTest();
+
+  test.AddScale(2.0 /* factor */, m2::PointD(500.0, 500.0), false /* isAnim */);
+  test.RunTest();
+  std::vector<std::string> const expected = {"ended"};
+  TEST_EQUAL(test.AnimatedScaleLog(), expected, ());
 }
 
 #endif

--- a/libs/drape_frontend/drape_frontend_tests/user_event_stream_tests.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/user_event_stream_tests.cpp
@@ -1,7 +1,9 @@
 #include "testing/testing.hpp"
 
+#include "drape_frontend/animation_system.hpp"
 #include "drape_frontend/drape_frontend_tests/visual_params_fixture.hpp"
 #include "drape_frontend/user_event_stream.hpp"
+#include "drape_frontend/visual_params.hpp"
 
 #include "base/thread.hpp"
 
@@ -9,6 +11,8 @@
 #include <cstring>
 #include <functional>
 #include <list>
+#include <string>
+#include <vector>
 
 namespace user_event_stream_test
 {
@@ -25,6 +29,7 @@ public:
   explicit UserEventStreamTest(bool filtrateTouches) : m_filtrate(filtrateTouches)
   {
     m_stream.SetTestBridge(std::bind(&UserEventStreamTest::TestBridge, this, _1));
+    m_stream.SetListener(ref_ptr<df::UserEventStream::Listener>(this));
   }
 
   void OnTap(m2::PointD const & pt, bool isLong) override {}
@@ -43,7 +48,8 @@ public:
   void CorrectGlobalScalePoint(m2::PointD & pt) const override {}
   void OnScaleEnded() override {}
   void OnTouchMapAction(df::TouchEvent::ETouchType touchType, bool isMapTouch) override {}
-  void OnAnimatedScaleEnded() override {}
+  void OnAnimatedScaleStarted() override { m_animatedScaleLog.push_back("started"); }
+  void OnAnimatedScaleEnded() override { m_animatedScaleLog.push_back("ended"); }
   bool OnNewVisibleViewport(m2::RectD const & oldViewport, m2::RectD const & newViewport, bool needOffset,
                             m2::PointD & gOffset) override
   {
@@ -72,6 +78,20 @@ public:
                                                          nullptr /* parallelAnimCreator */));
   }
 
+  void AddScale(double factor, m2::PointD const & pxPoint, bool isAnim)
+  {
+    m_stream.AddEvent(make_unique_dp<df::ScaleEvent>(factor, pxPoint, isAnim));
+  }
+
+  void AddFollowAndRotate(m2::PointD const & userPos, m2::PointD const & pixelZero, int preferredZoomLevel)
+  {
+    m_stream.AddEvent(make_unique_dp<df::FollowAndRotateEvent>(
+        userPos, pixelZero, 0.0 /* azimuth */, preferredZoomLevel, true /* isAnim */, nullptr /* onFinishAction */,
+        nullptr /* parallelAnimCreator */));
+  }
+
+  std::vector<std::string> const & AnimatedScaleLog() const { return m_animatedScaleLog; }
+
   ScreenBase const & GetScreen() const { return m_stream.GetCurrentScreen(); }
 
   void AddExpectation(char const * action) { m_expectation.push_back(action); }
@@ -93,10 +113,30 @@ private:
   }
 
 private:
+  // UserEventStream's constructor reads the drag threshold from VisualParams, so the params must be
+  // initialized before m_stream is constructed. This member is declared first to guarantee that
+  // order, which also lets a single test run in isolation (--filter) without another test having
+  // initialized VisualParams first.
+  struct VisualParamsInitializer
+  {
+    VisualParamsInitializer() { df::VisualParams::Init(1.0 /* visualScale */, 1024 /* tileSize */); }
+  };
+  VisualParamsInitializer m_visualParamsInitializer;
   df::UserEventStream m_stream;
   std::list<char const *> m_expectation;
+  std::vector<std::string> m_animatedScaleLog;
   bool m_filtrate;
 };
+
+// The animation system is a process-wide singleton: complete all pending animations so their
+// callbacks cannot leak into another test. Advance() only drains the front block of the animation
+// chain, so loop until the whole chain is empty.
+void FinishAllAnimations()
+{
+  auto & animationSystem = df::AnimationSystem::Instance();
+  while (animationSystem.HasAnimations())
+    animationSystem.Advance(1000.0 /* elapsedSeconds */);
+}
 
 int touchTimeStamp = 1;
 
@@ -244,6 +284,65 @@ UNIT_CLASS_TEST(VisualParamsFixture, SetCenter_AlignsToVisibleViewportCenter)
     TEST(std::fabs(pixelPos.y - viewportCenter.y) < kEps,
          (pixelPos.y, "expected", viewportCenter.y, "trackVisibleViewport", trackVisibleViewport));
   }
+}
+
+UNIT_TEST(AnimatedScale_CallbacksOrder)
+{
+  FinishAllAnimations();
+
+  UserEventStreamTest test(false);
+  test.AddResizeEvent(1000, 1000);
+  test.SetRect(m2::RectD(-250.0, -250.0, 250.0, 250.0));
+  test.RunTest();
+  TEST(test.AnimatedScaleLog().empty(), ());
+
+  // An accepted animated scale reports the start before running the animation...
+  test.AddScale(2.0 /* factor */, m2::PointD(500.0, 500.0), true /* isAnim */);
+  test.RunTest();
+  TEST_EQUAL(test.AnimatedScaleLog().front(), "started", ());
+
+  // ...and the end on its completion.
+  FinishAllAnimations();
+  std::vector<std::string> const expected = {"started", "ended"};
+  TEST_EQUAL(test.AnimatedScaleLog(), expected, ());
+}
+
+UNIT_TEST(AnimatedScale_RejectedScaleReportsNothing)
+{
+  FinishAllAnimations();
+
+  UserEventStreamTest test(false);
+  // Set up the screen exactly at zoom 9, so that the follow animation below changes
+  // the scale over a short distance and cannot become a "pretty" move animation.
+  test.AddResizeEvent(1000, 1000);
+  double const halfScreen = 500.0 * df::GetScreenScale(9);
+  test.SetRect(m2::RectD(-halfScreen, -halfScreen, halfScreen, halfScreen));
+  test.RunTest();
+
+  // A follow animation with a pixel offset is in flight: the animated scale must be
+  // rejected without reporting the start or the end.
+  test.AddFollowAndRotate(m2::PointD(0.0, 0.0), m2::PointD(500.0, 900.0), 8 /* preferredZoomLevel */);
+  test.AddScale(2.0 /* factor */, m2::PointD(500.0, 500.0), true /* isAnim */);
+  test.RunTest();
+  TEST(test.AnimatedScaleLog().empty(), ());
+
+  FinishAllAnimations();
+  TEST(test.AnimatedScaleLog().empty(), ());
+}
+
+UNIT_TEST(AnimatedScale_NotAnimatedScaleEndsInstantly)
+{
+  FinishAllAnimations();
+
+  UserEventStreamTest test(false);
+  test.AddResizeEvent(1000, 1000);
+  test.SetRect(m2::RectD(-250.0, -250.0, 250.0, 250.0));
+  test.RunTest();
+
+  test.AddScale(2.0 /* factor */, m2::PointD(500.0, 500.0), false /* isAnim */);
+  test.RunTest();
+  std::vector<std::string> const expected = {"ended"};
+  TEST_EQUAL(test.AnimatedScaleLog(), expected, ());
 }
 
 #endif

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -2224,6 +2224,14 @@ void FrontendRenderer::OnScaleEnded()
   m_selectionTrackInfo.reset();
 }
 
+void FrontendRenderer::OnAnimatedScaleStarted()
+{
+  // Block the auto zoom for the whole animation, not only after its completion in
+  // OnAnimatedScaleEnded(): otherwise a location update arriving mid-animation could
+  // cancel the user's zoom with an auto zoom one.
+  m_myPositionController->ResetBlockAutoZoomTimer();
+}
+
 void FrontendRenderer::OnAnimatedScaleEnded()
 {
   m_myPositionController->ResetBlockAutoZoomTimer();

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -685,7 +685,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
 
   case Message::Type::EnablePerspective:
   {
-    AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(true /* isAutoPerspective */));
+    UpdateRoutingPerspective();
     break;
   }
 
@@ -698,7 +698,10 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
     if (m_enablePerspectiveInNavigation == msg->AllowPerspective() &&
         m_enablePerspectiveInNavigation != screen.isPerspective())
     {
-      AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(m_enablePerspectiveInNavigation));
+      if (m_myPositionController->IsInRouting())
+        UpdateRoutingPerspective();
+      else
+        AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(m_enablePerspectiveInNavigation));
     }
 #endif
 
@@ -714,7 +717,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
       m_enablePerspectiveInNavigation = msg->AllowPerspective();
       m_myPositionController->EnablePerspectiveInRouting(m_enablePerspectiveInNavigation);
       if (m_myPositionController->IsInRouting())
-        AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(m_enablePerspectiveInNavigation));
+        UpdateRoutingPerspective();
     }
     break;
   }
@@ -1137,15 +1140,21 @@ void FrontendRenderer::UpdateContextDependentResources()
 void FrontendRenderer::FollowRoute(int preferredZoomLevel, int preferredZoomLevelIn3d, bool enableAutoZoom,
                                    bool isArrowGlued)
 {
-  m_myPositionController->ActivateRouting(
-      !m_enablePerspectiveInNavigation ? preferredZoomLevel : preferredZoomLevelIn3d, enableAutoZoom, isArrowGlued);
+  m_myPositionController->ActivateRouting(preferredZoomLevel, preferredZoomLevelIn3d, enableAutoZoom, isArrowGlued);
 
-  if (m_enablePerspectiveInNavigation)
-    AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(true /* isAutoPerspective */));
+  UpdateRoutingPerspective();
 
   m_routeRenderer->SetFollowingEnabled(true);
   CHECK(m_context != nullptr, ());
   m_postprocessRenderer->OnChangedRouteFollowingMode(m_context, true /* active */);
+}
+
+void FrontendRenderer::UpdateRoutingPerspective()
+{
+  if (!m_myPositionController->IsInRouting())
+    return;
+
+  AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(m_myPositionController->ShouldEnablePerspectiveInRouting()));
 }
 
 bool FrontendRenderer::CheckRouteRecaching(ref_ptr<BaseSubrouteData> subrouteData)
@@ -2615,6 +2624,14 @@ void FrontendRenderer::AddUserEvent(drape_ptr<UserEvent> && event)
 void FrontendRenderer::PositionChanged(m2::PointD const & position, bool hasPosition)
 {
   m_userPositionChangedHandler(position, hasPosition);
+}
+
+void FrontendRenderer::MyPositionModeChanged(location::EMyPositionMode mode, bool routingActive)
+{
+  // The routing perspective depends on the chosen routing orientation, so it changes only
+  // with a following mode; pending and not-follow states must not flatten the camera.
+  if (routingActive && location::IsFollowingMode(mode))
+    UpdateRoutingPerspective();
 }
 
 void FrontendRenderer::ChangeModelView(m2::PointD const & center, int zoomLevel,

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -695,7 +695,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
 
   case Message::Type::EnablePerspective:
   {
-    AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(true /* isAutoPerspective */));
+    UpdateRoutingPerspective();
     break;
   }
 
@@ -708,7 +708,10 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
     if (m_enablePerspectiveInNavigation == msg->AllowPerspective() &&
         m_enablePerspectiveInNavigation != screen.isPerspective())
     {
-      AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(m_enablePerspectiveInNavigation));
+      if (m_myPositionController->IsInRouting())
+        UpdateRoutingPerspective();
+      else
+        AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(m_enablePerspectiveInNavigation));
     }
 #endif
 
@@ -724,7 +727,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
       m_enablePerspectiveInNavigation = msg->AllowPerspective();
       m_myPositionController->EnablePerspectiveInRouting(m_enablePerspectiveInNavigation);
       if (m_myPositionController->IsInRouting())
-        AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(m_enablePerspectiveInNavigation));
+        UpdateRoutingPerspective();
     }
     break;
   }
@@ -1147,15 +1150,21 @@ void FrontendRenderer::UpdateContextDependentResources()
 void FrontendRenderer::FollowRoute(int preferredZoomLevel, int preferredZoomLevelIn3d, bool enableAutoZoom,
                                    bool isArrowGlued)
 {
-  m_myPositionController->ActivateRouting(
-      !m_enablePerspectiveInNavigation ? preferredZoomLevel : preferredZoomLevelIn3d, enableAutoZoom, isArrowGlued);
+  m_myPositionController->ActivateRouting(preferredZoomLevel, preferredZoomLevelIn3d, enableAutoZoom, isArrowGlued);
 
-  if (m_enablePerspectiveInNavigation)
-    AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(true /* isAutoPerspective */));
+  UpdateRoutingPerspective();
 
   m_routeRenderer->SetFollowingEnabled(true);
   CHECK(m_context != nullptr, ());
   m_postprocessRenderer->OnChangedRouteFollowingMode(m_context, true /* active */);
+}
+
+void FrontendRenderer::UpdateRoutingPerspective()
+{
+  if (!m_myPositionController->IsInRouting())
+    return;
+
+  AddUserEvent(make_unique_dp<SetAutoPerspectiveEvent>(m_myPositionController->ShouldEnablePerspectiveInRouting()));
 }
 
 bool FrontendRenderer::CheckRouteRecaching(ref_ptr<BaseSubrouteData> subrouteData)
@@ -2622,6 +2631,14 @@ void FrontendRenderer::AddUserEvent(drape_ptr<UserEvent> && event)
 void FrontendRenderer::PositionChanged(m2::PointD const & position, bool hasPosition)
 {
   m_userPositionChangedHandler(position, hasPosition);
+}
+
+void FrontendRenderer::MyPositionModeChanged(location::EMyPositionMode mode, bool routingActive)
+{
+  // The routing perspective depends on the chosen routing orientation, so it changes only
+  // with a following mode; pending and not-follow states must not flatten the camera.
+  if (routingActive && location::IsFollowingMode(mode))
+    UpdateRoutingPerspective();
 }
 
 void FrontendRenderer::ChangeModelView(m2::PointD const & center, int zoomLevel,

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -2231,6 +2231,14 @@ void FrontendRenderer::OnScaleEnded()
   m_selectionTrackInfo.reset();
 }
 
+void FrontendRenderer::OnAnimatedScaleStarted()
+{
+  // Block the auto zoom for the whole animation, not only after its completion in
+  // OnAnimatedScaleEnded(): otherwise a location update arriving mid-animation could
+  // cancel the user's zoom with an auto zoom one.
+  m_myPositionController->ResetBlockAutoZoomTimer();
+}
+
 void FrontendRenderer::OnAnimatedScaleEnded()
 {
   m_myPositionController->ResetBlockAutoZoomTimer();

--- a/libs/drape_frontend/frontend_renderer.hpp
+++ b/libs/drape_frontend/frontend_renderer.hpp
@@ -244,6 +244,7 @@ private:
   void CorrectScalePoint(m2::PointD & pt1, m2::PointD & pt2) const override;
   void CorrectGlobalScalePoint(m2::PointD & pt) const override;
   void OnScaleEnded() override;
+  void OnAnimatedScaleStarted() override;
   void OnAnimatedScaleEnded() override;
   void OnTouchMapAction(TouchEvent::ETouchType touchType, bool isMapTouch) override;
   bool OnNewVisibleViewport(m2::RectD const & oldViewport, m2::RectD const & newViewport, bool needOffset,

--- a/libs/drape_frontend/frontend_renderer.hpp
+++ b/libs/drape_frontend/frontend_renderer.hpp
@@ -154,6 +154,7 @@ public:
                        TAnimationCreator const & parallelAnimCreator) override;
   void ChangeModelView(double autoScale, m2::PointD const & userPos, double azimuth, m2::PointD const & pxZero,
                        TAnimationCreator const & parallelAnimCreator) override;
+  void MyPositionModeChanged(location::EMyPositionMode mode, bool routingActive) override;
 
   drape_ptr<ScenarioManager> const & GetScenarioManager() const { return m_scenarioManager; }
   location::EMyPositionMode GetMyPositionMode() const { return m_myPositionController->GetCurrentMode(); }
@@ -278,6 +279,7 @@ private:
   void RemoveRenderGroupsLater(TRenderGroupRemovePredicate const & predicate);
 
   void FollowRoute(int preferredZoomLevel, int preferredZoomLevelIn3d, bool enableAutoZoom, bool isArrowGlued);
+  void UpdateRoutingPerspective();
 
   bool CheckRouteRecaching(ref_ptr<BaseSubrouteData> subrouteData);
 

--- a/libs/drape_frontend/my_position_controller.cpp
+++ b/libs/drape_frontend/my_position_controller.cpp
@@ -11,6 +11,7 @@
 
 #include "platform/measurement_utils.hpp"
 
+#include "base/assert.hpp"
 #include "base/math.hpp"
 
 #include <algorithm>
@@ -112,11 +113,6 @@ void ResetNotification(uint64_t & notifyId)
 {
   notifyId = DrapeNotifier::kInvalidId;
 }
-
-bool IsModeChangeViewport(location::EMyPositionMode mode)
-{
-  return mode == location::Follow || mode == location::FollowAndRotate;
-}
 }  // namespace
 
 MyPositionController::MyPositionController(Params && params, ref_ptr<DrapeNotifier> notifier)
@@ -153,7 +149,6 @@ MyPositionController::MyPositionController(Params && params, ref_ptr<DrapeNotifi
 {
   using namespace location;
 
-  m_mode = PendingPosition;
   if (m_hints.m_isLaunchByDeepLink)
   {
     m_desiredInitMode = NotFollow;
@@ -172,11 +167,72 @@ MyPositionController::MyPositionController(Params && params, ref_ptr<DrapeNotifi
 
     // Do not start position if we ended previous session without it.
     if (!m_isInRouting && m_desiredInitMode == NotFollowNoPosition)
-      m_mode = NotFollowNoPosition;
+      m_positionStatus = PositionStatus::Stopped;
   }
 
   if (m_modeChangeCallback)
-    m_modeChangeCallback(m_mode, m_isInRouting);
+    m_modeChangeCallback(GetCurrentMode(), m_isInRouting);
+}
+
+location::EMyPositionMode MyPositionController::GetCurrentMode() const
+{
+  switch (m_positionStatus)
+  {
+  case PositionStatus::Stopped: return location::NotFollowNoPosition;
+  case PositionStatus::Acquiring: return location::PendingPosition;
+  case PositionStatus::Available:
+    if (m_tracking == CameraTracking::Free)
+      return location::NotFollow;
+    return m_rotation == CameraRotation::DirectionUp ? location::FollowAndRotate : location::Follow;
+  }
+  UNREACHABLE();
+}
+
+void MyPositionController::SetPositionStatus(PositionStatus status)
+{
+  auto const oldMode = GetCurrentMode();
+  m_positionStatus = status;
+  NotifyModeChanged(oldMode);
+}
+
+void MyPositionController::StartFollowing(CameraRotation rotation)
+{
+  auto const oldMode = GetCurrentMode();
+  // Following implies an available position, so claim one here: routing may start the following
+  // camera even before the first location fix.
+  m_positionStatus = PositionStatus::Available;
+  m_tracking = CameraTracking::Follow;
+  m_rotation = rotation;
+  NotifyModeChanged(oldMode);
+}
+
+void MyPositionController::StopFollowing()
+{
+  auto const oldMode = GetCurrentMode();
+  // A free camera still shows the user position.
+  m_positionStatus = PositionStatus::Available;
+  m_tracking = CameraTracking::Free;
+  NotifyModeChanged(oldMode);
+}
+
+void MyPositionController::NotifyModeChanged(location::EMyPositionMode oldMode)
+{
+  auto const newMode = GetCurrentMode();
+  if (m_isInRouting && oldMode != newMode && newMode == location::FollowAndRotate)
+    ResetBlockAutoZoomTimer();
+
+  if (m_modeChangeCallback)
+    m_modeChangeCallback(newMode, m_isInRouting);
+}
+
+bool MyPositionController::IsFollowing() const
+{
+  return m_positionStatus == PositionStatus::Available && m_tracking == CameraTracking::Follow;
+}
+
+bool MyPositionController::IsFollowingDirectionUp() const
+{
+  return IsFollowing() && m_rotation == CameraRotation::DirectionUp;
 }
 
 void MyPositionController::UpdatePosition()
@@ -218,12 +274,12 @@ double MyPositionController::GetHorizontalAccuracy() const
 
 bool MyPositionController::IsModeChangeViewport() const
 {
-  return df::IsModeChangeViewport(m_mode);
+  return IsFollowing();
 }
 
 bool MyPositionController::IsModeHasPosition() const
 {
-  return m_mode != location::PendingPosition && m_mode != location::NotFollowNoPosition;
+  return m_positionStatus == PositionStatus::Available;
 }
 
 void MyPositionController::DragStarted()
@@ -262,13 +318,13 @@ void MyPositionController::ScaleEnded()
 
 void MyPositionController::Rotated()
 {
-  if (m_mode == location::FollowAndRotate)
+  if (IsFollowingDirectionUp())
     m_wasRotationInScaling = true;
 }
 
 void MyPositionController::Scrolled(m2::PointD const & distance)
 {
-  if (m_mode == location::PendingPosition)
+  if (m_positionStatus == PositionStatus::Acquiring)
     return;
 
   if (distance.Length() > 0)
@@ -338,19 +394,18 @@ void MyPositionController::ResetRenderShape()
 void MyPositionController::NextMode(ScreenBase const & screen)
 {
   // When the app is awaiting location (indicator is active) and the user presses on the indicator, location updates
-  // will be stopped and goes into NotFollowNoPosition state. The next press on the indicator will start location
-  // updates again.
+  // will be stopped and goes into Stopped state. The next press on the indicator will start location updates again.
   if (IsWaitingForLocation())
   {
     m_desiredInitMode = location::Follow;
-    ChangeMode(location::NotFollowNoPosition);
+    SetPositionStatus(PositionStatus::Stopped);
     return;
   }
 
   // Start looking for location.
-  if (m_mode == location::NotFollowNoPosition)
+  if (m_positionStatus == PositionStatus::Stopped)
   {
-    ChangeMode(location::PendingPosition);
+    SetPositionStatus(PositionStatus::Acquiring);
 
     if (!m_isPositionAssigned)
     {
@@ -367,34 +422,31 @@ void MyPositionController::NextMode(ScreenBase const & screen)
   if (currentZoom < kZoomThreshold)
     preferredZoomLevel = std::min(GetZoomLevel(screen, m_position, m_errorRadius), kMaxScaleZoomLevel);
 
-  // In routing not-follow -> follow-and-rotate, otherwise not-follow -> follow.
-  if (m_mode == location::NotFollow)
+  // A free camera returns to following: direction-up in routing, fixed rotation otherwise.
+  if (m_tracking == CameraTracking::Free)
   {
-    ChangeMode(m_isInRouting ? location::FollowAndRotate : location::Follow);
+    StartFollowing(m_isInRouting ? CameraRotation::DirectionUp : CameraRotation::Fixed);
     UpdateViewport(preferredZoomLevel);
     return;
   }
 
-  // From follow mode we transit to follow-and-rotate if compass is available or
+  // From fixed rotation we transit to direction-up if compass is available or
   // routing is enabled.
-  if (m_mode == location::Follow)
+  if (m_rotation == CameraRotation::Fixed)
   {
     if (IsRotationAvailable() || m_isInRouting)
     {
-      ChangeMode(location::FollowAndRotate);
+      StartFollowing(CameraRotation::DirectionUp);
       UpdateViewport(preferredZoomLevel);
     }
     return;
   }
 
-  // From follow-and-rotate mode we can transit to follow mode.
-  if (m_mode == location::FollowAndRotate)
-  {
-    if (m_isInRouting && screen.isPerspective())
-      preferredZoomLevel = static_cast<int>(GetZoomLevel(ScreenBase::GetStartPerspectiveScale() * 1.1));
-    ChangeMode(location::Follow);
-    ChangeModelView(m_position, 0.0, m_visiblePixelRect.Center(), preferredZoomLevel);
-  }
+  // From direction-up we return to fixed rotation and reset the map to north-up.
+  if (m_isInRouting && screen.isPerspective())
+    preferredZoomLevel = static_cast<int>(GetZoomLevel(ScreenBase::GetStartPerspectiveScale() * 1.1));
+  StartFollowing(CameraRotation::Fixed);
+  ChangeModelView(m_position, 0.0, m_visiblePixelRect.Center(), preferredZoomLevel);
 }
 
 void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool isNavigable, ScreenBase const & screen)
@@ -447,33 +499,40 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
 
   if (!m_isPositionAssigned)
   {
-    location::EMyPositionMode newMode = m_desiredInitMode;
-    ChangeMode(newMode);
+    // The very first fix of the session applies the mode the controller was initialized with.
+    switch (m_desiredInitMode)
+    {
+    case location::Follow: StartFollowing(CameraRotation::Fixed); break;
+    case location::FollowAndRotate: StartFollowing(CameraRotation::DirectionUp); break;
+    case location::NotFollow: StopFollowing(); break;
+    case location::NotFollowNoPosition: SetPositionStatus(PositionStatus::Stopped); break;
+    case location::PendingPosition: SetPositionStatus(PositionStatus::Acquiring); break;
+    }
 
     if (!m_hints.m_isFirstLaunch || !AnimationSystem::Instance().AnimationExists(Animation::Object::MapPlane))
     {
-      if (m_mode == location::Follow)
-      {
-        ChangeModelView(m_position, kDoNotChangeZoom);
-      }
-      else if (m_mode == location::FollowAndRotate)
+      if (IsFollowingDirectionUp())
       {
         ChangeModelView(m_position, m_drawDirection,
                         m_isInRouting ? GetRoutingRotationPixelCenter() : m_visiblePixelRect.Center(),
                         kDoNotChangeZoom);
       }
+      else if (IsFollowing())
+      {
+        ChangeModelView(m_position, kDoNotChangeZoom);
+      }
     }
   }
-  else if (m_mode == location::PendingPosition)
+  else if (m_positionStatus == PositionStatus::Acquiring)
   {
     if (m_isInRouting)
     {
-      ChangeMode(location::FollowAndRotate);
+      StartFollowing(CameraRotation::DirectionUp);
       UpdateViewport(kMaxScaleZoomLevel);
     }
     else
     {
-      ChangeMode(location::Follow);
+      StartFollowing(CameraRotation::Fixed);
       if (m_hints.m_isFirstLaunch)
       {
         if (!AnimationSystem::Instance().AnimationExists(Animation::Object::MapPlane))
@@ -490,17 +549,17 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
       }
     }
   }
-  else if (m_mode == location::NotFollowNoPosition)
+  else if (m_positionStatus == PositionStatus::Stopped)
   {
     if (m_isInRouting)
     {
-      ChangeMode(location::FollowAndRotate);
+      StartFollowing(CameraRotation::DirectionUp);
       UpdateViewport(kMaxScaleZoomLevel);
     }
     else
     {
-      // Here we silently get the position and go to NotFollow mode.
-      ChangeMode(location::NotFollow);
+      // Here we silently get the position and stop following.
+      StopFollowing();
     }
   }
 
@@ -519,12 +578,15 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
 
 void MyPositionController::LoseLocation()
 {
-  if (m_mode == location::NotFollowNoPosition)
+  if (m_positionStatus == PositionStatus::Stopped)
     return;
-  else if (m_mode == location::Follow || m_mode == location::FollowAndRotate)
-    ChangeMode(location::PendingPosition);
+
+  // Keep searching for the position (Acquiring) when the camera was following, so following can
+  // resume once a fix returns; otherwise turn updates off.
+  if (IsFollowing())
+    SetPositionStatus(PositionStatus::Acquiring);
   else
-    ChangeMode(location::NotFollowNoPosition);
+    SetPositionStatus(PositionStatus::Stopped);
 
   if (m_listener != nullptr)
     m_listener->PositionChanged(Position(), false /* hasPosition */);
@@ -544,7 +606,7 @@ void MyPositionController::OnCompassUpdate(location::CompassInfo const & info, S
 
   SetDirection(info.m_bearing);
 
-  if (m_isPositionAssigned && m_mode == location::FollowAndRotate && !AlmostCurrentAzimut(oldAzimut))
+  if (m_isPositionAssigned && IsFollowingDirectionUp() && !AlmostCurrentAzimut(oldAzimut))
   {
     CreateAnim(GetDrawablePosition(), oldAzimut, screen);
     m_isDirtyViewport = true;
@@ -554,8 +616,7 @@ void MyPositionController::OnCompassUpdate(location::CompassInfo const & info, S
 bool MyPositionController::UpdateViewportWithAutoZoom()
 {
   double const autoScale = m_enablePerspectiveInRouting ? m_autoScale3d : m_autoScale2d;
-  if (autoScale > 0.0 && m_mode == location::FollowAndRotate && m_isInRouting && m_enableAutoZoomInRouting &&
-      !m_needBlockAutoZoom)
+  if (autoScale > 0.0 && IsFollowingDirectionUp() && m_isInRouting && m_enableAutoZoomInRouting && !m_needBlockAutoZoom)
   {
     ChangeModelView(autoScale, m_position, m_drawDirection, GetRoutingRotationPixelCenter());
     return true;
@@ -603,7 +664,7 @@ void MyPositionController::Render(ref_ptr<dp::GraphicsContext> context, ref_ptr<
 
 bool MyPositionController::IsRouteFollowingActive() const
 {
-  return IsInRouting() && m_mode == location::FollowAndRotate;
+  return IsInRouting() && IsFollowingDirectionUp();
 }
 
 bool MyPositionController::AlmostCurrentPosition(m2::PointD const & pos) const
@@ -624,31 +685,21 @@ void MyPositionController::SetDirection(double bearing)
   m_isDirectionAssigned = true;
 }
 
-void MyPositionController::ChangeMode(location::EMyPositionMode newMode)
-{
-  if (m_isInRouting && (m_mode != newMode) && (newMode == location::FollowAndRotate))
-    ResetBlockAutoZoomTimer();
-
-  m_mode = newMode;
-  if (m_modeChangeCallback)
-    m_modeChangeCallback(m_mode, m_isInRouting);
-}
-
 bool MyPositionController::IsWaitingForLocation() const
 {
-  if (m_mode == location::NotFollowNoPosition)
+  if (m_positionStatus == PositionStatus::Stopped)
     return false;
 
   if (!m_isPositionAssigned)
     return true;
 
-  return m_mode == location::PendingPosition;
+  return m_positionStatus == PositionStatus::Acquiring;
 }
 
 void MyPositionController::StopLocationFollow()
 {
-  if (m_mode == location::Follow || m_mode == location::FollowAndRotate)
-    ChangeMode(location::NotFollow);
+  if (IsFollowing())
+    StopFollowing();
   m_desiredInitMode = location::NotFollow;
 
   ResetRoutingNotFollowTimer();
@@ -660,16 +711,16 @@ void MyPositionController::OnEnterForeground(double backgroundTime)
   if (backgroundTime >= kMaxTimeInBackgroundSec)
   {
     // When location was active during previous session the app will try to follow the user.
-    if (m_mode == location::NotFollow)
+    if (m_positionStatus == PositionStatus::Available && m_tracking == CameraTracking::Free)
     {
-      ChangeMode(m_isInRouting ? location::FollowAndRotate : location::Follow);
+      StartFollowing(m_isInRouting ? CameraRotation::DirectionUp : CameraRotation::Fixed);
       UpdateViewport(kDoNotChangeZoom);
     }
 
     // When location was stopped by the user manually app will try to find position but without following.
-    else if (m_mode == location::NotFollowNoPosition)
+    else if (m_positionStatus == PositionStatus::Stopped)
     {
-      ChangeMode(location::PendingPosition);
+      SetPositionStatus(PositionStatus::Acquiring);
     }
   }
 }
@@ -678,9 +729,9 @@ void MyPositionController::OnEnterBackground() {}
 
 void MyPositionController::OnCompassTapped()
 {
-  if (m_mode == location::FollowAndRotate)
+  if (IsFollowingDirectionUp())
   {
-    ChangeMode(location::Follow);
+    StartFollowing(CameraRotation::Fixed);
     ChangeModelView(m_position, 0.0, m_visiblePixelRect.Center(), kDoNotChangeZoom);
   }
   else
@@ -731,24 +782,24 @@ void MyPositionController::UpdateViewport(int zoomLevel)
   if (IsWaitingForLocation())
     return;
 
-  if (m_mode == location::Follow)
-  {
-    ChangeModelView(m_position, zoomLevel);
-  }
-  else if (m_mode == location::FollowAndRotate)
+  if (IsFollowingDirectionUp())
   {
     ChangeModelView(m_position, m_drawDirection,
                     m_isInRouting ? GetRoutingRotationPixelCenter() : m_visiblePixelRect.Center(), zoomLevel);
+  }
+  else if (IsFollowing())
+  {
+    ChangeModelView(m_position, zoomLevel);
   }
 }
 
 m2::PointD MyPositionController::GetRotationPixelCenter() const
 {
-  if (m_mode == location::Follow)
-    return m_visiblePixelRect.Center();
-
-  if (m_mode == location::FollowAndRotate)
+  if (IsFollowingDirectionUp())
     return m_isInRouting ? GetRoutingRotationPixelCenter() : m_visiblePixelRect.Center();
+
+  if (IsFollowing())
+    return m_visiblePixelRect.Center();
 
   return m2::PointD::Zero();
 }
@@ -845,7 +896,7 @@ void MyPositionController::ActivateRouting(int zoomLevel, bool enableAutoZoom, b
     m_isArrowGluedInRouting = isArrowGlued;
     m_enableAutoZoomInRouting = enableAutoZoom;
 
-    ChangeMode(location::FollowAndRotate);
+    StartFollowing(CameraRotation::DirectionUp);
     ChangeModelView(m_position, m_isDirectionAssigned ? m_drawDirection : 0.0, GetRoutingRotationPixelCenter(),
                     zoomLevel, [this](ref_ptr<Animation> anim) { UpdateViewport(kDoNotChangeZoom); });
     ResetRoutingNotFollowTimer();
@@ -861,7 +912,7 @@ void MyPositionController::DeactivateRouting()
 
     m_isDirectionAssigned = m_isCompassAvailable && m_isDirectionAssigned;
 
-    ChangeMode(location::Follow);
+    StartFollowing(CameraRotation::Fixed);
     ChangeModelView(m_position, 0.0, m_visiblePixelRect.Center(), kDoNotChangeZoom);
   }
 }
@@ -883,12 +934,13 @@ void MyPositionController::DeactivateRouting()
 
 void MyPositionController::CheckNotFollowRouting()
 {
-  if (!m_blockRoutingNotFollowTimer && IsInRouting() && m_mode == location::NotFollow)
+  if (!m_blockRoutingNotFollowTimer && IsInRouting() && m_positionStatus == PositionStatus::Available &&
+      m_tracking == CameraTracking::Free)
   {
     CHECK_ON_TIMEOUT(m_routingNotFollowNotifyId, kMaxNotFollowRoutingTimeSec, CheckNotFollowRouting);
     if (m_routingNotFollowTimer.ElapsedSeconds() >= kMaxNotFollowRoutingTimeSec)
     {
-      ChangeMode(location::FollowAndRotate);
+      StartFollowing(CameraRotation::DirectionUp);
       UpdateViewport(kDoNotChangeZoom);
     }
   }

--- a/libs/drape_frontend/my_position_controller.cpp
+++ b/libs/drape_frontend/my_position_controller.cpp
@@ -120,6 +120,8 @@ MyPositionController::MyPositionController(Params && params, ref_ptr<DrapeNotifi
   , m_modeChangeCallback(std::move(params.m_myPositionModeCallback))
   , m_hints(params.m_hints)
   , m_isInRouting(params.m_isRoutingActive)
+  , m_routingOrientation(params.m_routingOrientation)
+  , m_routingOrientationChangedCallback(std::move(params.m_routingOrientationChangedCallback))
   , m_needBlockAnimation(false)
   , m_wasRotationInScaling(false)
   , m_errorRadius(0.0)
@@ -170,6 +172,12 @@ MyPositionController::MyPositionController(Params && params, ref_ptr<DrapeNotifi
       m_positionStatus = PositionStatus::Stopped;
   }
 
+  // During active routing the camera follows the route (isRoutingActive is passed as
+  // IsRoutingActive() && IsRoutingFollowing()), so no non-following init mode is coherent: restore
+  // the preferred routing orientation and re-enable the location search if it had been turned off.
+  if (m_isInRouting)
+    m_desiredInitMode = GetPreferredRoutingMode();
+
   if (m_modeChangeCallback)
     m_modeChangeCallback(GetCurrentMode(), m_isInRouting);
 }
@@ -218,11 +226,59 @@ void MyPositionController::StopFollowing()
 void MyPositionController::NotifyModeChanged(location::EMyPositionMode oldMode)
 {
   auto const newMode = GetCurrentMode();
-  if (m_isInRouting && oldMode != newMode && newMode == location::FollowAndRotate)
+  if (m_isInRouting && oldMode != newMode && location::IsFollowingMode(newMode))
     ResetBlockAutoZoomTimer();
 
   if (m_modeChangeCallback)
     m_modeChangeCallback(newMode, m_isInRouting);
+  if (m_listener)
+    m_listener->MyPositionModeChanged(newMode, m_isInRouting);
+}
+
+void MyPositionController::SetRoutingOrientation(location::MapOrientation orientation)
+{
+  CHECK(m_isInRouting, ());
+  if (m_routingOrientation == orientation)
+    return;
+
+  m_routingOrientation = orientation;
+  if (m_routingOrientationChangedCallback)
+    m_routingOrientationChangedCallback(orientation);
+}
+
+location::EMyPositionMode MyPositionController::GetPreferredRoutingMode() const
+{
+  return location::ToPositionMode(m_routingOrientation);
+}
+
+MyPositionController::CameraRotation MyPositionController::GetPreferredRoutingRotation() const
+{
+  return m_routingOrientation == location::MapOrientation::NorthUp ? CameraRotation::Fixed
+                                                                   : CameraRotation::DirectionUp;
+}
+
+void MyPositionController::UpdateRoutingViewport(int zoomLevel, Animation::TAction const & onFinishAction)
+{
+  CHECK(m_isInRouting, ());
+  CHECK(IsFollowing(), ());
+
+  if (m_routingOrientation == location::MapOrientation::NorthUp)
+  {
+    // Request the azimuth explicitly: the center-only ChangeModelView() overload
+    // would keep the current map rotation instead of north-up.
+    ChangeModelView(m_position, 0.0 /* north up */, m_visiblePixelRect.Center(), zoomLevel, onFinishAction);
+    return;
+  }
+
+  ChangeModelView(m_position, m_isDirectionAssigned ? m_drawDirection : 0.0, GetRoutingRotationPixelCenter(), zoomLevel,
+                  onFinishAction);
+}
+
+bool MyPositionController::ShouldEnablePerspectiveInRouting() const
+{
+  // The perspective policy depends on the chosen routing orientation only: temporary states
+  // like an on-going location search or a not-follow pan must not flatten the camera.
+  return m_isInRouting && m_enablePerspectiveInRouting && m_routingOrientation == location::MapOrientation::HeadingUp;
 }
 
 bool MyPositionController::IsFollowing() const
@@ -397,7 +453,8 @@ void MyPositionController::NextMode(ScreenBase const & screen)
   // will be stopped and goes into Stopped state. The next press on the indicator will start location updates again.
   if (IsWaitingForLocation())
   {
-    m_desiredInitMode = location::Follow;
+    // Preserve the routing orientation that should be restored after location becomes available.
+    m_desiredInitMode = m_isInRouting ? GetPreferredRoutingMode() : location::Follow;
     SetPositionStatus(PositionStatus::Stopped);
     return;
   }
@@ -411,7 +468,7 @@ void MyPositionController::NextMode(ScreenBase const & screen)
     {
       // This is the first user location request (button touch) after controller's initialization
       // with some previous not Follow state. The new mode will be Follow to center on the position.
-      m_desiredInitMode = location::Follow;
+      m_desiredInitMode = m_isInRouting ? GetPreferredRoutingMode() : location::Follow;
     }
     return;
   }
@@ -422,10 +479,10 @@ void MyPositionController::NextMode(ScreenBase const & screen)
   if (currentZoom < kZoomThreshold)
     preferredZoomLevel = std::min(GetZoomLevel(screen, m_position, m_errorRadius), kMaxScaleZoomLevel);
 
-  // A free camera returns to following: direction-up in routing, fixed rotation otherwise.
+  // A free camera returns to following: the preferred orientation in routing, fixed rotation otherwise.
   if (m_tracking == CameraTracking::Free)
   {
-    StartFollowing(m_isInRouting ? CameraRotation::DirectionUp : CameraRotation::Fixed);
+    StartFollowing(m_isInRouting ? GetPreferredRoutingRotation() : CameraRotation::Fixed);
     UpdateViewport(preferredZoomLevel);
     return;
   }
@@ -436,6 +493,8 @@ void MyPositionController::NextMode(ScreenBase const & screen)
   {
     if (IsRotationAvailable() || m_isInRouting)
     {
+      if (m_isInRouting)
+        SetRoutingOrientation(location::MapOrientation::HeadingUp);
       StartFollowing(CameraRotation::DirectionUp);
       UpdateViewport(preferredZoomLevel);
     }
@@ -445,6 +504,8 @@ void MyPositionController::NextMode(ScreenBase const & screen)
   // From direction-up we return to fixed rotation and reset the map to north-up.
   if (m_isInRouting && screen.isPerspective())
     preferredZoomLevel = static_cast<int>(GetZoomLevel(ScreenBase::GetStartPerspectiveScale() * 1.1));
+  if (m_isInRouting)
+    SetRoutingOrientation(location::MapOrientation::NorthUp);
   StartFollowing(CameraRotation::Fixed);
   ChangeModelView(m_position, 0.0, m_visiblePixelRect.Center(), preferredZoomLevel);
 }
@@ -511,23 +572,19 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
 
     if (!m_hints.m_isFirstLaunch || !AnimationSystem::Instance().AnimationExists(Animation::Object::MapPlane))
     {
-      if (IsFollowingDirectionUp())
-      {
-        ChangeModelView(m_position, m_drawDirection,
-                        m_isInRouting ? GetRoutingRotationPixelCenter() : m_visiblePixelRect.Center(),
-                        kDoNotChangeZoom);
-      }
+      if (m_isInRouting && IsFollowing())
+        UpdateRoutingViewport(kDoNotChangeZoom);
+      else if (IsFollowingDirectionUp())
+        ChangeModelView(m_position, m_drawDirection, m_visiblePixelRect.Center(), kDoNotChangeZoom);
       else if (IsFollowing())
-      {
         ChangeModelView(m_position, kDoNotChangeZoom);
-      }
     }
   }
   else if (m_positionStatus == PositionStatus::Acquiring)
   {
     if (m_isInRouting)
     {
-      StartFollowing(CameraRotation::DirectionUp);
+      StartFollowing(GetPreferredRoutingRotation());
       UpdateViewport(kMaxScaleZoomLevel);
     }
     else
@@ -553,7 +610,7 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
   {
     if (m_isInRouting)
     {
-      StartFollowing(CameraRotation::DirectionUp);
+      StartFollowing(GetPreferredRoutingRotation());
       UpdateViewport(kMaxScaleZoomLevel);
     }
     else
@@ -615,10 +672,22 @@ void MyPositionController::OnCompassUpdate(location::CompassInfo const & info, S
 
 bool MyPositionController::UpdateViewportWithAutoZoom()
 {
-  double const autoScale = m_enablePerspectiveInRouting ? m_autoScale3d : m_autoScale2d;
-  if (autoScale > 0.0 && IsFollowingDirectionUp() && m_isInRouting && m_enableAutoZoomInRouting && !m_needBlockAutoZoom)
+  if (!m_isInRouting || !m_enableAutoZoomInRouting || m_needBlockAutoZoom)
+    return false;
+
+  if (IsFollowingDirectionUp())
   {
-    ChangeModelView(autoScale, m_position, m_drawDirection, GetRoutingRotationPixelCenter());
+    double const autoScale = ShouldEnablePerspectiveInRouting() ? m_autoScale3d : m_autoScale2d;
+    if (autoScale > 0.0)
+    {
+      ChangeModelView(autoScale, m_position, m_drawDirection, GetRoutingRotationPixelCenter());
+      return true;
+    }
+  }
+  else if (IsFollowing() && m_autoScale2d > 0.0)
+  {
+    // North-up navigation: use the 2D speed scale, keep the north-up azimuth and center the user.
+    ChangeModelView(m_autoScale2d, m_position, 0.0 /* north up */, m_visiblePixelRect.Center());
     return true;
   }
   return false;
@@ -664,7 +733,9 @@ void MyPositionController::Render(ref_ptr<dp::GraphicsContext> context, ref_ptr<
 
 bool MyPositionController::IsRouteFollowingActive() const
 {
-  return IsInRouting() && IsFollowingDirectionUp();
+  // North-up navigation follows the route in the fixed-rotation camera, so any following
+  // camera counts, not only the direction-up one.
+  return IsInRouting() && IsFollowing();
 }
 
 bool MyPositionController::AlmostCurrentPosition(m2::PointD const & pos) const
@@ -713,7 +784,7 @@ void MyPositionController::OnEnterForeground(double backgroundTime)
     // When location was active during previous session the app will try to follow the user.
     if (m_positionStatus == PositionStatus::Available && m_tracking == CameraTracking::Free)
     {
-      StartFollowing(m_isInRouting ? CameraRotation::DirectionUp : CameraRotation::Fixed);
+      StartFollowing(m_isInRouting ? GetPreferredRoutingRotation() : CameraRotation::Fixed);
       UpdateViewport(kDoNotChangeZoom);
     }
 
@@ -731,6 +802,8 @@ void MyPositionController::OnCompassTapped()
 {
   if (IsFollowingDirectionUp())
   {
+    if (m_isInRouting)
+      SetRoutingOrientation(location::MapOrientation::NorthUp);
     StartFollowing(CameraRotation::Fixed);
     ChangeModelView(m_position, 0.0, m_visiblePixelRect.Center(), kDoNotChangeZoom);
   }
@@ -782,13 +855,21 @@ void MyPositionController::UpdateViewport(int zoomLevel)
   if (IsWaitingForLocation())
     return;
 
+  // Every routing-follow restoration goes through UpdateRoutingViewport() to apply
+  // the chosen routing orientation.
+  if (m_isInRouting && IsFollowing())
+  {
+    UpdateRoutingViewport(zoomLevel);
+    return;
+  }
+
   if (IsFollowingDirectionUp())
   {
-    ChangeModelView(m_position, m_drawDirection,
-                    m_isInRouting ? GetRoutingRotationPixelCenter() : m_visiblePixelRect.Center(), zoomLevel);
+    ChangeModelView(m_position, m_drawDirection, m_visiblePixelRect.Center(), zoomLevel);
   }
   else if (IsFollowing())
   {
+    // Outside routing the map may retain a manually chosen fixed angle.
     ChangeModelView(m_position, zoomLevel);
   }
 }
@@ -888,17 +969,19 @@ void MyPositionController::EnableAutoZoomInRouting(bool enableAutoZoom)
   ResetBlockAutoZoomTimer();
 }
 
-void MyPositionController::ActivateRouting(int zoomLevel, bool enableAutoZoom, bool isArrowGlued)
+void MyPositionController::ActivateRouting(int zoomLevel, int zoomLevelIn3d, bool enableAutoZoom, bool isArrowGlued)
 {
   if (!m_isInRouting)
   {
     m_isInRouting = true;
     m_isArrowGluedInRouting = isArrowGlued;
     m_enableAutoZoomInRouting = enableAutoZoom;
+    // Preserve the routing orientation that should be restored after location becomes available.
+    m_desiredInitMode = GetPreferredRoutingMode();
 
-    StartFollowing(CameraRotation::DirectionUp);
-    ChangeModelView(m_position, m_isDirectionAssigned ? m_drawDirection : 0.0, GetRoutingRotationPixelCenter(),
-                    zoomLevel, [this](ref_ptr<Animation> anim) { UpdateViewport(kDoNotChangeZoom); });
+    StartFollowing(GetPreferredRoutingRotation());
+    int const preferredZoomLevel = ShouldEnablePerspectiveInRouting() ? zoomLevelIn3d : zoomLevel;
+    UpdateRoutingViewport(preferredZoomLevel, [this](ref_ptr<Animation> anim) { UpdateViewport(kDoNotChangeZoom); });
     ResetRoutingNotFollowTimer();
   }
 }
@@ -940,7 +1023,7 @@ void MyPositionController::CheckNotFollowRouting()
     CHECK_ON_TIMEOUT(m_routingNotFollowNotifyId, kMaxNotFollowRoutingTimeSec, CheckNotFollowRouting);
     if (m_routingNotFollowTimer.ElapsedSeconds() >= kMaxNotFollowRoutingTimeSec)
     {
-      StartFollowing(CameraRotation::DirectionUp);
+      StartFollowing(GetPreferredRoutingRotation());
       UpdateViewport(kDoNotChangeZoom);
     }
   }

--- a/libs/drape_frontend/my_position_controller.cpp
+++ b/libs/drape_frontend/my_position_controller.cpp
@@ -120,6 +120,8 @@ MyPositionController::MyPositionController(Params && params, ref_ptr<DrapeNotifi
   , m_modeChangeCallback(std::move(params.m_myPositionModeCallback))
   , m_hints(params.m_hints)
   , m_isInRouting(params.m_isRoutingActive)
+  , m_routingOrientation(params.m_routingOrientation)
+  , m_routingOrientationChangedCallback(std::move(params.m_routingOrientationChangedCallback))
   , m_needBlockAnimation(false)
   , m_wasRotationInScaling(false)
   , m_errorRadius(0.0)
@@ -165,10 +167,17 @@ MyPositionController::MyPositionController(Params && params, ref_ptr<DrapeNotifi
   {
     m_desiredInitMode = params.m_initMode;
 
-    // Do not start position if we ended previous session without it.
+    // Do not start position if we ended previous session without it. Routing is exempt: it needs
+    // the position, so the location search stays on even if it was off in the previous session.
     if (!m_isInRouting && m_desiredInitMode == NotFollowNoPosition)
       m_positionStatus = PositionStatus::Stopped;
   }
+
+  // During active routing the camera follows the route (isRoutingActive is passed as
+  // IsRoutingActive() && IsRoutingFollowing()), so no non-following init mode is coherent: restore
+  // the preferred routing orientation.
+  if (m_isInRouting)
+    m_desiredInitMode = GetPreferredRoutingMode();
 
   if (m_modeChangeCallback)
     m_modeChangeCallback(GetCurrentMode(), m_isInRouting);
@@ -218,11 +227,59 @@ void MyPositionController::StopFollowing()
 void MyPositionController::NotifyModeChanged(location::EMyPositionMode oldMode)
 {
   auto const newMode = GetCurrentMode();
-  if (m_isInRouting && oldMode != newMode && newMode == location::FollowAndRotate)
+  if (m_isInRouting && oldMode != newMode && location::IsFollowingMode(newMode))
     ResetBlockAutoZoomTimer();
 
   if (m_modeChangeCallback)
     m_modeChangeCallback(newMode, m_isInRouting);
+  if (m_listener)
+    m_listener->MyPositionModeChanged(newMode, m_isInRouting);
+}
+
+void MyPositionController::SetRoutingOrientation(location::MapOrientation orientation)
+{
+  CHECK(m_isInRouting, ());
+  if (m_routingOrientation == orientation)
+    return;
+
+  m_routingOrientation = orientation;
+  if (m_routingOrientationChangedCallback)
+    m_routingOrientationChangedCallback(orientation);
+}
+
+location::EMyPositionMode MyPositionController::GetPreferredRoutingMode() const
+{
+  return location::ToPositionMode(m_routingOrientation);
+}
+
+MyPositionController::CameraRotation MyPositionController::GetPreferredRoutingRotation() const
+{
+  return m_routingOrientation == location::MapOrientation::NorthUp ? CameraRotation::Fixed
+                                                                   : CameraRotation::DirectionUp;
+}
+
+void MyPositionController::UpdateRoutingViewport(int zoomLevel, Animation::TAction const & onFinishAction)
+{
+  CHECK(m_isInRouting, ());
+  CHECK(IsFollowing(), ());
+
+  if (m_routingOrientation == location::MapOrientation::NorthUp)
+  {
+    // Request the azimuth explicitly: the center-only ChangeModelView() overload
+    // would keep the current map rotation instead of north-up.
+    ChangeModelView(m_position, 0.0 /* north up */, m_visiblePixelRect.Center(), zoomLevel, onFinishAction);
+    return;
+  }
+
+  ChangeModelView(m_position, m_isDirectionAssigned ? m_drawDirection : 0.0, GetRoutingRotationPixelCenter(), zoomLevel,
+                  onFinishAction);
+}
+
+bool MyPositionController::ShouldEnablePerspectiveInRouting() const
+{
+  // The perspective policy depends on the chosen routing orientation only: temporary states
+  // like an on-going location search or a not-follow pan must not flatten the camera.
+  return m_isInRouting && m_enablePerspectiveInRouting && m_routingOrientation == location::MapOrientation::HeadingUp;
 }
 
 bool MyPositionController::IsFollowing() const
@@ -397,7 +454,8 @@ void MyPositionController::NextMode(ScreenBase const & screen)
   // will be stopped and goes into Stopped state. The next press on the indicator will start location updates again.
   if (IsWaitingForLocation())
   {
-    m_desiredInitMode = location::Follow;
+    // Preserve the routing orientation that should be restored after location becomes available.
+    m_desiredInitMode = m_isInRouting ? GetPreferredRoutingMode() : location::Follow;
     SetPositionStatus(PositionStatus::Stopped);
     return;
   }
@@ -411,7 +469,7 @@ void MyPositionController::NextMode(ScreenBase const & screen)
     {
       // This is the first user location request (button touch) after controller's initialization
       // with some previous not Follow state. The new mode will be Follow to center on the position.
-      m_desiredInitMode = location::Follow;
+      m_desiredInitMode = m_isInRouting ? GetPreferredRoutingMode() : location::Follow;
     }
     return;
   }
@@ -422,10 +480,10 @@ void MyPositionController::NextMode(ScreenBase const & screen)
   if (currentZoom < kZoomThreshold)
     preferredZoomLevel = std::min(GetZoomLevel(screen, m_position, m_errorRadius), kMaxScaleZoomLevel);
 
-  // A free camera returns to following: direction-up in routing, fixed rotation otherwise.
+  // A free camera returns to following: the preferred orientation in routing, fixed rotation otherwise.
   if (m_tracking == CameraTracking::Free)
   {
-    StartFollowing(m_isInRouting ? CameraRotation::DirectionUp : CameraRotation::Fixed);
+    StartFollowing(m_isInRouting ? GetPreferredRoutingRotation() : CameraRotation::Fixed);
     UpdateViewport(preferredZoomLevel);
     return;
   }
@@ -436,6 +494,8 @@ void MyPositionController::NextMode(ScreenBase const & screen)
   {
     if (IsRotationAvailable() || m_isInRouting)
     {
+      if (m_isInRouting)
+        SetRoutingOrientation(location::MapOrientation::HeadingUp);
       StartFollowing(CameraRotation::DirectionUp);
       UpdateViewport(preferredZoomLevel);
     }
@@ -445,6 +505,8 @@ void MyPositionController::NextMode(ScreenBase const & screen)
   // From direction-up we return to fixed rotation and reset the map to north-up.
   if (m_isInRouting && screen.isPerspective())
     preferredZoomLevel = static_cast<int>(GetZoomLevel(ScreenBase::GetStartPerspectiveScale() * 1.1));
+  if (m_isInRouting)
+    SetRoutingOrientation(location::MapOrientation::NorthUp);
   StartFollowing(CameraRotation::Fixed);
   ChangeModelView(m_position, 0.0, m_visiblePixelRect.Center(), preferredZoomLevel);
 }
@@ -511,23 +573,19 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
 
     if (!m_hints.m_isFirstLaunch || !AnimationSystem::Instance().AnimationExists(Animation::Object::MapPlane))
     {
-      if (IsFollowingDirectionUp())
-      {
-        ChangeModelView(m_position, m_drawDirection,
-                        m_isInRouting ? GetRoutingRotationPixelCenter() : m_visiblePixelRect.Center(),
-                        kDoNotChangeZoom);
-      }
+      if (m_isInRouting && IsFollowing())
+        UpdateRoutingViewport(kDoNotChangeZoom);
+      else if (IsFollowingDirectionUp())
+        ChangeModelView(m_position, m_drawDirection, m_visiblePixelRect.Center(), kDoNotChangeZoom);
       else if (IsFollowing())
-      {
         ChangeModelView(m_position, kDoNotChangeZoom);
-      }
     }
   }
   else if (m_positionStatus == PositionStatus::Acquiring)
   {
     if (m_isInRouting)
     {
-      StartFollowing(CameraRotation::DirectionUp);
+      StartFollowing(GetPreferredRoutingRotation());
       UpdateViewport(kMaxScaleZoomLevel);
     }
     else
@@ -553,7 +611,7 @@ void MyPositionController::OnLocationUpdate(location::GpsInfo const & info, bool
   {
     if (m_isInRouting)
     {
-      StartFollowing(CameraRotation::DirectionUp);
+      StartFollowing(GetPreferredRoutingRotation());
       UpdateViewport(kMaxScaleZoomLevel);
     }
     else
@@ -615,10 +673,22 @@ void MyPositionController::OnCompassUpdate(location::CompassInfo const & info, S
 
 bool MyPositionController::UpdateViewportWithAutoZoom()
 {
-  double const autoScale = m_enablePerspectiveInRouting ? m_autoScale3d : m_autoScale2d;
-  if (autoScale > 0.0 && IsFollowingDirectionUp() && m_isInRouting && m_enableAutoZoomInRouting && !m_needBlockAutoZoom)
+  if (!m_isInRouting || !m_enableAutoZoomInRouting || m_needBlockAutoZoom)
+    return false;
+
+  if (IsFollowingDirectionUp())
   {
-    ChangeModelView(autoScale, m_position, m_drawDirection, GetRoutingRotationPixelCenter());
+    double const autoScale = ShouldEnablePerspectiveInRouting() ? m_autoScale3d : m_autoScale2d;
+    if (autoScale > 0.0)
+    {
+      ChangeModelView(autoScale, m_position, m_drawDirection, GetRoutingRotationPixelCenter());
+      return true;
+    }
+  }
+  else if (IsFollowing() && m_autoScale2d > 0.0)
+  {
+    // North-up navigation: use the 2D speed scale, keep the north-up azimuth and center the user.
+    ChangeModelView(m_autoScale2d, m_position, 0.0 /* north up */, m_visiblePixelRect.Center());
     return true;
   }
   return false;
@@ -664,7 +734,9 @@ void MyPositionController::Render(ref_ptr<dp::GraphicsContext> context, ref_ptr<
 
 bool MyPositionController::IsRouteFollowingActive() const
 {
-  return IsInRouting() && IsFollowingDirectionUp();
+  // North-up navigation follows the route in the fixed-rotation camera, so any following
+  // camera counts, not only the direction-up one.
+  return IsInRouting() && IsFollowing();
 }
 
 bool MyPositionController::AlmostCurrentPosition(m2::PointD const & pos) const
@@ -713,7 +785,7 @@ void MyPositionController::OnEnterForeground(double backgroundTime)
     // When location was active during previous session the app will try to follow the user.
     if (m_positionStatus == PositionStatus::Available && m_tracking == CameraTracking::Free)
     {
-      StartFollowing(m_isInRouting ? CameraRotation::DirectionUp : CameraRotation::Fixed);
+      StartFollowing(m_isInRouting ? GetPreferredRoutingRotation() : CameraRotation::Fixed);
       UpdateViewport(kDoNotChangeZoom);
     }
 
@@ -731,6 +803,8 @@ void MyPositionController::OnCompassTapped()
 {
   if (IsFollowingDirectionUp())
   {
+    if (m_isInRouting)
+      SetRoutingOrientation(location::MapOrientation::NorthUp);
     StartFollowing(CameraRotation::Fixed);
     ChangeModelView(m_position, 0.0, m_visiblePixelRect.Center(), kDoNotChangeZoom);
   }
@@ -782,13 +856,21 @@ void MyPositionController::UpdateViewport(int zoomLevel)
   if (IsWaitingForLocation())
     return;
 
+  // Every routing-follow restoration goes through UpdateRoutingViewport() to apply
+  // the chosen routing orientation.
+  if (m_isInRouting && IsFollowing())
+  {
+    UpdateRoutingViewport(zoomLevel);
+    return;
+  }
+
   if (IsFollowingDirectionUp())
   {
-    ChangeModelView(m_position, m_drawDirection,
-                    m_isInRouting ? GetRoutingRotationPixelCenter() : m_visiblePixelRect.Center(), zoomLevel);
+    ChangeModelView(m_position, m_drawDirection, m_visiblePixelRect.Center(), zoomLevel);
   }
   else if (IsFollowing())
   {
+    // Outside routing the map may retain a manually chosen fixed angle.
     ChangeModelView(m_position, zoomLevel);
   }
 }
@@ -888,17 +970,19 @@ void MyPositionController::EnableAutoZoomInRouting(bool enableAutoZoom)
   ResetBlockAutoZoomTimer();
 }
 
-void MyPositionController::ActivateRouting(int zoomLevel, bool enableAutoZoom, bool isArrowGlued)
+void MyPositionController::ActivateRouting(int zoomLevel, int zoomLevelIn3d, bool enableAutoZoom, bool isArrowGlued)
 {
   if (!m_isInRouting)
   {
     m_isInRouting = true;
     m_isArrowGluedInRouting = isArrowGlued;
     m_enableAutoZoomInRouting = enableAutoZoom;
+    // Preserve the routing orientation that should be restored after location becomes available.
+    m_desiredInitMode = GetPreferredRoutingMode();
 
-    StartFollowing(CameraRotation::DirectionUp);
-    ChangeModelView(m_position, m_isDirectionAssigned ? m_drawDirection : 0.0, GetRoutingRotationPixelCenter(),
-                    zoomLevel, [this](ref_ptr<Animation> anim) { UpdateViewport(kDoNotChangeZoom); });
+    StartFollowing(GetPreferredRoutingRotation());
+    int const preferredZoomLevel = ShouldEnablePerspectiveInRouting() ? zoomLevelIn3d : zoomLevel;
+    UpdateRoutingViewport(preferredZoomLevel, [this](ref_ptr<Animation> anim) { UpdateViewport(kDoNotChangeZoom); });
     ResetRoutingNotFollowTimer();
   }
 }
@@ -940,7 +1024,7 @@ void MyPositionController::CheckNotFollowRouting()
     CHECK_ON_TIMEOUT(m_routingNotFollowNotifyId, kMaxNotFollowRoutingTimeSec, CheckNotFollowRouting);
     if (m_routingNotFollowTimer.ElapsedSeconds() >= kMaxNotFollowRoutingTimeSec)
     {
-      StartFollowing(CameraRotation::DirectionUp);
+      StartFollowing(GetPreferredRoutingRotation());
       UpdateViewport(kDoNotChangeZoom);
     }
   }

--- a/libs/drape_frontend/my_position_controller.hpp
+++ b/libs/drape_frontend/my_position_controller.hpp
@@ -111,7 +111,7 @@ public:
   void StopLocationFollow();
   void NextMode(ScreenBase const & screen);
   void LoseLocation();
-  location::EMyPositionMode GetCurrentMode() const { return m_mode; }
+  location::EMyPositionMode GetCurrentMode() const;
 
   void OnEnterForeground(double backgroundTime);
   void OnEnterBackground();
@@ -133,7 +133,40 @@ public:
   void UpdateRoutingOffsetY(bool useDefault, int offsetY);
 
 private:
-  void ChangeMode(location::EMyPositionMode newMode);
+  // The state is split into three independent axes: whether a position is available, whether
+  // the camera follows the user and how a following camera is rotated. The platform-facing
+  // location::EMyPositionMode is a projection of them, derived in GetCurrentMode().
+  enum class PositionStatus
+  {
+    Stopped,    // Location updates are turned off.
+    Acquiring,  // Waiting for a location fix.
+    Available   // A position is available — from a location fix, or claimed when following starts.
+  };
+
+  enum class CameraTracking
+  {
+    Free,   // The user controls the viewport.
+    Follow  // The camera tracks the user position.
+  };
+
+  enum class CameraRotation
+  {
+    Fixed,       // The map keeps its current azimuth.
+    DirectionUp  // The map rotates after the movement/compass direction.
+  };
+
+  // Named state transitions: each one updates only the axes it owns, then notifies the platforms.
+  // Changing the position status leaves the tracking/rotation axes as they were; reacquisition
+  // re-derives the rotation (fixed outside routing, the preferred one in routing) rather than
+  // restoring the pre-loss rotation.
+  void SetPositionStatus(PositionStatus status);
+  void StartFollowing(CameraRotation rotation);
+  void StopFollowing();
+  void NotifyModeChanged(location::EMyPositionMode oldMode);
+
+  bool IsFollowing() const;
+  bool IsFollowingDirectionUp() const;
+
   void SetDirection(double bearing);
 
   void ChangeModelView(m2::PointD const & center, int zoomLevel);
@@ -160,7 +193,11 @@ private:
 
   ref_ptr<DrapeNotifier> m_notifier;
 
-  location::EMyPositionMode m_mode;
+  PositionStatus m_positionStatus = PositionStatus::Acquiring;
+  CameraTracking m_tracking = CameraTracking::Free;
+  CameraRotation m_rotation = CameraRotation::Fixed;
+  // The mode to adopt when the very first location fix of the session arrives;
+  // it is consumed exactly once in OnLocationUpdate().
   location::EMyPositionMode m_desiredInitMode;
   location::TMyPositionModeChanged m_modeChangeCallback;
   Hints m_hints;

--- a/libs/drape_frontend/my_position_controller.hpp
+++ b/libs/drape_frontend/my_position_controller.hpp
@@ -45,26 +45,32 @@ public:
                                  TAnimationCreator const & parallelAnimCreator) = 0;
     virtual void ChangeModelView(double autoScale, m2::PointD const & userPos, double azimuth,
                                  m2::PointD const & pxZero, TAnimationCreator const & parallelAnimCreator) = 0;
+    virtual void MyPositionModeChanged(location::EMyPositionMode /* mode */, bool /* routingActive */) {}
   };
 
   struct Params
   {
-    Params(location::EMyPositionMode initMode, double timeInBackground, Hints const & hints, bool isRoutingActive,
-           bool isAutozoomEnabled, location::TMyPositionModeChanged && fn)
+    Params(location::EMyPositionMode initMode, location::MapOrientation routingOrientation, double timeInBackground,
+           Hints const & hints, bool isRoutingActive, bool isAutozoomEnabled, location::TMyPositionModeChanged && fn,
+           location::TRoutingOrientationChanged && routingOrientationFn)
       : m_initMode(initMode)
+      , m_routingOrientation(routingOrientation)
       , m_timeInBackground(timeInBackground)
       , m_hints(hints)
       , m_isRoutingActive(isRoutingActive)
       , m_isAutozoomEnabled(isAutozoomEnabled)
       , m_myPositionModeCallback(std::move(fn))
+      , m_routingOrientationChangedCallback(std::move(routingOrientationFn))
     {}
 
     location::EMyPositionMode m_initMode;
+    location::MapOrientation m_routingOrientation;
     double m_timeInBackground;
     Hints m_hints;
     bool m_isRoutingActive;
     bool m_isAutozoomEnabled;
     location::TMyPositionModeChanged m_myPositionModeCallback;
+    location::TRoutingOrientationChanged m_routingOrientationChangedCallback;
   };
 
   MyPositionController(Params && params, ref_ptr<DrapeNotifier> notifier);
@@ -102,7 +108,7 @@ public:
                       drape_ptr<MyPosition> && shape, Arrow3d::PreloadedData && preloadedData);
   void ResetRenderShape();
 
-  void ActivateRouting(int zoomLevel, bool enableAutoZoom, bool isArrowGlued);
+  void ActivateRouting(int zoomLevel, int zoomLevelIn3d, bool enableAutoZoom, bool isArrowGlued);
   void DeactivateRouting();
 
   void EnablePerspectiveInRouting(bool enablePerspective);
@@ -125,6 +131,7 @@ public:
 
   bool IsRotationAvailable() const { return m_isDirectionAssigned; }
   bool IsInRouting() const { return m_isInRouting; }
+  bool ShouldEnablePerspectiveInRouting() const;
   bool IsRouteFollowingActive() const;
   bool IsModeChangeViewport() const;
 
@@ -163,6 +170,15 @@ private:
   void StartFollowing(CameraRotation rotation);
   void StopFollowing();
   void NotifyModeChanged(location::EMyPositionMode oldMode);
+
+  // Remembers the user's routing orientation choice. Automatic state restoration may apply
+  // the preference, but only an explicit user action may modify it.
+  void SetRoutingOrientation(location::MapOrientation orientation);
+  location::EMyPositionMode GetPreferredRoutingMode() const;
+  CameraRotation GetPreferredRoutingRotation() const;
+
+  // Applies the routing-follow camera according to the chosen routing orientation.
+  void UpdateRoutingViewport(int zoomLevel, Animation::TAction const & onFinishAction = nullptr);
 
   bool IsFollowing() const;
   bool IsFollowingDirectionUp() const;
@@ -203,6 +219,9 @@ private:
   Hints m_hints;
 
   bool m_isInRouting = false;
+  // The user's orientation choice for route navigation; persisted across sessions.
+  location::MapOrientation m_routingOrientation;
+  location::TRoutingOrientationChanged m_routingOrientationChangedCallback;
   bool m_isArrowGluedInRouting = false;
 
   bool m_needBlockAnimation;

--- a/libs/drape_frontend/user_event_stream.cpp
+++ b/libs/drape_frontend/user_event_stream.cpp
@@ -370,6 +370,11 @@ bool UserEventStream::OnSetScale(ref_ptr<ScaleEvent> scaleEvent)
       ResetAnimations(Animation::Type::Parallel, kParallelFollowAnim);
     }
 
+    // The scale is accepted: notify right away so that a competing viewport update
+    // (e.g. the routing auto zoom) cannot cancel the started animation.
+    if (m_listener)
+      m_listener->OnAnimatedScaleStarted();
+
     m2::PointD glbScaleCenter = m_navigator.PtoG(m_navigator.P3dtoP(scaleCenter));
     if (m_listener)
       m_listener->CorrectGlobalScalePoint(glbScaleCenter);

--- a/libs/drape_frontend/user_event_stream.hpp
+++ b/libs/drape_frontend/user_event_stream.hpp
@@ -415,6 +415,7 @@ public:
     virtual void CorrectGlobalScalePoint(m2::PointD & pt) const = 0;
     virtual void CorrectScalePoint(m2::PointD & pt1, m2::PointD & pt2) const = 0;
     virtual void OnScaleEnded() = 0;
+    virtual void OnAnimatedScaleStarted() = 0;
     virtual void OnAnimatedScaleEnded() = 0;
 
     virtual void OnTouchMapAction(TouchEvent::ETouchType touchType, bool isMapTouch) = 0;

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1699,8 +1699,8 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::GraphicsContextFactory> contextFac
   {
     GetPlatform().RunTask(Platform::Thread::Gui, [this, mode, routingActive]()
     {
-      // Deactivate selection (and hide place page) if we return to routing in F&R mode.
-      if (routingActive && mode == location::FollowAndRotate)
+      // Hide the current selection whenever route navigation owns the camera.
+      if (routingActive && location::IsFollowingMode(mode))
         DeactivateMapSelection();
 
       if (m_myPositionListener != nullptr)

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1784,8 +1784,8 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::GraphicsContextFactory> contextFac
   {
     GetPlatform().RunTask(Platform::Thread::Gui, [this, mode, routingActive]()
     {
-      // Deactivate selection (and hide place page) if we return to routing in F&R mode.
-      if (routingActive && mode == location::FollowAndRotate)
+      // Hide the current selection whenever route navigation owns the camera.
+      if (routingActive && location::IsFollowingMode(mode))
         DeactivateMapSelection();
 
       if (m_myPositionListener != nullptr)

--- a/libs/platform/location.hpp
+++ b/libs/platform/location.hpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <functional>
+#include <string>
 
 namespace location
 {
@@ -138,6 +139,31 @@ enum EMyPositionMode
   FollowAndRotate
 };
 
+// Returns true when the camera follows the user position.
+// Routing activity and the user's on-screen placement are separate properties.
+inline bool IsFollowingMode(EMyPositionMode mode)
+{
+  return mode == Follow || mode == FollowAndRotate;
+}
+
+// The map orientation chosen by the user for route navigation.
+enum class MapOrientation
+{
+  NorthUp,
+  HeadingUp
+};
+
+constexpr EMyPositionMode ToPositionMode(MapOrientation orientation)
+{
+  return orientation == MapOrientation::NorthUp ? Follow : FollowAndRotate;
+}
+
+inline std::string DebugPrint(MapOrientation orientation)
+{
+  return orientation == MapOrientation::NorthUp ? "NorthUp" : "HeadingUp";
+}
+
 using TMyPositionModeChanged = std::function<void(location::EMyPositionMode, bool)>;
+using TRoutingOrientationChanged = std::function<void(location::MapOrientation)>;
 
 }  // namespace location

--- a/libs/platform/location.hpp
+++ b/libs/platform/location.hpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <functional>
+#include <string>
 
 namespace location
 {
@@ -133,6 +134,31 @@ enum EMyPositionMode
   FollowAndRotate
 };
 
+// Returns true when the camera follows the user position.
+// Routing activity and the user's on-screen placement are separate properties.
+inline bool IsFollowingMode(EMyPositionMode mode)
+{
+  return mode == Follow || mode == FollowAndRotate;
+}
+
+// The map orientation chosen by the user for route navigation.
+enum class MapOrientation
+{
+  NorthUp,
+  HeadingUp
+};
+
+constexpr EMyPositionMode ToPositionMode(MapOrientation orientation)
+{
+  return orientation == MapOrientation::NorthUp ? Follow : FollowAndRotate;
+}
+
+inline std::string DebugPrint(MapOrientation orientation)
+{
+  return orientation == MapOrientation::NorthUp ? "NorthUp" : "HeadingUp";
+}
+
 using TMyPositionModeChanged = std::function<void(location::EMyPositionMode, bool)>;
+using TRoutingOrientationChanged = std::function<void(location::MapOrientation)>;
 
 }  // namespace location

--- a/libs/platform/settings.cpp
+++ b/libs/platform/settings.cpp
@@ -339,6 +339,30 @@ bool FromString<location::EMyPositionMode>(string const & s, location::EMyPositi
 }
 
 template <>
+string ToString<location::MapOrientation>(location::MapOrientation const & v)
+{
+  switch (v)
+  {
+  case location::MapOrientation::NorthUp: return "NorthUp";
+  case location::MapOrientation::HeadingUp: return "HeadingUp";
+  }
+  UNREACHABLE();
+}
+
+template <>
+bool FromString<location::MapOrientation>(string const & s, location::MapOrientation & v)
+{
+  if (s == "NorthUp")
+    v = location::MapOrientation::NorthUp;
+  else if (s == "HeadingUp")
+    v = location::MapOrientation::HeadingUp;
+  else
+    return false;
+
+  return true;
+}
+
+template <>
 string ToString<Transliteration::Mode>(Transliteration::Mode const & mode)
 {
   switch (mode)


### PR DESCRIPTION
## What

Improved version of https://github.com/organicmaps/organicmaps/pull/13003
Closes #13003

Adds support for **north-up** map orientation during route navigation and persists the choice across sessions. Until now navigation always forced heading-up (`FollowAndRotate`), so any switch to north-up (`Follow`) was lost after the ~20 s auto-recenter or when navigation restarted.

Three reviewable core commits, plus the CarPlay button (see Notes):

1. **[drape] Separate location and camera state** — behavior-preserving refactor of `MyPositionController`: the single `EMyPositionMode` is split into three independent axes (position status, camera tracking, camera rotation) with named transitions (`SetPositionStatus`/`StartFollowing`/`StopFollowing`); the platform-facing mode is derived in `GetCurrentMode()`. New unit tests capture the state machine and pass unchanged before and after the refactor.
2. **[drape] Block auto zoom during animated scaling** — the animated zoom buttons reset the routing auto-zoom block only on animation completion, so a location update arriving mid-animation could cancel the user's zoom. Adds `UserEventStream::Listener::OnAnimatedScaleStarted()` to reset the block timer the moment an animated scale is accepted.
3. **[drape] Persist navigation orientation** — tracks the chosen orientation as `location::MapOrientation`, persisted under `LastRoutingOrientation`. Only explicit user actions change it (cycling the location button, tapping the compass during navigation); automatic transitions (route start, location loss/recovery, 20 s auto-recenter, foreground restore, pending-position button) restore the preference but never modify it. Route auto-perspective now depends only on the chosen orientation — north-up stays 2D and uses the 2D navigation zoom. First-ever navigation defaults to heading-up.

No platform UI changes are required: the location button already cycles modes through the core `NextMode()`. Because north-up now follows the route in `Follow` (not only `FollowAndRotate`), a new `location::IsFollowingMode()` fixes the call sites that used `FollowAndRotate` as a proxy for "route following is active" (place page, 30 fps power cap, iOS prediction, speed-based auto-zoom).

## Why

Closes #5898.

## Testing

- New `my_position_controller` unit tests — every orientation restoration path asserts the requested camera (overload, azimuth, anchor, zoom) and the explicit-choice-only persistence.
- New `user_event_stream` tests — animated-scale callback ordering, including rejected scales; verified to pass in isolation as well as in the suite.
- `drape_frontend_tests` build and pass at **each** of the three core commits independently (the fourth is iOS-only).
- Android `assembleGoogleDebug -Parm64` builds; the iOS legs are covered by CI.

## Notes

- The fourth commit adds the CarPlay orientation button (#805): a map button in follow / follow-and-rotate that calls the same core `NextMode()`, reusing the phone glyphs.
- LLM tooling (Claude Code) was used to assist with the state-machine refactor, the tests, and the review pass.

