### PR TITLE
[kml] Fix bookmark names lost on GeoJSON and GPX export

### DIFF
--- a/libs/kml/kml_tests/CMakeLists.txt
+++ b/libs/kml/kml_tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRC
   minzoom_quadtree_tests.cpp
   serdes_tests.cpp
   tests_data.hpp
+  type_utils_tests.cpp
   geojson_tests.cpp
 )
 

--- a/libs/kml/kml_tests/geojson_tests.cpp
+++ b/libs/kml/kml_tests/geojson_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "base/timer.hpp"
 #include "indexer/classificator.hpp"
+#include "indexer/classificator_loader.hpp"
 
 #include "geometry/mercator.hpp"
 #include "geometry/point_with_altitude.hpp"
@@ -388,7 +389,7 @@ UNIT_TEST(GeoJson_Writer_Simple)
         ]
       },
       "properties": {
-        "name": "Marcador de prueba",
+        "name": "Mi lugar favorito",
         "marker-color": "blue",
         "description": "Test bookmark description"
       }
@@ -527,7 +528,7 @@ UNIT_TEST(GeoJson_Writer_MultiTrack)
 UNIT_TEST(GeoJson_Writer_Simple_Minimized)
 {
   // clang-format off
-  std::string_view constexpr expected_geojson = R"({"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[13.39712,52.48982]},"properties":{"name":"Marcador de prueba","marker-color":"blue","description":"Test bookmark description"}}]})";
+  std::string_view constexpr expected_geojson = R"({"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[13.39712,52.48982]},"properties":{"name":"Mi lugar favorito","marker-color":"blue","description":"Test bookmark description"}}]})";
   // clang-format on
 
   kml::FileData const testData = GenerateKmlFileData();
@@ -551,7 +552,7 @@ UNIT_TEST(GeoJson_Writer_UMap)
         ]
       },
       "properties": {
-        "name": "Marcador de prueba",
+        "name": "Mi lugar favorito",
         "marker-color": "blue",
         "description": "Test bookmark description",
         "_umap_options": {
@@ -678,7 +679,7 @@ UNIT_TEST(GeoJson_Writer_UMap_Invalid_Json)
         ]
       },
       "properties": {
-        "name": "Marcador de prueba",
+        "name": "Mi lugar favorito",
         "marker-color": "blue",
         "description": "Test bookmark description"
       }
@@ -1513,6 +1514,93 @@ UNIT_TEST(GeoJson_Writer_Elevation_AllDefault)
   TEST_EQUAL(parsed.m_tracksData.size(), 1, ());
   for (auto const & pt : parsed.m_tracksData[0].m_geometry.m_lines[0])
     TEST_EQUAL(pt.GetAltitude(), geometry::kInvalidAltitude, ());
+}
+
+// Exports a single bookmark and returns the value of its "name" property, or nullopt if the
+// property is absent. Parses the result instead of scraping the raw Json so that escaped string
+// content is compared correctly.
+std::optional<std::string> ExportedName(kml::BookmarkData bookmark)
+{
+  bookmark.m_point = mercator::FromLatLon(52.48982, 13.39712);
+  kml::FileData fileData;
+  fileData.m_bookmarksData.push_back(std::move(bookmark));
+
+  auto const json = SaveToGeoJsonString(fileData, true /* minimize */);
+  kml::geojson::GeoJsonData exported;
+  auto const error = glz::read_json(exported, json);
+  TEST(!error, (glz::format_error(error, json)));
+  TEST_EQUAL(exported.features.size(), 1, (json));
+
+  auto const & properties = exported.features.front().properties;
+  auto const name = properties.find("name");
+  if (name == properties.end())
+    return std::nullopt;
+  TEST(name->second.is_string(), (json));
+  return name->second.get_string();
+}
+
+UNIT_TEST(GeoJson_Writer_CustomName)
+{
+  // A name typed by the user lives in m_customName, while m_name keeps the auto-generated one
+  // (for a bookmark saved at the current position it is the creation date). Exporting m_name
+  // only would replace the user's name with that date, see issue #13237.
+  kml::BookmarkData bookmark;
+  bookmark.m_name[kml::kDefaultLangCode] = "28 July 2026 at 20:14";
+  bookmark.m_customName[kml::kDefaultLangCode] = "Скважина 12";
+  TEST_EQUAL(ExportedName(bookmark), "Скважина 12", ());
+
+  // Multiple custom translations still win when none uses default/int_name/en.
+  auto const kDeLang = StringUtf8Multilang::GetLangIndex("de");
+  auto const kRuLang = StringUtf8Multilang::GetLangIndex("ru");
+  kml::BookmarkData localizedCustom;
+  localizedCustom.m_name[kml::kDefaultLangCode] = "Original name";
+  localizedCustom.m_customName[kRuLang] = "Любимое место";
+  localizedCustom.m_customName[kDeLang] = "Lieblingsort";
+  TEST_EQUAL(ExportedName(localizedCustom), "Lieblingsort", ());
+
+  // Json-special characters survive the round trip unchanged.
+  kml::BookmarkData escaped;
+  escaped.m_customName[kml::kDefaultLangCode] = "The \"quoted\" \\\\ place";
+  TEST_EQUAL(ExportedName(escaped), "The \"quoted\" \\\\ place", ());
+}
+
+UNIT_TEST(GeoJson_Writer_NameWithoutDefaultLanguage)
+{
+  auto const kEnLang = StringUtf8Multilang::kEnglishCode;
+  auto const kRuLang = StringUtf8Multilang::GetLangIndex("ru");
+
+  // A POI tagged with name:ru/name:en only (no plain name) has no default-language entry.
+  kml::BookmarkData bookmark;
+  bookmark.m_name[kRuLang] = "Эрмитаж";
+  bookmark.m_name[kEnLang] = "Hermitage";
+  TEST_EQUAL(ExportedName(bookmark), "Hermitage", ());
+
+  // The only available name is exported regardless of its language.
+  kml::BookmarkData single;
+  single.m_name[kRuLang] = "Эрмитаж";
+  TEST_EQUAL(ExportedName(single), "Эрмитаж", ());
+
+  // With several non-preferred translations, use the lowest stable language code instead of
+  // dropping the name. "de" has a lower StringUtf8Multilang code than "ru".
+  auto const kDeLang = StringUtf8Multilang::GetLangIndex("de");
+  kml::BookmarkData multiple;
+  multiple.m_name[kRuLang] = "Эрмитаж";
+  multiple.m_name[kDeLang] = "Eremitage";
+  TEST_EQUAL(ExportedName(multiple), "Eremitage", ());
+}
+
+UNIT_TEST(GeoJson_Writer_NameFallbacks)
+{
+  classificator::Load();
+
+  // Nameless bookmarks are exported with their localized type, as KML and GPX do. In tests
+  // platform::GetLocalizedTypeName() is the identity, so the readable type name is written as is.
+  kml::BookmarkData typed;
+  typed.m_featureTypes = {classif().GetTypeByPath({"historic", "castle"})};
+  TEST_EQUAL(ExportedName(typed), "historic-castle", ());
+
+  // Nothing to export at all: the property is omitted instead of being empty.
+  TEST(!ExportedName({}), ());
 }
 
 }  // namespace geojson_tests

--- a/libs/kml/kml_tests/geojson_tests.cpp
+++ b/libs/kml/kml_tests/geojson_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "base/timer.hpp"
 #include "indexer/classificator.hpp"
+#include "indexer/classificator_loader.hpp"
 
 #include "geometry/mercator.hpp"
 #include "geometry/point_with_altitude.hpp"
@@ -388,7 +389,7 @@ UNIT_TEST(GeoJson_Writer_Simple)
         ]
       },
       "properties": {
-        "name": "Marcador de prueba",
+        "name": "Mi lugar favorito",
         "marker-color": "blue",
         "description": "Test bookmark description"
       }
@@ -527,7 +528,7 @@ UNIT_TEST(GeoJson_Writer_MultiTrack)
 UNIT_TEST(GeoJson_Writer_Simple_Minimized)
 {
   // clang-format off
-  std::string_view constexpr expected_geojson = R"({"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[13.39712,52.48982]},"properties":{"name":"Marcador de prueba","marker-color":"blue","description":"Test bookmark description"}}]})";
+  std::string_view constexpr expected_geojson = R"({"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[13.39712,52.48982]},"properties":{"name":"Mi lugar favorito","marker-color":"blue","description":"Test bookmark description"}}]})";
   // clang-format on
 
   kml::FileData const testData = GenerateKmlFileData();
@@ -551,7 +552,7 @@ UNIT_TEST(GeoJson_Writer_UMap)
         ]
       },
       "properties": {
-        "name": "Marcador de prueba",
+        "name": "Mi lugar favorito",
         "marker-color": "blue",
         "description": "Test bookmark description",
         "_umap_options": {
@@ -678,7 +679,7 @@ UNIT_TEST(GeoJson_Writer_UMap_Invalid_Json)
         ]
       },
       "properties": {
-        "name": "Marcador de prueba",
+        "name": "Mi lugar favorito",
         "marker-color": "blue",
         "description": "Test bookmark description"
       }
