### PR TITLE
[android] Report the system locale as a BCP 47 language tag

### DIFF
--- a/android/sdk/src/main/java/app/organicmaps/sdk/util/Language.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/util/Language.java
@@ -1,7 +1,7 @@
 package app.organicmaps.sdk.util;
 
 import android.content.Context;
-import android.text.TextUtils;
+import android.os.Build;
 import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
 import androidx.annotation.Keep;
@@ -10,27 +10,21 @@ import java.util.Locale;
 
 public class Language
 {
-  // Locale.getLanguage() returns even 3-letter codes, not that we need in the C++ core,
-  // so we use locale itself, like zh_CN
+  // The core expects a BCP 47 language tag, e.g. "en-UA", "zh-Hans-CN" or "pt-BR". Never report
+  // Locale.toString() here: it is documented as a debugging aid and spells locales the POSIX way
+  // ("pt_BR"), which does not match the core's hyphenated locale tables.
   // Called from JNI.
   @Keep
   @SuppressWarnings("unused")
   @NonNull
   public static String getDefaultLocale()
   {
-    String lang = Locale.getDefault().toString();
-    if (TextUtils.isEmpty(lang))
-      return Locale.US.toString();
+    final Locale locale = Locale.getDefault();
+    // toLanguageTag() spells a language-less locale as "und", so test the language itself.
+    if (locale.getLanguage().isEmpty())
+      return Locale.US.toLanguageTag();
 
-    // Replace deprecated language codes:
-    // in* -> id
-    // iw* -> he
-    if (lang.startsWith("in"))
-      return "id";
-    if (lang.startsWith("iw"))
-      return "he";
-
-    return lang;
+    return toLanguageTag(locale);
   }
 
   // After some testing on Galaxy S4, looks like this method doesn't work on all devices:
@@ -38,7 +32,7 @@ public class Language
   @NonNull
   public static String getKeyboardLocale(@NonNull Context context)
   {
-    InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+    final InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
     if (imm == null)
       return getDefaultLocale();
 
@@ -46,10 +40,56 @@ public class Language
     if (ims == null)
       return getDefaultLocale();
 
-    String locale = ims.getLocale();
-    if (TextUtils.isEmpty(locale.trim()))
+    final String locale = getSubtypeLanguageTag(ims);
+    if (locale.isEmpty())
       return getDefaultLocale();
 
-    return locale;
+    return toModernLanguageTag(locale);
+  }
+
+  // Drops the Unicode extensions that Android 14+ uses to store regional preferences, so that
+  // "en-UA-u-fw-mon-ms-metric-mu-celsius" (first day of week, measurement system, temperature unit)
+  // becomes plain "en-UA". They say nothing about the language.
+  @NonNull
+  private static String toLanguageTag(@NonNull Locale locale)
+  {
+    // stripExtensions() needs API 26 and is not backported by core library desugaring. Regional
+    // preferences did not exist before Android 14, so there is nothing to strip on older devices.
+    final Locale stripped = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ? locale.stripExtensions() : locale;
+    return toModernLanguageTag(stripped.toLanguageTag());
+  }
+
+  // Spells any locale Android reports the way the core expects it.
+  // Locale stores the deprecated ISO 639 codes internally, rewriting "id" as "in", "he" as "iw"
+  // and "yi" as "ji". toLanguageTag() is documented to emit the modern codes that the core knows,
+  // but only does so since API 24: Lollipop and Marshmallow return the stored code verbatim, and an
+  // IME is free to declare android:languageTag="in" by hand, so undo the rewrite here.
+  // The primary subtag is compared as a whole, otherwise "inh" (Ingush) would become Indonesian.
+  // Package-private for LanguageTest: it is the only part of this class free of Android APIs.
+  @NonNull
+  static String toModernLanguageTag(@NonNull String locale)
+  {
+    // A legacy IME subtype spells its locale the POSIX way ("in_ID"), see getSubtypeLanguageTag().
+    final String tag = locale.replace('_', '-');
+    final int end = tag.indexOf('-');
+    final String primary = end < 0 ? tag : tag.substring(0, end);
+    final String rest = end < 0 ? "" : tag.substring(end);
+
+    return switch (primary)
+    {
+      case "in" -> "id" + rest;
+      case "iw" -> "he" + rest;
+      case "ji" -> "yi" + rest;
+      default -> tag;
+    };
+  }
+
+  @NonNull
+  private static String getSubtypeLanguageTag(@NonNull InputMethodSubtype ims)
+  {
+    // InputMethodSubtype.getLocale() is deprecated and spells the locale the POSIX way ("en_US").
+    // Its BCP 47 replacement needs API 24; below that toModernLanguageTag() turns it into a tag.
+    final String tag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ? ims.getLanguageTag() : ims.getLocale();
+    return tag == null ? "" : tag.trim();
   }
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/util/Language.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/util/Language.java
@@ -59,13 +59,10 @@ public class Language
     return toModernLanguageTag(stripped.toLanguageTag());
   }
 
