### PR TITLE
[map] Fix crash on tap of a temporary relation track selection mark

### DIFF
--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -647,7 +647,7 @@ void Framework::FillPointInfoForBookmark(Bookmark const & bmk, place_page::Info 
   });
 }
 
-void Framework::FillUserMarkInfo(UserMark const * mark, place_page::Info & outInfo)
+bool Framework::FillUserMarkInfo(UserMark const * mark, place_page::Info & outInfo)
 {
   outInfo.SetSelectedObject(df::SelectionShape::OBJECT_USER_MARK);
 
@@ -661,14 +661,12 @@ void Framework::FillUserMarkInfo(UserMark const * mark, place_page::Info & outIn
   case UserMark::Type::TRACK_INFO:
   {
     auto const & infoMark = *static_cast<TrackInfoMark const *>(mark);
-    BuildTrackPlacePage(GetBookmarkManager().GetTrackSelectionInfo(infoMark.GetTrackId()), outInfo);
-    return;
+    return BuildTrackPlacePage(GetBookmarkManager().GetTrackSelectionInfo(infoMark.GetTrackId()), outInfo);
   }
   case UserMark::Type::TRACK_SELECTION:
   {
     auto const & selMark = *static_cast<TrackSelectionMark const *>(mark);
-    BuildTrackPlacePage(GetBookmarkManager().GetTrackSelectionInfo(selMark.GetTrackId()), outInfo);
-    return;
+    return BuildTrackPlacePage(GetBookmarkManager().GetTrackSelectionInfo(selMark.GetTrackId()), outInfo);
   }
   case UserMark::Type::TRANSIT:
   {
@@ -684,6 +682,7 @@ void Framework::FillUserMarkInfo(UserMark const * mark, place_page::Info & outIn
   }
 
   GetSelectionProcessor().SetPlacePageLocation(outInfo);
+  return true;
 }
 
 void Framework::FillBookmarkInfo(Bookmark const & bmk, place_page::Info & info) const
@@ -958,7 +957,8 @@ void Framework::SelectTrackCandidate(kml::TrackId trackId, RelationID const & re
   CHECK(candidate != candidates.end(), ());
   CHECK(candidate->IsValid(), ());
 
-  BuildTrackPlacePage(*candidate, m_currentPlacePageInfo.value());
+  if (!BuildTrackPlacePage(*candidate, m_currentPlacePageInfo.value()))
+    return;
 
   GetBookmarkManager().UpdateElevationMyPosition(trackId, true /* ignoreLocationCache */);
   ActivateMapSelection();
@@ -2361,28 +2361,32 @@ FeatureID Framework::FindBuildingAtPoint(m2::PointD const & mercator) const
 
 bool Framework::BuildTrackPlacePage(Track::TrackSelectionInfo const & trackSelectionInfo, place_page::Info & info)
 {
-  info.SetSelectedObject(df::SelectionShape::OBJECT_TRACK);
   auto & bm = GetBookmarkManager();
-  Track const * track = nullptr;
   Track::TrackSelectionInfo selectedInfo = trackSelectionInfo;
 
-  if (trackSelectionInfo.IsRelation())
+  if (selectedInfo.IsRelation())
   {
     auto trackData = TryBuildRelationTrack(selectedInfo);
     if (!trackData)
       return false;
 
     bm.SetTempRelationTrack(std::move(trackData.value()));
-    track = bm.GetTrack(kml::kTempRelationTrackId);
     auto const tapPoint = selectedInfo.m_trackPoint;  // Copy tap point before mutation.
-    track->UpdateSelectionInfo(tapPoint, selectedInfo);
+    bm.GetTrack(kml::kTempRelationTrackId)->UpdateSelectionInfo(tapPoint, selectedInfo);
   }
-  else
+  else if (selectedInfo.m_trackId != kml::kTempRelationTrackId)
   {
+    // Never drop the temporary track when it is the selected one: it can't be rebuilt without the
+    // relation metadata that this selection is missing.
     bm.ClearTempRelationTrack();
-    track = bm.GetTrack(selectedInfo.m_trackId);
   }
 
+  // Can be null for a stale selection mark, left over from an already deleted track.
+  auto const * track = bm.GetTrack(selectedInfo.m_trackId);
+  if (track == nullptr)
+    return false;
+
+  info.SetSelectedObject(df::SelectionShape::OBJECT_TRACK);
   FillTrackInfo(*track, selectedInfo, info);
   bm.SetTrackSelectionInfo(selectedInfo, true /* notifyListeners */);
   return true;
@@ -2410,8 +2414,12 @@ place_page::Info Framework::BuildPlacePageInfo(place_page::BuildInfo const & bui
 
     if (mark)
     {
-      FillUserMarkInfo(mark, outInfo);
-      return outInfo;
+      if (FillUserMarkInfo(mark, outInfo))
+        return outInfo;
+
+      // Stale track mark: drop the partially filled info and continue with the regular matching.
+      outInfo = {};
+      outInfo.SetBuildInfo(buildInfo);
     }
   }
 
@@ -2439,9 +2447,9 @@ place_page::Info Framework::BuildPlacePageInfo(place_page::BuildInfo const & bui
       auto const rect = df::TapInfo::GetPreciseTapRect(outInfo.GetMercator(), kEps);
       UserMark const * mark = GetBookmarkManager().FindNearestUserMark([&rect](UserMark::Type) { return rect; },
                                                                        [](UserMark::Type) { return true; });
-      if (mark)
+      // On a stale track mark keep the feature info filled above and fall back to the POI selection.
+      if (mark && FillUserMarkInfo(mark, outInfo))
       {
-        FillUserMarkInfo(mark, outInfo);
         sp.SetPlacePageLocation(outInfo);
         return outInfo;
       }

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -629,7 +629,9 @@ private:
 
   static bool ParseAllTypesDebugCommand(search::SearchParams const & params);
 
-  void FillUserMarkInfo(UserMark const * mark, place_page::Info & outInfo);
+  /// @return false if @a outInfo was not filled (e.g. a stale track mark), so the caller should fall
+  /// back to the regular tap matching instead of activating an empty selection.
+  bool FillUserMarkInfo(UserMark const * mark, place_page::Info & outInfo);
   void FillApiMarkInfo(ApiMarkPoint const & api, place_page::Info & info) const;
   void FillSearchResultInfo(SearchMarkPoint const & smp, place_page::Info & info) const;
   void FillMyPositionInfo(place_page::Info & info, place_page::BuildInfo const & buildInfo) const;

--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -2,6 +2,7 @@
 
 #include "map/bookmark_helpers.hpp"
 #include "map/framework.hpp"
+#include "map/track_mark.hpp"
 
 #include "drape_frontend/visual_params.hpp"
 
@@ -312,32 +313,118 @@ UNIT_CLASS_TEST(Runner, Bookmarks_ExportKML)
   TEST(base::GetFileSize(fileName, dummy), ());
 }
 
+namespace
+{
+double constexpr kTrackDistance = 10.0;
+m2::PointD constexpr kTrackPoint(0.5, 0.0);
+
+kml::TrackData MakeLineTrackData()
+{
+  kml::TrackData trackData;
+  trackData.m_layers.push_back(kml::TrackLayer());
+  trackData.m_geometry.AddLine({{{0.0, 0.0}, 1}, {{1.0, 0.0}, 2}});
+  trackData.m_geometry.AddTimestamps({});
+  return trackData;
+}
+
+kml::MarkId FindTrackSelectionMark(BookmarkManager const & bm, kml::TrackId trackId)
+{
+  for (auto markId : bm.GetUserMarkIds(UserMark::Type::TRACK_SELECTION))
+    if (bm.GetMark<TrackSelectionMark>(markId)->GetTrackId() == trackId)
+      return markId;
+  return kml::kInvalidMarkId;
+}
+
+// Emulates a tap on an already rendered user mark: Drape hit-tests it on the renderer thread and
+// posts only its id to the GUI thread, exactly like place_page::BuildInfo(df::TapInfo const &).
+void TapUserMark(Framework & fm, kml::MarkId markId)
+{
+  place_page::BuildInfo buildInfo;
+  buildInfo.m_source = place_page::BuildInfo::Source::User;
+  buildInfo.m_mercator = kTrackPoint;
+  buildInfo.m_userMarkId = markId;
+  fm.BuildAndSetPlacePageInfo(buildInfo);
+}
+}  // namespace
+
 UNIT_CLASS_TEST(Runner, Bookmarks_ClearTempRelationTrackDeletesSelectionMark)
 {
   BookmarkManager bmManager(BM_CALLBACKS);
   bmManager.EnableTestMode(true);
 
-  kml::TrackData trackData;
-  trackData.m_layers.push_back(kml::TrackLayer());
-  trackData.m_geometry.AddLine({{{0.0, 0.0}, 1}, {{1.0, 0.0}, 2}});
-  trackData.m_geometry.AddTimestamps({});
-
-  TEST_EQUAL(bmManager.SetTempRelationTrack(std::move(trackData)), kml::kTempRelationTrackId, ());
+  TEST_EQUAL(bmManager.SetTempRelationTrack(MakeLineTrackData()), kml::kTempRelationTrackId, ());
   TEST_NOT_EQUAL(bmManager.GetTrack(kml::kTempRelationTrackId), nullptr, ());
 
-  double constexpr kDistance = 10.0;
-  m2::PointD constexpr kTrackPoint(0.5, 0.0);
-  bmManager.SetTrackSelectionInfo({kml::kTempRelationTrackId, kTrackPoint, kDistance}, false /* notifyListeners */);
+  bmManager.SetTrackSelectionInfo({kml::kTempRelationTrackId, kTrackPoint, kTrackDistance},
+                                  false /* notifyListeners */);
 
   auto const selectionInfo = bmManager.GetTrackSelectionInfo(kml::kTempRelationTrackId);
   TEST_EQUAL(selectionInfo.m_trackId, kml::kTempRelationTrackId, ());
   TEST(selectionInfo.m_trackPoint.EqualDxDy(kTrackPoint, 1e-10), ());
-  TEST_EQUAL(selectionInfo.m_distFromBegM, kDistance, ());
+  TEST_EQUAL(selectionInfo.m_distFromBegM, kTrackDistance, ());
 
   bmManager.ClearTempRelationTrack();
 
   TEST_EQUAL(bmManager.GetTrack(kml::kTempRelationTrackId), nullptr, ());
   TEST_EQUAL(bmManager.GetTrackSelectionInfo(kml::kTempRelationTrackId).m_trackId, kml::kInvalidTrackId, ());
+}
+
+// A selection mark stores the track id only, so a tap on the mark of the current temp relation track
+// comes back without a relation id and can't be rebuilt from it. Such a tap must reuse the already
+// built track instead of clearing it - it used to leave BuildTrackPlacePage with a null Track.
+UNIT_TEST(Bookmarks_TapSelectionMarkOfTempRelationTrack)
+{
+  ScopedBookmarksDir scopedDir;
+  Framework fm(kFrameworkParams);
+  df::VisualParams::Init(1.0, 1024);
+
+  auto & bmManager = fm.GetBookmarkManager();
+  bmManager.EnableTestMode(true);
+
+  TEST_EQUAL(bmManager.SetTempRelationTrack(MakeLineTrackData()), kml::kTempRelationTrackId, ());
+  bmManager.SetTrackSelectionInfo({kml::kTempRelationTrackId, kTrackPoint, kTrackDistance},
+                                  false /* notifyListeners */);
+
+  auto const markId = FindTrackSelectionMark(bmManager, kml::kTempRelationTrackId);
+  TEST_NOT_EQUAL(markId, kml::kInvalidMarkId, ());
+
+  TapUserMark(fm, markId);
+
+  TEST_NOT_EQUAL(bmManager.GetTrack(kml::kTempRelationTrackId), nullptr, ("The tapped track was cleared"));
+  TEST(fm.HasPlacePageInfo(), ());
+  auto const & info = fm.GetCurrentPlacePageInfo();
+  TEST(info.IsRelationTrack(), ());
+  TEST_EQUAL(info.GetSelectedObject(), df::SelectionShape::OBJECT_TRACK, ());
+}
+
+// The counterpart: selecting any other track still drops the temp relation track.
+UNIT_TEST(Bookmarks_TapSelectionMarkClearsTempRelationTrack)
+{
+  ScopedBookmarksDir scopedDir;
+  Framework fm(kFrameworkParams);
+  df::VisualParams::Init(1.0, 1024);
+
+  auto & bmManager = fm.GetBookmarkManager();
+  bmManager.EnableTestMode(true);
+
+  auto const catId = bmManager.CreateBookmarkCategory("cat", false /* autoSave */);
+  kml::TrackId trackId;
+  {
+    auto es = bmManager.GetEditSession();
+    trackId = es.CreateTrack(MakeLineTrackData())->GetId();
+    es.AttachTrack(trackId, catId);
+  }
+  bmManager.SetTrackSelectionInfo({trackId, kTrackPoint, kTrackDistance}, false /* notifyListeners */);
+  TEST_EQUAL(bmManager.SetTempRelationTrack(MakeLineTrackData()), kml::kTempRelationTrackId, ());
+
+  auto const markId = FindTrackSelectionMark(bmManager, trackId);
+  TEST_NOT_EQUAL(markId, kml::kInvalidMarkId, ());
+
+  TapUserMark(fm, markId);
+
+  TEST_EQUAL(bmManager.GetTrack(kml::kTempRelationTrackId), nullptr, ());
+  TEST(fm.HasPlacePageInfo(), ());
+  TEST_EQUAL(fm.GetCurrentPlacePageInfo().GetTrackId(), trackId, ());
 }
 
 namespace

--- a/libs/map/track.hpp
+++ b/libs/map/track.hpp
@@ -65,6 +65,9 @@ public:
     /// @return true  Data is initialized and correct (after UpdateSelectionInfo call).
     /// Can be false if input m_squareDist filtered all track's segments.
     bool IsValid() const { return m_trackId != kml::kInvalidTrackId; }
+    /// @return true if the relation metadata to (re)build the temporary track is here. Stronger than
+    /// "this selection is the temporary relation track": a selection restored from a
+    /// TrackSelectionMark keeps m_trackId only (see BookmarkManager::GetTrackSelectionInfo).
     bool IsRelation() const { return m_trackId == kml::kTempRelationTrackId && m_relationId.IsValid(); }
 
     kml::TrackId m_trackId = kml::kInvalidTrackId;


### PR DESCRIPTION
Follow up to https://github.com/organicmaps/organicmaps/pull/13069#issuecomment-5023824278

TrackSelectionInfo::IsRelation() answers "is there relation metadata to (re)build the temporary track", but BuildTrackPlacePage used it to answer "is this selection the temporary relation track". A selection restored from a TrackSelectionMark keeps the track id only, so a tap on the mark of the currently shown relation track took the ordinary branch, cleared the very track it was about to fetch and dereferenced a null Track.

Key the decision on the track id instead, so such a tap reuses the already built track, and null check GetTrack() before use: a selection mark could also outlive its track, which is what ClearTempRelationTrack() left behind before 9be7f77d57.

A null check alone would turn the segfault into an abort, because FillUserMarkInfo ignored the failure and ActivateMapSelection rejects an OBJECT_EMPTY selection. Propagate it instead, so a stale mark falls back to the regular tap matching.