### PR TITLE
[platform][indexer] Match Chinese locale subtags instead of substrings

### DIFF
--- a/libs/base/base_tests/string_utils_test.cpp
+++ b/libs/base/base_tests/string_utils_test.cpp
@@ -198,6 +198,22 @@ UNIT_TEST(EqualNoCase)
   TEST(strings::EqualNoCase("HaHaHa", "hahaha"), ());
 }
 
+UNIT_TEST(EqualAsciiNoCase)
+{
+  TEST(strings::EqualAsciiNoCase("", ""), ());
+  TEST(strings::EqualAsciiNoCase("HaHaHa", "hahaha"), ());
+  TEST(strings::EqualAsciiNoCase("zh-Hant", "ZH-HANT"), ());
+  TEST(strings::EqualAsciiNoCase("0;9z", "0;9Z"), ());
+
+  TEST(!strings::EqualAsciiNoCase("fi", "fil"), ());
+  TEST(!strings::EqualAsciiNoCase("fil", "fi"), ());
+  TEST(!strings::EqualAsciiNoCase("", "a"), ());
+  // Case-insensitive comparison must not fold characters that merely differ by the same 0x20 bit.
+  TEST(!strings::EqualAsciiNoCase("[", "{"), ());
+  // Non-ASCII bytes are compared as-is, without Unicode case folding.
+  TEST(!strings::EqualAsciiNoCase("Ä", "ä"), ());
+}
+
 UNIT_TEST(to_double)
 {
   std::string s;
@@ -1465,6 +1481,12 @@ UNIT_TEST(ToLower_ToUpper)
 
   strings::AsciiToUpper(s);
   TEST_EQUAL(s, "ABC0;9Z", ());
+
+  // Only ASCII letters are converted, everything else is passed through unchanged.
+  static_assert(strings::AsciiToLower('A') == 'a' && strings::AsciiToLower('a') == 'a');
+  static_assert(strings::AsciiToUpper('z') == 'Z' && strings::AsciiToUpper('Z') == 'Z');
+  static_assert(strings::AsciiToLower('9') == '9' && strings::AsciiToUpper(';') == ';');
+  static_assert(strings::AsciiToLower('[') == '[' && strings::AsciiToUpper('{') == '{');
 }
 
 }  // namespace string_utils_test

--- a/libs/base/string_utils.cpp
+++ b/libs/base/string_utils.cpp
@@ -178,30 +178,18 @@ size_t Utf8Length(std::string_view const s)
 
 void AsciiToLower(std::string & s)
 {
-  std::transform(s.begin(), s.end(), s.begin(), [](char in)
-  {
-    char constexpr diff = 'z' - 'Z';
-    static_assert(diff == 'a' - 'A');
-    static_assert(diff > 0);
-
-    if (in >= 'A' && in <= 'Z')
-      return char(in + diff);
-    return in;
-  });
+  std::transform(s.begin(), s.end(), s.begin(), [](char c) { return AsciiToLower(c); });
 }
 
 void AsciiToUpper(std::string & s)
 {
-  std::transform(s.begin(), s.end(), s.begin(), [](char in)
-  {
-    char constexpr diff = 'z' - 'Z';
-    static_assert(diff == 'a' - 'A');
-    static_assert(diff > 0);
+  std::transform(s.begin(), s.end(), s.begin(), [](char c) { return AsciiToUpper(c); });
+}
 
-    if (in >= 'a' && in <= 'z')
-      return char(in - diff);
-    return in;
-  });
+bool EqualAsciiNoCase(std::string_view s1, std::string_view s2) noexcept
+{
+  return s1.size() == s2.size() && std::equal(s1.begin(), s1.end(), s2.begin(),
+                                              [](char c1, char c2) { return AsciiToLower(c1) == AsciiToLower(c2); });
 }
 
 void Trim(std::string & s)

--- a/libs/base/string_utils.hpp
+++ b/libs/base/string_utils.hpp
@@ -108,8 +108,22 @@ size_t CountNormLowerSymbols(UniString const & s, UniString const & lowStr);
 
 size_t Utf8Length(std::string_view const s);
 
+constexpr char AsciiToLower(char c) noexcept
+{
+  return c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c;
+}
+
+constexpr char AsciiToUpper(char c) noexcept
+{
+  return c >= 'a' && c <= 'z' ? static_cast<char>(c - 'a' + 'A') : c;
+}
+
 void AsciiToLower(std::string & s);
 void AsciiToUpper(std::string & s);
+
+/// Compares ASCII strings ignoring case. Unlike EqualNoCase() it neither allocates nor applies
+/// Unicode case folding, so it is only correct for ASCII inputs like language tags or URL schemes.
+bool EqualAsciiNoCase(std::string_view s1, std::string_view s2) noexcept;
 
 // All trimming functions do in-place trimming. Only ASCII whitespaces are trimmed.
 void Trim(std::string & s);

--- a/libs/indexer/categories_holder.cpp
+++ b/libs/indexer/categories_holder.cpp
@@ -309,8 +309,9 @@ int8_t CategoriesHolder::MapLocaleToInteger(std::string_view const locale)
   ASSERT_EQUAL(kLocaleMapping[0].m_name, std::string_view("en"), ());
   ASSERT_EQUAL(kLocaleMapping[0].m_code, kEnglishCode, ());
 
+  // Reverse order so that a regional variant ("en-GB") wins over its base language ("en").
   for (auto it = kLocaleMapping.crbegin(); it != kLocaleMapping.crend(); ++it)
-    if (locale.find(it->m_name) == 0)
+    if (languages::StartsWithSubtags(locale, it->m_name))
       return it->m_code;
 
   // Special cases for different Chinese variations

--- a/libs/indexer/categories_holder.cpp
+++ b/libs/indexer/categories_holder.cpp
@@ -2,6 +2,8 @@
 #include "indexer/classificator.hpp"
 #include "indexer/search_string_utils.hpp"
 
