### PR TITLE
[ios] Display exact routing building progress for every alt route

### DIFF
--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardPresenter.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardPresenter.swift
@@ -66,9 +66,7 @@ extension NavigationDashboard {
 
       case .updateRouteBuildingProgress(let progress, routerType: let routerType):
         viewModel.routerType = routerType
-        if progress > viewModel.progress {
-          viewModel.progress = progress
-        }
+        viewModel.progress = progress
 
       case .updateNavigationInfo(let entity):
         let estimates = buildEstimatesString(routerType: viewModel.routerType,


### PR DESCRIPTION
Now the progress will show exact value passed from the core. It means for the every alt route it will reset to zero.