### PR TITLE
[ios] Show active point on map for pedestrian and bike route preview

### DIFF
--- a/iphone/Chart/Chart/Views/ChartInfo/ChartInfoView.swift
+++ b/iphone/Chart/Chart/Views/ChartInfo/ChartInfoView.swift
@@ -20,7 +20,7 @@ class ChartInfoView: ExpandedTouchView {
   private let myPositionView = ChartMyPositionView(frame: CGRect(x: 0, y: 0, width: 2, height: 0))
   private var lineInfo: ChartLineInfo?
 
-  fileprivate var captured = false
+  private(set) var captured = false
 
   private var _infoX: CGFloat = 0
   var infoX: CGFloat {

--- a/iphone/Chart/Chart/Views/ChartView.swift
+++ b/iphone/Chart/Chart/Views/ChartView.swift
@@ -20,7 +20,7 @@ public class ChartView: UIView {
   var showPreview: Bool = false // Set true to show the preview
 
   private var tapGR: UITapGestureRecognizer!
-  private var selectedPointDistance: Double = 0
+  private var hasSelectedPoint = false
   private var panStartPoint = 0
   private var panGR: UIPanGestureRecognizer!
   private var pinchStartLower = 0
@@ -218,8 +218,8 @@ public class ChartView: UIView {
   }
 
   public func setSelectedPoint(_ x: Double) {
-    guard selectedPointDistance != x else { return }
-    selectedPointDistance = x
+    guard hasSelectedPoint || !x.isZero else { return }
+    hasSelectedPoint = true
     let routeLength = chartData.distance(forChartX: CGFloat(chartData.pointsCount - 1))
     let upper = chartData.xAxisValueAt(CGFloat(chartPreviewView.maxX))
     var lower = chartData.xAxisValueAt(CGFloat(chartPreviewView.minX))
@@ -396,6 +396,12 @@ public class ChartView: UIView {
     let selectedPointX = chartInfoView.infoX * chartInfoView.bounds.width
     return abs(clampedPointX - selectedPointX) <= Self.selectedPointCaptureRadius
   }
+
+  private func notifySelectedPointChanged(at chartX: CGFloat) {
+    let distance = chartData.distance(forChartX: chartX)
+    hasSelectedPoint = true
+    onSelectedPointChanged?(distance)
+  }
 }
 
 extension ChartView: ChartPreviewViewDelegate {
@@ -405,7 +411,7 @@ extension ChartView: ChartPreviewViewDelegate {
     chartInfoView.update()
     setMyPosition(myPosition)
     let chartX = chartInfoView.infoX * CGFloat(xAxisView.upperBound - xAxisView.lowerBound) + CGFloat(xAxisView.lowerBound)
-    onSelectedPointChanged?(chartData.distance(forChartX: chartX))
+    notifySelectedPointChanged(at: chartX)
   }
 }
 
@@ -413,7 +419,7 @@ extension ChartView: ChartInfoViewDelegate {
   func chartInfoView(_ view: ChartInfoView, didMoveToPoint pointX: CGFloat) {
     let p = convert(CGPoint(x: pointX, y: 0), from: view)
     let chartX = (p.x / bounds.width) * CGFloat(xAxisView.upperBound - xAxisView.lowerBound) + CGFloat(xAxisView.lowerBound)
-    onSelectedPointChanged?(chartData.distance(forChartX: chartX))
+    notifySelectedPointChanged(at: chartX)
   }
 
   func chartInfoView(_: ChartInfoView, shouldStartSelectingAtPoint pointX: CGFloat) -> Bool {
@@ -424,7 +430,9 @@ extension ChartView: ChartInfoViewDelegate {
     guard let chartData, bounds.width > 0 else { return nil }
     let p = convert(CGPoint(x: pointX, y: .zero), from: view)
     let chartX = (p.x / bounds.width) * CGFloat(xAxisView.upperBound - xAxisView.lowerBound) + CGFloat(xAxisView.lowerBound)
-    guard !pointX.isZero, chartX >= 0, chartX <= CGFloat(chartData.pointsCount - 1) else { return nil }
+    guard !pointX.isZero || view.captured || hasSelectedPoint,
+          chartX >= 0,
+          chartX <= CGFloat(chartData.pointsCount - 1) else { return nil }
     let distance = CGFloat(chartData.distance(forChartX: chartX))
     let label = chartData.labelAt(chartX)
 

--- a/iphone/Maps/Core/Routing/MWMRouter.h
+++ b/iphone/Maps/Core/Routing/MWMRouter.h
@@ -64,6 +64,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)hasRouteAltitude;
 + (void)saveRouteAsTrack;
 + (nullable RouteElevationPreviewData *)routeElevationProfileData;
++ (void)setRouteElevationActivePointDistance:(double)distance;
++ (void)resetRouteElevationActivePoint;
 
 + (void)saveRouteIfNeeded;
 + (void)restoreRouteIfNeeded;

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -85,6 +85,28 @@ using namespace routing;
   return [[RouteElevationPreviewData alloc] initWithTrackInfo:trackInfo elevationInfo:profileData];
 }
 
++ (void)setRouteElevationActivePointDistance:(double)distance
+{
+  auto & framework = GetFramework();
+  if (framework.GetDrapeEngine() == nullptr)
+    return;
+
+  auto const point = framework.GetRoutingManager().GetRoutePointAtDistance(distance);
+  if (!point)
+    return;
+
+  framework.GetDrapeEngine()->SelectObject(df::SelectionShape::ESelectedObject::OBJECT_TRACK, *point, FeatureID(),
+                                           false /* isAnim */, false /* isGeometrySelectionAllowed */,
+                                           true /* isSelectionShapeVisible */);
+}
+
++ (void)resetRouteElevationActivePoint
+{
+  auto & framework = GetFramework();
+  if (!framework.HasPlacePageInfo())
+    framework.DeactivateMapSelectionCircle(false /* restoreViewport */);
+}
+
 + (void)saveRouteAsTrack
 {
   GetFramework().SaveRoute();

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardInteractor.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardInteractor.swift
@@ -4,6 +4,8 @@ extension NavigationDashboard {
     private let router: MWMRouter.Type
     private let mapViewController: MapViewController
     private let searchManager: SearchOnMapManager
+    private var routeElevationActivePointDistance: Double?
+    private var presentationStep: NavigationDashboardModalPresentationStep = .hidden
 
     weak var delegate: MWMRoutePreviewDelegate?
 
@@ -55,9 +57,11 @@ extension NavigationDashboard {
         return .show(points: router.points(), routerType: router.type())
 
       case .startNavigation:
+        clearRouteElevationActivePoint()
         return .showNavigationDashboard
 
       case .stopNavigation:
+        clearRouteElevationActivePoint()
         return .close
 
       case .showError(let errorMessage):
@@ -92,8 +96,8 @@ extension NavigationDashboard {
       case .updateTrackRecordingState(let state):
         return .updateTrackRecordingState(state)
 
-      case .updateElevationInfo(let elevationInfo):
-        return .updateElevationInfo(elevationInfo)
+      case .updateElevationInfo(let elevationInfo, let activePointDistance):
+        return .updateElevationInfo(elevationInfo, activePointDistance: activePointDistance)
 
       case .updateNavigationInfoAvailableArea(let frame):
         return .updateNavigationInfoAvailableArea(frame)
@@ -125,6 +129,11 @@ extension NavigationDashboard {
         return .setHidden(hidden)
 
       case .didUpdatePresentationStep(let step):
+        let shouldRestoreActivePoint = presentationStep == .hidden && step != .hidden
+        presentationStep = step
+        if shouldRestoreActivePoint {
+          restoreRouteElevationActivePoint()
+        }
         return .updatePresentationStep(step)
 
       case .close:
@@ -132,6 +141,25 @@ extension NavigationDashboard {
         return .close
       }
     }
+
+    fileprivate func clearRouteElevationActivePoint() {
+      routeElevationActivePointDistance = nil
+      router.resetRouteElevationActivePoint()
+    }
+
+    fileprivate func restoreRouteElevationActivePoint() {
+      guard let routeElevationActivePointDistance else { return }
+      router.setRouteElevationActivePointDistance(routeElevationActivePointDistance)
+    }
+  }
+}
+
+// MARK: - ElevationProfileViewControllerDelegate
+
+extension NavigationDashboard.Interactor: ElevationProfileViewControllerDelegate {
+  func updateMapPoint(distance: Double) {
+    routeElevationActivePointDistance = distance
+    router.setRouteElevationActivePointDistance(distance)
   }
 }
 
@@ -167,6 +195,7 @@ extension NavigationDashboard.Interactor: NavigationDashboardView {
   }
 
   func statePrepare() {
+    clearRouteElevationActivePoint()
     process(.updateState(.prepare))
   }
 
@@ -209,7 +238,19 @@ extension NavigationDashboard.Interactor: NavigationDashboardView {
   }
 
   private func buildElevationInfoIfNeeded() {
-    let elevationInfo = router.routeElevationProfileData()
-    process(.updateElevationInfo(elevationInfo))
+    guard let elevationInfo = router.routeElevationProfileData() else {
+      clearRouteElevationActivePoint()
+      process(.updateElevationInfo(nil, activePointDistance: nil))
+      return
+    }
+
+    let maxDistance = elevationInfo.elevationProfileData?.points.last?.distance ?? 0
+    let activePointDistance = routeElevationActivePointDistance.map { min(max(0, $0), maxDistance) }
+    routeElevationActivePointDistance = activePointDistance
+    process(.updateElevationInfo(elevationInfo, activePointDistance: activePointDistance))
+    // Restore on the next run loop because Place Page finishes deselecting its map marker after the route-ready callback.
+    DispatchQueue.main.async { [weak self] in
+      self?.restoreRouteElevationActivePoint()
+    }
   }
 }

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardPresenter.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardPresenter.swift
@@ -30,8 +30,9 @@ extension NavigationDashboard {
         if state == .planning {
           viewModel.progress = 0
         }
-        if state == .error {
+        if state == .prepare || state == .error {
           viewModel.routeElevationPreviewData = nil
+          viewModel.routeElevationActivePointDistance = nil
         }
 
       case .close:
@@ -79,8 +80,9 @@ extension NavigationDashboard {
       case .updateTrackRecordingState(let state):
         viewModel.trackRecordingState = state
 
-      case .updateElevationInfo(let elevationInfo):
+      case .updateElevationInfo(let elevationInfo, let activePointDistance):
         viewModel.routeElevationPreviewData = elevationInfo
+        viewModel.routeElevationActivePointDistance = activePointDistance
 
       case .updateNavigationInfoAvailableArea(let rect):
         viewModel.navigationInfo.availableArea = rect

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardRequest.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardRequest.swift
@@ -21,7 +21,7 @@ extension NavigationDashboard {
 
     case updateRouteBuildingProgress(CGFloat, routerType: MWMRouterType)
     case updateNavigationInfo(MWMNavigationDashboardEntity)
-    case updateElevationInfo(RouteElevationPreviewData?)
+    case updateElevationInfo(RouteElevationPreviewData?, activePointDistance: Double?)
     case updateTrackRecordingState(TrackRecordingState)
     case updateVisibleAreaInsets(UIEdgeInsets)
     case updateNavigationInfoAvailableArea(CGRect)

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardResponse.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardResponse.swift
@@ -6,7 +6,7 @@ extension NavigationDashboard {
 
     case updateRouteBuildingProgress(CGFloat, routerType: MWMRouterType)
     case updateNavigationInfo(MWMNavigationDashboardEntity)
-    case updateElevationInfo(RouteElevationPreviewData?)
+    case updateElevationInfo(RouteElevationPreviewData?, activePointDistance: Double?)
     case updateTrackRecordingState(TrackRecordingState)
     case updatePresentationStep(NavigationDashboardModalPresentationStep)
     case updateNavigationInfoAvailableArea(CGRect)

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardViewController.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardViewController.swift
@@ -43,6 +43,7 @@ final class NavigationDashboardViewController: UIViewController {
   private let elevationProfileContainerView = UIView()
   private var elevationProfileViewController: ElevationProfileViewController?
   private var currentRouteElevationPreviewData: RouteElevationPreviewData?
+  private var currentRouteElevationActivePointDistance: Double?
   private let settingsButton = UIButton(type: .system)
   private let settingsBadge = BadgeWithNumber()
   private var routePointsView = RoutePointsView()
@@ -262,12 +263,15 @@ final class NavigationDashboardViewController: UIViewController {
     routePointsView.scrollViewDelegate = self
   }
 
-  private func updateElevationProfile(with routeElevationPreviewData: RouteElevationPreviewData?) {
-    guard routeElevationPreviewData !== currentRouteElevationPreviewData else {
+  private func updateElevationProfile(with routeElevationPreviewData: RouteElevationPreviewData?,
+                                      activePointDistance: Double?) {
+    guard routeElevationPreviewData !== currentRouteElevationPreviewData ||
+      activePointDistance != currentRouteElevationActivePointDistance else {
       elevationProfileContainerView.isHidden = routeElevationPreviewData == nil
       return
     }
     currentRouteElevationPreviewData = routeElevationPreviewData
+    currentRouteElevationActivePointDistance = activePointDistance
 
     guard let routeElevationPreviewData else {
       removeElevationProfileIfNeeded()
@@ -275,7 +279,10 @@ final class NavigationDashboardViewController: UIViewController {
       return
     }
 
-    guard let state = ElevationProfileBuilder.makeRoutePreviewState(routeElevationPreviewData: routeElevationPreviewData) else {
+    guard let state = ElevationProfileBuilder.makeRoutePreviewState(
+      routeElevationPreviewData: routeElevationPreviewData,
+      activePointDistance: activePointDistance ?? 0
+    ) else {
       removeElevationProfileIfNeeded()
       elevationProfileContainerView.isHidden = true
       return
@@ -289,7 +296,7 @@ final class NavigationDashboardViewController: UIViewController {
     }
 
     let viewController = ElevationProfileBuilder.build(state: state,
-                                                       delegate: nil,
+                                                       delegate: interactor,
                                                        presentationStyle: .routePreview)
     addChild(viewController)
     elevationProfileContainerView.addSubview(viewController.view)
@@ -312,6 +319,7 @@ final class NavigationDashboardViewController: UIViewController {
     elevationProfileViewController.removeFromParent()
     self.elevationProfileViewController = nil
     currentRouteElevationPreviewData = nil
+    currentRouteElevationActivePointDistance = nil
   }
 
   // MARK: - Actions
@@ -527,7 +535,7 @@ extension NavigationDashboardViewController {
     case .error:
       estimatesView.setState(viewModel.estimatesState)
       transportTransitStepsView.setNavigationInfo(nil)
-      updateElevationProfile(with: nil)
+      updateElevationProfile(with: nil, activePointDistance: nil)
       saveRouteAsTrackButton.isEnabled = viewModel.canSaveRouteAsTrack
       navigationControlView.isVisible = false
 
@@ -536,7 +544,8 @@ extension NavigationDashboardViewController {
                                selectedRouterType: viewModel.routerType)
       estimatesView.setState(viewModel.estimatesState)
       transportTransitStepsView.setNavigationInfo(viewModel.entity)
-      updateElevationProfile(with: viewModel.routeElevationPreviewData)
+      updateElevationProfile(with: viewModel.routeElevationPreviewData,
+                             activePointDistance: viewModel.routeElevationActivePointDistance)
       routePointsView.setRoutePoints(viewModel.routePoints)
       settingsBadge.isHidden = !viewModel.routingOptions.hasOptions
       settingsBadge.number = viewModel.routingOptions.enabledOptionsCount

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardViewModel.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardViewModel.swift
@@ -7,6 +7,7 @@ enum NavigationDashboard {
     var trackRecordingState: TrackRecordingState
     var routingOptions: RoutingOptions
     var routeElevationPreviewData: RouteElevationPreviewData?
+    var routeElevationActivePointDistance: Double?
     var navigationInfo: NavigationInfo
     var estimates: NSAttributedString
     var dashboardState: MWMNavigationDashboardState
@@ -41,6 +42,7 @@ extension NavigationDashboard.ViewModel {
       trackRecordingState: TrackRecordingManager.shared.recordingState,
       routingOptions: RoutingOptions(),
       routeElevationPreviewData: nil,
+      routeElevationActivePointDistance: nil,
       navigationInfo: .hidden,
       estimates: NSAttributedString(),
       dashboardState: .hidden,

--- a/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfileBuilder.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfileBuilder.swift
@@ -31,14 +31,15 @@ class ElevationProfileBuilder {
     build(state: makeTrackRecordingState(trackData: trackData), delegate: delegate, presentationStyle: presentationStyle)
   }
 
-  static func makeRoutePreviewState(routeElevationPreviewData: RouteElevationPreviewData) -> ElevationProfileState? {
+  static func makeRoutePreviewState(routeElevationPreviewData: RouteElevationPreviewData,
+                                    activePointDistance: Double = 0) -> ElevationProfileState? {
     guard let chartData = makeChartData(elevationProfileData: routeElevationPreviewData.elevationProfileData) else {
       return nil
     }
     let data = ElevationProfileDisplayData(trackInfo: routeElevationPreviewData.trackInfo,
                                            chartData: chartData,
-                                           activePointDistance: 0,
-                                           myPositionDistance: 0)
+                                           activePointDistance: activePointDistance,
+                                           myPositionDistance: -1)
     return .routePreview(data)
   }
 

--- a/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfilePresenter.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfilePresenter.swift
@@ -112,16 +112,14 @@ extension ElevationProfilePresenter: ElevationProfilePresenterProtocol {
     view?.isChartViewHidden = false
 
     switch state {
-    case .track(let data):
-      configureTrack(data)
+    case .track(let data), .routePreview(let data):
+      configureInteractiveProfile(data)
     case .trackRecording(let data):
       configureTrackRecording(data)
-    case .routePreview(let data):
-      configureRoutePreview(data)
     }
   }
 
-  private func configureTrack(_ data: ElevationProfileDisplayData) {
+  private func configureInteractiveProfile(_ data: ElevationProfileDisplayData) {
     view?.setChartData(ChartPresentationData(data.chartData, formatter: formatter))
     view?.reloadDescription()
     view?.isXAxisViewHidden = false
@@ -139,17 +137,6 @@ extension ElevationProfilePresenter: ElevationProfilePresenterProtocol {
     view?.placeholderText = data.chartData.isPlaceholder ? Constants.placeholderText : nil
     view?.userInteractionEnabled = false
     view?.isChartViewInfoHidden = true
-  }
-
-  private func configureRoutePreview(_ data: ElevationProfileDisplayData) {
-    view?.setChartData(ChartPresentationData(data.chartData, formatter: formatter))
-    view?.reloadDescription()
-    view?.isXAxisViewHidden = false
-    view?.placeholderText = nil
-    view?.userInteractionEnabled = false
-    view?.isChartViewInfoHidden = true
-    view?.setActivePointDistance(data.activePointDistance)
-    view?.setMyPositionDistance(data.myPositionDistance)
   }
 
   func onSelectedPointChanged(_ distance: Double) {

--- a/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfileViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ElevationProfile/ElevationProfileViewController.swift
@@ -52,7 +52,7 @@ final class ElevationProfileViewController: UIViewController {
       case .track:
         nil
       case .routePreview:
-        false
+        true
       }
     }
 
@@ -61,7 +61,7 @@ final class ElevationProfileViewController: UIViewController {
       case .track:
         nil
       case .routePreview:
-        true
+        false
       }
     }
   }


### PR DESCRIPTION
Now when the user drags the ele chart the point will be drawn on the track preview.
Current active point is preserved during other POI/track selections when the user goes back to the route building.
Current active point is preserved during alt route switching.

<img width="344" height="748" alt="image" src="https://github.com/user-attachments/assets/b130db20-9f2c-477a-8fd7-9bba894779f2" />

https://github.com/user-attachments/assets/5b340e00-7f9e-4877-ad0d-ac7c88f819d3