@@ -1513,6 +1514,92 @@ UNIT_TEST(GeoJson_Writer_Elevation_AllDefault)
   TEST_EQUAL(parsed.m_tracksData.size(), 1, ());
   for (auto const & pt : parsed.m_tracksData[0].m_geometry.m_lines[0])
     TEST_EQUAL(pt.GetAltitude(), geometry::kInvalidAltitude, ());
+}
+
+// Returns the value of the first "name" property in the exported GeoJson, or nullopt if the
+// property is absent.
+std::optional<std::string> ExportedName(kml::BookmarkData bookmark)
+{
+  bookmark.m_point = mercator::FromLatLon(52.48982, 13.39712);
+  kml::FileData fileData;
+  fileData.m_bookmarksData.push_back(std::move(bookmark));
+
+  auto const json = SaveToGeoJsonString(fileData, true /* minimize */);
+  kml::geojson::GeoJsonData exported;
+  auto const error = glz::read_json(exported, json);
+  TEST(!error, (glz::format_error(error, json)));
+  if (error || exported.features.size() != 1)
+    return std::nullopt;
+
+  auto const & properties = exported.features.front().properties;
+  auto const name = properties.find("name");
+  if (name == properties.end())
+    return std::nullopt;
+  TEST(name->second.is_string(), ());
+  return name->second.is_string() ? std::optional<std::string>{name->second.get_string()} : std::nullopt;
+}
+
+UNIT_TEST(GeoJson_Writer_CustomName)
+{
+  // A name typed by the user lives in m_customName, while m_name keeps the auto-generated one
+  // (for a bookmark saved at the current position it is the creation date). Exporting m_name
+  // only would replace the user's name with that date, see issue #13237.
+  kml::BookmarkData bookmark;
+  bookmark.m_name[kml::kDefaultLang] = "28 July 2026 at 20:14";
+  bookmark.m_customName[kml::kDefaultLang] = "Скважина 12";
+  TEST_EQUAL(ExportedName(bookmark), "Скважина 12", ());
+
+  // Multiple custom translations still win when none uses default/int_name/en.
+  auto const kDeLang = StringUtf8Multilang::GetLangIndex("de");
+  auto const kRuLang = StringUtf8Multilang::GetLangIndex("ru");
+  kml::BookmarkData localizedCustom;
+  localizedCustom.m_name[kml::kDefaultLang] = "Original name";
+  localizedCustom.m_customName[kRuLang] = "Любимое место";
+  localizedCustom.m_customName[kDeLang] = "Lieblingsort";
+  TEST_EQUAL(ExportedName(localizedCustom), "Lieblingsort", ());
+
+  // Parse the JSON instead of scraping for quotes so escaped string content is checked correctly.
+  kml::BookmarkData escaped;
+  escaped.m_customName[kml::kDefaultLang] = "The \"quoted\" \\\\ place";
+  TEST_EQUAL(ExportedName(escaped), "The \"quoted\" \\\\ place", ());
+}
+
+UNIT_TEST(GeoJson_Writer_NameWithoutDefaultLanguage)
+{
+  auto const kEnLang = StringUtf8Multilang::kEnglishCode;
+  auto const kRuLang = StringUtf8Multilang::GetLangIndex("ru");
+
+  // A POI tagged with name:ru/name:en only (no plain name) has no default-language entry.
+  kml::BookmarkData bookmark;
+  bookmark.m_name[kRuLang] = "Эрмитаж";
+  bookmark.m_name[kEnLang] = "Hermitage";
+  TEST_EQUAL(ExportedName(bookmark), "Hermitage", ());
+
+  // The only available name is exported regardless of its language.
+  kml::BookmarkData single;
+  single.m_name[kRuLang] = "Эрмитаж";
+  TEST_EQUAL(ExportedName(single), "Эрмитаж", ());
+
+  // With several non-preferred translations, use the lowest stable language code instead of
+  // dropping the name. "de" has a lower StringUtf8Multilang code than "ru".
+  auto const kDeLang = StringUtf8Multilang::GetLangIndex("de");
+  kml::BookmarkData multiple;
+  multiple.m_name[kRuLang] = "Эрмитаж";
+  multiple.m_name[kDeLang] = "Eremitage";
+  TEST_EQUAL(ExportedName(multiple), "Eremitage", ());
+}
+
+UNIT_TEST(GeoJson_Writer_NameFallbacks)
+{
+  classificator::Load();
+
+  // Nameless bookmarks are exported with their localized type, as KML and GPX do.
+  kml::BookmarkData typed;
+  typed.m_featureTypes = {classif().GetTypeByPath({"historic", "castle"})};
+  TEST_EQUAL(ExportedName(typed), kml::GetLocalizedFeatureType(typed.m_featureTypes), ());
+
+  // Nothing to export at all: the property is omitted instead of being empty.
+  TEST(!ExportedName({}), ());
 }
 
 }  // namespace geojson_tests

--- a/libs/kml/kml_tests/gpx_tests.cpp
+++ b/libs/kml/kml_tests/gpx_tests.cpp
@@ -495,4 +495,38 @@ UNIT_TEST(MapGarminColor)
   TEST_EQUAL("DarkYellow", kml::MapGarminColor(0xb5b721ff), ());
 }
 
+UNIT_TEST(Gpx_Export_Names)
+{
+  auto const exportBookmark = [](kml::BookmarkData bookmark)
+  {
+    bookmark.m_point = mercator::FromLatLon(52.48982, 13.39712);
+    kml::FileData fileData;
+    fileData.m_bookmarksData.push_back(std::move(bookmark));
+    return Serialize(fileData);
+  };
+
+  // A name typed by the user (m_customName) wins over the one the bookmark was created with.
+  kml::BookmarkData renamed;
+  renamed.m_name[kml::kDefaultLang] = "28 July 2026 at 20:14";
+  renamed.m_customName[kml::kDefaultLang] = "Скважина 12";
+  TEST(exportBookmark(renamed).find("<name>Скважина 12</name>") != std::string::npos, ());
+
+  // A POI tagged with name:ru/name:en only has no default-language name, but must not be
+  // exported nameless.
+  kml::BookmarkData localized;
+  localized.m_name[StringUtf8Multilang::GetLangIndex("ru")] = "Эрмитаж";
+  localized.m_name[StringUtf8Multilang::kEnglishCode] = "Hermitage";
+  TEST(exportBookmark(localized).find("<name>Hermitage</name>") != std::string::npos, ());
+
+  // Several non-preferred translations still produce a name. "de" has a lower stable language
+  // code than "ru", so it is the deterministic last resort.
+  kml::BookmarkData multipleLocalized;
+  multipleLocalized.m_name[StringUtf8Multilang::GetLangIndex("ru")] = "Эрмитаж";
+  multipleLocalized.m_name[StringUtf8Multilang::GetLangIndex("de")] = "Eremitage";
+  TEST(exportBookmark(multipleLocalized).find("<name>Eremitage</name>") != std::string::npos, ());
+
+  // A bookmark with no name at all has no <name> element.
+  TEST(exportBookmark({}).find("<name>") == std::string::npos, ());
+}
+
 }  // namespace gpx_tests

--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -1049,6 +1049,51 @@ UNIT_TEST(SaveStringWithCDATA_AllInvalidBecomesEmpty)
   TEST_EQUAL(WriteCDATA(std::string("\x01\x02\x03\x1F")), "", ());
 }
 
+UNIT_TEST(ExportStringLanguageFallbacks)
+{
+  auto const kDeLang = StringUtf8Multilang::GetLangIndex("de");
+  auto const kRuLang = StringUtf8Multilang::GetLangIndex("ru");
+
+  kml::LocalizableString value{{kRuLang, "Русский"}, {kDeLang, "Deutsch"}};
+  TEST_EQUAL(kml::GetStringForExport(value), "Deutsch", ());
+
+  value[StringUtf8Multilang::kEnglishCode] = "English";
+  TEST_EQUAL(kml::GetStringForExport(value), "English", ());
+
+  value[StringUtf8Multilang::kInternationalCode] = "International";
+  TEST_EQUAL(kml::GetStringForExport(value), "International", ());
+
+  value[StringUtf8Multilang::kDefaultCode] = "Default";
+  TEST_EQUAL(kml::GetStringForExport(value), "Default", ());
+
+  // Empty preferred entries do not hide a usable lower-priority value.
+  value[StringUtf8Multilang::kDefaultCode].clear();
+  TEST_EQUAL(kml::GetStringForExport(value), "International", ());
+
+  // alt_name/old_name are OSM pseudo-names: a real language wins even with a higher code.
+  kml::LocalizableString const pseudo{{StringUtf8Multilang::kOldNameCode, "Old"},
+                                      {StringUtf8Multilang::kAltNameCode, "Alt"},
+                                      {StringUtf8Multilang::GetLangIndex("hi"), "हिन्दी"}};
+  TEST_EQUAL(kml::GetStringForExport(pseudo), "हिन्दी", ());
+
+  // ...but they are still better than exporting nothing.
+  kml::LocalizableString const onlyPseudo{{StringUtf8Multilang::kOldNameCode, "Old"},
+                                          {StringUtf8Multilang::kAltNameCode, "Alt"}};
+  TEST_EQUAL(kml::GetStringForExport(onlyPseudo), "Alt", ());
+}
+
+UNIT_TEST(ExportBookmarkCustomNameFallback)
+{
+  auto const kDeLang = StringUtf8Multilang::GetLangIndex("de");
+  auto const kRuLang = StringUtf8Multilang::GetLangIndex("ru");
+
+  kml::BookmarkData bookmark;
+  bookmark.m_name[kml::kDefaultLang] = "Original name";
+  bookmark.m_customName[kRuLang] = "Любимое место";
+  bookmark.m_customName[kDeLang] = "Lieblingsort";
+  TEST_EQUAL(kml::GetNameForExport(bookmark), "Lieblingsort", ());
+}
+
 namespace
 {
 std::string WrapKmlDoc(std::string const & body)

--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -1049,6 +1049,40 @@ UNIT_TEST(SaveStringWithCDATA_AllInvalidBecomesEmpty)
   TEST_EQUAL(WriteCDATA(std::string("\x01\x02\x03\x1F")), "", ());
 }
 
