### PR TITLE
[android] Fix zoom buttons stuck at the top after closing a place page

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/RoutingPlanViewModel.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingPlanViewModel.java
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import app.organicmaps.util.SingleLiveEvent;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import java.util.Objects;
 
 public class RoutingPlanViewModel extends ViewModel
 {
@@ -33,9 +34,11 @@ public class RoutingPlanViewModel extends ViewModel
     return mIsPlacePageActive;
   }
 
+  // State, not an event: only dispatch on change.
   public void setIsPlacePageActive(boolean active)
   {
-    mIsPlacePageActive.setValue(active);
+    if (!Objects.equals(mIsPlacePageActive.getValue(), active))
+      mIsPlacePageActive.setValue(active);
   }
 
   public LiveData<Boolean> getIsSearchActive()

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
@@ -104,6 +104,8 @@ public class PlacePageController
           if (PlacePageUtils.isHiddenState(newState))
           {
             mEasyDismissEnabled = false;
+            // Clear before onHiddenInternal(): it may restore a transit PP, which sets the flag again.
+            mPlacePageListener.onPlacePageActiveChanged(false);
             onHiddenInternal();
           }
         }
@@ -255,8 +257,13 @@ public class PlacePageController
   private void close()
   {
     setPlacePageInteractions(false);
-    mPlacePageBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
-    mPlacePageListener.onPlacePageActiveChanged(false);
+    // Normally the flag is cleared in onStateChanged(HIDDEN), but setState() fires no callback when
+    // the sheet is already hidden: on re-entry from onHiddenInternal() -> setMapObject(null) ->
+    // onChanged(null), which happens on every close, and when dismissed before the open animation.
+    if (PlacePageUtils.isHiddenState(mPlacePageBehavior.getState()))
+      mPlacePageListener.onPlacePageActiveChanged(false);
+    else
+      mPlacePageBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
   }
 
   private void resetPlacePageHeightBounds()


### PR DESCRIPTION
## What

Fixed: https://github.com/organicmaps/organicmaps/issues/13284

Zoom and my-position buttons stayed pinned to the top of the screen after a place page was closed with the system back button or a tap on the map. Closing with the X button was unaffected.

The buttons follow the place page bottom sheet through `onSlide`, and `MapButtonsController.move()` ignores those updates unless `RoutingPlanViewModel.isPlacePageActive` is set. `PlacePageController.close()` cleared that flag in the same call that started the hide animation, so every frame of the animation was dropped and the buttons never came back down.

The flag is now cleared in `onStateChanged(STATE_HIDDEN)`, once the sheet has actually finished sliding away. It is cleared before `onHiddenInternal()` so that a restored transit place page can set it again.