### PR TITLE
[android] Don't re-import a shared file when relaunched from Recents

### DIFF
--- a/android/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/android/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -331,6 +331,19 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
     showMap();
   }
 
+  /**
+   * This screen is shown while the resources required to start are still downloading, so the payload
+   * has not reached {@link MwmActivity} yet. Say it explicitly, otherwise a relaunch from Recents lets
+   * {@link SplashActivity} treat a shared file as already imported. Only fills in what is still
+   * unknown: an existing mark came from someone better informed, and downgrading it revives the replay.
+   */
+  @Override
+  protected void prepareIntentForCoreRestart(@NonNull Intent intent, @Nullable Bundle savedInstanceState)
+  {
+    if (!intent.hasExtra(MwmActivity.EXTRA_CONSUMED))
+      intent.putExtra(MwmActivity.EXTRA_CONSUMED, false);
+  }
+
   public void showMap()
   {
     if (!mAreResourcesDownloaded)

--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -41,6 +41,7 @@ import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
 import androidx.core.graphics.Insets;
@@ -139,7 +140,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public static final String EXTRA_BOOKMARK_ID = "bookmark_id";
   public static final String EXTRA_TRACK_ID = "track_id";
   public static final String EXTRA_UPDATE_THEME = "update_theme";
-  private static final String EXTRA_CONSUMED = "mwm.extra.intent.processed";
+  // Stored both in the saved instance state and, when the core restarts, in the intent itself.
+  static final String EXTRA_CONSUMED = "mwm.extra.intent.processed";
   private boolean mIntentConsumed = false;
   private boolean mPreciseLocationDialogShown = false;
 
@@ -453,6 +455,35 @@ public class MwmActivity extends BaseMwmFragmentActivity
     recreate();
   }
 
+  /**
+   * The activity created once the core is up does not inherit this instance's saved state, so the
+   * mark has to travel in the intent, which outlives the flag reset in {@link SplashActivity}.
+   * <p>
+   * The mark is written even when it is {@code false}. Its mere presence tells the splash that the
+   * state of this intent is known, so a file that has not been imported yet is not written off as
+   * handled by {@link SplashActivity#markIntentConsumedIfRelaunchedFromHistory}.
+   */
+  @Override
+  protected void prepareIntentForCoreRestart(@NonNull Intent intent, @Nullable Bundle savedInstanceState)
+  {
+    if (savedInstanceState != null)
+      intent.putExtra(EXTRA_CONSUMED, savedInstanceState.getBoolean(EXTRA_CONSUMED, false));
+  }
+
+  /**
+   * Tells whether the intent this activity starts with has already been processed. A configuration
+   * change restores the mark from the instance's own state, while a core restart through
+   * {@link SplashActivity} re-creates the activity from scratch and only the intent survives.
+   */
+  @VisibleForTesting
+  static boolean isIntentConsumed(@Nullable Bundle savedInstanceState, @Nullable Intent intent)
+  {
+    if (savedInstanceState != null)
+      return savedInstanceState.getBoolean(EXTRA_CONSUMED, false);
+
+    return intent != null && intent.getBooleanExtra(EXTRA_CONSUMED, false);
+  }
+
   @SuppressLint("InlinedApi")
   @CallSuper
   @Override
@@ -460,8 +491,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     super.onSafeCreate(savedInstanceState);
 
-    if (savedInstanceState != null)
-      mIntentConsumed = savedInstanceState.getBoolean(EXTRA_CONSUMED, false);
+    mIntentConsumed = isIntentConsumed(savedInstanceState, getIntent());
 
     setContentView(R.layout.activity_map);
     makeNavigationBarTransparentInLightMode();

--- a/android/app/src/main/java/app/organicmaps/SplashActivity.java
+++ b/android/app/src/main/java/app/organicmaps/SplashActivity.java
@@ -16,6 +16,7 @@ import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.ViewCompat;
 import app.organicmaps.downloader.DownloaderActivity;
@@ -178,7 +179,11 @@ public class SplashActivity extends AppCompatActivity
     // https://github.com/organicmaps/organicmaps/pull/7287
     // FORWARD_RESULT_FLAG conflicts with the ActivityResultLauncher.
     // https://github.com/organicmaps/organicmaps/issues/8984