+#include "platform/preferred_languages.hpp"
+
 #include "coding/reader.hpp"
 #include "coding/reader_streambuf.hpp"
 
@@ -312,16 +314,11 @@ int8_t CategoriesHolder::MapLocaleToInteger(std::string_view const locale)
       return it->m_code;
 
   // Special cases for different Chinese variations
-  if (locale.find("zh") == 0)
+  switch (languages::GetChineseScript(locale))
   {
-    std::string lower(locale);
-    strings::AsciiToLower(lower);
-
-    for (char const * s : {"hant", "tw", "hk", "mo"})
-      if (lower.find(s) != std::string::npos)
-        return kTraditionalChineseCode;
-    // Simplified Chinese by default for all other cases.
-    return kSimplifiedChineseCode;
+  case languages::ChineseScript::Traditional: return kTraditionalChineseCode;
+  case languages::ChineseScript::Simplified: return kSimplifiedChineseCode;
+  case languages::ChineseScript::NotChinese: break;
   }
 
   return kUnsupportedLocaleCode;

--- a/libs/indexer/indexer_tests/categories_test.cpp
+++ b/libs/indexer/indexer_tests/categories_test.cpp
@@ -117,6 +117,35 @@ UNIT_TEST(CategoriesHolder_Smoke)
   }
 }
 
+// Android 14+ appends regional preferences to the locale as Unicode extensions, e.g.
+// Locale.toString() == "zh_CN_#Hans-u-fw-mon" when the user picks Monday as the first day of the
+// week. The "mon" value must not be matched as the Macau ("mo") region subtag, which would show
+// Traditional Chinese categories to a Simplified Chinese user.
+UNIT_TEST(CategoriesHolder_LocaleExtensions)
+{
+  auto const simplified = CategoriesHolder::kSimplifiedChineseCode;
+  auto const traditional = CategoriesHolder::kTraditionalChineseCode;
+
+  for (char const * locale : {"zh_CN_#u-fw-mon", "zh_CN_#Hans-u-fw-mon", "zh_CN_#Hans-u-fw-sun",
+                              "zh_CN_#u-fw-mon-ms-metric-mu-celsius", "zh_CN_#Hans"})
+    TEST_EQUAL(CategoriesHolder::MapLocaleToInteger(locale), simplified, (locale));
+
+  for (char const * locale : {"zh_TW_#Hant-u-fw-mon", "zh_HK_#u-fw-mon", "zh_MO_#u-fw-sun"})
+    TEST_EQUAL(CategoriesHolder::MapLocaleToInteger(locale), traditional, (locale));
+
+  // Non-Chinese locales are unaffected by their extensions.
+  TEST_EQUAL(CategoriesHolder::MapLocaleToInteger("en_UA_#u-fw-mon-ms-metric-mu-celsius"),
+             CategoriesHolder::kEnglishCode, ());
+
+  // Chinese variants are matched case-insensitively.
+  TEST_EQUAL(CategoriesHolder::MapLocaleToInteger("ZH_TW"), traditional, ());
+  TEST_EQUAL(CategoriesHolder::MapLocaleToInteger("ZH_CN"), simplified, ());
+
+  // POSIX $LANG on Linux/Qt carries a charset suffix.
+  TEST_EQUAL(CategoriesHolder::MapLocaleToInteger("zh_TW.UTF-8"), traditional, ());
+  TEST_EQUAL(CategoriesHolder::MapLocaleToInteger("zh_CN.UTF-8"), simplified, ());
+}
+
 UNIT_CLASS_TEST(TestWithClassificator, CategoriesHolder_LoadDefault)
 {
   uint32_t counter = 0;

--- a/libs/indexer/indexer_tests/categories_test.cpp
+++ b/libs/indexer/indexer_tests/categories_test.cpp
@@ -146,6 +146,19 @@ UNIT_TEST(CategoriesHolder_LocaleExtensions)
   TEST_EQUAL(CategoriesHolder::MapLocaleToInteger("zh_CN.UTF-8"), simplified, ());
 }
 
