### PR TITLE
[generator] Map access=unknown to RoadAccess::Type::Destination

### DIFF
--- a/generator/road_access_generator.cpp
+++ b/generator/road_access_generator.cpp
@@ -133,6 +133,7 @@ TagMapping const kDefaultTagMapping = {
     {OsmElement::Tag("access", "military"), RoadAccess::Type::No},
     {OsmElement::Tag("access", "agricultural"), RoadAccess::Type::Private},
     {OsmElement::Tag("access", "forestry"), RoadAccess::Type::Private},
+    {OsmElement::Tag("access", "unknown"), RoadAccess::Type::Destination},
     {OsmElement::Tag("locked", "yes"), RoadAccess::Type::Locked},
 };
 


### PR DESCRIPTION
### What changed
`kDefaultTagMapping` in `generator/road_access_generator.cpp` had no entry for `access=unknown`, so it silently fell through to the default `RoadAccess::Type::Yes` (same as an untagged way), even though the tag specifically means a mapper found access unverified and flagged it for survey (https://wiki.openstreetmap.org/wiki/Tag:access%3Dunknown).

This adds `{"access", "unknown"} -> RoadAccess::Type::Destination`, the same bucket `access=private`/`agricultural`/`forestry` already use. It's not a hard block: `IsAccessNoForSure()` (`libs/routing/index_graph.hpp`) only excludes `Type::No`, so `Destination`-tagged roads stay reachable and only pick up the existing crossing penalty already applied to `Private`/`Destination` in `IndexGraph::GetPenalties` (`libs/routing/index_graph.cpp:424`, which notes Private and Destination aren't distinguished there).

### Issue
No existing issue tracks this, opening directly since the fix is a single mapping-table entry.

### How this was tested
Not build-verified. I don't have a full C++ toolchain/dependency set available in my environment to run `generator_tests`. The change is a single entry in an existing table (`kDefaultTagMapping`), shaped identically to the 8 entries already there, and I traced `GetAccessTypeFromMapping()` and the downstream `IsAccessNoForSure`/`GetPenalties` consumers by hand to confirm the intended effect. Flagging this plainly for CI and maintainer review rather than claiming it's verified. Happy to add a targeted test if pointed at the right harness, `GetAccessTypeFromMapping` and `kDefaultTagMapping` are currently only exercised indirectly through generator integration tests, not a unit test I could find to extend.

### LLM disclosure
This PR (code and description) was drafted with the help of an AI coding assistant (Claude), based on manual reading of this repo's source. Please review accordingly.