### PR TITLE
[ios] CarPlay: toggle north-up / heading-up while navigating

### DIFF
--- a/iphone/Maps/Core/CarPlay/Template Builders/MapTemplateBuilder.swift
+++ b/iphone/Maps/Core/CarPlay/Template Builders/MapTemplateBuilder.swift
@@ -6,6 +6,7 @@ final class MapTemplateBuilder {
     case zoomIn
     case zoomOut
     case recenter
+    case switchOrientation(MWMMyPositionMode)
   }
 
   enum BarButtonType {
@@ -108,11 +109,16 @@ final class MapTemplateBuilder {
       mapTemplate.hidesButtonsWithNavigationBar = true
       FrameworkHelper.switchMyPositionMode()
     }
+    // While the camera follows the user, this button toggles the orientation (north-up <-> heading-up):
+    // switchMyPositionMode() cycles the following camera's rotation through the core NextMode().
+    let orientationButton = buildMapButton(type: .switchOrientation(positionMode)) { _ in
+      FrameworkHelper.switchMyPositionMode()
+    }
 
     switch positionMode {
     case .follow, .followAndRotate:
       if !mapTemplate.isPanningInterfaceVisible {
-        mapTemplate.mapButtons = [panningButton, zoomInButton, zoomOutButton]
+        mapTemplate.mapButtons = [orientationButton, panningButton, zoomInButton, zoomOutButton]
       }
     case .notFollow:
       if !mapTemplate.isPanningInterfaceVisible {
@@ -164,6 +170,10 @@ final class MapTemplateBuilder {
       button.image = UIImage.btnZoomOut
     case .recenter:
       button.image = UIImage.btnGetPosition
+    case .switchOrientation(let positionMode):
+      // Reuse the phone location-button glyphs (as the recenter button reuses btnGetPosition) to
+      // show the current orientation: north-up (Follow) vs heading-up (FollowAndRotate).
+      button.image = positionMode == .follow ? UIImage.btnFollow : UIImage.btnFollowAndRotate
     }
     return button
   }


### PR DESCRIPTION
## What

Adds a CarPlay map button to switch between **north-up** and **heading-up** while following the user. Until now the mode-switch button appeared only in the not-follow (panned-away) state, so a driver had no way to change orientation mid-navigation.

The 4th map button (shown in the follow / follow-and-rotate states) calls `switchMyPositionMode()` — the same core `NextMode()` cycle the phone location button and Android Auto already use — which toggles the following camera's rotation. It reuses the existing phone location glyphs (`btn_follow` / `btn_follow_and_rotate`), exactly as the recenter button reuses `btn_get_position`, and shows the current orientation. `setupMapButtons()` re-runs on every position-mode change, so the icon updates after each toggle. In the follow states the map buttons become `[orientation, panning, zoomIn, zoomOut]` (CarPlay's maximum of four).

## Why

Closes #805.

**Stacked on #13165** (north-up navigation) — please review/merge that PR first; the base of this PR is `ab/navigation-north-refactoring` and will retarget to `master` once it merges.

## Testing

- The orientation toggle itself (`NextMode()` north-up ↔ heading-up) is covered by the `my_position_controller` unit tests in the base PR.
- iOS build + on-device/simulator CarPlay verification relies on CI — the iOS target was not built in the authoring environment.

## Notes

LLM tooling (Claude Code) was used to assist with this change.