+// Locales are matched by whole subtags, so a three-letter language is never mistaken for a
+// two-letter one it happens to start with: Filipino ("fil") is not Finnish ("fi").
+UNIT_TEST(CategoriesHolder_ThreeLetterLanguages)
+{
+  for (char const * locale : {"fil", "fil_PH", "fil-PH", "bem_ZM", "rof_TZ", "bgc_IN"})
+    TEST_EQUAL(CategoriesHolder::MapLocaleToInteger(locale), CategoriesHolder::kUnsupportedLocaleCode, (locale));
+
+  // The two-letter languages they shadow still resolve.
+  TEST_EQUAL(CategoriesHolder::MapLocaleToInteger("fi"), CategoriesHolder::MapLocaleToInteger("fi_FI"), ());
+  TEST_NOT_EQUAL(CategoriesHolder::MapLocaleToInteger("fi"), CategoriesHolder::kUnsupportedLocaleCode, ());
+  TEST_NOT_EQUAL(CategoriesHolder::MapLocaleToInteger("be_BY"), CategoriesHolder::kUnsupportedLocaleCode, ());
+}
+
 UNIT_CLASS_TEST(TestWithClassificator, CategoriesHolder_LoadDefault)
 {
   uint32_t counter = 0;

--- a/libs/platform/platform_tests/cjk_resolver_tests.cpp
+++ b/libs/platform/platform_tests/cjk_resolver_tests.cpp
@@ -41,6 +41,9 @@ UNIT_TEST(CJKResolver_FromLanguageTag)
   TEST_EQUAL(CJKResolver::FromLanguageTag("zh_HK"), V::HK, ());
   TEST_EQUAL(CJKResolver::FromLanguageTag("zh-Hant-HK"), V::HK, ());
   TEST_EQUAL(CJKResolver::FromLanguageTag("ZH-HK"), V::HK, ());
+  // An explicit script wins over the region, so a Simplified-preferring Hong Kong user gets SC.
+  TEST_EQUAL(CJKResolver::FromLanguageTag("zh-Hans-HK"), V::SC, ());
+  TEST_EQUAL(CJKResolver::FromLanguageTag("zh_HK_#Hans"), V::SC, ());
 
   // Non-CJK locales default to SC so a Han glyph is at least rendered.
   TEST_EQUAL(CJKResolver::FromLanguageTag("en"), V::SC, ());

--- a/libs/platform/platform_tests/language_test.cpp
+++ b/libs/platform/platform_tests/language_test.cpp
@@ -51,6 +51,11 @@ UNIT_TEST(LangGetChineseScript)
   TEST_EQUAL(GetChineseScript("zh-Hans-CN"), ChineseScript::Simplified, ());
   TEST_EQUAL(GetChineseScript("zh-SG"), ChineseScript::Simplified, ());
 
+  // An explicit script subtag is authoritative and wins over a Traditional region.
+  TEST_EQUAL(GetChineseScript("zh-Hans-HK"), ChineseScript::Simplified, ());
+  TEST_EQUAL(GetChineseScript("zh_HK_#Hans"), ChineseScript::Simplified, ());
+  TEST_EQUAL(GetChineseScript("zh-Hans-TW"), ChineseScript::Simplified, ());
+
   TEST_EQUAL(GetChineseScript("zh-Hant"), ChineseScript::Traditional, ());
   TEST_EQUAL(GetChineseScript("zh_TW"), ChineseScript::Traditional, ());
   TEST_EQUAL(GetChineseScript("zh-HK"), ChineseScript::Traditional, ());

--- a/libs/platform/platform_tests/language_test.cpp
+++ b/libs/platform/platform_tests/language_test.cpp
@@ -17,6 +17,29 @@ UNIT_TEST(LangNormalize_Smoke)
     TEST_EQUAL(arr2[i], languages::Normalize(arr1[i]), ());
 }
 
+UNIT_TEST(LangSelectMapLanguage)
+{
+  using languages::SelectMapLanguage;
+
+  // The first core-supported language wins, with its script and region preserved, so the Twine
+  // locale derived downstream (GetCurrentMapTwine) can tell Traditional from Simplified Chinese
+  // instead of collapsing both to "zh".
+  TEST_EQUAL(SelectMapLanguage({"zh-Hant", "en"}), "zh-Hant", ());
+  TEST_EQUAL(SelectMapLanguage({"zh_TW", "en"}), "zh_TW", ());
+  TEST_EQUAL(SelectMapLanguage({"en-US"}), "en-US", ());
+
+  // Languages the core does not support are skipped in favour of the next supported one.
+  TEST_EQUAL(SelectMapLanguage({"xyz", "ru-RU"}), "ru-RU", ());
+
+  // Nothing supported (or an empty list) falls back to the default code.
+  TEST_EQUAL(SelectMapLanguage({"xyz"}), "default", ());
+  TEST_EQUAL(SelectMapLanguage({}), "default", ());
+
+  // The derived Twine locale keeps the script: this is the actual GetCurrentMapTwine fix.
+  TEST_EQUAL(languages::GetTwine(SelectMapLanguage({"zh-Hant", "en"})), "zh-Hant", ());
+  TEST_EQUAL(languages::GetTwine(SelectMapLanguage({"zh-Hans", "en"})), "zh-Hans", ());
+}
+
 UNIT_TEST(LangGetChineseScript)
 {
   using languages::ChineseScript;

--- a/libs/platform/platform_tests/language_test.cpp
+++ b/libs/platform/platform_tests/language_test.cpp
@@ -17,6 +17,70 @@ UNIT_TEST(LangNormalize_Smoke)
     TEST_EQUAL(arr2[i], languages::Normalize(arr1[i]), ());
 }
 
