### PR TITLE
[android] Stretch route elevation chart to full panel width

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/ElevationChartUtils.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/ElevationChartUtils.java
@@ -71,6 +71,7 @@ public final class ElevationChartUtils
     x.setGranularityEnabled(true);
     x.setTextColor(ThemeUtils.getColor(context, R.attr.elevationProfileAxisLabelColor));
     x.setPosition(XAxis.XAxisPosition.BOTTOM);
+    x.setAvoidFirstLastClipping(true);
     int dividerColor = ThemeUtils.getColor(context, androidx.appcompat.R.attr.dividerHorizontal);
     x.setAxisLineColor(dividerColor);
     x.setAxisLineWidth(context.getResources().getDimensionPixelSize(R.dimen.divider_height));

--- a/android/app/src/main/res/layout/altitude_chart_panel.xml
+++ b/android/app/src/main/res/layout/altitude_chart_panel.xml
@@ -9,12 +9,12 @@
   android:layout_marginTop="@dimen/margin_quarter_plus"
   android:layout_weight="1"
   android:orientation="vertical"
-  android:paddingStart="@dimen/altitude_chart_container_padding_left"
-  android:paddingEnd="@dimen/altitude_chart_container_padding_left"
   android:paddingBottom="@dimen/margin_half_plus"
   tools:showIn="@layout/routing_bottom_sheet">
 
   <LinearLayout
+    android:paddingStart="@dimen/routing_plan_horizontal_padding"
+    android:paddingEnd="@dimen/routing_plan_horizontal_padding"
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -171,6 +171,8 @@
     android:id="@+id/transit_recycler_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/routing_plan_horizontal_padding"
+    android:layout_marginEnd="@dimen/routing_plan_horizontal_padding"
     android:layout_marginTop="@dimen/margin_half_plus"
     android:visibility="gone"
     tools:visibility="visible" />

--- a/android/app/src/main/res/layout/routing_plan_header.xml
+++ b/android/app/src/main/res/layout/routing_plan_header.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/routing_types_header"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:layout_marginTop="@dimen/margin_half"
   android:orientation="horizontal"
-  android:paddingStart="@dimen/altitude_chart_container_padding_left"
-  android:paddingEnd="@dimen/altitude_chart_container_padding_left">
+  android:paddingStart="@dimen/routing_plan_horizontal_padding"
+  android:paddingEnd="@dimen/routing_plan_horizontal_padding">
 
   <FrameLayout
     android:layout_width="0dp"

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -109,7 +109,7 @@
   <dimen name="map_button_arrow_icon_size">34dp</dimen>
 
   <!-- routing layout -->
-    <dimen name="routing_transit_step_corner_radius">4dp</dimen>
+  <dimen name="routing_transit_step_corner_radius">4dp</dimen>
   <dimen name="routing_transit_step_min_height">20dp</dimen>
   <dimen name="routing_transit_setp_min_acceptable_with">104dp</dimen>
   <dimen name="track_recorder_status_top_margin">64dp</dimen>
@@ -165,8 +165,10 @@
   <!-- Login -->
   <dimen name="osm_logo">64dp</dimen>
 
+  <!-- Routing plan panel: horizontal content inset (mode header, time row, transit list) -->
+  <dimen name="routing_plan_horizontal_padding">16dp</dimen>
+
   <!-- Altitude chart -->
-  <dimen name="altitude_chart_container_padding_left">16dp</dimen>
   <dimen name="altitude_chart_container_padding_bottom">10dp</dimen>
   <dimen name="altitude_chart_margin_bottom">4dp</dimen>
   <dimen name="altitude_chart_margin_top">14dp</dimen>


### PR DESCRIPTION
## What

The route-planning elevation chart now spans the full width of the panel, so the plotted line lines up with the mode selector, time/distance row and route points instead of sitting inset from them.

Previously the chart was inset twice -- by the panel's horizontal padding and again by the chart's own viewport offset -- leaving it visibly narrower than the surrounding content. The fix moves the horizontal inset off the panel root onto the specific content rows, leaving the chart container full-width. The chart's internal geometry is untouched, so axis labels and the min/max altitude badges keep their original spacing.

The chart's X-axis distance labels ("0 m" on the left, total distance on the right) are now pinned to the plot edges via `setAvoidFirstLastClipping`, so they no longer overhang the start and end of the plotted line. Both charts share the same axis setup, so this applies to the track elevation profile too.

Also renames the shared dimen `altitude_chart_container_padding_left` to `routing_plan_horizontal_padding` to match its actual role (it is used by the routing plan header too, symmetrically on both sides).

## Screenshots

| Before | After |
|--------|-------|
| <img width="265" height="265" alt="image" src="https://github.com/user-attachments/assets/52c9148d-0f6e-4fe8-9347-5a66cf95a32a" />  | <img width="278" height="256" alt="image" src="https://github.com/user-attachments/assets/84b84212-f7a8-4769-970e-a60e6efce722" />|
| <img width="284" height="263" alt="image" src="https://github.com/user-attachments/assets/e2fc3381-005c-4284-a4e7-4bbad28199fc" /> | <img width="309" height="282" alt="image" src="https://github.com/user-attachments/assets/1609c950-a2e5-4e9d-8c07-d320ad5b1767" /> |