-    intent.setFlags(intent.getFlags() & Intent.FLAG_GRANT_READ_URI_PERMISSION);
+    final int launchFlags = intent.getFlags();
+    intent.setFlags(launchFlags & Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+    if (markIntentConsumedIfRelaunchedFromHistory(intent, launchFlags))
+      Logger.w(TAG, "Relaunched from history, the intent payload is treated as already processed");
 
     if (Factory.isStartedForApiResult(intent))
     {
@@ -190,6 +195,29 @@ public class SplashActivity extends AppCompatActivity
     Config.setFirstStartDialogSeen(this);
     startActivity(intent);
     finish();
+  }
+
+  /**
+   * A relaunch from Recents re-delivers the intent the task started with, whose one-shot payload is
+   * most likely spent: a bookmarks file shared through a temporary content:// URI is gone by then
+   * and would only fail to open. An explicit {@link MwmActivity#EXTRA_CONSUMED} wins over this
+   * guess, since only the map activity really knows. Without one the two cases are indistinguishable
+   * here, and resolving them to "processed" drops a file shared just before a kill during startup.
+   *
+   * @param launchFlags the flags the intent was launched with, taken before they are reset.
+   * @return whether the intent was marked as already processed.
+   */
+  @VisibleForTesting
+  static boolean markIntentConsumedIfRelaunchedFromHistory(@NonNull Intent intent, int launchFlags)
+  {
+    if (intent.hasExtra(MwmActivity.EXTRA_CONSUMED))
+      return false;
+
+    if ((launchFlags & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == 0)
+      return false;
+
+    intent.putExtra(MwmActivity.EXTRA_CONSUMED, true);
+    return true;
   }
 
   private boolean isManageSpaceActivity(@NonNull Intent intent)

--- a/android/app/src/main/java/app/organicmaps/base/BaseMwmFragmentActivity.java
+++ b/android/app/src/main/java/app/organicmaps/base/BaseMwmFragmentActivity.java
@@ -43,6 +43,7 @@ public abstract class BaseMwmFragmentActivity extends AppCompatActivity
     if (!MwmApplication.from(this).getOrganicMaps().arePlatformAndCoreInitialized())
     {
       final Intent intent = Objects.requireNonNull(getIntent());
+      prepareIntentForCoreRestart(intent, savedInstanceState);
       intent.setComponent(new ComponentName(this, SplashActivity.class));
       startActivity(intent);
       finish();
@@ -51,6 +52,16 @@ public abstract class BaseMwmFragmentActivity extends AppCompatActivity
 
     onSafeCreate(savedInstanceState);
   }
+
+  /**
+   * Preserves activity-specific state when a restored activity must restart the core through
+   * {@link SplashActivity}. The new activity created after initialization does not receive this
+   * instance's saved state.
+   * <p>
+   * Staying silent means "the state of this intent is unknown", which lets {@link SplashActivity}
+   * guess. Override whenever this screen's intent can carry a payload that MwmActivity acts on.
+   */
+  protected void prepareIntentForCoreRestart(@NonNull Intent intent, @Nullable Bundle savedInstanceState) {}
 
   /**
    * Status-bar style passed to {@link EdgeToEdge#enable}. The default uses light (white)

--- a/android/app/src/test/java/app/organicmaps/MwmActivityTest.java
+++ b/android/app/src/test/java/app/organicmaps/MwmActivityTest.java
@@ -12,18 +12,10 @@ import org.junit.Test;
 public class MwmActivityTest
 {
   @Test
-  public void freshIntentIsNotConsumed()
-  {
-    final Intent intent = mock(Intent.class);
-    when(intent.getBooleanExtra(MwmActivity.EXTRA_CONSUMED, false)).thenReturn(false);
-
-    assertFalse(MwmActivity.isIntentConsumed(null, intent));
-  }
-
-  @Test
-  public void missingIntentIsNotConsumed()
+  public void unmarkedOrMissingIntentIsNotConsumed()
   {
     assertFalse(MwmActivity.isIntentConsumed(null, null));
+    assertFalse(MwmActivity.isIntentConsumed(null, mock(Intent.class)));
   }
 
   @Test

--- a/android/app/src/test/java/app/organicmaps/MwmActivityTest.java
+++ b/android/app/src/test/java/app/organicmaps/MwmActivityTest.java
@@ -1,0 +1,52 @@
+package app.organicmaps;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.Intent;
+import android.os.Bundle;
+import org.junit.Test;
+
+public class MwmActivityTest
+{
+  @Test
+  public void freshIntentIsNotConsumed()
+  {
+    final Intent intent = mock(Intent.class);
+    when(intent.getBooleanExtra(MwmActivity.EXTRA_CONSUMED, false)).thenReturn(false);
+
+    assertFalse(MwmActivity.isIntentConsumed(null, intent));
+  }
+
+  @Test
+  public void missingIntentIsNotConsumed()
+  {
+    assertFalse(MwmActivity.isIntentConsumed(null, null));
+  }
+
+  @Test
+  public void consumedStateSurvivesCoreRestart()
+  {
+    final Intent intent = mock(Intent.class);
+    when(intent.getBooleanExtra(MwmActivity.EXTRA_CONSUMED, false)).thenReturn(true);
+
+    assertTrue(MwmActivity.isIntentConsumed(null, intent));
+  }
+
+  /**
+   * The saved state belongs to this very instance, so it is more recent than anything the intent was
+   * marked with back when the instance was created.
+   */
+  @Test
+  public void savedStateWinsOverIntent()
+  {
+    final Bundle savedInstanceState = mock(Bundle.class);
+    when(savedInstanceState.getBoolean(MwmActivity.EXTRA_CONSUMED, false)).thenReturn(false);
+    final Intent intent = mock(Intent.class);
+    when(intent.getBooleanExtra(MwmActivity.EXTRA_CONSUMED, false)).thenReturn(true);
+
+    assertFalse(MwmActivity.isIntentConsumed(savedInstanceState, intent));
+  }
+}

--- a/android/app/src/test/java/app/organicmaps/SplashActivityTest.java
+++ b/android/app/src/test/java/app/organicmaps/SplashActivityTest.java
@@ -1,0 +1,56 @@
+package app.organicmaps;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Intent;
+import org.junit.Test;
+
+public class SplashActivityTest
+{
+  @Test
+  public void intentRelaunchedFromHistoryIsMarkedConsumed()
+  {
+    final Intent intent = mock(Intent.class);
+    when(intent.hasExtra(MwmActivity.EXTRA_CONSUMED)).thenReturn(false);
+    when(intent.getFlags()).thenReturn(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY);
+
+    assertTrue(SplashActivity.markIntentConsumedIfRelaunchedFromHistory(intent));
+
+    verify(intent).putExtra(MwmActivity.EXTRA_CONSUMED, true);
+  }
+
+  @Test
+  public void freshIntentIsLeftUntouched()
+  {
+    final Intent intent = mock(Intent.class);
+    when(intent.hasExtra(MwmActivity.EXTRA_CONSUMED)).thenReturn(false);
+    when(intent.getFlags()).thenReturn(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+    assertFalse(SplashActivity.markIntentConsumedIfRelaunchedFromHistory(intent));
+
+    verify(intent, never()).putExtra(anyString(), anyBoolean());
+  }
+
+  /**
+   * An activity restarting the core forwards what it really knows about the intent, so the history
+   * flag must not overwrite a file that has been shared but not imported yet.
+   */
+  @Test
+  public void forwardedStateWinsOverHistoryFlag()
+  {
+    final Intent intent = mock(Intent.class);
+    when(intent.hasExtra(MwmActivity.EXTRA_CONSUMED)).thenReturn(true);
+    when(intent.getFlags()).thenReturn(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY);
+
+    assertFalse(SplashActivity.markIntentConsumedIfRelaunchedFromHistory(intent));
+
+    verify(intent, never()).putExtra(anyString(), anyBoolean());
+  }
+}

--- a/android/app/src/test/java/app/organicmaps/SplashActivityTest.java
+++ b/android/app/src/test/java/app/organicmaps/SplashActivityTest.java
@@ -2,10 +2,7 @@ package app.organicmaps;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -18,24 +15,20 @@ public class SplashActivityTest
   public void intentRelaunchedFromHistoryIsMarkedConsumed()
   {
     final Intent intent = mock(Intent.class);
-    when(intent.hasExtra(MwmActivity.EXTRA_CONSUMED)).thenReturn(false);
-    when(intent.getFlags()).thenReturn(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY);
 
-    assertTrue(SplashActivity.markIntentConsumedIfRelaunchedFromHistory(intent));
+    assertTrue(
+        SplashActivity.markIntentConsumedIfRelaunchedFromHistory(intent, Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY));
 
     verify(intent).putExtra(MwmActivity.EXTRA_CONSUMED, true);
   }
 
   @Test
-  public void freshIntentIsLeftUntouched()
+  public void freshIntentIsNotMarked()
   {
     final Intent intent = mock(Intent.class);
-    when(intent.hasExtra(MwmActivity.EXTRA_CONSUMED)).thenReturn(false);
-    when(intent.getFlags()).thenReturn(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
-    assertFalse(SplashActivity.markIntentConsumedIfRelaunchedFromHistory(intent));
-
-    verify(intent, never()).putExtra(anyString(), anyBoolean());
+    assertFalse(
+        SplashActivity.markIntentConsumedIfRelaunchedFromHistory(intent, Intent.FLAG_GRANT_READ_URI_PERMISSION));
   }
 
   /**
@@ -47,10 +40,8 @@ public class SplashActivityTest
   {
     final Intent intent = mock(Intent.class);
     when(intent.hasExtra(MwmActivity.EXTRA_CONSUMED)).thenReturn(true);
-    when(intent.getFlags()).thenReturn(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY);
 
-    assertFalse(SplashActivity.markIntentConsumedIfRelaunchedFromHistory(intent));
-
-    verify(intent, never()).putExtra(anyString(), anyBoolean());
+    assertFalse(
+        SplashActivity.markIntentConsumedIfRelaunchedFromHistory(intent, Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY));
   }
 }


### PR DESCRIPTION
## Problem

A user imported a `.kmz` attachment from K-9 Mail ("Open with → Organic Maps"). The import worked, but from then on **every** app start greeted them with:

> **Lesezeichen werden geladen**
> Datei konnte nicht geöffnet werden `content://com.fsck.k9.tempfileprovider/temp/9b42…?displayName=Camping_Plan_A.kmz&mime_type=application%2Fvnd.google-earth.kmz`
>
> `java.io.FileNotFoundException: open failed: ENOENT (No such file or directory)`

## Root cause

The `ACTION_VIEW` intent that carries the file is a **one-shot** intent, but it stays the intent of our task:

1. K-9 shares the file through a temporary `content://` URI and deletes the backing file right after the first read.
2. `MwmActivity` is `launchMode="singleTask"`, so that intent sticks to the task.
3. When the process is killed in the background and the user comes back, the intent is delivered again and `Factory.KmzKmlProcessor` re-runs the import.
4. `ContentResolver.openInputStream()` now throws `FileNotFoundException`, which surfaces as `onBookmarksFileDownloadFailed()` → the `failed_to_open_file` dialog.

The existing `mIntentConsumed` guard did not cover this: it is restored from the saved instance state, but on a cold start the core is not initialized yet, so `BaseMwmFragmentActivity` bounces the intent through `SplashActivity` and the **new** `MwmActivity` never sees the old instance's saved state.

Note that the file name still resolves from the provider's `DISPLAY_NAME` metadata after the file is gone — only the byte stream fails. That is why the "could not be opened" dialog appears rather than "unknown file type".

## Fix

Keep the "this intent was already processed" mark alive across every way the activity can be re-created:

- **Configuration change** — unchanged, restored from the saved instance state.
- **Core restart through `SplashActivity`** — a new `BaseMwmFragmentActivity.prepareIntentForCoreRestart()` hook lets an activity copy what it knows into the intent, which does survive the restart. `MwmActivity` writes the mark *even when it is `false`*: its mere presence tells the splash that the state of this intent is known.
- **Relaunch from the Recents stack with no state at all** — detected via `FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY` in `SplashActivity`. That check has to live there: `processNavigation()` resets the intent flags to `FLAG_GRANT_READ_URI_PERMISSION`, so `SplashActivity` is the last place that still sees the original flags.

That last check is only a **fallback** for the case where nothing else knows: an activity that does know states it explicitly and wins. `DownloadResourcesLegacyActivity` does, because a payload still waiting for the initial resources provably has not reached `MwmActivity` yet (`showMap()` finishes that activity, so it is only ever on top before the map exists). Without it, killing the process during a first-run download would silently drop a shared file. The one remaining indistinguishable case is resolved to "processed" and logged, so it shows up in a bug report.

The guard sits in `processIntent()` for intents in general, not only for file imports, so a deep link is not replayed either when the task is resumed from history.

## Testing

- `./gradlew :app:testGoogleDebugUnitTest` — 23 tests, 0 failures (`--rerun-tasks` verified). Unit tests cover the mark surviving a core restart, the saved state taking precedence, null-intent handling, and the history-flag fallback in `SplashActivity` including the case where a forwarded mark overrides it.
- `./gradlew :app:compileGoogleDebugJavaWithJavac` — clean, no new warnings.
- Manual check: open a KMZ from a mail client, `adb shell am kill app.organicmaps.debug` (`am kill`, not `force-stop` — force-stopping empties the task and hides the bug, see the second point below), then reopen from the **Recents** switcher. Before: the ENOENT dialog. After: the map opens normally and the imported bookmarks are intact.

## Verified on a device (Android 14, API 34 emulator)

Two claims that the review threads left open were checked on a device. Steps below use the debug build (`app.organicmaps.debug`) so another developer can re-test them.

**1. On an empty-task Recents relaunch the system really does stamp `FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY` onto the stored base intent, and the fallback fires.**

```sh
adb shell am start -a android.intent.action.VIEW -d "geo:52.520008,13.404954" app.organicmaps.debug
# wait for the map to show the point, then:
adb shell input keyevent KEYCODE_HOME
adb shell am force-stop app.organicmaps.debug   # empties the task but keeps it in Recents
# reopen Organic Maps from the Recents switcher, watch logcat
```

`logcat` shows the stored base intent redelivered with the flag added — `flg=0x10000000` became `flg=0x10100000` (`0x00100000` is `FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY`) — followed by

```
SplashActivity: processNavigation(): Relaunched from history, the intent payload is treated as already processed
```

and the old `geo:` point is not re-executed: the map opens on the restored viewport, no place page. So the branch in `markIntentConsumedIfRelaunchedFromHistory()` is reachable on real hardware, not defensive coding.

**2. A stale intent that still carries `FLAG_GRANT_READ_URI_PERMISSION` cannot be replayed through the empty-task path at all — the system refuses the launch once the grant is gone.**

Import a KMZ through a real provider (Files app → Downloads → tap the file), press Home, then `adb shell am force-stop app.organicmaps.debug` or reboot — either way the one-shot URI grant is revoked and the activity records are dropped while the task card stays in Recents. Tapping that card then does nothing: the app never starts, and `logcat` shows

```
TaskView: Failed to launch task (task=Intent { act=android.intent.action.VIEW dat=content://... cmp=.../app.organicmaps.MwmActivity })
```

because the persisted intent demands a URI grant the app no longer holds. On this Android version the ENOENT replay therefore reaches the app only through the retained-records path (`MwmActivity` recreated → core-restart bounce), which the `prepareIntentForCoreRestart()` half of this PR covers; the history-flag fallback matters for grant-free payloads such as deep links (verified above) and possibly for older Android versions, which I could not test.

## Review notes

Addressed in the latest push: inlined the single-caller `copyConsumedStateToIntent()` into the override; reverted the `onNewIntent()` change (`mFrameworkInitialized` is set once and never cleared, so the core-restart bounce only happens in a fresh process, where no `MwmActivity` instance exists to receive a marked intent); corrected a test comment that described an unreachable state and moved the non-obvious "explicit `false` matters" note to where the write happens; made the dropped-payload case visible with a `Logger.i`; toned down the javadoc claim; and added the `DownloadResourcesLegacyActivity` override.

Not adopted: moving the flag check into `MwmActivity.isIntentConsumed()` and keeping `FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY` in the mask — see the inline thread for the reasoning.

## Note

LLM tooling (Claude Code) was used while investigating and preparing this change.

