### PR TITLE
[transit] Set max PT speed to 60 km/h.

### DIFF
--- a/libs/transit/transit_entities.hpp
+++ b/libs/transit/transit_entities.hpp
@@ -4,15 +4,12 @@
 
 #include "geometry/point2d.hpp"
 
-#include "base/macros.hpp"
-#include "base/newtype.hpp"
 #include "base/visitor.hpp"
-
-#include "std/boost_container_hash.hpp"
 
 #include "defines.hpp"
 
-#include <cstdint>
+#include <boost/container_hash/hash.hpp>
+
 #include <limits>
 #include <string>
 #include <tuple>
@@ -20,11 +17,10 @@
 #include <unordered_set>
 #include <vector>
 
-#include "3party/opening_hours/opening_hours.hpp"
-
 namespace routing
 {
-inline double constexpr kTransitMaxSpeedKMpH = 400.0;
+/// 60 km/h is the optimal MaxSpeed for Transit now (we don't take into account HS trains).
+inline double constexpr kTransitMaxSpeedKMpH = 60.0;
 }  // namespace routing
 
 namespace transit

--- a/libs/transit/transit_entities.hpp
+++ b/libs/transit/transit_entities.hpp
@@ -6,15 +6,12 @@
 
 #include "geometry/point2d.hpp"
 
-#include "base/macros.hpp"
-#include "base/newtype.hpp"
 #include "base/visitor.hpp"
-
-#include "std/boost_container_hash.hpp"
 
 #include "defines.hpp"
 
-#include <cstdint>
+#include <boost/container_hash/hash.hpp>
+
 #include <limits>
 #include <string>
 #include <tuple>
@@ -24,7 +21,8 @@
 
 namespace routing
 {
-inline double constexpr kTransitMaxSpeedKMpH = 400.0;
+/// 60 km/h is the optimal MaxSpeed for Transit now (we don't take into account HS trains).
+inline double constexpr kTransitMaxSpeedKMpH = 60.0;
 }  // namespace routing
 
 namespace transit

--- a/libs/transit/transit_graph_data.hpp
+++ b/libs/transit/transit_graph_data.hpp
@@ -8,13 +8,11 @@
 #include "coding/reader.hpp"
 #include "coding/writer.hpp"
 
-#include "base/exception.hpp"
 #include "base/geo_object_id.hpp"
 #include "base/visitor.hpp"
 
 #include <glaze/json.hpp>
 
-#include <cstdint>
 #include <cstring>
 #include <map>
 #include <string>

--- a/libs/transit/transit_schedule.hpp
+++ b/libs/transit/transit_schedule.hpp
@@ -1,18 +1,14 @@
 #pragma once
 
-#include "base/macros.hpp"
-#include "base/newtype.hpp"
+#include "base/macros.hpp"  // for SerDes macro
 #include "base/visitor.hpp"
 
 #include <array>
-#include <chrono>
 #include <cstdint>
 #include <ctime>
 #include <map>
 #include <tuple>
 #include <unordered_map>
-#include <utility>
-#include <vector>
 
 #include "3party/just_gtfs/just_gtfs.h"
 

--- a/libs/transit/transit_schedule.hpp
+++ b/libs/transit/transit_schedule.hpp
@@ -1,18 +1,13 @@
 #pragma once
 
-#include "base/macros.hpp"
-#include "base/newtype.hpp"
+#include "base/assert.hpp"  // for DebugPrint
 #include "base/visitor.hpp"
 
 #include <array>
-#include <chrono>
-#include <cstdint>
 #include <ctime>
 #include <map>
 #include <tuple>
 #include <unordered_map>
-#include <utility>
-#include <vector>
 
 #include "3party/just_gtfs/just_gtfs.h"
 

--- a/libs/transit/transit_types.cpp
+++ b/libs/transit/transit_types.cpp
@@ -1,9 +1,5 @@
 #include "transit/transit_types.hpp"
-
-#include "transit/transit_serdes.hpp"
 #include "transit/transit_version.hpp"
-
-#include "base/string_utils.hpp"
 
 namespace
 {

--- a/libs/transit/world_feed/world_feed.cpp
+++ b/libs/transit/world_feed/world_feed.cpp
@@ -1220,18 +1220,17 @@ bool WorldFeed::SpeedExceedsMaxVal(EdgeId const & edgeId, EdgeData const & edgeD
   m2::PointD const & stop1 = m_stops.m_data.at(edgeId.m_fromStopId).m_point;
   m2::PointD const & stop2 = m_stops.m_data.at(edgeId.m_toStopId).m_point;
 
-  static double const maxSpeedMpS = measurement_utils::KmphToMps(routing::kTransitMaxSpeedKMpH);
-  double const speedMpS = mercator::DistanceOnEarth(stop1, stop2) / edgeData.m_weight;
+  double constexpr kMaxSpeedMpS = measurement_utils::KmphToMps(routing::kTransitMaxSpeedKMpH);
+  double constexpr kMaxReasonableSpeedMpS = measurement_utils::KmphToMps(400.0);
 
-  bool speedExceedsMaxVal = speedMpS > maxSpeedMpS;
-  if (speedExceedsMaxVal)
+  double const speedMpS = mercator::DistanceOnEarth(stop1, stop2) / edgeData.m_weight;
+  if (speedMpS > kMaxSpeedMpS)
   {
-    LOG(LWARNING, ("Invalid edge weight conflicting with kTransitMaxSpeedKMpH:", edgeId.m_fromStopId, edgeId.m_toStopId,
-                   edgeId.m_lineId, "speed (km/h):", measurement_utils::MpsToKmph(speedMpS),
-                   "maxSpeed (km/h):", routing::kTransitMaxSpeedKMpH));
+    LOG(LWARNING, ("Edge weight conflicting with kTransitMaxSpeedKMpH:", edgeId.m_fromStopId, edgeId.m_toStopId,
+                   edgeId.m_lineId, "speed =", measurement_utils::MpsToKmph(speedMpS), "km/h"));
   }
 
-  return speedExceedsMaxVal;
+  return speedMpS > kMaxReasonableSpeedMpS;
 }
 
 bool WorldFeed::ClearFeedByLineIds(std::unordered_set<TransitId> const & corruptedLineIds)


### PR DESCRIPTION
Keep the old 400 km/h as the upper bound on the world feed (generator) stage, but print LOG(WARNING) for the calculated weight that exceeds _honest_ kTransitMaxSpeedKMpH (60 km/h). To see how many _wrong_ cases we have