-  // Spells any locale Android reports the way the core expects it.
-  // Locale stores the deprecated ISO 639 codes internally, rewriting "id" as "in", "he" as "iw"
-  // and "yi" as "ji". toLanguageTag() is documented to emit the modern codes that the core knows,
-  // but only does so since API 24: Lollipop and Marshmallow return the stored code verbatim, and an
-  // IME is free to declare android:languageTag="in" by hand, so undo the rewrite here.
-  // The primary subtag is compared as a whole, otherwise "inh" (Ingush) would become Indonesian.
-  // Package-private for LanguageTest: it is the only part of this class free of Android APIs.
+  // Rewrites the deprecated ISO 639 codes Locale keeps internally ("in"->"id", "iw"->"he", "ji"->"yi").
+  // toLanguageTag() does this itself, but only since API 24, and an IME may declare "in" by hand.
+  // Matches the whole primary subtag, so "inh" (Ingush) is not mistaken for Indonesian.
+  // Package-private for LanguageTest (the only Android-API-free part).
   @NonNull
   static String toModernLanguageTag(@NonNull String locale)
   {
@@ -87,9 +84,16 @@ public class Language
   @NonNull
   private static String getSubtypeLanguageTag(@NonNull InputMethodSubtype ims)
   {
-    // InputMethodSubtype.getLocale() is deprecated and spells the locale the POSIX way ("en_US").
-    // Its BCP 47 replacement needs API 24; below that toModernLanguageTag() turns it into a tag.
-    final String tag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ? ims.getLanguageTag() : ims.getLocale();
-    return tag == null ? "" : tag.trim();
+    // A subtype reports a BCP 47 tag only if its IME declares android:languageTag (API 24);
+    // getLanguageTag() is empty for the many that declare only the older android:imeSubtypeLocale.
+    // Fall back to the deprecated getLocale() for those, as the framework's getLocaleObject() does.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+    {
+      final String tag = ims.getLanguageTag();
+      if (!tag.isEmpty())
+        return tag;
+    }
+
+    return ims.getLocale().trim();
   }
 }