+UNIT_TEST(ExportStringLanguageFallbacks)
+{
+  auto const kDeLang = StringUtf8Multilang::GetLangIndex("de");
+  auto const kRuLang = StringUtf8Multilang::GetLangIndex("ru");
+
+  kml::LocalizableString value{{kRuLang, "Русский"}, {kDeLang, "Deutsch"}};
+  TEST_EQUAL(kml::GetStringForExport(value), "Deutsch", ());
+
+  value[StringUtf8Multilang::kEnglishCode] = "English";
+  TEST_EQUAL(kml::GetStringForExport(value), "English", ());
+
+  value[StringUtf8Multilang::kInternationalCode] = "International";
+  TEST_EQUAL(kml::GetStringForExport(value), "International", ());
+
+  value[StringUtf8Multilang::kDefaultCode] = "Default";
+  TEST_EQUAL(kml::GetStringForExport(value), "Default", ());
+
+  // Empty preferred entries do not hide a usable lower-priority value.
+  value[StringUtf8Multilang::kDefaultCode].clear();
+  TEST_EQUAL(kml::GetStringForExport(value), "International", ());
+}
+
+UNIT_TEST(ExportBookmarkCustomNameFallback)
+{
+  auto const kDeLang = StringUtf8Multilang::GetLangIndex("de");
+  auto const kRuLang = StringUtf8Multilang::GetLangIndex("ru");
+
+  kml::BookmarkData bookmark;
+  bookmark.m_name[kml::kDefaultLang] = "Original name";
+  bookmark.m_customName[kRuLang] = "Любимое место";
+  bookmark.m_customName[kDeLang] = "Lieblingsort";
+  TEST_EQUAL(kml::GetNameForExport(bookmark), "Lieblingsort", ());
+}
+
 namespace
 {
 std::string WrapKmlDoc(std::string const & body)

--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -1082,7 +1082,7 @@ UNIT_TEST(ExportStringLanguageFallbacks)
   TEST_EQUAL(kml::GetStringForExport(onlyPseudo), "Alt", ());
 }
 
-UNIT_TEST(ExportBookmarkCustomNameFallback)
+UNIT_TEST(DefaultLanguageBookmarkCustomNameFallback)
 {
   auto const kDeLang = StringUtf8Multilang::GetLangIndex("de");
   auto const kRuLang = StringUtf8Multilang::GetLangIndex("ru");
@@ -1091,7 +1091,7 @@ UNIT_TEST(ExportBookmarkCustomNameFallback)
   bookmark.m_name[kml::kDefaultLang] = "Original name";
   bookmark.m_customName[kRuLang] = "Любимое место";
   bookmark.m_customName[kDeLang] = "Lieblingsort";
-  TEST_EQUAL(kml::GetNameForExport(bookmark), "Lieblingsort", ());
+  TEST_EQUAL(kml::GetPreferredBookmarkName(bookmark, "default"), "Lieblingsort", ());
 }
 
 namespace
@@ -1142,6 +1142,69 @@ kml::ColorData RoundTripBookmarkColor(kml::ColorData const & color)
   return parsed.m_bookmarksData.front().m_color;
 }
 }  // namespace
+
+UNIT_TEST(Kml_Export_NameWithoutPreferredLanguage)
+{
+  kml::FileData data;
+  kml::BookmarkData bookmark;
+  bookmark.m_point = mercator::FromLatLon(53.89, 27.55);
+  bookmark.m_name[StringUtf8Multilang::GetLangIndex("ru")] = "Эрмитаж";
+  bookmark.m_name[StringUtf8Multilang::GetLangIndex("de")] = "Eremitage";
+  data.m_bookmarksData.push_back(std::move(bookmark));
+
+  TEST(SerializeKmlText(data).find("<name>Eremitage</name>") != std::string::npos, ());
+}
+
+UNIT_TEST(Kml_RoundTrip_PromotesFallbackToDefaultLanguage)
+{
+  auto const kDeLang = StringUtf8Multilang::GetLangIndex("de");
+  auto const kRuLang = StringUtf8Multilang::GetLangIndex("ru");
+
+  kml::FileData data;
+  data.m_categoryData.m_name[kDeLang] = "Kategorie";
+  data.m_categoryData.m_name[kRuLang] = "Категория";
+  data.m_categoryData.m_description[kDeLang] = "Kategoriebeschreibung";
+  data.m_categoryData.m_description[kRuLang] = "Описание категории";
+
+  kml::BookmarkData bookmark;
+  bookmark.m_point = mercator::FromLatLon(53.89, 27.55);
+  bookmark.m_name[kDeLang] = "Lesezeichen";
+  bookmark.m_name[kRuLang] = "Метка";
+  bookmark.m_description[kDeLang] = "Lesezeichenbeschreibung";
+  bookmark.m_description[kRuLang] = "Описание метки";
+  data.m_bookmarksData.push_back(std::move(bookmark));
+
+  kml::TrackData track;
+  track.m_name[kDeLang] = "Strecke";
+  track.m_name[kRuLang] = "Трек";
+  track.m_description[kDeLang] = "Streckenbeschreibung";
+  track.m_description[kRuLang] = "Описание трека";
+  track.m_layers.emplace_back();
+  track.m_geometry.AddLine({{{45.9242, 56.8679}, 1}, {{45.2244, 56.2786}, 2}});
+  track.m_geometry.AddTimestamps({});
+  data.m_tracksData.push_back(std::move(track));
+
+  auto const parsed = ParseKmlText(SerializeKmlText(data));
+  TEST_EQUAL(parsed.m_bookmarksData.size(), 1, ());
+  TEST_EQUAL(parsed.m_tracksData.size(), 1, ());
+
+  // Plain KML elements have no metadata that distinguishes a deterministic projection from an
+  // explicit default. The parser retains that projection as default and preserves both translations.
+  auto const promoted =
+      [=](kml::LocalizableString const & s, std::string const & expectedDe, std::string const & expectedRu)
+  {
+    TEST_EQUAL(s.size(), 3, ());
+    TEST_EQUAL(kml::GetDefaultStr(s), expectedDe, ());
+    TEST_EQUAL(s.at(kDeLang), expectedDe, ());
+    TEST_EQUAL(s.at(kRuLang), expectedRu, ());
+  };
+  promoted(parsed.m_categoryData.m_name, "Kategorie", "Категория");
+  promoted(parsed.m_categoryData.m_description, "Kategoriebeschreibung", "Описание категории");
+  promoted(parsed.m_bookmarksData.front().m_name, "Lesezeichen", "Метка");
+  promoted(parsed.m_bookmarksData.front().m_description, "Lesezeichenbeschreibung", "Описание метки");
+  promoted(parsed.m_tracksData.front().m_name, "Strecke", "Трек");
+  promoted(parsed.m_tracksData.front().m_description, "Streckenbeschreibung", "Описание трека");
+}
 
 UNIT_TEST(Kml_BookmarkColor_CustomRoundTrip)
 {

--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -1132,6 +1132,18 @@ kml::ColorData RoundTripBookmarkColor(kml::ColorData const & color)
 }
 }  // namespace
 
