### PR TITLE
[routing] Improve bicycle alternative routes

### DIFF
--- a/libs/routing/edge_estimator.cpp
+++ b/libs/routing/edge_estimator.cpp
@@ -321,8 +321,8 @@ public:
     if (purpose == Purpose::Weight && GetStrategy() == Strategy::Shortest)
       return road.GetDistance(segment.GetSegmentIdx()) / GetMaxWeightSpeedMpS();
 
-    return CalcClimbSegment(purpose, segment, road,
-                            [purpose, this](double speedMpS, double tangent, geometry::Altitude altitude)
+    double const weight = CalcClimbSegment(purpose, segment, road,
+                                           [purpose, this](double speedMpS, double tangent, geometry::Altitude altitude)
     {
       auto const factor = GetBicycleClimbPenalty(purpose, tangent, altitude);
       ASSERT_GREATER(factor, 0.0, ());
@@ -351,6 +351,7 @@ public:
 
       return std::min(speedMpS, GetMaxWeightSpeedMpS());
     });
+    return ApplyRouteSegmentPenalty(segment, purpose, weight);
   }
 };
 
@@ -433,6 +434,33 @@ double CarEstimator::CalcSegmentWeight(Segment const & segment, RoadGeometry con
 }
 
 // EdgeEstimator -----------------------------------------------------------------------------------
+void EdgeEstimator::SetRouteSegmentsPenalty(std::vector<Segment> const & segments, double factor)
+{
+  CHECK_GREATER_OR_EQUAL(factor, 1.0, (factor));
+
+  m_penalizedSegments.clear();
+  m_penalizedSegments.reserve(segments.size() * 2);
+  for (auto const & segment : segments)
+  {
+    m_penalizedSegments.insert(segment);
+    m_penalizedSegments.insert(segment.GetReversed());
+  }
+  m_routeSegmentPenaltyFactor = factor;
+}
+
+void EdgeEstimator::ClearRouteSegmentsPenalty()
+{
+  m_penalizedSegments.clear();
+  m_routeSegmentPenaltyFactor = 1.0;
+}
+
+double EdgeEstimator::ApplyRouteSegmentPenalty(Segment const & segment, Purpose purpose, double weight) const
+{
+  if (purpose == Purpose::Weight && m_penalizedSegments.contains(segment))
+    return weight * m_routeSegmentPenaltyFactor;
+  return weight;
+}
+
 // static
 std::shared_ptr<EdgeEstimator> EdgeEstimator::Create(VehicleType vehicleType, double maxWeighSpeedKMpH,
                                                      SpeedKMpH const & offroadSpeedKMpH,

--- a/libs/routing/edge_estimator.hpp
+++ b/libs/routing/edge_estimator.hpp
@@ -10,6 +10,8 @@
 #include "geometry/point_with_altitude.hpp"
 
 #include <memory>
+#include <unordered_set>
+#include <vector>
 
 class DataSource;
 
@@ -44,6 +46,11 @@ public:
 
   void SetStrategy(Strategy strategy) { m_strategy = strategy; }
   Strategy GetStrategy() const { return m_strategy; }
+
+  // Applies a temporary routing-weight penalty to the supplied road segments. ETA remains based on
+  // the real road model. Both directions are penalized because route overlap is direction-independent.
+  void SetRouteSegmentsPenalty(std::vector<Segment> const & segments, double factor);
+  void ClearRouteSegmentsPenalty();
 
   /// \brief Transit alternative route bias. Scales the routing weight (Purpose::Weight only, ETA
   /// stays the real time) of walking legs and of the transit transfer/boarding penalty, to favour
@@ -85,12 +92,17 @@ public:
                                                std::shared_ptr<TrafficStash> trafficStash, DataSource * dataSourcePtr,
                                                std::shared_ptr<NumMwmIds> numMwmIds);
 
+protected:
+  double ApplyRouteSegmentPenalty(Segment const & segment, Purpose purpose, double weight) const;
+
 private:
   double const m_maxWeightSpeedMpS;
   SpeedKMpH const m_offroadSpeedKMpH;
   Strategy m_strategy = Strategy::Normal;
   double m_transitWalkWeightFactor = 1.0;
   double m_transitTransferFactor = 1.0;