+UNIT_TEST(LangGetChineseScript)
+{
+  using languages::ChineseScript;
+  using languages::GetChineseScript;
+
+  TEST_EQUAL(GetChineseScript("zh"), ChineseScript::Simplified, ());
+  TEST_EQUAL(GetChineseScript("zh-Hans"), ChineseScript::Simplified, ());
+  TEST_EQUAL(GetChineseScript("zh_CN"), ChineseScript::Simplified, ());
+  TEST_EQUAL(GetChineseScript("zh-Hans-CN"), ChineseScript::Simplified, ());
+  TEST_EQUAL(GetChineseScript("zh-SG"), ChineseScript::Simplified, ());
+
+  TEST_EQUAL(GetChineseScript("zh-Hant"), ChineseScript::Traditional, ());
+  TEST_EQUAL(GetChineseScript("zh_TW"), ChineseScript::Traditional, ());
+  TEST_EQUAL(GetChineseScript("zh-HK"), ChineseScript::Traditional, ());
+  TEST_EQUAL(GetChineseScript("zh-MO"), ChineseScript::Traditional, ());
+  TEST_EQUAL(GetChineseScript("ZH-TW"), ChineseScript::Traditional, ());
+
+  // Android resource qualifiers spell the region with an "r" prefix.
+  TEST_EQUAL(GetChineseScript("zh-rTW"), ChineseScript::Traditional, ());
+  TEST_EQUAL(GetChineseScript("zh_rCN"), ChineseScript::Simplified, ());
+
+  // POSIX locales from $LANG carry a charset suffix and may carry an @modifier.
+  TEST_EQUAL(GetChineseScript("zh_TW.UTF-8"), ChineseScript::Traditional, ());
+  TEST_EQUAL(GetChineseScript("zh_HK.UTF-8"), ChineseScript::Traditional, ());
+  TEST_EQUAL(GetChineseScript("zh_MO.UTF-8"), ChineseScript::Traditional, ());
+  TEST_EQUAL(GetChineseScript("zh_CN.UTF-8"), ChineseScript::Simplified, ());
+
+  TEST_EQUAL(GetChineseScript("en"), ChineseScript::NotChinese, ());
+  TEST_EQUAL(GetChineseScript("en_UA"), ChineseScript::NotChinese, ());
+  TEST_EQUAL(GetChineseScript(""), ChineseScript::NotChinese, ());
+  // Primary subtag is matched exactly, so Zhuang is not Chinese.
+  TEST_EQUAL(GetChineseScript("zha"), ChineseScript::NotChinese, ());
+  // "mo"/"hk" must be whole subtags, not substrings.
+  TEST_EQUAL(GetChineseScript("zh-Mong"), ChineseScript::Simplified, ());
+  TEST_EQUAL(GetChineseScript("zh-Hank"), ChineseScript::Simplified, ());
+}
+
+// Android 14+ stores regional preferences (first day of week, measurement system, temperature
+// unit) as Unicode locale extensions, and Locale.toString() surfaces them as
+// "en_UA_#u-fw-mon-ms-metric-mu-celsius". The "mon" value must not be read as Macau ("mo").
+UNIT_TEST(LangAndroidRegionalPreferences)
+{
+  using languages::ChineseScript;
+  using languages::GetChineseScript;
+
+  TEST_EQUAL(languages::Normalize("en_UA_#u-fw-mon-ms-metric-mu-celsius"), "en", ());
+  TEST_EQUAL(languages::GetTwine("en_UA_#u-fw-mon-ms-metric-mu-celsius"), "en", ());
+
+  // Simplified Chinese must survive every regional preference, Monday included.
+  for (char const * tag : {"zh_CN_#u-fw-mon", "zh_CN_#u-fw-mon-ms-metric-mu-celsius", "zh_CN_#Hans-u-fw-mon",
+                           "zh_CN_#Hans-u-fw-sun", "zh_CN_#Hans"})
+  {
+    TEST_EQUAL(GetChineseScript(tag), ChineseScript::Simplified, (tag));
+    TEST_EQUAL(languages::GetTwine(tag), "zh-Hans", (tag));
+  }
+
+  // Traditional Chinese must stay Traditional with the same extensions attached.
+  for (char const * tag : {"zh_TW_#Hant-u-fw-mon", "zh_TW_#u-fw-sun", "zh_HK_#Hant-u-fw-mon"})
+  {
+    TEST_EQUAL(GetChineseScript(tag), ChineseScript::Traditional, (tag));
+    TEST_EQUAL(languages::GetTwine(tag), "zh-Hant", (tag));
+  }
+}
+
 UNIT_TEST(PrefLanguages_Smoke)
 {
   std::string s = languages::GetPreferred();

--- a/libs/platform/preferred_languages.cpp
+++ b/libs/platform/preferred_languages.cpp
@@ -10,7 +10,6 @@
 
 #include "std/target_os.hpp"
 
-#include <algorithm>
 #include <cstdlib>  // getenv
 #include <cstring>  // strlen
 #include <string>
@@ -573,30 +572,6 @@ bool IsSubtagDelimiter(char c) noexcept
   return std::string_view{kSubtagDelimiters}.find(c) != std::string_view::npos;
 }
 
-constexpr char AsciiLower(char c) noexcept
-{
-  return c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c;
-}
-
-// Language tags are ASCII by definition, so comparing them needs neither the locale-aware
-// casefolding nor the allocations of strings::EqualNoCase.
-bool EqualAsciiNoCase(std::string_view a, std::string_view b) noexcept
-{
-  return a.size() == b.size() &&
-         std::equal(a.begin(), a.end(), b.begin(), [](char x, char y) { return AsciiLower(x) == AsciiLower(y); });
-}
-
-// True if `segment` spells `subtag`. Android resource qualifiers prefix a two-letter region with
-// "r" ("zh-rTW", cf. android/app/src/main/res/values-zh-rTW), which is accepted as an alternate
-// spelling of that region.
-bool SegmentSpells(std::string_view segment, std::string_view subtag) noexcept
-{
-  if (EqualAsciiNoCase(segment, subtag))
-    return true;
-  return subtag.size() == 2 && segment.size() == 3 && AsciiLower(segment.front()) == 'r' &&
-         EqualAsciiNoCase(segment.substr(1), subtag);
-}
-
 // Parses BCP 47 / POSIX-style language tags and reports whether `subtag` appears as a whole
 // segment, not just as a substring. Substring matching reads Android's "-u-fw-mon" regional
 // preference (first day of week = Monday) as Macau, because "mo" sits inside "mon".
