### PR TITLE
[android] Fix route reorder crash during RecyclerView layout

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/ManageRouteController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/ManageRouteController.java
@@ -57,10 +57,8 @@ public class ManageRouteController implements ManageRouteAdapter.ManageRouteList
     mTouchHelper.attachToRecyclerView(manageRouteList);
   }
 
-  public void onRouteOrderChanged()
+  public void onRouteOrderChanged(@NonNull ArrayList<RouteMarkData> newRoutePoints)
   {
-    ArrayList<RouteMarkData> newRoutePoints = mManageRouteAdapter.getRoutePoints();
-
     // Make sure that the new route contains at least 2 points (start and destination).
     Assert.debug(newRoutePoints.size() >= 2, "There must be at least two route points");
 
@@ -97,7 +95,7 @@ public class ManageRouteController implements ManageRouteAdapter.ManageRouteList
   public void onRoutePointDeleted(RecyclerView.ViewHolder viewHolder)
   {
     mManageRouteAdapter.deleteRoutePoint(viewHolder);
-    onRouteOrderChanged();
+    onRouteOrderChanged(mManageRouteAdapter.getRoutePoints());
   }
   @Override
   public void onAddStopButtonClicked()
@@ -221,8 +219,11 @@ public class ManageRouteController implements ManageRouteAdapter.ManageRouteList
       viewHolder.itemView.setTranslationZ(0f);
       if (mOrderChanged)
       {
-        mController.onRouteOrderChanged();
         mOrderChanged = false;
+        // clearView can fire mid-layout, and the rebuild chain ends in notifyDataSetChanged (forbidden during
+        // layout) — post it past the layout pass. Snapshot the order: a queued refresh() may rewrite it first.
+        ArrayList<RouteMarkData> newOrder = new ArrayList<>(mManageRouteAdapter.getRoutePoints());
+        recyclerView.post(() -> mController.onRouteOrderChanged(newOrder));
       }
       mDragStartOrder = null;
     }


### PR DESCRIPTION
Fixes a production `IllegalStateException` crash (`RecyclerView.assertNotInLayoutOrScroll`) when reordering route points in the manage route list.

`ItemTouchHelper.clearView` is not only called when the user drops an item —it also fires synchronously from inside a RecyclerView layout pass when the recovering child gets detached (an async route update lands while the drop animation is still in flight). The reorder callback then synchronously reached `notifyDataSetChanged` through `launchPlanning` → `updateMenu` → LiveData → `refresh`, which is forbidden during layout.

https://play.google.com/console/u/0/developers/8084273541548442467/app/4972992444534608608/vitals/crashes/639a426e62bede03760a1b2d216a89d3/details?days=28&versionCode=26062903&isUserPerceived=true