+  std::unordered_set<Segment> m_penalizedSegments;
+  double m_routeSegmentPenaltyFactor = 1.0;
 
   // DataSource * m_dataSourcePtr;
   // std::shared_ptr<NumMwmIds> m_numMwmIds;

--- a/libs/routing/index_router.cpp
+++ b/libs/routing/index_router.cpp
@@ -74,6 +74,10 @@ double constexpr kLeapsStageContribution = 0.15;
 double constexpr kCandidatesStageContribution = 0.55;
 double constexpr kAlmostZeroContribution = 1e-7;
 
+// A soft penalty preserves unavoidable overlap near route endpoints while encouraging a bicycle
+// alternative that differs from the primary route without discarding bicycle speeds or elevation.
+double constexpr kBicycleAltRouteSegmentPenalty = 1.35;
+
 // If user left the route within this range(meters), adjust the route. Else full rebuild.
 double constexpr kAdjustRangeM = 5000.0;
 // Full rebuild if distance(meters) is less.
@@ -448,9 +452,9 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
       code = DoCalculateRoute(checkpoints, startDirection, delegate, route);
 
       // Compute an alternative alongside the Normal route. Only on a full (non-adjust) build and only
-      // within a reasonable distance budget — alt computation roughly doubles latency. Road vehicles
-      // get a Shortest-strategy alternative; transit gets a less-walking / fewer-transfers alternative
-      // (e.g. a direct bus instead of subway + walk).
+      // within a reasonable distance budget — alt computation roughly doubles latency. Cars and pedestrians
+      // get a Shortest-strategy alternative, bicycles use the normal model with an overlap penalty, and transit
+      // gets a less-walking / fewer-transfers alternative (e.g. a direct bus instead of subway + walk).
       double const altMaxDistanceM = m_vehicleType == VehicleType::Car ? 300'000.0 : 100'000.0;
       if ((code == RouterResultCode::NoError || code == RouterResultCode::HasWarnings) && !delegate.IsCancelled() &&
           mercator::DistanceOnEarth(startPoint, finalPoint) <= altMaxDistanceM)