@@ -607,7 +582,12 @@ bool HasSubtag(std::string_view tag, std::string_view subtag) noexcept
   {
     auto const end = tag.find_first_of(kSubtagDelimiters, start);
     // substr() clamps the count, so an npos `end` simply spans the rest of the tag.
-    if (SegmentSpells(tag.substr(start, end - start), subtag))
+    auto segment = tag.substr(start, end - start);
+    // Android resource qualifiers prefix a two-letter region with "r" ("zh-rTW", cf.
+    // android/app/src/main/res/values-zh-rTW), accepted here as an alternate spelling of it.
+    if (subtag.size() == 2 && segment.size() == 3 && strings::AsciiToLower(segment.front()) == 'r')
+      segment.remove_prefix(1);
+    if (strings::EqualAsciiNoCase(segment, subtag))
       return true;
     if (end == std::string_view::npos)
       return false;
@@ -653,7 +633,7 @@ bool StartsWithSubtags(std::string_view tag, std::string_view prefix) noexcept
 ChineseScript GetChineseScript(std::string_view tag)
 {
   // Match the primary subtag exactly so "zha" (Zhuang) isn't treated as Chinese.
-  if (!EqualAsciiNoCase(PrimarySubtag(tag), "zh"))
+  if (!strings::EqualAsciiNoCase(PrimarySubtag(tag), "zh"))
     return ChineseScript::NotChinese;
 
   // Traditional script: explicit "Hant", or the regions that use it (Taiwan, Hong Kong, Macau).
@@ -709,13 +689,13 @@ CJKResolver::Variant CJKResolver::FromLanguageTag(std::string_view tag)
   // Match the primary language subtag exactly so "jav" (Javanese) isn't treated as Japanese.
   std::string_view const primary = PrimarySubtag(tag);
 
-  if (EqualAsciiNoCase(primary, "ja"))
+  if (strings::EqualAsciiNoCase(primary, "ja"))
     return Variant::JP;
-  if (EqualAsciiNoCase(primary, "ko"))
+  if (strings::EqualAsciiNoCase(primary, "ko"))
     return Variant::KR;
 
   // Hong Kong has its own glyph variants, so it is resolved before the Traditional/Simplified split.
-  if (EqualAsciiNoCase(primary, "zh") && HasSubtag(tag, "hk"))
+  if (strings::EqualAsciiNoCase(primary, "zh") && HasSubtag(tag, "hk"))
     return Variant::HK;
   if (GetChineseScript(tag) == ChineseScript::Traditional)
     return Variant::TC;

--- a/libs/platform/preferred_languages.cpp
+++ b/libs/platform/preferred_languages.cpp
@@ -636,6 +636,11 @@ ChineseScript GetChineseScript(std::string_view tag)
   if (!strings::EqualAsciiNoCase(PrimarySubtag(tag), "zh"))
     return ChineseScript::NotChinese;
 
+  // An explicit script subtag is authoritative (BCP 47), so it wins over the region: Android can
+  // report "zh_HK_#Hans" for a Simplified-preferring user living in a Traditional region.
+  if (HasSubtag(tag, "hans"))
+    return ChineseScript::Simplified;
+
   // Traditional script: explicit "Hant", or the regions that use it (Taiwan, Hong Kong, Macau).
   for (char const * s : {"hant", "tw", "hk", "mo"})
     if (HasSubtag(tag, s))
@@ -694,14 +699,16 @@ CJKResolver::Variant CJKResolver::FromLanguageTag(std::string_view tag)
   if (strings::EqualAsciiNoCase(primary, "ko"))
     return Variant::KR;
 
-  // Hong Kong has its own glyph variants, so it is resolved before the Traditional/Simplified split.
-  if (strings::EqualAsciiNoCase(primary, "zh") && HasSubtag(tag, "hk"))
-    return Variant::HK;
-  if (GetChineseScript(tag) == ChineseScript::Traditional)
-    return Variant::TC;
+  switch (GetChineseScript(tag))
+  {
+  // Hong Kong has its own glyph variants of the Traditional script.
+  case ChineseScript::Traditional: return HasSubtag(tag, "hk") ? Variant::HK : Variant::TC;
+  case ChineseScript::Simplified:
+  case ChineseScript::NotChinese: break;
+  }
 
-  // Non-CJK locales fall back to Simplified Chinese — the most widely recognized variant for any
-  // Han glyph the user might encounter on the map.
+  // Simplified and non-CJK locales alike fall back to Simplified Chinese — the most widely
+  // recognized variant for any Han glyph the user might encounter on the map.
   return Variant::SC;
 }
 

--- a/libs/platform/preferred_languages.cpp
+++ b/libs/platform/preferred_languages.cpp
@@ -568,6 +568,11 @@ std::string_view PrimarySubtag(std::string_view tag) noexcept
   return tag.substr(0, tag.find_first_of(kSubtagDelimiters));
 }
 
+bool IsSubtagDelimiter(char c) noexcept
+{
+  return std::string_view{kSubtagDelimiters}.find(c) != std::string_view::npos;
+}
+
 constexpr char AsciiLower(char c) noexcept
 {
   return c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c;
@@ -636,6 +641,11 @@ std::string GetCurrentMapLanguage()
     return std::string(StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kDefaultCode));
   }
   return languageCode;
+}
+
+bool StartsWithSubtags(std::string_view tag, std::string_view prefix) noexcept
+{
+  return tag.starts_with(prefix) && (tag.size() == prefix.size() || IsSubtagDelimiter(tag[prefix.size()]));
 }
 
 ChineseScript GetChineseScript(std::string_view tag)

--- a/libs/platform/preferred_languages.cpp
+++ b/libs/platform/preferred_languages.cpp
@@ -10,9 +10,11 @@
 
 #include "std/target_os.hpp"
 
+#include <algorithm>
 #include <cstdlib>  // getenv
 #include <cstring>  // strlen
 #include <string>
+#include <string_view>
 
 #if defined(OMIM_OS_MAC) || defined(OMIM_OS_IPHONE)
 #include <CoreFoundation/CFLocale.h>
@@ -554,9 +556,65 @@ std::string GetCurrentOrig()
     return arr[0];
 }
 