+UNIT_TEST(Kml_Export_NameWithoutPreferredLanguage)
+{
+  kml::FileData data;
+  kml::BookmarkData bookmark;
+  bookmark.m_point = mercator::FromLatLon(53.89, 27.55);
+  bookmark.m_name[StringUtf8Multilang::GetLangIndex("ru")] = "Эрмитаж";
+  bookmark.m_name[StringUtf8Multilang::GetLangIndex("de")] = "Eremitage";
+  data.m_bookmarksData.push_back(std::move(bookmark));
+
+  TEST(SerializeKmlText(data).find("<name>Eremitage</name>") != std::string::npos, ());
+}
+
 UNIT_TEST(Kml_BookmarkColor_CustomRoundTrip)
 {
   auto const custom = kml::MakeCustomBookmarkColorData(dp::Color(0x12, 0x34, 0x56, 0xFF));

--- a/libs/kml/kml_tests/type_utils_tests.cpp
+++ b/libs/kml/kml_tests/type_utils_tests.cpp
@@ -1,0 +1,102 @@
+#include "testing/testing.hpp"
+
+#include "kml/type_utils.hpp"
+#include "kml/types.hpp"
+
+#include "indexer/classificator.hpp"
+#include "indexer/classificator_loader.hpp"
+#include "indexer/feature_data.hpp"
+
+#include "coding/string_utf8_multilang.hpp"
+
+namespace type_utils_tests
+{
+using kml::GetPreferredBookmarkName;
+using kml::GetPreferredBookmarkStr;
+
+int8_t const kEn = StringUtf8Multilang::kEnglishCode;
+int8_t const kInt = StringUtf8Multilang::kInternationalCode;
+int8_t const kDe = StringUtf8Multilang::GetLangIndex("de");
+int8_t const kRu = StringUtf8Multilang::GetLangIndex("ru");
+
+UNIT_TEST(GetPreferredBookmarkStr_MatchingLanguage)
+{
+  kml::LocalizableString const name{{kRu, "Эрмитаж"}, {kDe, "Eremitage"}};
+
+  // The map language always wins when it is present.
+  TEST_EQUAL(GetPreferredBookmarkStr(name, "ru"), "Эрмитаж", ());
+  TEST_EQUAL(GetPreferredBookmarkStr(name, "de"), "Eremitage", ());
+
+  // So do the languages every device understands, before the last-resort pick below.
+  kml::LocalizableString withEn = name;
+  withEn[kEn] = "Hermitage";
+  TEST_EQUAL(GetPreferredBookmarkStr(withEn, "fr"), "Hermitage", ());
+}
+
+UNIT_TEST(GetPreferredBookmarkStr_NoMatchingLanguage)
+{
+  // A single translation is shown as is, whatever its language.
+  TEST_EQUAL(GetPreferredBookmarkStr({{kRu, "Эрмитаж"}}, "fr"), "Эрмитаж", ());
+
+  // With no preferred-language match, the stable fallback keeps the value visible and agrees with
+  // serialization.
+  kml::LocalizableString const name{{kRu, "Эрмитаж"}, {kDe, "Eremitage"}};
+  TEST_EQUAL(GetPreferredBookmarkStr(name, "fr"), kml::GetStringForExport(name), ());
+  TEST_EQUAL(GetPreferredBookmarkStr(name, "fr"), "Eremitage", ());
+
+  // A string with nothing in it stays empty, so the callers' own fallbacks still kick in.
+  TEST_EQUAL(GetPreferredBookmarkStr({}, "fr"), "", ());
+}
+
+UNIT_TEST(GetPreferredBookmarkStr_DefaultLanguagePreservesInternationalName)
+{
+  kml::LocalizableString const name{{kInt, "Arabian Island, Arabia"}, {kRu, "Арабский остров"}};
+
+  // Feature-name rendering shortens comma-separated int_name values. The device-independent
+  // resolver keeps the stored bookmark string intact.
+  TEST_EQUAL(GetPreferredBookmarkStr(name, "default"), kml::GetStringForExport(name), ());
+  TEST_EQUAL(GetPreferredBookmarkStr(name, "default"), "Arabian Island, Arabia", ());
+}
+
+UNIT_TEST(GetPreferredBookmarkName_DefaultLanguagePreservesInternationalName)
+{
+  kml::BookmarkData bookmark;
+  bookmark.m_name = {{kInt, "Arabian Island, Arabia"}, {kRu, "Арабский остров"}};
+  TEST_EQUAL(GetPreferredBookmarkName(bookmark, "default"), "Arabian Island, Arabia", ());
+}
+
+UNIT_TEST(GetPreferredBookmarkStr_NoMatchingRegionLanguage)
+{
+  feature::RegionData regionData;
+  regionData.SetLanguages({"uk"});
+  kml::LocalizableString const name{{kRu, "Эрмитаж"}, {kDe, "Eremitage"}};
+
+  TEST_EQUAL(GetPreferredBookmarkStr(name, regionData, "fr"), "Eremitage", ());
+}
+
+UNIT_TEST(GetPreferredBookmarkName_NoMatchingLanguage)
+{
+  classificator::Load();
+  auto const castle = classif().GetTypeByPath({"historic", "castle"});
+
+  // The bookmark's own name is preferred over its feature type even when no language matches.
+  kml::BookmarkData named;
+  named.m_name = {{kRu, "Эрмитаж"}, {kDe, "Eremitage"}};
+  named.m_featureTypes = {castle};
+  TEST_EQUAL(GetPreferredBookmarkName(named, "fr"), "Eremitage", ());
+
+  // A name typed by the user still wins over the one the bookmark was created with.
+  kml::BookmarkData renamed = named;
+  renamed.m_customName = {{kRu, "Мой Эрмитаж"}, {kDe, "Meine Eremitage"}};
+  TEST_EQUAL(GetPreferredBookmarkName(renamed, "fr"), "Meine Eremitage", ());
+
+  // The localized feature type remains the last resort for a nameless bookmark.
+  kml::BookmarkData nameless;
+  nameless.m_featureTypes = {castle};
+  TEST_EQUAL(GetPreferredBookmarkName(nameless, "fr"), kml::GetLocalizedFeatureType({castle}), ());
+
+  // A default-language request uses the complete serialization fallback ladder.
+  for (auto const & bookmark : {named, renamed, nameless})
+    TEST_EQUAL(GetPreferredBookmarkName(bookmark, "fr"), GetPreferredBookmarkName(bookmark, "default"), ());
+}
+}  // namespace type_utils_tests

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -339,17 +339,17 @@ void SaveCategoryData(Writer & writer, CategoryData const & categoryData, std::s
     }
 
     // Use CDATA if we have special symbols in the name.
-    if (auto name = GetDefaultLanguage(categoryData.m_name))
+    if (auto const name = GetStringForExport(categoryData.m_name); !name.empty())
     {
       writer << kIndent2 << "<name>";
-      SaveStringWithCDATA(writer, *name);
+      SaveStringWithCDATA(writer, name);
       writer << "</name>\n";
     }
 
-    if (auto const description = GetDefaultLanguage(categoryData.m_description))
+    if (auto const description = GetStringForExport(categoryData.m_description); !description.empty())
     {
       writer << kIndent2 << "<description>";
-      SaveStringWithCDATA(writer, *description);
+      SaveStringWithCDATA(writer, description);
       writer << "</description>\n";
     }
 
@@ -428,14 +428,13 @@ void SaveBookmarkData(Writer & writer, BookmarkData const & bookmarkData)
 {
   writer << kIndent2 << "<Placemark>\n";
   writer << kIndent4 << "<name>";
-  auto const defaultLang = StringUtf8Multilang::GetLangByCode(kDefaultLangCode);
-  SaveStringWithCDATA(writer, GetPreferredBookmarkName(bookmarkData, defaultLang));
+  SaveStringWithCDATA(writer, GetPreferredBookmarkName(bookmarkData, "default"));
   writer << "</name>\n";
 
-  if (auto const description = GetDefaultLanguage(bookmarkData.m_description))
+  if (auto const description = GetStringForExport(bookmarkData.m_description); !description.empty())
   {
     writer << kIndent4 << "<description>";
-    SaveStringWithCDATA(writer, *description);
+    SaveStringWithCDATA(writer, description);
     writer << "</description>\n";
   }
 
@@ -596,17 +595,17 @@ void SaveTrackExtendedData(Writer & writer, TrackData const & trackData)
 void SaveTrackData(Writer & writer, TrackData const & trackData)
 {
   writer << kIndent2 << "<Placemark>\n";
-  if (auto name = GetDefaultLanguage(trackData.m_name))
+  if (auto const name = GetStringForExport(trackData.m_name); !name.empty())
   {
     writer << kIndent4 << "<name>";
-    SaveStringWithCDATA(writer, *name);
+    SaveStringWithCDATA(writer, name);
     writer << "</name>\n";
   }
 
-  if (auto const description = GetDefaultLanguage(trackData.m_description))
+  if (auto const description = GetStringForExport(trackData.m_description); !description.empty())
   {
     writer << kIndent4 << "<description>";
-    SaveStringWithCDATA(writer, *description);
+    SaveStringWithCDATA(writer, description);
     writer << "</description>\n";
   }
 
@@ -1276,6 +1275,10 @@ void KmlParser::CharData(std::string & value)
         //        language in extended data.
         // 2. We have NOT read extended data yet (or at all). In this case m_name must be empty.
         // If extended data will be read, it can rewrite "default" language, since we prefer extended data.
+        //
+        // Plain KML elements are interoperability projections and carry no provenance that lets the
+        // parser distinguish a projected value from an explicit default. A round trip therefore
+        // retains the projected value as default while preserving translations from ExtendedData.
         if (m_name.find(kDefaultLang) == m_name.end())
           m_name[kDefaultLang] = value;
       }

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -339,17 +339,17 @@ void SaveCategoryData(Writer & writer, CategoryData const & categoryData, std::s
     }
 
     // Use CDATA if we have special symbols in the name.
-    if (auto name = GetDefaultLanguage(categoryData.m_name))
+    if (auto const name = GetStringForExport(categoryData.m_name); !name.empty())
     {
       writer << kIndent2 << "<name>";
-      SaveStringWithCDATA(writer, *name);
+      SaveStringWithCDATA(writer, name);
       writer << "</name>\n";
     }
 
-    if (auto const description = GetDefaultLanguage(categoryData.m_description))
+    if (auto const description = GetStringForExport(categoryData.m_description); !description.empty())
     {
       writer << kIndent2 << "<description>";
-      SaveStringWithCDATA(writer, *description);
+      SaveStringWithCDATA(writer, description);
       writer << "</description>\n";
     }
 
@@ -430,14 +430,13 @@ void SaveBookmarkData(Writer & writer, BookmarkData const & bookmarkData)
 {
   writer << kIndent2 << "<Placemark>\n";
   writer << kIndent4 << "<name>";
-  auto const defaultLang = StringUtf8Multilang::GetLangByCode(kDefaultLangCode);
-  SaveStringWithCDATA(writer, GetPreferredBookmarkName(bookmarkData, defaultLang));
+  SaveStringWithCDATA(writer, GetNameForExport(bookmarkData));
   writer << "</name>\n";
 
-  if (auto const description = GetDefaultLanguage(bookmarkData.m_description))
+  if (auto const description = GetStringForExport(bookmarkData.m_description); !description.empty())
   {
     writer << kIndent4 << "<description>";
-    SaveStringWithCDATA(writer, *description);
+    SaveStringWithCDATA(writer, description);
     writer << "</description>\n";
   }
 
@@ -596,17 +595,17 @@ void SaveTrackExtendedData(Writer & writer, TrackData const & trackData)
 void SaveTrackData(Writer & writer, TrackData const & trackData)
 {
   writer << kIndent2 << "<Placemark>\n";
-  if (auto name = GetDefaultLanguage(trackData.m_name))
+  if (auto const name = GetStringForExport(trackData.m_name); !name.empty())
   {
     writer << kIndent4 << "<name>";
-    SaveStringWithCDATA(writer, *name);
+    SaveStringWithCDATA(writer, name);
     writer << "</name>\n";
   }
 
-  if (auto const description = GetDefaultLanguage(trackData.m_description))
+  if (auto const description = GetStringForExport(trackData.m_description); !description.empty())
   {
     writer << kIndent4 << "<description>";
-    SaveStringWithCDATA(writer, *description);
+    SaveStringWithCDATA(writer, description);
     writer << "</description>\n";
   }
 

--- a/libs/kml/serdes_common.cpp
+++ b/libs/kml/serdes_common.cpp
@@ -79,14 +79,6 @@ void SaveStringWithCDATA(Writer & writer, std::string const & s)
     writer << *clean;
 }
 
-std::string const * GetDefaultLanguage(LocalizableString const & lstr)
-{
-  auto const find = lstr.find(kDefaultLang);
-  if (find != lstr.end())
-    return &find->second;
-  return nullptr;
-}
-
 std::string GetStringForExport(LocalizableString const & lstr)
 {
   auto const getNonEmpty = [&lstr](int8_t const lang) -> std::string const *

--- a/libs/kml/serdes_common.cpp
+++ b/libs/kml/serdes_common.cpp
@@ -42,7 +42,7 @@ bool LineHasAltitude(TrackGeometry const & line)
   });
 }
 
-void SaveStringWithCDATA(Writer & writer, std::string const & s)
+void SaveStringWithCDATA(Writer & writer, std::string_view s)
 {
   if (s.empty())
     return;
@@ -61,21 +61,21 @@ void SaveStringWithCDATA(Writer & writer, std::string const & s)
 
   // Only copy and modify the string if invalid chars are actually found (rare case).
   std::string filtered;
-  std::string const * clean = &s;
+  std::string_view clean = s;
   if (std::any_of(s.begin(), s.end(), isInvalidXmlChar))
   {
     filtered = s;
     std::erase_if(filtered, isInvalidXmlChar);
     if (filtered.empty())
       return;
-    clean = &filtered;
+    clean = filtered;
   }
 
   // According to kml/xml spec, we need to escape special symbols with CDATA.
-  if (clean->find_first_of("<&") != std::string::npos)
-    writer << "<![CDATA[" << *clean << "]]>";
+  if (clean.find_first_of("<&") != std::string_view::npos)
+    writer << "<![CDATA[" << clean << "]]>";
   else
-    writer << *clean;
+    writer << clean;
 }
 
 std::string const * GetDefaultLanguage(LocalizableString const & lstr)

--- a/libs/kml/serdes_common.cpp
+++ b/libs/kml/serdes_common.cpp
@@ -1,4 +1,5 @@
 #include "kml/serdes_common.hpp"
+#include "kml/types.hpp"
 
 #include "geometry/mercator.hpp"
 
@@ -84,6 +85,41 @@ std::string const * GetDefaultLanguage(LocalizableString const & lstr)
   if (find != lstr.end())
     return &find->second;
   return nullptr;
+}
+
+std::string GetStringForExport(LocalizableString const & lstr)
+{
+  auto const getNonEmpty = [&lstr](int8_t const lang) -> std::string const *
+  {
+    auto const it = lstr.find(lang);
+    return it != lstr.end() && !it->second.empty() ? &it->second : nullptr;
+  };
+
+  for (auto const lang : {kDefaultLang, StringUtf8Multilang::kInternationalCode, StringUtf8Multilang::kEnglishCode})
+    if (auto const value = getNonEmpty(lang))
+      return *value;
+
+  std::string const * fallback = nullptr;
+  int8_t fallbackLang = StringUtf8Multilang::kMaxSupportedLanguages;
+  for (auto const & [lang, value] : lstr)
+  {
+    if (!value.empty() && lang < fallbackLang)
+    {
+      fallback = &value;
+      fallbackLang = lang;
+    }
+  }
+  return fallback ? *fallback : std::string{};
+}
+
+std::string GetNameForExport(BookmarkData const & bmData)
+{
+  std::string name = GetStringForExport(bmData.m_customName);
+  if (name.empty())
+    name = GetStringForExport(bmData.m_name);
+  if (name.empty())
+    name = GetLocalizedFeatureType(bmData.m_featureTypes);
+  return name;
 }
 
 }  // namespace kml

