### PR TITLE
[platform] [indexer] Fix build and tests with a smaller unity build batch size

### DIFF
--- a/libs/indexer/indexer_tests/CMakeLists.txt
+++ b/libs/indexer/indexer_tests/CMakeLists.txt
@@ -50,6 +50,8 @@ omim_add_test(${PROJECT_NAME} ${SRC})
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
+    # @todo Take TestWithClassificator out into some common test support lib,
+    # so that indexer tests don't depend on the generator above them.
     generator_tests_support
     platform_tests_support
     indexer

--- a/libs/indexer/indexer_tests/categories_test.cpp
+++ b/libs/indexer/indexer_tests/categories_test.cpp
@@ -3,7 +3,8 @@
 #include "indexer/categories_holder.hpp"
 #include "indexer/categories_index.hpp"
 #include "indexer/classificator.hpp"
-#include "indexer/classificator_loader.hpp"
+
+#include "generator/generator_tests_support/test_with_classificator.hpp"
 
 #include "coding/reader.hpp"
 #include "coding/string_utf8_multilang.hpp"
@@ -16,6 +17,7 @@
 
 namespace categories_test
 {
+using namespace generator::tests_support;
 using namespace indexer;
 using namespace std;
 
@@ -94,10 +96,8 @@ struct Checker
   size_t & m_count;
 };
 
-UNIT_TEST(LoadCategories)
+UNIT_CLASS_TEST(TestWithClassificator, LoadCategories)
 {
-  classificator::Load();
-
   CategoriesHolder h(make_unique<MemReader>(g_testCategoriesTxt, sizeof(g_testCategoriesTxt) - 1));
   size_t count = 0;
   Checker f(count);
@@ -117,10 +117,8 @@ UNIT_TEST(CategoriesHolder_Smoke)
   }
 }
 
-UNIT_TEST(CategoriesHolder_LoadDefault)
+UNIT_CLASS_TEST(TestWithClassificator, CategoriesHolder_LoadDefault)
 {
-  classificator::Load();
-
   uint32_t counter = 0;
   auto const count = [&counter](CategoriesHolder::Category const &) { ++counter; };
 
@@ -134,7 +132,7 @@ UNIT_TEST(CategoriesHolder_LoadDefault)
   TEST_GREATER(counter, 0, ());
 }
 
-UNIT_TEST(CategoriesHolder_ForEach)
+UNIT_CLASS_TEST(TestWithClassificator, CategoriesHolder_ForEach)
 {
   char const kCategories[] =
       "amenity-bar\n"
@@ -151,7 +149,6 @@ UNIT_TEST(CategoriesHolder_ForEach)
       "\n"
       "";
 
-  classificator::Load();
   CategoriesHolder holder(make_unique<MemReader>(kCategories, ARRAY_SIZE(kCategories) - 1));
 
   {
@@ -176,10 +173,8 @@ UNIT_TEST(CategoriesHolder_ForEach)
   }
 }
 
-UNIT_TEST(CategoriesIndex_Smoke)
+UNIT_CLASS_TEST(TestWithClassificator, CategoriesIndex_Smoke)
 {
-  classificator::Load();
-
   CategoriesHolder holder(make_unique<MemReader>(g_testCategoriesTxt, sizeof(g_testCategoriesTxt) - 1));
   CategoriesIndex index(holder);
 
@@ -230,7 +225,7 @@ UNIT_TEST(CategoriesIndex_Smoke)
   TEST_EQUAL(cats[1].m_synonyms[0].m_name, "village", ());
 }
 
-UNIT_TEST(CategoriesIndex_MultipleTokens)
+UNIT_CLASS_TEST(TestWithClassificator, CategoriesIndex_MultipleTokens)
 {
   char const kCategories[] =
       "shop-bakery\n"
@@ -239,7 +234,6 @@ UNIT_TEST(CategoriesIndex_MultipleTokens)
       "shop-butcher\n"
       "en:shop of meat";
 
-  classificator::Load();
   CategoriesHolder holder(make_unique<MemReader>(kCategories, sizeof(kCategories) - 1));
   CategoriesIndex index(holder);
 
@@ -261,7 +255,7 @@ UNIT_TEST(CategoriesIndex_MultipleTokens)
   testTypes("shop meat", {type2});
 }
 