@@ -462,6 +466,7 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
         {
           m_estimator->SetStrategy(EdgeEstimator::Strategy::Normal);
           m_estimator->SetTransitAltFactors(1.0, 1.0);
+          m_estimator->ClearRouteSegmentsPenalty();
           // Save the alternative route's adjust-cache.
           m_lastAltRoute = std::move(m_lastRoute);
           m_lastAltFakeEdges = std::move(m_lastFakeEdges);
@@ -474,6 +479,18 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
         {
           // Rewrite walking and transfer/boarding penalty for the alternative route.
           m_estimator->SetTransitAltFactors(3.0 /* walk */, 2.0 /* transfer */);
+        }
+        else if (m_vehicleType == VehicleType::Bicycle)
+        {
+          std::vector<Segment> primarySegments;
+          primarySegments.reserve(route.GetRouteSegments().size());
+          for (auto const & routeSegment : route.GetRouteSegments())
+          {
+            auto const & segment = routeSegment.GetSegment();
+            if (segment.IsRealSegment())
+              primarySegments.push_back(segment);
+          }
+          m_estimator->SetRouteSegmentsPenalty(primarySegments, kBicycleAltRouteSegmentPenalty);
         }
         else
         {

--- a/libs/routing/routing_tests/edge_estimator_tests.cpp
+++ b/libs/routing/routing_tests/edge_estimator_tests.cpp
@@ -1,7 +1,11 @@
 #include "testing/testing.hpp"
 
 #include "routing/edge_estimator.hpp"
+#include "routing/geometry.hpp"
 
+#include "routing_common/maxspeed_conversion.hpp"
+
+#include "geometry/mercator.hpp"
 #include "geometry/point_with_altitude.hpp"
 
 #include <cmath>
@@ -14,6 +18,41 @@ double const kTan = 0.1;
 geometry::Altitude const kAlt = 100.0;
 auto const kPurposes = {EdgeEstimator::Purpose::Weight, EdgeEstimator::Purpose::ETA};
 constexpr double kAccuracyEps = 1e-5;
+
+UNIT_TEST(EdgeEstimator_RouteSegmentPenaltyAffectsWeightOnly)
+{
+  Segment const primary(1 /* mwmId */, 2 /* featureId */, 3 /* segmentIdx */, true /* forward */);
+  Segment const unrelated(1 /* mwmId */, 4 /* featureId */, 5 /* segmentIdx */, true /* forward */);
+  double constexpr kPenalty = 1.35;
+
+  RoadGeometry::Points const points = {mercator::FromLatLon(0.0, 0.0),   mercator::FromLatLon(0.0, 0.001),
+                                       mercator::FromLatLon(0.0, 0.002), mercator::FromLatLon(0.0, 0.003),
+                                       mercator::FromLatLon(0.0, 0.004), mercator::FromLatLon(0.0, 0.005),
+                                       mercator::FromLatLon(0.0, 0.006)};
+  Maxspeed const maxspeed(measurement_utils::Units::Metric, 20 /* forward */, 20 /* backward */);
+  RoadGeometry const road(true /* oneWay */, maxspeed, points);
+  auto estimator =
+      EdgeEstimator::Create(VehicleType::Bicycle, 30.0 /* maxWeightSpeedKMpH */, SpeedKMpH(5.0),
+                            nullptr /* trafficStash */, nullptr /* dataSourcePtr */, nullptr /* numMwmIds */);
+
+  double const primaryWeight = estimator->CalcSegmentWeight(primary, road, EdgeEstimator::Purpose::Weight);
+  double const primaryEta = estimator->CalcSegmentWeight(primary, road, EdgeEstimator::Purpose::ETA);
+
+  estimator->SetRouteSegmentsPenalty({primary}, kPenalty);
+
+  TEST_ALMOST_EQUAL_ABS(estimator->CalcSegmentWeight(primary, road, EdgeEstimator::Purpose::Weight),
+                        primaryWeight * kPenalty, kAccuracyEps, ());
+  TEST_ALMOST_EQUAL_ABS(estimator->CalcSegmentWeight(primary.GetReversed(), road, EdgeEstimator::Purpose::Weight),
+                        primaryWeight * kPenalty, kAccuracyEps, ());
+  TEST_ALMOST_EQUAL_ABS(estimator->CalcSegmentWeight(unrelated, road, EdgeEstimator::Purpose::Weight), primaryWeight,
+                        kAccuracyEps, ());
+  TEST_ALMOST_EQUAL_ABS(estimator->CalcSegmentWeight(primary, road, EdgeEstimator::Purpose::ETA), primaryEta,
+                        kAccuracyEps, ());
+
+  estimator->ClearRouteSegmentsPenalty();
+  TEST_ALMOST_EQUAL_ABS(estimator->CalcSegmentWeight(primary, road, EdgeEstimator::Purpose::Weight), primaryWeight,
+                        kAccuracyEps, ());
+}
 
 // Climb penalty on plain surface (tangent = 0) must be 1.0 for ETA and Weight estimations.
 UNIT_TEST(ClimbPenalty_ZeroTangent)


### PR DESCRIPTION
## What changed

Bicycle alternatives now use the normal bicycle road-speed and elevation model for route selection. A soft weight-only penalty on primary-route segments encourages a meaningfully different path without changing either route's ETA. The penalty covers both segment directions and is cleared after each alternative calculation. Car and transit alternative routing are unchanged.

The reported duration was not an ETA accumulator error. The previous shortest strategy selected bicycle alternatives using distance divided by maximum speed, then evaluated the selected path with the real bicycle model. This could choose a marginally shorter path containing very slow footways or paths and display its correct but unexpectedly large ETA.

A unit test verifies that the overlap penalty affects bicycle routing weight in both directions, leaves unrelated segments unchanged, and never changes ETA.

Fixes #12953

## Testing

- `build-issue12953/routing_tests`
- `android/gradlew assembleFdroidDebug -Parm64` (arm64)
- Reproduced with the Vancouver map and the route from `49.2104555,-123.1258019` to `49.24945,-123.1055`
- Before: primary 5.89 km / 1307 s; alternative 5.71 km / 3657 s
- After: primary 5.89 km / 1307 s; alternative 5.96 km / 1398 s
- Installed and verified on a Pixel 8 Pro: the UI shows distinct 22-minute and 23-minute bicycle routes instead of 22 minutes and 1 h 4 min

## LLM disclosure

LLM tools assisted with investigation, implementation, and test drafting. The changes were reviewed and tested manually.