--- a/libs/kml/serdes_common.cpp
+++ b/libs/kml/serdes_common.cpp
@@ -78,12 +78,4 @@ void SaveStringWithCDATA(Writer & writer, std::string_view s)
     writer << clean;
 }
 
-std::string const * GetDefaultLanguage(LocalizableString const & lstr)
-{
-  auto const find = lstr.find(kDefaultLang);
-  if (find != lstr.end())
-    return &find->second;
-  return nullptr;
-}
-
 }  // namespace kml

--- a/libs/kml/serdes_common.hpp
+++ b/libs/kml/serdes_common.hpp
@@ -21,7 +21,7 @@ std::string PointToGxString(geometry::PointWithAltitude const & pt);
 // flat sea-level track isn't bloated with zero altitudes. Mirrors Track::HasAltitudes intent.
 bool LineHasAltitude(TrackGeometry const & line);
 
-void SaveStringWithCDATA(Writer & writer, std::string const & s);
+void SaveStringWithCDATA(Writer & writer, std::string_view s);
 std::string const * GetDefaultLanguage(LocalizableString const & lstr);
 
 std::string_view constexpr kIndent0{};

--- a/libs/kml/serdes_common.hpp
+++ b/libs/kml/serdes_common.hpp
@@ -22,7 +22,6 @@ std::string PointToGxString(geometry::PointWithAltitude const & pt);
 bool LineHasAltitude(TrackGeometry const & line);
 
 void SaveStringWithCDATA(Writer & writer, std::string const & s);
-std::string const * GetDefaultLanguage(LocalizableString const & lstr);
 
 // Name/description to write into an exported file, shared by all exporters (KML, GPX, GeoJSON).
 // A name typed by the user is stored in m_customName and must win over the original (POI) name

--- a/libs/kml/serdes_common.hpp
+++ b/libs/kml/serdes_common.hpp
@@ -24,6 +24,13 @@ bool LineHasAltitude(TrackGeometry const & line);
 void SaveStringWithCDATA(Writer & writer, std::string const & s);
 std::string const * GetDefaultLanguage(LocalizableString const & lstr);
 
+// Name/description to write into an exported file, shared by all exporters (KML, GPX, GeoJSON).
+// A name typed by the user is stored in m_customName and must win over the original (POI) name
+// kept in m_name. Strings prefer default/int_name/en; if none exists, the lowest language code is
+// used as a deterministic last resort so that a non-empty localized value is never dropped.
+std::string GetNameForExport(BookmarkData const & bmData);
+std::string GetStringForExport(LocalizableString const & lstr);
+
 std::string_view constexpr kIndent0{};
 std::string_view constexpr kIndent2{"  "};
 std::string_view constexpr kIndent4{"    "};

--- a/libs/kml/serdes_common.hpp
+++ b/libs/kml/serdes_common.hpp
@@ -22,7 +22,6 @@ std::string PointToGxString(geometry::PointWithAltitude const & pt);
 bool LineHasAltitude(TrackGeometry const & line);
 
 void SaveStringWithCDATA(Writer & writer, std::string_view s);
