### PR TITLE
[android] Try fix nativeGetStatus ANR.

### DIFF
--- a/android/app/src/main/java/app/organicmaps/downloader/BottomPanel.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/BottomPanel.java
@@ -103,56 +103,47 @@ class BottomPanel
 
   public void update()
   {
-    DownloaderAdapter adapter = mFragment.getAdapter();
-    boolean search = adapter.isSearchResultsMode();
+    final DownloaderAdapter adapter = mFragment.getAdapter();
+    boolean showFab = false;
+    boolean showButton = false;
 
-    boolean show = !search;
-    String root = adapter.getCurrentRootId();
-    int status = MapManager.nativeGetStatus(root);
-
-    // Hide FAB when all maps are already downloaded - nothing new to download
-    UiUtils.showIf(show && adapter.isMyMapsMode() && status != STATUS_DONE, mFab);
-
-    if (show)
+    if (!adapter.isSearchResultsMode())
     {
-      if (adapter.isMyMapsMode())
+      final String root = adapter.getCurrentRootId();
+      final boolean myMapsMode = adapter.isMyMapsMode();
+
+      showButton = myMapsMode || !CountryItem.isRoot(root);
+      if (showButton)
       {
+        final int status = MapManager.nativeGetStatus(root);
+        // Hide FAB when all maps are already downloaded - nothing new to download.
+        showFab = myMapsMode && status != STATUS_DONE;
         switch (status)
         {
-        case STATUS_UPDATABLE ->
-        {
-          UpdateInfo info = MapManager.nativeGetUpdateInfo(root);
-          setUpdateAllState(info);
-        } // Special case for "Countries" node when no maps currently downloaded.
-        case STATUS_DOWNLOADABLE, STATUS_DONE, STATUS_PARTLY -> show = false;
+        case STATUS_UPDATABLE -> setUpdateAllState(MapManager.nativeGetUpdateInfo(root));
         case STATUS_PROGRESS, STATUS_APPLYING, STATUS_ENQUEUED -> setCancelState();
         case STATUS_FAILED -> setRetryFailedStates();
-        default -> throw new IllegalArgumentException("Inappropriate status for \"" + root + "\": " + status);
-        }
-      }
-      else
-      {
-        show = !CountryItem.isRoot(root);
-        if (show)
+        case STATUS_DONE -> showButton = false;
+        case STATUS_DOWNLOADABLE, STATUS_PARTLY ->
         {
-          switch (status)
-          {
-          case STATUS_UPDATABLE ->
-          {
-            UpdateInfo info = MapManager.nativeGetUpdateInfo(root);
-            setUpdateAllState(info);
-          }
-          case STATUS_DONE -> show = false;
-          case STATUS_PROGRESS, STATUS_APPLYING, STATUS_ENQUEUED -> setCancelState();
-          case STATUS_FAILED -> setRetryFailedStates();
-          default -> setDownloadAllState();
-          }
+          // My Maps lists downloaded maps only, so there is nothing to offer here.
+          if (myMapsMode)
+            showButton = false;
+          else
+            setDownloadAllState();
+        }
+        default ->
+        {
+          if (myMapsMode)
+            throw new IllegalArgumentException("Inappropriate status for \"" + root + "\": " + status);
+          setDownloadAllState();
+        }
         }
       }
     }
 
-    UiUtils.showIf(show, mButton);
-
+    UiUtils.showIf(showFab, mFab);
+    UiUtils.showIf(showButton, mButton);
     mFragment.requireView().requestApplyInsets();
   }
 }

--- a/android/app/src/main/java/app/organicmaps/downloader/DownloaderFragment.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/DownloaderFragment.java
@@ -37,6 +37,7 @@ public class DownloaderFragment
   private boolean mSearchRunning;
 
   private int mSubscriberSlot;
+  private final Runnable mUpdateRunnable = this::update;
 
   final ActivityResultLauncher<Intent> startVoiceRecognitionForResult =
       registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
@@ -111,6 +112,10 @@ public class DownloaderFragment
 
   void update()
   {
+    // Ignore asynchronous updates after the fragment's view has been destroyed.
+    if (getView() == null)
+      return;
+
     mToolbarController.update();
     mBottomPanel.update();
   }
@@ -133,8 +138,13 @@ public class DownloaderFragment
       @Override
       public void onStatusChanged(List<MapManager.StorageCallbackData> data)
       {
-        if (isAdded())
-          update();
+        final View view = getView();
+        if (view == null)
+          return;
+
+        // Return from the native callback before querying storage again and collapse notification bursts.
+        view.removeCallbacks(mUpdateRunnable);
+        view.post(mUpdateRunnable);
       }
 
       @Override


### PR DESCRIPTION
Trying to fix: https://play.google.com/console/u/0/developers/8084273541548442467/app/4972992444534608608/vitals/crashes/c8897c1cfed5bb096cef9e6ea4d5a814/details?days=28&isUserPerceived=true

- skips the expensive nativeGetStatus() traversal while search results hide the panel.
- defers storage notifications, preventing synchronous JNI callback re-entry into nativeGetStatus()
- cancels pending refreshes when the view is destroyed

This fix was proposed by LLM, but I have doubts here.
Need review for this hotfix.
Best fix is to simplify/reconsider the whole Java Native - JNI - Storage C++ notification mechanics.