### PR TITLE
[ios] Restore native custom color picker in palette popover

### DIFF
--- a/iphone/Maps/UI/ColorPicker/ColorGridViewController.swift
+++ b/iphone/Maps/UI/ColorPicker/ColorGridViewController.swift
@@ -22,7 +22,6 @@ final class ColorGridViewController: UIViewController {
   private let predefinedColors: [PredefinedColor]
   private let onSelectColor: (UIColor) -> Void
   private let onSelectCustomColor: (UIViewController) -> Void
-  private let showsCustomColor = !ProcessInfo.processInfo.isiOSAppOnMac
   private let stackView = UIStackView()
 
   init(currentColor: UIColor?,
@@ -34,7 +33,7 @@ final class ColorGridViewController: UIViewController {
     self.onSelectColor = onSelectColor
     self.onSelectCustomColor = onSelectCustomColor
     super.init(nibName: nil, bundle: nil)
-    preferredContentSize = Constants.preferredContentSize(forItemCount: predefinedColors.count + (showsCustomColor ? 1 : 0))
+    preferredContentSize = Constants.preferredContentSize(forItemCount: predefinedColors.count + 1)
   }
 
   @available(*, unavailable)
@@ -68,9 +67,7 @@ final class ColorGridViewController: UIViewController {
 
   private func configureColorButtons() {
     var buttons = predefinedColors.map { button(for: $0) }
-    if showsCustomColor {
-      buttons.append(customColorButton())
-    }
+    buttons.append(customColorButton())
 
     for rowItems in buttons.chunked(by: Constants.columnCount) {
       let rowView = UIStackView()

--- a/iphone/Maps/UI/ColorPicker/ColorPicker.swift
+++ b/iphone/Maps/UI/ColorPicker/ColorPicker.swift
@@ -1,8 +1,13 @@
 final class ColorPicker: NSObject {
   static let shared = ColorPicker()
 
-  private var pickerViewController: UIViewController?
+  private var pickerViewController: ColorGridViewController?
+  // Strong reference: on macOS the "Show Colors..." button closes the picker and hands the
+  // selection over to the system color panel, which keeps reporting through this picker's
+  // delegate only while the picker is alive (FB8981193).
+  private var nativeColorPickerViewController: UIColorPickerViewController?
   private var onUpdateColorHandler: ((UIColor) -> Void)?
+  private var isIOSAppOnMac: Bool { ProcessInfo.processInfo.isiOSAppOnMac }
   private var nativePickedColor: UIColor?
 
   /// Presents the default bookmark/track color grid.
@@ -13,16 +18,17 @@ final class ColorPicker: NSObject {
                anchor: UIView?,
                currentColor: UIColor?,
                completionHandler: ((UIColor) -> Void)?) {
+    nativeColorPickerViewController = nil
     let picker = ColorGridViewController(currentColor: currentColor,
                                          predefinedColors: BookmarksManager.predefinedColors().compactMap {
                                            PredefinedColor(rawValue: $0.intValue)
                                          }) { [weak self] color in
-      self?.commitSelection(color)
+      self?.selectColor(color)
     } onSelectCustomColor: { [weak self] viewController in
       self?.presentNativeColorPicker(from: viewController, currentColor: currentColor)
     }
     picker.onDismiss = { [weak self] in
-      self?.resetPresentationState()
+      self?.endColorPicker()
     }
     picker.modalPresentationStyle = .popover
     if let popover = picker.popoverPresentationController {
@@ -40,34 +46,46 @@ final class ColorPicker: NSObject {
     onUpdateColorHandler = completionHandler
     updatePopoverUserInterfaceStyle(rootViewController.traitCollection.userInterfaceStyle)
     subscribeToTraitChanges()
-    rootViewController.present(picker, animated: true)
+    // Animated presentation can cause visual artifacts on macOS; dismissal can remain animated.
+    rootViewController.present(picker, animated: !isIOSAppOnMac)
   }
 
-  private func commitSelection(_ color: UIColor) {
-    let onUpdateColorHandler = onUpdateColorHandler
-    self.onUpdateColorHandler = nil
+  private func selectColor(_ color: UIColor) {
     onUpdateColorHandler?(color)
-    pickerViewController?.dismiss(animated: true)
-    resetPresentationState()
+    endColorPicker()
   }
 
   private func presentNativeColorPicker(from rootViewController: UIViewController, currentColor: UIColor?) {
-    let picker = UIColorPickerViewController()
+    let picker = DismissReportingColorPickerViewController()
     picker.supportsAlpha = false
     if let currentColor {
       picker.selectedColor = currentColor
     }
     picker.delegate = self
-    picker.presentationController?.delegate = self
+    picker.onDismiss = { [weak self] in
+      guard let self else { return }
+      let didCommitSelection = self.commitNativeSelection()
+
+      // On macOS the system color panel ("Show Colors...") keeps reporting through the
+      // dismissed picker's delegate. On iOS a cancelled picker can be released immediately.
+      if didCommitSelection {
+        self.endColorPicker(keepingNativePicker: isIOSAppOnMac)
+      } else if !isIOSAppOnMac {
+        self.nativeColorPickerViewController = nil
+      }
+    }
+    nativeColorPickerViewController = picker
     nativePickedColor = nil
     rootViewController.present(picker, animated: true)
   }
 
-  private func finishNativeColorPicker() {
-    guard let nativePickedColor else { return }
+  @discardableResult
+  private func commitNativeSelection() -> Bool {
+    guard let nativePickedColor else { return false }
 
     self.nativePickedColor = nil
-    commitSelection(nativePickedColor)
+    onUpdateColorHandler?(nativePickedColor)
+    return true
   }
 
   private func subscribeToTraitChanges() {
@@ -95,10 +113,20 @@ final class ColorPicker: NSObject {
     pickerViewController?.overrideUserInterfaceStyle = userInterfaceStyle
   }
 
-  private func resetPresentationState() {
+  private func closeColorGrid() {
     unsubscribeFromTraitChanges()
+    let picker = pickerViewController
     pickerViewController = nil
-    onUpdateColorHandler = nil
+    picker?.onDismiss = nil
+    picker?.dismiss(animated: true)
+  }
+
+  private func endColorPicker(keepingNativePicker: Bool = false) {
+    closeColorGrid()
+    if !keepingNativePicker {
+      nativeColorPickerViewController = nil
+      onUpdateColorHandler = nil
+    }
   }
 }
 
@@ -113,21 +141,29 @@ extension ColorGridViewController: UIPopoverPresentationControllerDelegate {
 }
 
 extension ColorPicker: UIColorPickerViewControllerDelegate {
-  func colorPickerViewController(_: UIColorPickerViewController, didSelect color: UIColor, continuously _: Bool) {
+  func colorPickerViewController(_ viewController: UIColorPickerViewController, didSelect color: UIColor, continuously: Bool) {
     nativePickedColor = color.sRGBColor
-  }
-
-  func colorPickerViewControllerDidFinish(_: UIColorPickerViewController) {
-    finishNativeColorPicker()
+    // On macOS colorPickerViewControllerDidFinish is never called, so commit and close
+    // the picker as soon as the user clicks a color.
+    if isIOSAppOnMac, !continuously {
+      commitNativeSelection()
+      viewController.dismiss(animated: true)
+      closeColorGrid()
+    }
   }
 }
 
-extension ColorPicker: UIAdaptivePresentationControllerDelegate {
-  func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-    guard presentationController.presentedViewController is UIColorPickerViewController else {
-      return
+/// Reports the start of the picker's dismissal — the only signal delivered on every platform.
+/// colorPickerViewControllerDidFinish is not called at all on macOS, and on iOS it is not
+/// called for the interactive swipe-down dismissal.
+private final class DismissReportingColorPickerViewController: UIColorPickerViewController {
+  var onDismiss: (() -> Void)?
+
+  override func viewWillDisappear(_ animated: Bool) {
+    // Skip transient disappearances (e.g. the eyedropper): commit only on a real dismissal.
+    if isBeingDismissed {
+      onDismiss?()
     }
-    // Swipe-down dismissal does not call colorPickerViewControllerDidFinish(_:).
-    finishNativeColorPicker()
+    super.viewWillDisappear(animated)
   }
 }


### PR DESCRIPTION
Bring back the native custom color picker flow for the new color palette popover. Keep the native picker alive for iOS apps running on macOS so the system color panel can continue reporting selected colors, and close the palette popover after the native color selection is committed.