### PR TITLE
Fix assert when debugging CarPlay

### DIFF
--- a/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
+++ b/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SRC
   shape_test_fixture.hpp
   stylist_tests.cpp
   user_event_stream_tests.cpp
+  visual_params_tests.cpp
 )
 
 omim_add_test(${PROJECT_NAME} ${SRC})

--- a/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
+++ b/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SRC
   stylist_tests.cpp
   user_event_stream_tests.cpp
   visual_params_fixture.hpp
+  visual_params_tests.cpp
 )
 
 omim_add_test(${PROJECT_NAME} ${SRC})

--- a/libs/drape_frontend/drape_frontend_tests/visual_params_tests.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/visual_params_tests.cpp
@@ -1,0 +1,19 @@
+#include "testing/testing.hpp"
+
+#include "drape_frontend/visual_params.hpp"
+
+#include "geometry/mercator.hpp"
+
+namespace visual_params_tests
+{
+UNIT_TEST(DrawTileScale_DependsOnVisualScale)
+{
+  uint32_t constexpr kTileSize = 1024;
+  int constexpr kBaseScale = 10;
+  double constexpr kRectSize = mercator::Bounds::kRangeX / (1 << kBaseScale);
+  m2::RectD const rect(0.0, 0.0, kRectSize, kRectSize);
+
+  TEST_EQUAL(df::GetDrawTileScale(rect, kTileSize, 3.0), kBaseScale, ());
+  TEST_EQUAL(df::GetDrawTileScale(rect, kTileSize, 2.0), kBaseScale + 1, ());
+}
+}  // namespace visual_params_tests

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -1803,9 +1803,7 @@ void FrontendRenderer::RenderFrame()
   if (viewportChanged || m_needRestoreSize)
     OnResize(modelView);
 
-  bool const zoomChanged = ResolveZoomLevel(modelView);
-  /// @todo Put ResolveZoomLevel under modelViewChanged after testing.
-  ASSERT(!zoomChanged || modelViewChanged, ());
+  bool const zoomChanged = modelViewChanged && ResolveZoomLevel(modelView);
 
   // Skip starting a new GPU frame if rendering is being disabled (e.g. the app is going to the
   // background). SetRenderingEnabled(false) sets the flag on the UI thread and then blocks until this