+namespace
+{
+// Delimiters between subtags: "-" (BCP 47), "_" (POSIX), "#" (Java's Locale.toString() prefixes the
+// script and extensions with it), and "." / "@" (POSIX $LANG spells the charset and modifier as
+// "zh_TW.UTF-8@modifier"). " " is defensive.
+constexpr char kSubtagDelimiters[] = "-_ #.@";
+
+std::string_view PrimarySubtag(std::string_view tag) noexcept
+{
+  return tag.substr(0, tag.find_first_of(kSubtagDelimiters));
+}
+
+constexpr char AsciiLower(char c) noexcept
+{
+  return c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c;
+}
+
+// Language tags are ASCII by definition, so comparing them needs neither the locale-aware
+// casefolding nor the allocations of strings::EqualNoCase.
+bool EqualAsciiNoCase(std::string_view a, std::string_view b) noexcept
+{
+  return a.size() == b.size() &&
+         std::equal(a.begin(), a.end(), b.begin(), [](char x, char y) { return AsciiLower(x) == AsciiLower(y); });
+}
+
+// True if `segment` spells `subtag`. Android resource qualifiers prefix a two-letter region with
+// "r" ("zh-rTW", cf. android/app/src/main/res/values-zh-rTW), which is accepted as an alternate
+// spelling of that region.
+bool SegmentSpells(std::string_view segment, std::string_view subtag) noexcept
+{
+  if (EqualAsciiNoCase(segment, subtag))
+    return true;
+  return subtag.size() == 2 && segment.size() == 3 && AsciiLower(segment.front()) == 'r' &&
+         EqualAsciiNoCase(segment.substr(1), subtag);
+}
+
+// Parses BCP 47 / POSIX-style language tags and reports whether `subtag` appears as a whole
+// segment, not just as a substring. Substring matching reads Android's "-u-fw-mon" regional
+// preference (first day of week = Monday) as Macau, because "mo" sits inside "mon".
+bool HasSubtag(std::string_view tag, std::string_view subtag) noexcept
+{
+  size_t start = 0;
+  while (start < tag.size())
+  {
+    auto const end = tag.find_first_of(kSubtagDelimiters, start);
+    // substr() clamps the count, so an npos `end` simply spans the rest of the tag.
+    if (SegmentSpells(tag.substr(start, end - start), subtag))
+      return true;
+    if (end == std::string_view::npos)
+      return false;
+    start = end + 1;
+  }
+  return false;
+}
+}  // namespace
+
 std::string Normalize(std::string_view lang)
 {
-  return std::string{lang.substr(0, lang.find_first_of("-_ "))};
+  return std::string{PrimarySubtag(lang)};
 }
 
 std::string GetCurrentNorm()
@@ -580,21 +638,40 @@ std::string GetCurrentMapLanguage()
   return languageCode;
 }
 
-std::string GetTwine(std::string const & lang)
+ChineseScript GetChineseScript(std::string_view tag)
+{
+  // Match the primary subtag exactly so "zha" (Zhuang) isn't treated as Chinese.
+  if (!EqualAsciiNoCase(PrimarySubtag(tag), "zh"))
+    return ChineseScript::NotChinese;
+
+  // Traditional script: explicit "Hant", or the regions that use it (Taiwan, Hong Kong, Macau).
+  for (char const * s : {"hant", "tw", "hk", "mo"})
+    if (HasSubtag(tag, s))
+      return ChineseScript::Traditional;
+
+  // Simplified Chinese by default for all other cases.
+  return ChineseScript::Simplified;
+}
+
+std::string DebugPrint(ChineseScript script)
+{
+  switch (script)
+  {
+  case ChineseScript::NotChinese: return "NotChinese";
+  case ChineseScript::Simplified: return "Simplified";
+  case ChineseScript::Traditional: return "Traditional";
+  }
+  UNREACHABLE();
+}
+
+std::string GetTwine(std::string_view lang)
 {
   // Special cases for different Chinese variations.
-  if (lang.find("zh") == 0)
+  switch (GetChineseScript(lang))
   {
-    std::string lower = lang;
-    strings::AsciiToLower(lower);
-
-    // Traditional Chinese.
-    for (char const * s : {"hant", "tw", "hk", "mo"})
-      if (lower.find(s) != std::string::npos)
-        return "zh-Hant";
-
-    // Simplified Chinese by default for all other cases.
-    return "zh-Hans";
+  case ChineseScript::Traditional: return "zh-Hant";
+  case ChineseScript::Simplified: return "zh-Hans";
+  case ChineseScript::NotChinese: break;
   }
   // Use short (2 or 3 chars) versions for all other languages.
   return Normalize(lang);
@@ -610,48 +687,22 @@ std::string GetCurrentMapTwine()
   return GetTwine(GetCurrentMapLanguage());
 }
 
-namespace
+CJKResolver::Variant CJKResolver::FromLanguageTag(std::string_view tag)
 {
-// Parses BCP 47 / POSIX-style language tags and reports whether `subtag` appears as a whole
-// segment, not just as a substring. Delimiters cover "-" (BCP 47), "_" (POSIX), " " and "#"
-// (defensive — some platforms surface "@" or "#"-prefixed locale modifiers). Substring matching
-// would mis-classify e.g. "zh-Hank" as containing "hk".
-bool HasSubtag(std::string_view tag, std::string_view subtag) noexcept
-{
-  size_t start = 0;
-  while (start < tag.size())
-  {
-    auto const end = tag.find_first_of("-_ #", start);
-    if (tag.substr(start, end == std::string_view::npos ? end : end - start) == subtag)
-      return true;
-    if (end == std::string_view::npos)
-      return false;
-    start = end + 1;
-  }
-  return false;
-}
-}  // namespace
-
-CJKResolver::Variant CJKResolver::FromLanguageTag(std::string tag)
-{
-  strings::AsciiToLower(tag);
-
   // Match the primary language subtag exactly so "jav" (Javanese) isn't treated as Japanese.
-  std::string_view const primary = std::string_view(tag).substr(0, tag.find_first_of("-_ #"));
+  std::string_view const primary = PrimarySubtag(tag);
 
-  if (primary == "ja")
+  if (EqualAsciiNoCase(primary, "ja"))
     return Variant::JP;
-  if (primary == "ko")
+  if (EqualAsciiNoCase(primary, "ko"))
     return Variant::KR;
-  if (primary == "zh")
-  {
-    if (HasSubtag(tag, "hk"))
-      return Variant::HK;
-    for (char const * s : {"hant", "tw", "mo"})
-      if (HasSubtag(tag, s))
-        return Variant::TC;
-    return Variant::SC;
-  }
+
+  // Hong Kong has its own glyph variants, so it is resolved before the Traditional/Simplified split.
+  if (EqualAsciiNoCase(primary, "zh") && HasSubtag(tag, "hk"))
+    return Variant::HK;
+  if (GetChineseScript(tag) == ChineseScript::Traditional)
+    return Variant::TC;
+
   // Non-CJK locales fall back to Simplified Chinese — the most widely recognized variant for any
   // Han glyph the user might encounter on the map.
   return Variant::SC;

--- a/libs/platform/preferred_languages.cpp
+++ b/libs/platform/preferred_languages.cpp
@@ -627,20 +627,22 @@ std::string GetCurrentNorm()
   return Normalize(GetCurrentOrig());
 }
 
