### PR TITLE
[android] Dismiss keyboard on every search close path

### DIFF
--- a/android/app/src/main/java/app/organicmaps/search/SearchFragmentController.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchFragmentController.java
@@ -378,6 +378,9 @@ public class SearchFragmentController extends Fragment implements SearchFragment
   // this programmatic close is the only path to STATE_HIDDEN (setState(HIDDEN) is rejected when !hideable).
   private void hideSearchSheet()
   {
+    // Dismiss the keyboard on every programmatic close path (X button, back, place page, forceCloseSearchFragment).
+    // Otherwise the IME inset lingers and the routing panel re-appearing underneath gets pushed down by it.
+    InputUtils.hideKeyboard(mSearchPageContainer);
     mBottomSheetBehavior.setHideable(true);
     mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
   }


### PR DESCRIPTION
## What
Closing the search sheet while the keyboard is open left the routing plan panel shifted down. The X button (and other programmatic closes) never dismissed the keyboard, so with `adjustResize` the window stayed shrunk and the re-appearing routing panel settled against the shortened window.

Fix: dismiss the keyboard in `SearchFragmentController.hideSearchSheet()` — the single point every close path funnels through. Once the IME is gone the window returns to full height and the panel re-snaps correctly. The back-press path already dismissed the keyboard via `deactivate()`; this aligns the remaining paths.

## Testing
Manually on Android 12:
- Routing panel → search → close with X while keyboard is up → panel  stays in place ✓
- Routing panel → search → pick a result as a route point while the keyboard is up → panel stays in place ✓
- Search → back button → no regression ✓