@@ -2662,7 +2660,7 @@ ScreenBase const & FrontendRenderer::ProcessEvents(bool & modelViewChanged, bool
     modelViewChanged = true;
 
   // Draw-tile zoom also depends on visual scale, not only on the model view.
-  if (m_lastResolvedVisualScale != VisualParams::Instance().GetVisualScale())
+  if (!modelViewChanged && m_lastResolvedVisualScale != VisualParams::Instance().GetVisualScale())
     modelViewChanged = true;
 
   // Location- or compass-update could have changed model view on the previous frame.

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -166,6 +166,7 @@ FrontendRenderer::FrontendRenderer(Params && params)
   , m_modelViewChangedHandler(std::move(params.m_modelViewChangedHandler))
   , m_tapEventInfoHandler(std::move(params.m_tapEventHandler))
   , m_userPositionChangedHandler(std::move(params.m_positionChangedHandler))
+  , m_lastResolvedVisualScale(VisualParams::Instance().GetVisualScale())
   , m_requestedTiles(params.m_requestedTiles)
   , m_maxGeneration(0)
   , m_maxUserMarksGeneration(0)
@@ -2075,7 +2076,9 @@ void FrontendRenderer::CheckIsometryMinScale(ScreenBase const & screen)
 bool FrontendRenderer::ResolveZoomLevel(ScreenBase const & screen)
 {
   int const prevZoomLevel = m_currentZoomLevel;
-  m_currentZoomLevel = GetDrawTileScale(screen);
+  VisualParams const & visualParams = VisualParams::Instance();
+  m_lastResolvedVisualScale = visualParams.GetVisualScale();
+  m_currentZoomLevel = GetDrawTileScale(screen, visualParams.GetTileSize(), m_lastResolvedVisualScale);
   gui::DrapeGui::Instance().GetScaleFpsHelper().SetScale(m_currentZoomLevel);
 
   CheckIsometryMinScale(screen);
@@ -2656,6 +2659,10 @@ ScreenBase const & FrontendRenderer::ProcessEvents(bool & modelViewChanged, bool
   // modelViewChanged == false and m_currentZoomLevel == -1 is possible on the first render ..
   // Set modelViewChanged flag is logical here ATM.
   if (!IsValidCurrentZoom())
+    modelViewChanged = true;
+
+  // Draw-tile zoom also depends on visual scale, not only on the model view.
+  if (m_lastResolvedVisualScale != VisualParams::Instance().GetVisualScale())
     modelViewChanged = true;
 
   // Location- or compass-update could have changed model view on the previous frame.

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -676,6 +676,9 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
 
   case Message::Type::VisualScaleChanged:
   {
+    double const vs = VisualParams::Instance().GetVisualScale();
+    m_overlayTree->SetVisualScale(vs);
+    m_searchMarkTextOverlayTree->SetVisualScale(vs);
     // Draw tile zoom depends on the visual scale, but ResolveZoomLevel runs only when the model view
     // changes, so re-resolve it here before all tiles are re-requested in UpdateAll.
     ResolveZoomLevel(m_userEventStream.GetCurrentScreen());
@@ -2477,9 +2480,7 @@ void FrontendRenderer::OnContextCreate()
   m_debugRectRenderer->SetEnabled(m_isDebugRectRenderingEnabled);
 
   m_overlayTree->SetDebugRectRenderer(make_ref(m_debugRectRenderer));
-  m_overlayTree->SetVisualScale(VisualParams::Instance().GetVisualScale());
   m_searchMarkTextOverlayTree->SetDebugRectRenderer(make_ref(m_debugRectRenderer));
-  m_searchMarkTextOverlayTree->SetVisualScale(VisualParams::Instance().GetVisualScale());
 
   // Resources recovering.
   m_screenQuadRenderer = make_unique_dp<ScreenQuadRenderer>(m_context);

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -674,7 +674,14 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
 
   case Message::Type::UpdateMapStyle: UpdateAll<SwitchMapStyleMessage>(); break;
 
-  case Message::Type::VisualScaleChanged: UpdateAll<VisualScaleChangedMessage>(); break;
+  case Message::Type::VisualScaleChanged:
+  {
+    // Draw tile zoom depends on the visual scale, but ResolveZoomLevel runs only when the model view
+    // changes, so re-resolve it here before all tiles are re-requested in UpdateAll.
+    ResolveZoomLevel(m_userEventStream.GetCurrentScreen());
+    UpdateAll<VisualScaleChangedMessage>();
+    break;
+  }
 
   case Message::Type::AllowAutoZoom:
   {
@@ -1802,9 +1809,7 @@ void FrontendRenderer::RenderFrame()
   if (viewportChanged || m_needRestoreSize)
     OnResize(modelView);
 
-  bool const zoomChanged = ResolveZoomLevel(modelView);
-  /// @todo Put ResolveZoomLevel under modelViewChanged after testing.
-  ASSERT(!zoomChanged || modelViewChanged, ());
+  bool const zoomChanged = modelViewChanged && ResolveZoomLevel(modelView);
 
   // Skip starting a new GPU frame if rendering is being disabled (e.g. the app is going to the
   // background). SetRenderingEnabled(false) sets the flag on the UI thread and then blocks until this

--- a/libs/drape_frontend/frontend_renderer.hpp
+++ b/libs/drape_frontend/frontend_renderer.hpp
@@ -364,9 +364,8 @@ private:
   ScreenBase m_lastReadedModelView;
   TTilesCollection m_notFinishedTiles;
 
-  // ResolveZoomLevel is called early in RenderFrame, so zoom is always valid during rendering.
-  // This check is only needed for UpdateContextDependentResources, which can be triggered
-  // by messages processed before the first RenderFrame.
+  // ProcessEvents marks the first frame as changed, so ResolveZoomLevel initializes zoom before rendering.
+  // This check is only needed for messages processed before the first RenderFrame.
   bool IsValidCurrentZoom() const { return m_currentZoomLevel >= 0; }
 
   int GetCurrentZoom() const

--- a/libs/drape_frontend/frontend_renderer.hpp
+++ b/libs/drape_frontend/frontend_renderer.hpp
@@ -375,6 +375,7 @@ private:
     return m_currentZoomLevel;
   }
 
+  double m_lastResolvedVisualScale;
   int m_currentZoomLevel = -1;
 
   ref_ptr<RequestedTiles> m_requestedTiles;


### PR DESCRIPTION
Debug builds hit `ASSERT(!zoomChanged || modelViewChanged)` in `FrontendRenderer::RenderFrame` on CarPlay connect/disconnect when the phone and the car display have different scales (simulator: iPhone @3x, CarPlay @2x).

**Root cause.** Draw tile zoom is a function of the model view *and* the global visual scale (`GetTileScaleIncrement`). `DrapeEngine::UpdateVisualScale` flips `VisualParams` between two frames while the render threads are parked and only then posts `UpdateVisualScaleMessage`, which the frontend processes at the end of the next frame. `ResolveZoomLevel` ran at the start of every frame, so that frame saw a zoom change without a model view change.

**Fix.** Resolve zoom only when the model view changes (the `@todo` next to the assert) and re-resolve it in the `VisualScaleChanged` handler, right before `UpdateAll` re-requests all tiles, so the frontend reacts to the visual scale exactly when the change is delivered instead of observing the global mid-cycle. The second commit moves the overlay trees' `SetVisualScale` into the same handler: it was refreshed only on context recreation, so it stayed stale when the scale changed while rendering was disabled.

**Testing.**
- `drape_frontend_tests` (incl. new `DrawTileScale_DependsOnVisualScale`), `desktop` and `dev_sandbox` build.
- dev_sandbox with a temporary scripted `Framework::UpdateVisualScale` probe (context-reset and rendering-disabled paths, 6 flips): master aborts on the first flip; with the fix all tiles are re-requested at the new zoom and accepted.
- iOS simulator (iPhone 17 Pro, iOS 26.5, Debug): repeated CarPlay connect/disconnect, no assert, the map re-renders correctly on the phone.