+std::string SelectMapLanguage(buffer_vector<std::string, 4> const & preferred)
+{
+  for (auto const & lang : preferred)
+    if (StringUtf8Multilang::GetLangIndex(Normalize(lang)) != StringUtf8Multilang::kUnsupportedLanguageCode)
+      return lang;
+  return std::string(StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kDefaultCode));
+}
+
 std::string GetCurrentMapLanguage()
 {
+  // A map-language override is stored as a core code (possibly with '_', e.g. "zh_pinyin") and is
+  // used verbatim; a system language like "en-US" is normalized to its core code "en".
   std::string languageCode;
-  if (!settings::Get(settings::kMapLanguageCode, languageCode) || languageCode.empty())
-  {
-    for (auto const & systemLanguage : GetSystemPreferred())
-    {
-      auto normalizedLang = Normalize(systemLanguage);
-      if (StringUtf8Multilang::GetLangIndex(normalizedLang) != StringUtf8Multilang::kUnsupportedLanguageCode)
-        return normalizedLang;
-    }
-    return std::string(StringUtf8Multilang::GetLangByCode(StringUtf8Multilang::kDefaultCode));
-  }
-  return languageCode;
+  if (settings::Get(settings::kMapLanguageCode, languageCode) && !languageCode.empty())
+    return languageCode;
+  return Normalize(SelectMapLanguage(GetSystemPreferred()));
 }
 
 bool StartsWithSubtags(std::string_view tag, std::string_view prefix) noexcept
@@ -694,7 +696,12 @@ std::string GetCurrentTwine()
 
 std::string GetCurrentMapTwine()
 {
-  return GetTwine(GetCurrentMapLanguage());
+  // Not GetTwine(GetCurrentMapLanguage()): that normalizes "zh-Hant" to "zh" first, so a Traditional
+  // Chinese user would get Simplified ("zh-Hans") search categories. Keep the script here.
+  std::string languageCode;
+  if (settings::Get(settings::kMapLanguageCode, languageCode) && !languageCode.empty())
+    return GetTwine(languageCode);
+  return GetTwine(SelectMapLanguage(GetSystemPreferred()));
 }
 
 CJKResolver::Variant CJKResolver::FromLanguageTag(std::string_view tag)

--- a/libs/platform/preferred_languages.hpp
+++ b/libs/platform/preferred_languages.hpp
@@ -34,6 +34,11 @@ std::string Normalize(std::string_view lang);
 std::string GetCurrentNorm();
 std::string GetCurrentMapLanguage();
 