--- a/android/sdk/src/test/java/app/organicmaps/sdk/util/LanguageTest.java
+++ b/android/sdk/src/test/java/app/organicmaps/sdk/util/LanguageTest.java
@@ -1,0 +1,60 @@
+package app.organicmaps.sdk.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+// Only toModernLanguageTag() is covered: it is the one part of Language free of Android APIs.
+// These tests run on the JVM, whose java.util.Locale differs from Android's -- notably it no longer
+// stores the deprecated codes -- so they deliberately pass string literals and never build a Locale.
+public class LanguageTest
+{
+  // Android's Locale rewrites "id"/"he"/"yi" to the deprecated "in"/"iw"/"ji" and keeps them
+  // internally. toLanguageTag() undoes that only since API 24, so getDefaultLocale() must undo it
+  // itself or the core, which only knows the modern codes, would not recognise the language.
+  @Test
+  public void toModernLanguageTag_replacesDeprecatedCodes()
+  {
+    assertEquals("id", Language.toModernLanguageTag("in"));
+    assertEquals("id-ID", Language.toModernLanguageTag("in-ID"));
+    assertEquals("he-IL", Language.toModernLanguageTag("iw-IL"));
+    assertEquals("yi", Language.toModernLanguageTag("ji"));
+    assertEquals("yi-US", Language.toModernLanguageTag("ji-US"));
+  }
+
+  // A no-op on API 24+, where toLanguageTag() has already replaced them.
+  @Test
+  public void toModernLanguageTag_keepsModernCodes()
+  {
+    assertEquals("id-ID", Language.toModernLanguageTag("id-ID"));
+    assertEquals("he-IL", Language.toModernLanguageTag("he-IL"));
+    assertEquals("en-UA", Language.toModernLanguageTag("en-UA"));
+    assertEquals("zh-Hans-CN", Language.toModernLanguageTag("zh-Hans-CN"));
+    assertEquals("pt-BR", Language.toModernLanguageTag("pt-BR"));
+    assertEquals("", Language.toModernLanguageTag(""));
+  }
+
+  // The primary subtag is compared as a whole: three-letter codes that merely start with a
+  // deprecated one keep their own language.
+  @Test
+  public void toModernLanguageTag_matchesWholePrimarySubtag()
+  {
+    assertEquals("inh", Language.toModernLanguageTag("inh"));
+    assertEquals("inh-RU", Language.toModernLanguageTag("inh-RU"));
+    assertEquals("ind-ID", Language.toModernLanguageTag("ind-ID"));
+  }
+
+  // An IME subtype that declares only the older android:imeSubtypeLocale reports a POSIX-style
+  // locale instead of a tag. Hyphens make it one, so that the deprecated code is replaced here too
+  // and the core sees the region: "en-US" and "pt-BR" are categories.txt locales, "en_US" is not.
+  @Test
+  public void toModernLanguageTag_convertsPosixLocales()
+  {
+    assertEquals("en-US", Language.toModernLanguageTag("en_US"));
+    assertEquals("pt-BR", Language.toModernLanguageTag("pt_BR"));
+    assertEquals("zh-TW", Language.toModernLanguageTag("zh_TW"));
+    assertEquals("id-ID", Language.toModernLanguageTag("in_ID"));
+    assertEquals("he-IL", Language.toModernLanguageTag("iw_IL"));
+    assertEquals("inh-RU", Language.toModernLanguageTag("inh_RU"));
+  }
+}

--- a/libs/editor/editor_tests/new_feature_categories_test.cpp
+++ b/libs/editor/editor_tests/new_feature_categories_test.cpp
@@ -1,12 +1,49 @@
 #include "testing/testing.hpp"
 
+#include "editor/config_loader.hpp"
 #include "editor/editor_config.hpp"
 #include "editor/new_feature_categories.hpp"
 
 #include "indexer/classificator_loader.hpp"
 
+#include <pugixml.hpp>
+
 #include <algorithm>
 #include <string>