-UNIT_TEST(CategoriesIndex_Groups)
+UNIT_CLASS_TEST(TestWithClassificator, CategoriesIndex_Groups)
 {
   char const kCategories[] =
       "@shop\n"
@@ -278,7 +272,6 @@ UNIT_TEST(CategoriesIndex_Groups)
       "en:butcher\n"
       "";
 
-  classificator::Load();
   CategoriesHolder holder(make_unique<MemReader>(kCategories, sizeof(kCategories) - 1));
   CategoriesIndex index(holder);
 
@@ -305,10 +298,8 @@ UNIT_TEST(CategoriesIndex_Groups)
 
 #ifdef DEBUG
 // A check that this data structure is not too heavy.
-UNIT_TEST(CategoriesIndex_AllCategories)
+UNIT_CLASS_TEST(TestWithClassificator, CategoriesIndex_AllCategories)
 {
-  classificator::Load();
-
   CategoriesIndex index;
 
   index.AddAllCategoriesInAllLangs();
@@ -318,10 +309,8 @@ UNIT_TEST(CategoriesIndex_AllCategories)
 }
 
 // A check that this data structure is not too heavy.
-UNIT_TEST(CategoriesIndex_AllCategoriesEnglishName)
+UNIT_CLASS_TEST(TestWithClassificator, CategoriesIndex_AllCategoriesEnglishName)
 {
-  classificator::Load();
-
   CategoriesIndex index;
 
   index.AddAllCategoriesInLang(CategoriesHolder::MapLocaleToInteger("en"));

--- a/libs/indexer/indexer_tests/centers_table_test.cpp
+++ b/libs/indexer/indexer_tests/centers_table_test.cpp
@@ -1,10 +1,11 @@
 #include "testing/testing.hpp"
 
 #include "indexer/centers_table.hpp"
-#include "indexer/classificator_loader.hpp"
 #include "indexer/data_header.hpp"
 #include "indexer/feature_algo.hpp"
 #include "indexer/features_vector.hpp"
+
+#include "generator/generator_tests_support/test_with_classificator.hpp"
 
 #include "platform/platform.hpp"
 
@@ -21,6 +22,7 @@
 
 namespace centers_table_test
 {
+using namespace generator::tests_support;
 using namespace search;
 using namespace std;
 
@@ -28,12 +30,7 @@ namespace
 {
 using TBuffer = vector<uint8_t>;
 
-struct CentersTableTest
-{
-  CentersTableTest() { classificator::Load(); }
-};
-
-UNIT_CLASS_TEST(CentersTableTest, Smoke)
+UNIT_CLASS_TEST(TestWithClassificator, CentersTable_Smoke)
 {
   string const kMap = base::JoinPath(GetPlatform().ResourcesDir(), "minsk-pass.mwm");
 
@@ -69,7 +66,7 @@ UNIT_CLASS_TEST(CentersTableTest, Smoke)
   }
 }
 
-UNIT_CLASS_TEST(CentersTableTest, Subset)
+UNIT_CLASS_TEST(TestWithClassificator, CentersTable_Subset)
 {
   vector<pair<uint32_t, m2::PointD>> const features = {
       {1, m2::PointD(0.0, 0.0)}, {5, m2::PointD(1.0, 1.0)}, {10, m2::PointD(2.0, 2.0)}};

--- a/libs/indexer/indexer_tests/checker_test.cpp
+++ b/libs/indexer/indexer_tests/checker_test.cpp
@@ -3,14 +3,16 @@
 #include "search/utils.hpp"
 
 #include "indexer/classificator.hpp"
-#include "indexer/classificator_loader.hpp"
 #include "indexer/ftypes_matcher.hpp"
+
+#include "generator/generator_tests_support/test_with_classificator.hpp"
 
 #include <string>
 #include <vector>
 
 namespace checker_test
 {
+using namespace generator::tests_support;
 using namespace std;
 
 namespace
@@ -54,9 +56,8 @@ uint32_t GetMotorwayJunctionType()
 
 }  // namespace
 
-UNIT_TEST(IsBridgeOrTunnelChecker)
+UNIT_CLASS_TEST(TestWithClassificator, IsBridgeOrTunnelChecker)
 {
-  classificator::Load();
   auto const & c = classif();
 
   ftypes::IsBridgeOrTunnelChecker checker;
@@ -76,9 +77,8 @@ UNIT_TEST(IsBridgeOrTunnelChecker)
     TEST(!checker(c.GetTypeByPath(e)), ());
 }
 
-UNIT_TEST(IsWayChecker)
+UNIT_CLASS_TEST(TestWithClassificator, IsWayChecker)
 {
-  classificator::Load();
   auto const & c = classif();
   auto const & checker = ftypes::IsWayChecker::Instance();
 
@@ -93,18 +93,14 @@ UNIT_TEST(IsWayChecker)
   checker.ForEachType([&checker](uint32_t t) { TEST(checker.GetSearchRank(t) != ftypes::IsWayChecker::Default, ()); });
 }
 
-UNIT_TEST(IsLinkChecker)
+UNIT_CLASS_TEST(TestWithClassificator, IsLinkChecker)
 {
-  classificator::Load();
-
   TEST(ftypes::IsLinkChecker::Instance()(GetLinkTypes()), ());
   TEST(!ftypes::IsLinkChecker::Instance()(GetStreetTypes()), ());
 }
 
-UNIT_TEST(GetHighwayClassTest)
+UNIT_CLASS_TEST(TestWithClassificator, GetHighwayClassTest)
 {
-  classificator::Load();
-
   Classificator const & c = classif();
 
   feature::TypesHolder types1;
@@ -124,9 +120,8 @@ UNIT_TEST(GetHighwayClassTest)
   TEST_EQUAL(ftypes::GetHighwayClass(types4), ftypes::HighwayClass::Undefined, ());
 }
 
-UNIT_TEST(IsAttractionsChecker)
+UNIT_CLASS_TEST(TestWithClassificator, IsAttractionsChecker)
 {
-  classificator::Load();
   Classificator const & c = classif();
   auto const & checker = ftypes::AttractionsChecker::Instance();
 
@@ -143,17 +138,14 @@ UNIT_TEST(IsAttractionsChecker)
       TEST(checker(t), (c.GetFullObjectName(t)));
 }
 
-UNIT_TEST(IsMotorwayJunctionChecker)
+UNIT_CLASS_TEST(TestWithClassificator, IsMotorwayJunctionChecker)
 {
-  classificator::Load();
-
   TEST(ftypes::IsMotorwayJunctionChecker::Instance()(GetMotorwayJunctionType()), ());
   TEST(!ftypes::IsMotorwayJunctionChecker::Instance()(GetStreetTypes()), ());
 }
 
-UNIT_TEST(IsRecyclingContainerChecker)
+UNIT_CLASS_TEST(TestWithClassificator, IsRecyclingContainerChecker)
 {
-  classificator::Load();
   auto const & c = classif();
 
   auto const & checker = ftypes::IsRecyclingContainerChecker::Instance();
@@ -161,9 +153,8 @@ UNIT_TEST(IsRecyclingContainerChecker)
   TEST(!checker(c.GetTypeByPath({"amenity", "recycling", "centre"})), ());
 }
 
-UNIT_TEST(BaseCheckerEx_Smoke)
+UNIT_CLASS_TEST(TestWithClassificator, BaseCheckerEx_Smoke)
 {
-  classificator::Load();
   auto const & c = classif();
 
   ftypes::BaseCheckerEx checker({{"shop"}, {"amenity", "parking"}, {"boundary", "protected_area", "1"}});

--- a/libs/indexer/indexer_tests/editable_map_object_test.cpp
+++ b/libs/indexer/indexer_tests/editable_map_object_test.cpp
@@ -1,17 +1,19 @@
 #include "testing/testing.hpp"
 
 #include "indexer/classificator.hpp"
-#include "indexer/classificator_loader.hpp"
 #include "indexer/editable_map_object.hpp"
 #include "indexer/feature.hpp"
 #include "indexer/feature_utils.hpp"
 #include "indexer/validate_and_format_contacts.hpp"
+
+#include "generator/generator_tests_support/test_with_classificator.hpp"
 
 #include <string>
 #include <vector>
 
 namespace editable_map_object_test
 {
+using namespace generator::tests_support;
 using namespace std;
 
 using osm::EditableMapObject;
@@ -328,10 +330,8 @@ void SetTypes(EditableMapObject & emo, std::initializer_list<base::StringIL> typ
 }
 }  // namespace
 
-UNIT_TEST(EditableMapObject_SetInternet)
+UNIT_CLASS_TEST(TestWithClassificator, EditableMapObject_SetInternet)
 {
-  classificator::Load();
-
   EditableMapObject emo;
   auto const wifiType = classif().GetTypeByPath({"internet_access", "wlan"});
   emo.SetType(wifiType);
@@ -374,10 +374,8 @@ UNIT_TEST(EditableMapObject_SetInternet)
   setInternetAndCheck(bunkerEmo, feature::Internet::Wlan, true);
 }
 
-UNIT_TEST(EditableMapObject_FromFeatureType)
+UNIT_CLASS_TEST(TestWithClassificator, EditableMapObject_FromFeatureType)
 {
-  classificator::Load();
-
   EditableMapObject emo;
   SetTypes(emo, {{"amenity", "cafe"}});
 
@@ -409,10 +407,8 @@ UNIT_TEST(EditableMapObject_FromFeatureType)
   TEST(emo2.IsPointType(), ());
 }
 
-UNIT_TEST(EditableMapObject_GetLocalizedAllTypes)
+UNIT_CLASS_TEST(TestWithClassificator, EditableMapObject_GetLocalizedAllTypes)
 {
-  classificator::Load();
-
   {
     EditableMapObject emo;
     SetTypes(emo, {{"amenity", "fuel"}, {"shop"}, {"building"}, {"toilets", "yes"}});

--- a/libs/indexer/indexer_tests/feature_types_test.cpp
+++ b/libs/indexer/indexer_tests/feature_types_test.cpp
@@ -1,11 +1,13 @@
 #include "testing/testing.hpp"
 
 #include "indexer/classificator.hpp"
-#include "indexer/classificator_loader.hpp"
 #include "indexer/feature_data.hpp"
+
+#include "generator/generator_tests_support/test_with_classificator.hpp"
 
 namespace feature_types_test
 {
+using namespace generator::tests_support;
 
 feature::TypesHolder MakeTypesHolder(std::initializer_list<base::StringIL> const & arr, bool sortBySpec = true,
                                      feature::GeomType geomType = feature::GeomType::Point)
@@ -23,10 +25,8 @@ feature::TypesHolder MakeTypesHolder(std::initializer_list<base::StringIL> const
   return types;
 }
 
-UNIT_TEST(Feature_UselessTypes)
+UNIT_CLASS_TEST(TestWithClassificator, Feature_UselessTypes)
 {
-  /// @todo Take out TestWithClassificator into some common test support lib.
-  classificator::Load();
   auto const & cl = classif();
 
   {
@@ -52,10 +52,8 @@ UNIT_TEST(Feature_UselessTypes)
   }
 }
 
-UNIT_TEST(Feature_TypesPriority)
+UNIT_CLASS_TEST(TestWithClassificator, Feature_TypesPriority)
 {
-  /// @todo Take out TestWithClassificator into some common test support lib.
-  classificator::Load();
   auto const & cl = classif();
 
   {
@@ -137,10 +135,8 @@ UNIT_TEST(Feature_TypesPriority)
   }
 }
 
-UNIT_TEST(Feature_TypesEqualUsefulSorted)
+UNIT_CLASS_TEST(TestWithClassificator, Feature_TypesEqualUsefulSorted)
 {
-  classificator::Load();
-
   {
     auto types1 = MakeTypesHolder(
         {

--- a/libs/indexer/indexer_tests/index_builder_test.cpp
+++ b/libs/indexer/indexer_tests/index_builder_test.cpp
@@ -1,10 +1,11 @@
 #include "testing/testing.hpp"
 
-#include "indexer/classificator_loader.hpp"
 #include "indexer/data_source.hpp"
 #include "indexer/features_vector.hpp"
 #include "indexer/index_builder.hpp"
 #include "indexer/scales.hpp"
+
+#include "generator/generator_tests_support/test_with_classificator.hpp"
 
 #include "defines.hpp"
 
@@ -20,12 +21,12 @@
 
 namespace index_builder_test
 {
+using namespace generator::tests_support;
 using namespace std;
 
-UNIT_TEST(BuildIndexTest)
+UNIT_CLASS_TEST(TestWithClassificator, BuildIndexTest)
 {
   Platform & p = GetPlatform();
-  classificator::Load();
 
   FilesContainerR originalContainer(p.GetReader("minsk-pass" DATA_FILE_EXTENSION));
 

--- a/libs/indexer/indexer_tests/rank_table_test.cpp
+++ b/libs/indexer/indexer_tests/rank_table_test.cpp
@@ -1,10 +1,11 @@
 #include "testing/testing.hpp"
 #include "tmp_mwm_copy.hpp"
 
-#include "indexer/classificator_loader.hpp"
 #include "indexer/data_source.hpp"
 #include "indexer/mwm_set.hpp"
 #include "indexer/rank_table.hpp"
+
+#include "generator/generator_tests_support/test_with_classificator.hpp"
 
 #include "coding/file_writer.hpp"
 #include "coding/files_container.hpp"
@@ -19,6 +20,7 @@
 
 namespace rank_table_test
 {
+using namespace generator::tests_support;
 using namespace std;
 
 namespace
@@ -71,10 +73,8 @@ UNIT_TEST(RankTableBuilder_Smoke)
   TestTable(ranks, kTestCont);
 }
 
-UNIT_TEST(RankTableBuilder_EndToEnd)
+UNIT_CLASS_TEST(TestWithClassificator, RankTableBuilder_EndToEnd)
 {
-  classificator::Load();
-
   tests::TempMwmCopy mwmCopy("minsk-pass");
   auto const & mwmPath = mwmCopy.GetPath();
 

--- a/libs/indexer/indexer_tests/read_features_tests.cpp
+++ b/libs/indexer/indexer_tests/read_features_tests.cpp
@@ -1,7 +1,8 @@
 #include "testing/testing.hpp"
 
-#include "indexer/classificator_loader.hpp"
 #include "indexer/data_source.hpp"
+
+#include "generator/generator_tests_support/test_with_classificator.hpp"
 
 #include "platform/local_country_file.hpp"
 
@@ -11,12 +12,11 @@
 
 namespace read_features_tests
 {
+using namespace generator::tests_support;
 using namespace std;
 
-UNIT_TEST(ReadFeatures_Smoke)
+UNIT_CLASS_TEST(TestWithClassificator, ReadFeatures_Smoke)
 {
-  classificator::Load();
-
   FrozenDataSource dataSource;
   dataSource.RegisterMap(platform::LocalCountryFile::MakeForTesting("minsk-pass"));
 

--- a/libs/indexer/indexer_tests/visibility_test.cpp
+++ b/libs/indexer/indexer_tests/visibility_test.cpp
@@ -1,10 +1,11 @@
 #include "testing/testing.hpp"
 
 #include "indexer/classificator.hpp"
-#include "indexer/classificator_loader.hpp"
 #include "indexer/feature_data.hpp"
 #include "indexer/feature_visibility.hpp"
 #include "indexer/scales.hpp"
+
+#include "generator/generator_tests_support/test_with_classificator.hpp"
 
 #include "base/logging.hpp"
 
@@ -16,6 +17,7 @@
 
 namespace visibility_test
 {
+using namespace generator::tests_support;
 using namespace std;
 
 namespace
@@ -77,7 +79,7 @@ public:
 
 }  // namespace
 
-UNIT_TEST(VisibleScales_Highway)
+UNIT_CLASS_TEST(TestWithClassificator, VisibleScales_Highway)
 {
   Classificator const & c = classif();
 

--- a/libs/indexer/indexer_tests/wheelchair_tests.cpp
+++ b/libs/indexer/indexer_tests/wheelchair_tests.cpp
@@ -1,12 +1,14 @@
 #include "testing/testing.hpp"
 
 #include "indexer/classificator.hpp"
-#include "indexer/classificator_loader.hpp"
 #include "indexer/ftraits.hpp"
 
-UNIT_TEST(Wheelchair_GetType)
+#include "generator/generator_tests_support/test_with_classificator.hpp"
+
+using namespace generator::tests_support;
+
+UNIT_CLASS_TEST(TestWithClassificator, Wheelchair_GetType)
 {
-  classificator::Load();
   Classificator const & c = classif();
 
   using ftraits::Wheelchair;

--- a/libs/platform/platform_android.cpp
+++ b/libs/platform/platform_android.cpp
@@ -12,6 +12,8 @@
 #include "base/string_utils.hpp"
 #include "base/thread.hpp"
 
+#include "defines.hpp"
+
 #include <algorithm>
 #include <memory>
 #include <ranges>


### PR DESCRIPTION
Fixes failed build because of missing include and missing Classificator::Load needed in https://github.com/organicmaps/organicmaps/pull/12966

## What changed

`CMAKE_UNITY_BUILD_BATCH_SIZE=8` broke both the build and `indexer_tests`. Neither is a
unity-build bug: both are implicit cross-TU dependencies that the default batch size (50)
happened to hide by putting the sources in one translation unit.

**`[platform] Fix missing include`** — `platform_android.cpp` uses `DATA_FILE_EXTENSION`,
`WORLD_FILE_NAME`, `WORLD_COASTS_FILE_NAME` and `SETTINGS_FILE_NAME` without including
`defines.hpp`. It compiled only because another source in the same unity batch included it;
a smaller batch regroups the sources and the include is gone.

**`[indexer] Fix test-order dependency in VisibleScales_Highway`** — the test called
`classif()` without ever loading the classificator, so it passed only when an unrelated
earlier test in the same binary happened to load it first. Test registration order is
guaranteed within a translation unit but not across them, so splitting the sources into
several TUs reordered the tests and this one aborted on an empty classificator:

```
Running visibility_test.cpp::VisibleScales_Highway
(1) ASSERT FAILED
indexer/classificator.cpp:398
CHECK(type != INVALID_TYPE) 0 0 [1: highway ]
```

This was never unity-specific — the same abort reproduces with the default batch size via
`./indexer_tests --filter=VisibleScales_Highway`.

**`[indexer] Use TestWithClassificator fixture in indexer_tests`** — the remaining 27 tests
loaded the classificator by hand, which is exactly what made the omission easy to miss. They
now use the `TestWithClassificator` fixture, which loads it per test (-24 lines).
`centers_table_test`'s private fixture existed only to call `Load()`, so it is dropped and
its tests renamed to `CentersTable_*` to keep the registered names descriptive.

Assertions are unchanged. `classificator_tests` already set `MapStyleMerged` through the same
fixture and the current style is process-wide, so these tests were effectively running under
it already; `VisibleScales_Highway` reports the identical `(16, 20) for type: elevator`
before and after. Only drules-driven assertions are style-sensitive — the classificator tree
itself is read from the same `classificator.txt`/`types.txt` for every style.