+/// @return The first of @a preferred languages the core supports, with its original script and
+/// region kept (e.g. "zh-Hant", not "zh"), or the default language code if none is supported.
+/// Normalize() it for a core language code, or GetTwine() it for a Twine locale.
+std::string SelectMapLanguage(buffer_vector<std::string, 4> const & preferred);
+
 /// Script a Chinese language tag is written in.
 enum class ChineseScript
 {

--- a/libs/platform/preferred_languages.hpp
+++ b/libs/platform/preferred_languages.hpp
@@ -20,7 +20,7 @@ std::string GetCurrentOrig();
 
 /// @return @a lang in our Twine translations compatible format, e.g. "en", "pt" or "zh-Hant".
 /// Drops the region but keeps the Chinese script.
-std::string GetTwine(std::string const & lang);
+std::string GetTwine(std::string_view lang);
 
 /// @return Current language in out Twine translations compatible format, e.g. "en", "pt" or "zh-Hant".
 std::string GetCurrentTwine();
@@ -33,6 +33,22 @@ std::string GetCurrentMapTwine();
 std::string Normalize(std::string_view lang);
 std::string GetCurrentNorm();
 std::string GetCurrentMapLanguage();
+
+/// Script a Chinese language tag is written in.
+enum class ChineseScript
+{
+  NotChinese,
+  Simplified,
+  Traditional,
+};
+
+/// @return Script of the Chinese locale @a tag, or NotChinese if its primary subtag is not "zh".
+/// Case-insensitive and subtag-aware: region and script subtags are matched as whole segments, so
+/// an Android regional preference like "zh-CN-u-fw-mon" (first day of week = Monday) stays
+/// Simplified instead of matching Macau ("mo") inside "mon".
+ChineseScript GetChineseScript(std::string_view tag);
+
+std::string DebugPrint(ChineseScript script);
 
 buffer_vector<std::string, 4> const & GetSystemPreferred();
 
@@ -52,7 +68,7 @@ public:
 
   /// Case-insensitive, primary-subtag aware. SC for non-CJK tags so callers always have a usable
   /// variant.
-  static Variant FromLanguageTag(std::string tag);
+  static Variant FromLanguageTag(std::string_view tag);
   static std::optional<Variant> FromSfntFamilyName(std::string_view family) noexcept;
   static std::optional<Variant> FromFontFileName(std::string_view fileName) noexcept;
 

--- a/libs/platform/preferred_languages.hpp
+++ b/libs/platform/preferred_languages.hpp
@@ -50,6 +50,11 @@ ChineseScript GetChineseScript(std::string_view tag);
 
 std::string DebugPrint(ChineseScript script);
 
+/// @return True if @a tag begins with @a prefix and @a prefix ends on a subtag boundary, so that
+/// the three-letter "fil-PH" (Filipino) does not start with "fi" (Finnish). Case-sensitive, and
+/// @a prefix must use the same subtag delimiters as @a tag: "en-US" is not a prefix of "en_US".
+bool StartsWithSubtags(std::string_view tag, std::string_view prefix) noexcept;
+
 buffer_vector<std::string, 4> const & GetSystemPreferred();
 
 /// Locale-driven CJK font variant resolver. Owns the variant enum, locale/SFNT-family-name


### PR DESCRIPTION
## What & why

Spotted in logs on an Android 17 device: the system locale arrives as
`en_UA_#u-fw-mon-ms-metric-mu-celsius`. Since Android 14, regional preferences
(first day of week, measurement system, temperature unit) are stored as Unicode
locale extensions, and `Locale.toString()` surfaces them raw to the core.

Chinese-variant detection in `GetTwine()` and `CategoriesHolder::MapLocaleToInteger()`
searched the whole tag for `hant`/`tw`/`hk`/`mo` as **plain substrings**. So
`fw-mon` (first day of week = Monday, the CLDR default across China and Europe)
matched Macau (`mo`) inside `mon`, and **every Simplified Chinese user who picked
Monday was switched to Traditional Chinese** — in downloader country names, search
category matching and editor feature types.

This is a core-side, defense-in-depth fix so the behaviour is correct regardless
of what any platform passes down. The companion Android PR #13197 stops sending
the extensions in the first place. The two are independent and can merge in
either order.

## Changes

- Centralize Chinese-variant detection into `languages::GetChineseScript()`, which
  matches **whole subtags** instead of substrings. It replaces three copies of the
  logic (`GetTwine`, `MapLocaleToInteger`, and the already-subtag-aware
  `CJKResolver::FromLanguageTag`), so the `{hant,tw,hk,mo}` list now lives in one place.
- The matcher treats `-`, `_`, `#`, `.` and `@` as subtag delimiters, so POSIX
  `$LANG` forms like `zh_TW.UTF-8@modifier` (Linux/Qt) resolve correctly too.
  `Normalize()` now shares the same delimiter set instead of keeping its own.
- **Second commit** fixes a related, pre-existing bug the review surfaced:
  `MapLocaleToInteger` accepted any table entry that was a plain string *prefix* of
  the locale, so a three-letter language resolved to whichever two-letter one it
  starts with — `fil_PH` (Filipino) was served **Finnish** synonyms, `bem_ZM` →
  Belarusian, `rof_TZ` → Romanian, `bgc_IN` → Bulgarian. Now matched on whole subtags.
- **Third commit** fixes `GetCurrentMapTwine()`, which fed the *normalized* map
  language into `GetTwine()` — collapsing `zh-Hant`/`zh-TW` to `zh` before the
  script was read, so a Traditional Chinese user got Simplified (`zh-Hans`) search
  category synonyms even though `categories.txt` has Traditional ones. The map
  language is now selected once with its script intact; the normalized core code
  (for map labels) and the Twine locale (for search) are both derived from it. The
  map-language override still passes through verbatim, so `zh_pinyin`-style codes
  are not normalized away. *(This is only the search-category half; genuine
  Traditional map **labels** additionally need a first-class `zh_Hant` core code +
  generator support + a data release — a separate, larger change.)*
- **Fourth commit** ([review](https://github.com/organicmaps/organicmaps/pull/13196#discussion_r3626233846))
  moves the ASCII case handling into `base/string_utils`: `constexpr char` overloads
  of `AsciiToLower()`/`AsciiToUpper()` (the `std::string` versions are now built on
  them, dropping the per-character lambda each had duplicated) plus
  `EqualAsciiNoCase(string_view, string_view)`. `EqualNoCase()` lowercases both sides
  through the full Unicode case-folding tables and allocates twice, so there was no
  cheap ASCII compare to reuse.
- **Fifth commit** drops the file-local copies in favour of those, and deletes the
  `SegmentSpells()` helper by inlining it into `HasSubtag()`
  ([review](https://github.com/organicmaps/organicmaps/pull/13196#discussion_r3626236490)).
  It was never a substring check — substring matching is the bug this PR fixes — it
  accepted `rTW` as an alternate spelling of the `TW` region subtag, which is how
  Android resource qualifiers spell regions. Inlined, that quirk is explained next to
  the loop that needs it.
- **Sixth commit** makes an explicit script subtag win over the region, per RFC 5646.
  `zh-Hans-HK` and its Java spelling `zh_HK_#Hans` — a Simplified-preferring user in a
  Traditional region, which both Android and CLDR express — resolved to Traditional.
  `CJKResolver::FromLanguageTag()` resolved Hong Kong before the script for the same
  reason, so `hk` now goes through the `Traditional` branch of `GetChineseScript()`;
  that already guarantees a `zh` primary subtag, so the separate guard keeping `en-HK`
  out is no longer needed.

## Testing

- New `LangGetChineseScript` / `LangAndroidRegionalPreferences` / `LangSelectMapLanguage`
  cases in `platform_tests` and `CategoriesHolder_LocaleExtensions` /
  `CategoriesHolder_ThreeLetterLanguages` in `indexer_tests`, including the exact
  `fw-mon` vs `fw-sun` controls, the `.UTF-8` forms, and `zh-Hant`/`zh-Hans` map-language selection.
- New `EqualAsciiNoCase` cases in `base_tests` covering `[` vs `{` (the chars that
  differ by the same 0x20 bit as letters do) and non-ASCII `Ä`/`ä` staying unequal,
  plus `static_assert`s pinning the `constexpr char` overloads.
- New `zh-Hans-HK` / `zh_HK_#Hans` cases in `cjk_resolver_tests` and `language_test`;
  `en-HK` still resolves to SC.
- Full `ctest` suite green on macOS, and a full `cmake --build` of the tree to confirm
  the new `AsciiToLower(char)` overload leaves every existing call site unambiguous.
  Each commit builds and passes tests on its own.

LLM tools (Claude Code) were used to help write and review this change.