-std::string const * GetDefaultLanguage(LocalizableString const & lstr);
 
 std::string_view constexpr kIndent0{};
 std::string_view constexpr kIndent2{"  "};

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -556,7 +556,7 @@ void GeoJsonWriter::Write(FileData const & fileData, bool minimizeOutput)
   {
     auto const [lat, lon] = mercator::ToLatLon(bookmark.m_point);
     GenericJsonMap bookmarkProperties;
-    if (auto name = GetNameForExport(bookmark); !name.empty())
+    if (auto name = GetPreferredBookmarkName(bookmark, "default"); !name.empty())
       bookmarkProperties["name"] = std::move(name);
     bookmarkProperties["marker-color"] = ToGeoJsonColor(bookmark.m_color);
     if (auto const description = GetStringForExport(bookmark.m_description); !description.empty())

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -555,10 +555,12 @@ void GeoJsonWriter::Write(FileData const & fileData, bool minimizeOutput)
   for (BookmarkData const & bookmark : fileData.m_bookmarksData)
   {
     auto const [lat, lon] = mercator::ToLatLon(bookmark.m_point);
-    GenericJsonMap bookmarkProperties{{"name", GetDefaultStr(bookmark.m_name)},
-                                      {"marker-color", ToGeoJsonColor(bookmark.m_color)}};
-    if (!bookmark.m_description.empty())
-      bookmarkProperties["description"] = GetDefaultStr(bookmark.m_description);
+    GenericJsonMap bookmarkProperties;
+    if (auto name = GetNameForExport(bookmark); !name.empty())
+      bookmarkProperties["name"] = std::move(name);
+    bookmarkProperties["marker-color"] = ToGeoJsonColor(bookmark.m_color);
+    if (auto const description = GetStringForExport(bookmark.m_description); !description.empty())
+      bookmarkProperties["description"] = std::string{description};
 
     // Add '_umap_options' if needed.
     if (auto const umapOptionsPair = bookmark.m_properties.find("_umap_options");
@@ -595,9 +597,12 @@ void GeoJsonWriter::Write(FileData const & fileData, bool minimizeOutput)
     ASSERT(!track.m_layers.empty(), ());
     auto const color = track.m_layers.front().m_color;
 
-    GenericJsonMap trackProps{{"name", GetDefaultStr(track.m_name)}, {"stroke", ToGeoJsonColor(color)}};
-    if (!track.m_description.empty())
-      trackProps["description"] = GetDefaultStr(track.m_description);
+    GenericJsonMap trackProps;
+    if (auto const name = GetStringForExport(track.m_name); !name.empty())
+      trackProps["name"] = std::string{name};
+    trackProps["stroke"] = ToGeoJsonColor(color);
+    if (auto const description = GetStringForExport(track.m_description); !description.empty())
+      trackProps["description"] = std::string{description};
 
     // Add '_umap_options' if needed.
     if (auto const umapOptionsPair = track.m_properties.find("_umap_options");

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -555,10 +555,12 @@ void GeoJsonWriter::Write(FileData const & fileData, bool minimizeOutput)
   for (BookmarkData const & bookmark : fileData.m_bookmarksData)
   {
     auto const [lat, lon] = mercator::ToLatLon(bookmark.m_point);
-    GenericJsonMap bookmarkProperties{{"name", GetDefaultStr(bookmark.m_name)},
-                                      {"marker-color", ToGeoJsonColor(bookmark.m_color)}};
-    if (!bookmark.m_description.empty())
-      bookmarkProperties["description"] = GetDefaultStr(bookmark.m_description);
+    GenericJsonMap bookmarkProperties;
+    if (auto name = GetNameForExport(bookmark); !name.empty())
+      bookmarkProperties["name"] = std::move(name);
+    bookmarkProperties["marker-color"] = ToGeoJsonColor(bookmark.m_color);
+    if (auto description = GetStringForExport(bookmark.m_description); !description.empty())
+      bookmarkProperties["description"] = std::move(description);
 
     // Add '_umap_options' if needed.
     if (auto const umapOptionsPair = bookmark.m_properties.find("_umap_options");
@@ -595,9 +597,12 @@ void GeoJsonWriter::Write(FileData const & fileData, bool minimizeOutput)
     ASSERT(!track.m_layers.empty(), ());
     auto const color = track.m_layers.front().m_color;
 
-    GenericJsonMap trackProps{{"name", GetDefaultStr(track.m_name)}, {"stroke", ToGeoJsonColor(color)}};
-    if (!track.m_description.empty())
-      trackProps["description"] = GetDefaultStr(track.m_description);
+    GenericJsonMap trackProps;
+    if (auto name = GetStringForExport(track.m_name); !name.empty())
+      trackProps["name"] = std::move(name);
+    trackProps["stroke"] = ToGeoJsonColor(color);
+    if (auto description = GetStringForExport(track.m_description); !description.empty())
+      trackProps["description"] = std::move(description);
 
     // Add '_umap_options' if needed.
     if (auto const umapOptionsPair = track.m_properties.find("_umap_options");

--- a/libs/kml/serdes_gpx.cpp
+++ b/libs/kml/serdes_gpx.cpp
@@ -61,7 +61,6 @@ void GpxParser::ResetPoint()
   m_comment.clear();
   m_org = {};
   m_color = kInvalidColor;
-  m_customName.clear();
   m_geometry.Clear();
   m_geometryType = GEOMETRY_TYPE_UNKNOWN;
   m_lat = 0.;
@@ -291,13 +290,12 @@ void GpxParser::Pop(std::string_view tag)
         // one gets the default preset. See NormalizeBookmarkColorData.
         data.m_color = NormalizeBookmarkColorData({PredefinedColor::None, m_color});
         data.m_point = m_org;
-        if (!m_customName.empty())
-          data.m_customName[kDefaultLang] = std::move(m_customName);
-        else if (!data.m_name.empty())
-        {
-          // Here we set custom name from 'name' field for KML-files exported from 3rd-party services.
-          data.m_customName = data.m_name;
-        }
+        // A GPX file carries no OM extended data, so its <name> is the only name it has. Store it
+        // in m_customName as well: that is the field the place page, search and every exporter
+        // treat as the user's own name, and a later rename replaces it instead of leaving two
+        // competing names behind. The KML parser copies the name for the same reason, but only for
+        // a plain single-language one - which is all this parser ever produces.
+        data.m_customName = data.m_name;
 
         m_data.m_bookmarksData.push_back(std::move(data));
       }

--- a/libs/kml/serdes_gpx.cpp
+++ b/libs/kml/serdes_gpx.cpp
@@ -459,16 +459,16 @@ void SaveColorToARGB(Writer & writer, uint32_t rgba)
 void SaveCategoryData(Writer & writer, CategoryData const & categoryData)
 {
   writer << "<metadata>\n";
-  if (auto const name = GetDefaultLanguage(categoryData.m_name))
+  if (auto const name = GetStringForExport(categoryData.m_name); !name.empty())
   {
     writer << kIndent2 << "<name>";
-    SaveStringWithCDATA(writer, *name);
+    SaveStringWithCDATA(writer, name);
     writer << "</name>\n";
   }
-  if (auto const description = GetDefaultLanguage(categoryData.m_description))
+  if (auto const description = GetStringForExport(categoryData.m_description); !description.empty())
   {
     writer << kIndent2 << "<desc>";
-    SaveStringWithCDATA(writer, *description);
+    SaveStringWithCDATA(writer, description);
     writer << "</desc>\n";
   }
   writer << "</metadata>\n";
@@ -488,20 +488,16 @@ void SaveBookmarkData(Writer & writer, BookmarkData const & bookmarkData)
 {
   auto const [lat, lon] = mercator::ToLatLon(bookmarkData.m_point);
   writer << "<wpt lat=\"" << CoordToString(lat) << "\" lon=\"" << CoordToString(lon) << "\">\n";
-  // If user customized the default bookmark name, it's saved in m_customName.
-  auto name = GetDefaultLanguage(bookmarkData.m_customName);
-  if (!name)
-    name = GetDefaultLanguage(bookmarkData.m_name);  // Original POI name stored when bookmark was created.
-  if (name)
+  if (auto const name = GetPreferredBookmarkName(bookmarkData, "default"); !name.empty())
   {
     writer << kIndent2 << "<name>";
-    SaveStringWithCDATA(writer, *name);
+    SaveStringWithCDATA(writer, name);
     writer << "</name>\n";
   }
-  if (auto const description = GetDefaultLanguage(bookmarkData.m_description))
+  if (auto const description = GetStringForExport(bookmarkData.m_description); !description.empty())
   {
     writer << kIndent2 << "<desc>";
-    SaveStringWithCDATA(writer, *description);
+    SaveStringWithCDATA(writer, description);
     writer << "</desc>\n";
   }
   if (auto const color = BookmarkColor(bookmarkData); color != kInvalidColor)
@@ -533,17 +529,16 @@ uint32_t TrackColor(TrackData const & trackData)
 void SaveTrackData(Writer & writer, TrackData const & trackData)
 {
   writer << "<trk>\n";
-  auto name = GetDefaultLanguage(trackData.m_name);
-  if (name)
+  if (auto const name = GetStringForExport(trackData.m_name); !name.empty())
   {
     writer << kIndent2 << "<name>";
-    SaveStringWithCDATA(writer, *name);
+    SaveStringWithCDATA(writer, name);
     writer << "</name>\n";
   }
-  if (auto const description = GetDefaultLanguage(trackData.m_description))
+  if (auto const description = GetStringForExport(trackData.m_description); !description.empty())
   {
     writer << kIndent2 << "<desc>";
-    SaveStringWithCDATA(writer, *description);
+    SaveStringWithCDATA(writer, description);
     writer << "</desc>\n";
   }
   if (auto const color = TrackColor(trackData); color != kDefaultTrackColor)

--- a/libs/kml/serdes_gpx.cpp
+++ b/libs/kml/serdes_gpx.cpp
@@ -459,16 +459,16 @@ void SaveColorToARGB(Writer & writer, uint32_t rgba)
 void SaveCategoryData(Writer & writer, CategoryData const & categoryData)
 {
   writer << "<metadata>\n";
-  if (auto const name = GetDefaultLanguage(categoryData.m_name))
+  if (auto const name = GetStringForExport(categoryData.m_name); !name.empty())
   {
     writer << kIndent2 << "<name>";
-    SaveStringWithCDATA(writer, *name);
+    SaveStringWithCDATA(writer, name);
     writer << "</name>\n";
   }
-  if (auto const description = GetDefaultLanguage(categoryData.m_description))
+  if (auto const description = GetStringForExport(categoryData.m_description); !description.empty())
   {
     writer << kIndent2 << "<desc>";
-    SaveStringWithCDATA(writer, *description);
+    SaveStringWithCDATA(writer, description);
     writer << "</desc>\n";
   }
   writer << "</metadata>\n";
@@ -488,20 +488,16 @@ void SaveBookmarkData(Writer & writer, BookmarkData const & bookmarkData)
 {
   auto const [lat, lon] = mercator::ToLatLon(bookmarkData.m_point);
   writer << "<wpt lat=\"" << CoordToString(lat) << "\" lon=\"" << CoordToString(lon) << "\">\n";
-  // If user customized the default bookmark name, it's saved in m_customName.
-  auto name = GetDefaultLanguage(bookmarkData.m_customName);
-  if (!name)
-    name = GetDefaultLanguage(bookmarkData.m_name);  // Original POI name stored when bookmark was created.
-  if (name)
+  if (auto const name = GetNameForExport(bookmarkData); !name.empty())
   {
     writer << kIndent2 << "<name>";
-    SaveStringWithCDATA(writer, *name);
+    SaveStringWithCDATA(writer, name);
     writer << "</name>\n";
   }
-  if (auto const description = GetDefaultLanguage(bookmarkData.m_description))
+  if (auto const description = GetStringForExport(bookmarkData.m_description); !description.empty())
   {
     writer << kIndent2 << "<desc>";
-    SaveStringWithCDATA(writer, *description);
+    SaveStringWithCDATA(writer, description);
     writer << "</desc>\n";
   }
   if (auto const color = BookmarkColor(bookmarkData); color != kInvalidColor)
@@ -533,17 +529,16 @@ uint32_t TrackColor(TrackData const & trackData)
 void SaveTrackData(Writer & writer, TrackData const & trackData)
 {
   writer << "<trk>\n";
-  auto name = GetDefaultLanguage(trackData.m_name);
-  if (name)
+  if (auto const name = GetStringForExport(trackData.m_name); !name.empty())
   {
     writer << kIndent2 << "<name>";
-    SaveStringWithCDATA(writer, *name);
+    SaveStringWithCDATA(writer, name);
     writer << "</name>\n";
   }
-  if (auto const description = GetDefaultLanguage(trackData.m_description))
+  if (auto const description = GetStringForExport(trackData.m_description); !description.empty())
   {
     writer << kIndent2 << "<desc>";
-    SaveStringWithCDATA(writer, *description);
+    SaveStringWithCDATA(writer, description);
     writer << "</desc>\n";
   }
   if (auto const color = TrackColor(trackData); color != kDefaultTrackColor)

--- a/libs/kml/serdes_gpx.cpp
+++ b/libs/kml/serdes_gpx.cpp
@@ -61,7 +61,6 @@ void GpxParser::ResetPoint()
   m_comment.clear();
   m_org = {};
   m_color = kInvalidColor;
-  m_customName.clear();
   m_geometry.Clear();
   m_geometryType = GEOMETRY_TYPE_UNKNOWN;
   m_lat = 0.;
@@ -291,13 +290,10 @@ void GpxParser::Pop(std::string_view tag)
         // one gets the default preset. See NormalizeBookmarkColorData.
         data.m_color = NormalizeBookmarkColorData({PredefinedColor::None, m_color});
         data.m_point = m_org;
-        if (!m_customName.empty())
-          data.m_customName[kDefaultLang] = std::move(m_customName);
-        else if (!data.m_name.empty())
-        {
-          // Here we set custom name from 'name' field for KML-files exported from 3rd-party services.
-          data.m_customName = data.m_name;
-        }
+        // A GPX file carries no OM extended data, so its <name> can only be a user-authored one.
+        // Keep it in m_customName too, as the KML parser does, so that it always wins over a name
+        // OM itself could derive later, see GetPreferredBookmarkName.
+        data.m_customName = data.m_name;
 
         m_data.m_bookmarksData.push_back(std::move(data));
       }

--- a/libs/kml/serdes_gpx.hpp
+++ b/libs/kml/serdes_gpx.hpp
@@ -97,7 +97,6 @@ private:
 
   MultiGeometry::LineT m_line;
   MultiGeometry::TimeT m_timestamps;
-  std::string m_customName;
   void ParseName(std::string const & value, std::string const & prevTag);
   void ParseDescription(std::string const & value, std::string const & prevTag);
   void ParseAltitude(std::string const & value);

--- a/libs/kml/type_utils.cpp
+++ b/libs/kml/type_utils.cpp
@@ -45,7 +45,9 @@ std::string GetPreferredBookmarkStr(LocalizableString const & name, std::string 
   if (feature::GetPreferredName(nameMultilang, deviceLang, preferredName))
     return std::string(preferredName);
 
-  return {};
+  // A category or track has no feature type to fall back to, so keep every non-empty localized
+  // string visible even when none of the preferred languages is present.
+  return std::string{GetStringForExport(name)};
 }
 
 std::string GetPreferredBookmarkStr(LocalizableString const & name, feature::RegionData const & regionData,
@@ -61,7 +63,11 @@ std::string GetPreferredBookmarkStr(LocalizableString const & name, feature::Reg
 
   feature::NameParamsOut out;
   feature::GetReadableName({nameMultilang, regionData, languageNorm, false /* allowTranslit */}, out);
-  return std::string(out.primary);
+  if (!out.primary.empty())
+    return std::string(out.primary);
+
+  // Keep the value visible when neither the device nor region languages are present.
+  return std::string{GetStringForExport(name)};
 }
 
 std::string GetLocalizedFeatureType(std::vector<uint32_t> const & types)

--- a/libs/kml/type_utils.cpp
+++ b/libs/kml/type_utils.cpp
@@ -9,6 +9,8 @@
 
 #include "coding/string_utf8_multilang.hpp"
 
+#include <limits>
+
 namespace kml
 {
 bool IsEqual(m2::PointD const & lhs, m2::PointD const & rhs)
@@ -73,5 +75,43 @@ std::string GetPreferredBookmarkName(BookmarkData const & bmData, std::string_vi
   if (name.empty())
     name = GetLocalizedFeatureType(bmData.m_featureTypes);
   return name;
+}
+
+std::string_view GetStringForExport(LocalizableString const & lstr)
+{
+  // Rank of a language in the export priority list, the lowest one wins.
+  auto const rank = [](int8_t lang)
+  {
+    // alt_name/old_name are OSM pseudo-names, not translations: an old name is worse than any
+    // real one, so push both behind every language instead of letting their codes (53/55) win
+    // over kk/mr/et/ku/mn/mk/lv/hi (56..63).
+    int constexpr kPseudoNamePenalty = StringUtf8Multilang::kMaxSupportedLanguages;
+    switch (lang)
+    {
+    case kDefaultLangCode: return 0;
+    case StringUtf8Multilang::kInternationalCode: return 1;
+    case StringUtf8Multilang::kEnglishCode: return 2;
+    // Any other language is a deterministic last resort, ordered by its stable code.
+    default: return 3 + lang + (StringUtf8Multilang::IsAltOrOldName(lang) ? kPseudoNamePenalty : 0);
+    }
+  };
+
+  std::string_view best;
+  int bestRank = std::numeric_limits<int>::max();
+  for (auto const & [lang, value] : lstr)
+    if (!value.empty())
+      if (auto const r = rank(lang); r < bestRank)
+        bestRank = r, best = value;
+
+  return best;
+}
+
+std::string GetNameForExport(BookmarkData const & bmData)
+{
+  if (auto const name = GetStringForExport(bmData.m_customName); !name.empty())
+    return std::string{name};
+  if (auto const name = GetStringForExport(bmData.m_name); !name.empty())
+    return std::string{name};
+  return GetLocalizedFeatureType(bmData.m_featureTypes);
 }
 }  // namespace kml

--- a/libs/kml/type_utils.cpp
+++ b/libs/kml/type_utils.cpp
@@ -28,6 +28,12 @@ std::string GetPreferredBookmarkStr(LocalizableString const & name, std::string 
   if (name.size() == 1)
     return name.begin()->second;
 
+  // "default" requests a device-independent value for serialization and other stable output.
+  // Resolve it directly to preserve an int_name verbatim; feature-name rendering deliberately
+  // shortens comma-separated int_name values and therefore has different semantics.
+  if (languageNorm == StringUtf8Multilang::GetLangByCode(kDefaultLangCode))
+    return std::string{GetStringForExport(name)};
+
   /// @todo Complicated logic here when transforming LocalizableString -> StringUtf8Multilang to call GetPreferredName.
   StringUtf8Multilang nameMultilang;
   for (auto const & pair : name)
@@ -106,12 +112,4 @@ std::string_view GetStringForExport(LocalizableString const & lstr)
   return best;
 }
 
-std::string GetNameForExport(BookmarkData const & bmData)
-{
-  if (auto const name = GetStringForExport(bmData.m_customName); !name.empty())
-    return std::string{name};
-  if (auto const name = GetStringForExport(bmData.m_name); !name.empty())
-    return std::string{name};
-  return GetLocalizedFeatureType(bmData.m_featureTypes);
-}
 }  // namespace kml

--- a/libs/kml/type_utils.hpp
+++ b/libs/kml/type_utils.hpp
@@ -120,25 +120,20 @@ bool IsEqual(std::vector<T> const & lhs, std::vector<T> const & rhs)
 }
 
 struct BookmarkData;
+// Passing "default" selects the device-independent LocalizableString ordering used for
+// serialization. The localized feature type remains the final fallback for a nameless bookmark.
 std::string GetPreferredBookmarkName(BookmarkData const & bmData, std::string_view languageOrig);
 std::string GetPreferredBookmarkStr(LocalizableString const & name, std::string const & languageNorm);
 std::string GetPreferredBookmarkStr(LocalizableString const & name, feature::RegionData const & regionData,
                                     std::string const & languageNorm);
 std::string GetLocalizedFeatureType(std::vector<uint32_t> const & types);
 
-// Same ladder as GetPreferredBookmarkName above, but for writing into a file instead of showing in
-// the UI: the language is not the device one, so that the same collection always exports the same.
-// Prefers default/int_name/en; if none exists, the lowest language code wins as a deterministic
-// last resort, so a non-empty localized value is never dropped. The view points into lstr.
+// Selects one device-independent value for serialization and other stable output. Prefers
+// default/int_name/en; if none exists, the lowest language code wins as a deterministic last
+// resort, so a non-empty localized value is never dropped. The view points into lstr.
 // Note that a value picked this way is promoted to the "default" language when a KML file written
 // with it is loaded back, see KmlParser::CharData.
 std::string_view GetStringForExport(LocalizableString const & lstr);
-
-// Name to write for a bookmark: the name typed by the user (m_customName) wins over the original
-// POI name it was created with (m_name). A bookmark with no name at all is exported under its
-// localized feature type, so the same collection exports as "Castle" or "Замок" depending on the
-// device UI language. Returns an empty string for a nameless bookmark with no feature type.
-std::string GetNameForExport(BookmarkData const & bmData);
 
 // m_collectionIndex is mutable because it is filled during serialization.
 /// @todo Not good design to store intermediate ser/des index inside data.

--- a/libs/kml/type_utils.hpp
+++ b/libs/kml/type_utils.hpp
@@ -126,6 +126,20 @@ std::string GetPreferredBookmarkStr(LocalizableString const & name, feature::Reg
                                     std::string const & languageNorm);
 std::string GetLocalizedFeatureType(std::vector<uint32_t> const & types);
 
+// Same ladder as GetPreferredBookmarkName above, but for writing into a file instead of showing in
+// the UI: the language is not the device one, so that the same collection always exports the same.
+// Prefers default/int_name/en; if none exists, the lowest language code wins as a deterministic
+// last resort, so a non-empty localized value is never dropped. The view points into lstr.
+// Note that a value picked this way is promoted to the "default" language when a KML file written
+// with it is loaded back, see KmlParser::CharData.
+std::string_view GetStringForExport(LocalizableString const & lstr);
+
+// Name to write for a bookmark: the name typed by the user (m_customName) wins over the original
+// POI name it was created with (m_name). A bookmark with no name at all is exported under its
+// localized feature type, so the same collection exports as "Castle" or "Замок" depending on the
+// device UI language. Returns an empty string for a nameless bookmark with no feature type.
+std::string GetNameForExport(BookmarkData const & bmData);
+
 // m_collectionIndex is mutable because it is filled during serialization.
 /// @todo Not good design to store intermediate ser/des index inside data.
 

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -84,7 +84,10 @@ public:
 
 std::string GetFileNameForExport(BookmarkManager::KMLDataCollectionPtr::element_type::value_type const & kmlToShare)
 {
-  std::string fileName = RemoveInvalidSymbols(kml::GetDefaultStr(kmlToShare.second->m_categoryData.m_name));
+  // Same name resolution as the exported file content, so a category named in one language only
+  // is not shared under its on-disk file name.
+  std::string fileName =
+      RemoveInvalidSymbols(std::string{kml::GetStringForExport(kmlToShare.second->m_categoryData.m_name)});
   if (fileName.empty())
     fileName = base::GetNameFromFullPathWithoutExt(kmlToShare.first);
   return TruncateToValidFileName(std::move(fileName));

--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -2029,6 +2029,30 @@ UNIT_CLASS_TEST(Runner, ExportSingleUnicode)
   bmManager.PrepareFileForSharing(std::move(categories), checker, FileType::Kml);
 }
 
+UNIT_CLASS_TEST(Runner, ExportSingleMultilingualCategoryName)
+{
+  BookmarkManager bmManager(BM_CALLBACKS);
+  bmManager.EnableTestMode(true);
+
+  kml::CategoryData category;
+  category.m_name[StringUtf8Multilang::GetLangIndex("ru")] = "Категория";
+  category.m_name[StringUtf8Multilang::GetLangIndex("de")] = "Kategorie";
+  auto const categoryId = bmManager.CreateBookmarkCategory(std::move(category), false /* autoSave */);
+
+  kml::BookmarkData bookmark;
+  bookmark.m_point = m2::PointD(0.0, 0.0);
+  kml::SetDefaultStr(bookmark.m_name, "Bookmark");
+  bmManager.GetEditSession().CreateBookmark(std::move(bookmark), categoryId);
+
+  auto const checker = [](BookmarkManager::SharingResult const & result)
+  {
+    TEST(result.m_code == BookmarkManager::SharingResult::Code::Success, (result.m_errorString));
+    TEST_EQUAL(base::FileNameFromFullPath(result.m_sharingPath), "Kategorie.geojson", ());
+    TEST(base::DeleteFileX(result.m_sharingPath), ());
+  };
+  bmManager.PrepareFileForSharing(kml::GroupIdCollection{categoryId}, checker, FileType::GeoJson);
+}
+
 UNIT_CLASS_TEST(Runner, ExportSingleTrackKmz)
 {
   std::string const file = GetPlatform().TestsDataPathForFile("test_data/gpx/export_test.gpx");


### PR DESCRIPTION
Fixes #13237.

A bookmark stores the name it was created with in `m_name` and the user-entered name in `m_customName`. GeoJSON exported only `m_name`, so renamed bookmarks—and bookmarks created at the current position—could be exported under an old name or creation date.

## What changed

- KML, GPX and GeoJSON bookmark writers now use `GetPreferredBookmarkName(bookmark, "default")`: custom name first, then original name, then the localized feature type.
- The `"default"` resolver path selects localized strings deterministically as `default` → `int_name` → `en` → lowest remaining language code. `alt_name` and `old_name` rank behind every real language.
- The resolver keeps comma-separated `int_name` values intact for serialization instead of applying feature-rendering truncation.
- Bookmark/category/track names and descriptions no longer disappear when they contain no default or matching device language. The UI and region-aware display paths use the same deterministic last resort.
- GeoJSON omits properties with no value. GPX omits an empty bookmark name; KML retains its existing empty `<name></name>` behavior.
- A shared category file uses the resolved category name instead of falling back to its internal on-disk basename.
- The unused `GpxParser::m_customName` state and its unreachable branch were removed.

No platform-specific bridge code changes are needed: the shared C++ implementation is used by iOS, Android and desktop.

## KML round trips

Plain KML `<name>` and `<description>` elements are interoperability projections for readers that do not understand Organic Maps extended data. KML carries no provenance that distinguishes such a projection from an explicit default value, so a round trip retains the selected projection as `default` while preserving all extended translations.

`Kml_RoundTrip_PromotesFallbackToDefaultLanguage` covers this behavior for category, bookmark and track names and descriptions with multiple unmatched languages.

## Validation

- Full arm64 Debug `kml_tests` suite with `CMAKE_UNITY_BUILD=OFF`.
- Unity builds of `kml_tests` and `map_tests`.
- Direct coverage for custom/original/type precedence, complete `int_name` preservation, language and region fallbacks, pseudo-name ranking, KML promotion, and KML/GPX/GeoJSON output.
- `ExportSingleMultilingualCategoryName` exercises the complete `BookmarkManager` sharing path and exported basename.
- `clang-format` and `git diff --check`.

LLM assistance: Codex was used for review, implementation and test design.
