### PR TITLE
[cmake] Fix macOS builds broken by a cached dead Metal compiler path

### DIFF
--- a/.github/workflows/build-cmake-mac.yaml
+++ b/.github/workflows/build-cmake-mac.yaml
@@ -62,6 +62,23 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
+      # dev_sandbox is skipped with a warning when the Metal toolchain is
+      # unavailable (see dev_sandbox/CMakeLists.txt), which would defeat the
+      # purpose of this workflow. Naming the target fails the job in that case,
+      # and doing it before the full build fails within minutes instead of after
+      # it, at no extra cost: dev_sandbox is a part of ALL_BUILD anyway.
+      - name: Check dev_sandbox is not skipped
+        working-directory: ${{ env.BUILD_DIR }}
+        run: |
+          xcodebuild build \
+            -project omim.xcodeproj \
+            -target dev_sandbox \
+            -configuration ${{ matrix.cmake-build-type }} \
+            -parallelizeTargets \
+            -quiet \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+
       - name: Build all targets
         working-directory: ${{ env.BUILD_DIR }}
         run: |

--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -146,6 +146,15 @@ jobs:
       - name: Enable inline compiler annotations
         run: echo "::add-matcher::.github/problem-matchers/gcc.json"
 
+      # dev_sandbox is skipped with a warning when the Metal toolchain is
+      # unavailable (see dev_sandbox/CMakeLists.txt). Ask for the target
+      # explicitly so that a skip fails the job instead of hiding in the log.
+      # Before the full build: ninja rejects an unknown target immediately, and
+      # dev_sandbox is a part of the default target anyway, so nothing is wasted.
+      - name: Check dev_sandbox is not skipped (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: cmake --build --preset ci --target dev_sandbox
+
       - name: Compile
         run: cmake --build --preset ci
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,16 +65,6 @@ endif()
 
 if(${PLATFORM_MAC})
   set(XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)
-
-  # Metal language support
-  list(APPEND CMAKE_MODULE_PATH ${OMIM_ROOT}/3party/CMake-MetalShaderSupport/cmake)
-  include(CheckLanguage)
-  include(CMakeMetalInformation)
-  include(MetalShaderSupport)
-  check_language(Metal)
-  if(CMAKE_Metal_COMPILER)
-    enable_language(Metal)
-  endif()
 endif()
 
 # Global compile options for all configurations.

--- a/cmake/OmimHelpers.cmake
+++ b/cmake/OmimHelpers.cmake
@@ -85,16 +85,6 @@ function(omim_add_tool_subdirectory subdir)
   add_subdirectory(${subdir})
 endfunction()
 
-# Wrapper for the 3party target_embed_metal_shader_libraries() that always
-# declares a build-order dependency on the embedded metallib(s). The Xcode
-# branch in 3party/CMake-MetalShaderSupport sets XCODE_EMBED_RESOURCES but does
-# not call add_dependencies(), so the .metallib may not exist yet when the
-# embed phase runs. PLATFORM_MAC only — caller is expected to guard.
-function(omim_target_embed_metal_shader_libraries target)
-  target_embed_metal_shader_libraries(${target} ${ARGN})
-  add_dependencies(${target} ${ARGN})
-endfunction()
-
 function(omim_link_libraries target)
   if (TARGET ${target})
     target_link_libraries(${target} PRIVATE ${ARGN} ${CMAKE_THREAD_LIBS_INIT})

--- a/dev_sandbox/CMakeLists.txt
+++ b/dev_sandbox/CMakeLists.txt
@@ -6,7 +6,48 @@ set(SRC
   imgui_renderer.hpp
 )
 
-if (${PLATFORM_MAC})
+if (PLATFORM_MAC)
+  # Metal language support. dev_sandbox is its only CMake consumer: iOS compiles
+  # the same libs/shaders/Metal/*.metal via xcode/omim.xcworkspace.
+  list(APPEND CMAKE_MODULE_PATH ${OMIM_ROOT}/3party/CMake-MetalShaderSupport/cmake)
+  include(CheckLanguage)
+  include(MetalShaderSupport)
+
+  # The Metal compiler lives in an on-demand cryptex mount whose path contains a
+  # suffix that changes on every remount, so a cached path goes dead. Drop it and
+  # let check_language() retry, as it skips detection when the variable is set,
+  # together with the compiler info file, which enable_language() would otherwise
+  # load in place of the freshly detected path.
+  if (NOT EXISTS "${CMAKE_Metal_COMPILER}")
+    unset(CMAKE_Metal_COMPILER CACHE)
+    file(REMOVE "${CMAKE_PLATFORM_INFO_DIR}/CMakeMetalCompiler.cmake")
+  endif()
+  check_language(Metal)
+
+  # While that mount is down xcrun answers with a stub in XcodeDefault.xctoolchain
+  # that does exist but fails to run. check_language()'s try_compile rejects it,
+  # except with the Xcode generator, where CMakeTestMetalCompiler assumes a
+  # working compiler and skips the test, so probe it directly. Clear the cache as
+  # well, otherwise the stub would be picked up again once the mount is back.
+  if (CMAKE_Metal_COMPILER)
+    execute_process(COMMAND "${CMAKE_Metal_COMPILER}" --version
+                    RESULT_VARIABLE METAL_COMPILER_RUNS OUTPUT_QUIET ERROR_QUIET)
+    if (NOT METAL_COMPILER_RUNS EQUAL 0)
+      unset(CMAKE_Metal_COMPILER CACHE)
+      unset(CMAKE_Metal_COMPILER)
+      file(REMOVE "${CMAKE_PLATFORM_INFO_DIR}/CMakeMetalCompiler.cmake")
+    endif()
+  endif()
+
+  if (NOT CMAKE_Metal_COMPILER)
+    # The shaders target below would still be generated, but with unexpanded rule
+    # placeholders that fail the build with a cryptic message.
+    message(WARNING "Skipping dev_sandbox: no Metal toolchain."
+                    " Install it with: xcodebuild -downloadComponent MetalToolchain")
+    return()
+  endif()
+  enable_language(Metal)
+
   append(SRC
     main.mm
     ../iphone/Maps/Core/MapRendering/MetalContextFactory.h

--- a/dev_sandbox/CMakeLists.txt
+++ b/dev_sandbox/CMakeLists.txt
@@ -93,12 +93,9 @@ if (Vulkan_FOUND)
   target_link_libraries(${PROJECT_NAME} PRIVATE Vulkan::Vulkan)
 endif()
 
-if(PLATFORM_MAC)
-  omim_target_embed_metal_shader_libraries(${PROJECT_NAME} shaders_metal)
-endif()
-
 target_compile_definitions(${PROJECT_NAME} PUBLIC GL_SILENCE_DEPRECATION)
 if (PLATFORM_MAC)
+  target_embed_metal_shader_libraries(${PROJECT_NAME} shaders_metal)
   set_target_properties(${PROJECT_NAME} PROPERTIES XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)
   # Xcode's multi-config generator puts the .app under $(CONFIGURATION)/ by default,
   # while copy_resources() writes directly to ${CMAKE_BINARY_DIR}/${BUNDLE_NAME}.app.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -252,6 +252,10 @@ presets include `relwithdebinfo`, `debug-no-unity` (disables Unity batching for
 lower peak memory), `coverage`, and `xcode` (macOS only; generates an Xcode
 project, needed for `dev_sandbox` and Metal shader development).
 
+On macOS `dev_sandbox` also needs Xcode's separately downloaded Metal toolchain.
+Install it with `xcodebuild -downloadComponent MetalToolchain`, otherwise CMake
+skips the target with a warning and the rest of the build proceeds as usual.
+
 Besides _desktop_ there are other targets like _generator_tool_; pass them to
 `--target`, or omit `--target` to build everything.
 


### PR DESCRIPTION
## What & why

On macOS the Metal compiler lives in an on-demand cryptex mount whose path carries a suffix that changes on every remount:

```
/var/run/com.apple.security.cryptexd/mnt/com.apple.MobileAsset.MetalToolchain-v17.6.109.0.2SZFwn/Metal.xctoolchain/usr/bin/metal
```

While that mount is down, `xcrun --find metal` silently falls back to a stub in `XcodeDefault.xctoolchain` that only prints `cannot execute tool 'metal' due to missing Metal Toolchain`. Either way `check_language()` stores the outcome in the cache and never looks again — it skips detection whenever `CMAKE_Metal_COMPILER` is already set. So:

* a build directory configured during such a window keeps `CMAKE_Metal_COMPILER=NOTFOUND` **forever**, no matter how many times you re-run cmake;
* a directory configured successfully keeps an absolute path that dies at the next remount.

`dev_sandbox` declared its shaders target regardless, so the generated link rule kept unexpanded placeholders and the build died with a rather unhelpful message:

```
FAILED: dev_sandbox/libshaders_metal.so
: && ccache CMAKE_Metal_COMPILER CMAKE_SHARED_LIBRARY_Metal_FLAGS ... && :
ccache: error: Could not find compiler "CMAKE_Metal_COMPILER" in PATH
```

## What changed

* Drop the cached `CMAKE_Metal_COMPILER` when it no longer points at an existing file, together with `CMakeFiles/<version>/CMakeMetalCompiler.cmake` — `enable_language()` loads the compiler from that file when it exists and would otherwise shadow the freshly detected path with the dead one. Covers both a rotated mount path and a previously failed detection, and costs one `EXISTS` check per configure. Existing broken build directories repair themselves on the next build, no manual cache surgery.
* Reject a compiler that cannot run, by probing `metal --version`. `check_language()` catches the stub itself under Ninja, but not with the Xcode generator: `CMakeTestMetalCompiler.cmake:16-20` sets `CMAKE_Metal_COMPILER_WORKS` for `XCODE_VERSION > 7.0` and skips the `try_compile`, so the stub is cached as usable and only fails at build time. The cache entry is cleared too, so the stub is not picked up again once the mount is back.
* Skip `dev_sandbox` with an actionable message when Metal really is unavailable, instead of generating a target that cannot link. The rest of the desktop build (`desktop`, tests, tools) configures and builds as usual.
* Both macOS CI legs name the `dev_sandbox` target *before* their full build, so a skip fails the job in the first minutes instead of passing unnoticed after a complete macOS build.
* Move the Metal setup from the root `CMakeLists.txt` next to its only CMake consumer. iOS compiles the same `libs/shaders/Metal/*.metal` through `xcode/omim.xcworkspace`, so nothing outside `dev_sandbox` needs the language enabled. Verified to work in a subdirectory with both the Ninja and Xcode generators.
* Second commit: `target_embed_metal_shader_libraries()` declares the build-order dependency itself since upstream 729da73, so the `omim_target_embed_metal_shader_libraries()` wrapper only added the same dependency twice. Removed.

## How tested

macOS 26.6, Xcode 26.6, CMake 4.4.0, all exit 0:

| Case | Result |
| --- | --- |
| Fresh `--preset debug` | detects the compiler, builds `shaders_metal.metallib` |
| Fresh `--preset xcode` | `CompileMetalFile` ×14 + `MetalLink`, `** BUILD SUCCEEDED **` |
| Pre-existing dir with `NOTFOUND` cached | self-heals on plain `ninja`, links `OMapsDevSandbox.app` with the metallib embedded in `Contents/Resources` |
| Pre-existing dir with a stale mount path | re-detects the current path in a single configure, Ninja and Xcode |
| Toolchain absent, Ninja (`xcrun` shim returning the broken stub) | configure succeeds with the warning, 0 Metal rules in `rules.ninja`, no `dev_sandbox` targets, `desktop` intact |
| Toolchain absent, Xcode | before the `--version` probe: stub cached, 29 `shaders_metal` references generated in `project.pbxproj`; after: warning, cache entry cleared, 0 references, 0 `dev_sandbox` targets |
| Cached stub, then toolchain back (Xcode) | re-detects the cryptex path, `MetalLink` + `** BUILD SUCCEEDED **` — no stickiness |
| Same tree once the toolchain is back | re-detects and builds in a single configure |
| After removing the wrapper | order-only dep `\|\| dev_sandbox/shaders_metal.metallib` still present for Ninja, `PBXTargetDependency` + `Embed Resources` phase still present for Xcode |
| Dropping `include(CMakeMetalInformation)` | `CMAKE_Metal_FLAGS*` cache entries, per-object flags and generated rules byte-identical (Ninja); `MTL_FAST_MATH` / `MTL_ENABLE_DEBUG_INFO` / `MTL_HEADER_SEARCH_PATHS` / `sourcecode.metal` settings identical (Xcode) |
| Missing `dev_sandbox` target | `cmake --build --target dev_sandbox` exits 1 (`ninja: error: unknown target`), `xcodebuild -target` exits 65 — so the new CI steps fail instead of going green |

Non-Apple platforms are untouched: everything stays inside `if (${PLATFORM_MAC})`.

## Notes

Two upstream improvements are worth doing separately, neither needed for this fix:

* `CMakeDetermineMetalCompiler.cmake` captures the `RESULT_VARIABLE` of `metal --version` and never checks it — the stub exits 1, so the module already has the signal that `xcrun` handed back a non-working compiler and discards it. Sent as dpogue/CMake-MetalShaderSupport#13, which also stops the `xcrun` branch from overriding a user-specified `CMAKE_Metal_COMPILER` (that mismatch puts CMake into an endless reconfigure loop). Once it lands, the `--version` probe here becomes redundant.
* dpogue/CMake-MetalShaderSupport#12 fixes the rotated-mount half upstream by rediscovering the path from the generated info file, which would make the `file(REMOVE)` here redundant as well. Both are worth picking up in a submodule bump later; neither is available in the pinned `459f52c`.
* CMake's `CheckLanguage` could re-run detection when the cached compiler path no longer exists. Its `NOTFOUND` memoization should stay as is: re-checking would re-spawn a nested configure on every reconfigure for machines legitimately lacking a language, and would break the documented `-DCMAKE_<LANG>_COMPILER=NOTFOUND` opt-out.

Investigated and implemented with the help of Claude Code.