+
+// A regional locale translates only a handful of categories: data/categories.txt has 34 "es-MX"
+// lines against 518 "es" ones. The index matches the language code exactly, so adding "es-MX" alone
+// would leave a Mexican user searching English for everything else.
+UNIT_TEST(NewFeatureCategories_RegionalLocaleKeepsBaseLanguage)
+{
+  classificator::Load();
+
+  pugi::xml_document doc;
+  editor::ConfigLoader::LoadFromLocal(doc);
+  editor::EditorConfig config;
+  config.SetConfig(doc);
+
+  auto search = [&config](std::string const & lang, std::string const & query)
+  {
+    osm::NewFeatureCategories categories(config);
+    categories.AddLanguage(lang);
+    return categories.Search(query).size();
+  };
+
+  // "Cajero" is only spelled in the base "es" translation of amenity-atm, never in "es-MX".
+  TEST_GREATER(search("es", "Cajero"), 0, ("Test premise: the base language must find it"));
+  TEST_EQUAL(search("es-MX", "Cajero"), search("es", "Cajero"), ("es-MX must keep the es names"));
+
+  TEST_GREATER(search("pt", "Terminal bancário"), 0, ("Test premise: the base language must find it"));
+  TEST_EQUAL(search("pt-BR", "Terminal bancário"), search("pt", "Terminal bancário"), ("pt-BR must keep the pt names"));
+
+  // A script is not a region: "zh-Hant" is a full translation (483 lines against 488 for "zh-Hans"),
+  // so it must keep only its own names. Its base "zh" resolves to Simplified Chinese.
+  TEST_GREATER(search("zh-Hans", "自动取款机"), 0, ("Test premise: Simplified must find it"));
+  TEST_EQUAL(search("zh-Hant", "自动取款机"), 0, ("zh-Hant must not merge the Simplified names"));
+  TEST_EQUAL(search("zh-TW", "自动取款机"), 0, ("zh-TW must not merge the Simplified names"));
+  TEST_GREATER(search("zh-TW", "自動櫃員機"), 0, ("zh-TW must keep the Traditional names"));
+}
 
 UNIT_TEST(NewFeatureCategories_UniqueNames)
 {

--- a/libs/editor/new_feature_categories.cpp
+++ b/libs/editor/new_feature_categories.cpp
@@ -3,6 +3,7 @@
 #include "base/string_utils.hpp"
 #include "indexer/categories_holder.hpp"
 #include "indexer/classificator.hpp"
+#include "platform/preferred_languages.hpp"
 #include "platform/settings.hpp"
 
 #include <algorithm>
@@ -40,6 +41,15 @@ NewFeatureCategories::NewFeatureCategories(NewFeatureCategories && other) noexce
 
 void NewFeatureCategories::AddLanguage(std::string lang)
 {
+  // A regional locale translates only a handful of categories ("es-MX" has 34 synonyms against 518
+  // for "es"), and the index matches the language code exactly, so add the base language too or
+  // everything it does not cover would fall back to English names. GetTwine() drops the region but
+  // keeps the script: unlike a region, a script is a translation of its own, and merging the other
+  // one is not a coverage gap to fill ("zh-Hant" has 483 synonyms, "zh-Hans" 488).
+  auto base = languages::GetTwine(lang);
+  if (base != lang)
+    AddLanguage(std::move(base));
+
   auto langCode = CategoriesHolder::MapLocaleToInteger(lang);
   if (langCode == CategoriesHolder::kUnsupportedLocaleCode)
   {

--- a/libs/platform/preferred_languages.hpp
+++ b/libs/platform/preferred_languages.hpp
@@ -18,6 +18,10 @@ std::string GetPreferred();
 /// @return Original language code for the current user in the form "en-US", "zh-Hant".
 std::string GetCurrentOrig();
 
+/// @return @a lang in our Twine translations compatible format, e.g. "en", "pt" or "zh-Hant".
+/// Drops the region but keeps the Chinese script.
+std::string GetTwine(std::string const & lang);
+
 /// @return Current language in out Twine translations compatible format, e.g. "en", "pt" or "zh-Hant".
 std::string GetCurrentTwine();
 std::string GetCurrentMapTwine();


### PR DESCRIPTION
## What & why

`Language.getDefaultLocale()` reported `Locale.getDefault().toString()` to the
core. That method is documented as a debugging aid: it spells locales the POSIX
way (`pt_BR`), which never matched the core's hyphenated locale tables, so:

- **Regional translations were unreachable on Android.** `data/categories.txt`
  carries 422 `pt-BR`, 34 `es-MX`, 12 `en-GB` and 8 `en-US` lines that Android
  users never saw — a Brazilian user got European Portuguese category names.
- Since Android 14 it also appends regional preferences as Unicode extensions
  (`en_UA_#u-fw-mon-ms-metric-mu-celsius`), which say nothing about the language
  and, at 36 chars, tripped the 32-char cap in `QuerySaver` that silently drops
  search history.

Report `toLanguageTag()` with the extensions stripped instead — exactly what
Android documents for serialization.

## Changes

- `getDefaultLocale()` / `getKeyboardLocale()` now emit a BCP 47 tag with
  `stripExtensions()` applied (guarded for API 26, since it is **not** covered by
  core-library desugaring — `NewApi` lint enforces this).
- `toModernLanguageTag()` turns every spelling Android may report into that one
  format:
  - `toLanguageTag()` already replaces the deprecated ISO codes Android keeps
    internally (`in`→`id`, `iw`→`he`, `ji`→`yi`), which is what the old
    `startsWith("in")` hack did by hand — but only since API 24, and an IME is
    free to declare `android:languageTag="in"` by hand, so an explicit mapping is
    kept (verified against AOSP libcore). Unlike the old one it matches the whole
    primary subtag, so `inh` (Ingush) is no longer reported as Indonesian.
  - the POSIX spelling a legacy IME subtype reports (`en_US`, `in_ID`) becomes a
    tag. Otherwise the mapping above cannot see the primary subtag there, and the
    region is dropped by the core: `MapLocaleToInteger()` answers plain `en` for
    `en_US` but `en-US` for `en-US`, and `pt` for `pt_BR` but `pt-BR` for `pt-BR`.
- Fall back to `InputMethodSubtype.getLocale()` when `getLanguageTag()` is empty:
  a subtype only reports a tag if its IME declares `android:languageTag` (API 24),
  and the many subtypes that declare only `android:imeSubtypeLocale` return `""`,
  which otherwise silently degraded the keyboard locale to the system one.
- **Second commit** keeps the base language alongside a regional one in the editor
  category index (`NewFeatureCategories::AddLanguage`). A regional locale translates
  only a handful of categories and the editor index matches the code exactly, so
  without this an `es-MX` user would see the localized category list, type a name
  off it, and get zero results. Regular search already unions the locales this way.
  The base comes from `languages::GetTwine()`, which drops the region but keeps the
  script: unlike a region, a script is a full translation of its own (`zh-Hant` has
  483 synonyms, `zh-Hans` 488), and plain `Normalize()` would merge the Simplified
  index into a Traditional user's, since a bare `zh` resolves to Simplified.
  `GetTwine()` is declared in `preferred_languages.hpp` for that — #13196 exports it
  too, so whichever lands second drops its copy (a 3-line conflict).

## Testing

- New `LanguageTest` JVM unit tests for `toModernLanguageTag` (whole-subtag
  matching, deprecated codes, POSIX locales, no-op on modern tags), each verified
  to fail without the code it covers; `:sdk:lintDebug` clean (guard verified by a
  negative control that fails without it); `assembleGoogleDebug` green.
- New `new_feature_categories_test.cpp` regression test proving `es-MX`/`pt-BR`
  keep their base-language names, and that `zh-Hant`/`zh-TW` keep only their own
  (`自动取款机` is Simplified-only, `自動櫃員機` Traditional-only); it fails on the
  `Normalize()` union. Full `ctest` suite green.
- Verified end-to-end against #13196 that the emitted tags resolve correctly
  (`pt-BR`→34 vs `pt-PT`→33, `id-ID`→23, `fil-PH`→unsupported, `en-UA-u-fw-mon`→en).

Depends on / complements #13196 (core-side subtag matching). The two are
independent and can merge in either order.

LLM tools (Claude Code) were used to help write and review this change.
