### PR TITLE
[map] Stop location following on map tap

### DIFF
--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -2321,6 +2321,14 @@ void Framework::OnTapEvent(place_page::BuildInfo const & buildInfo)
       GetBookmarkManager().UpdateElevationMyPosition(newTrackId, true /* ignoreLocationCache */);
     }
 
+    // Stop active non-navigating location follow before selection so drape can keep the place visible.
+    // The mode test is not redundant with StopLocationFollow(): that also clears the desired init mode,
+    // which would cancel the centering on the first fix while it is still pending.
+    auto const mode = GetMyPositionMode();
+    if (buildInfo.m_source == place_page::BuildInfo::Source::User &&
+        (mode == location::Follow || mode == location::FollowAndRotate) && !m_routingManager.IsRoutingFollowing())
+      StopLocationFollow();
+
     ActivateMapSelection();
   }
 }


### PR DESCRIPTION
Opening a place page changes the visible viewport. When location following is active, this recenters the map and causes an unexpected jump.

Stop location following before handling every regular map tap, including taps on the current-position marker. Keep long-tap behavior unchanged.

https://github.com/user-attachments/assets/584c1789-1364-4353-bca4-58b54181a8f6


