### PR TITLE
[android] Round compact routing durations

### DIFF
--- a/android/app/src/main/java/app/organicmaps/util/Utils.java
+++ b/android/app/src/main/java/app/organicmaps/util/Utils.java
@@ -451,13 +451,19 @@ public class Utils
   public static CharSequence formatRoutingTime(Context context, int seconds, @DimenRes int unitsSize,
                                                @DimenRes int textSize)
   {
-    long minutes = TimeUnit.SECONDS.toMinutes(seconds) % 60;
-    long hours = TimeUnit.SECONDS.toHours(seconds);
+    long totalMinutes = roundRoutingTimeToMinutes(seconds);
+    long minutes = totalMinutes % 60;
+    long hours = totalMinutes / 60;
     String min = context.getString(R.string.minute);
     String hour = context.getString(R.string.hour);
     SpannableStringBuilder displayedH = Utils.formatTime(context, textSize, unitsSize, String.valueOf(hours), hour);
     SpannableStringBuilder displayedM = Utils.formatTime(context, textSize, unitsSize, String.valueOf(minutes), min);
     return hours == 0 ? displayedM : TextUtils.concat(displayedH, "\u00A0", displayedM);
+  }
+
+  public static long roundRoutingTimeToMinutes(int seconds)
+  {
+    return TimeUnit.SECONDS.toMinutes(seconds + 30L);
   }
 
   @NonNull

--- a/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
@@ -20,11 +20,11 @@ import app.organicmaps.sdk.util.StringUtils;
 import app.organicmaps.util.Graphics;
 import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.UiUtils;
+import app.organicmaps.util.Utils;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.util.concurrent.TimeUnit;
 
 public class NavMenu implements DefaultLifecycleObserver
 {
@@ -209,8 +209,9 @@ public class NavMenu implements DefaultLifecycleObserver
 
   private void updateTimeLeft(int seconds)
   {
-    final long hours = TimeUnit.SECONDS.toHours(seconds);
-    final long minutes = TimeUnit.SECONDS.toMinutes(seconds) % 60;
+    final long totalMinutes = Utils.roundRoutingTimeToMinutes(seconds);
+    final long hours = totalMinutes / 60;
+    final long minutes = totalMinutes % 60;
     mTimeMinuteValue.setText(String.valueOf(minutes));
     String min = mActivity.getResources().getString(R.string.minute);
     mTimeMinuteUnits.setText(min);

--- a/android/app/src/test/java/app/organicmaps/util/UtilsTest.java
+++ b/android/app/src/test/java/app/organicmaps/util/UtilsTest.java
@@ -1,0 +1,21 @@
+package app.organicmaps.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class UtilsTest
+{
+  @Test
+  public void routingTimeRoundsToNearestMinute()
+  {
+    assertEquals(0, Utils.roundRoutingTimeToMinutes(0));
+    assertEquals(0, Utils.roundRoutingTimeToMinutes(29));
+    assertEquals(1, Utils.roundRoutingTimeToMinutes(30));
+    assertEquals(1, Utils.roundRoutingTimeToMinutes(89));
+    assertEquals(2, Utils.roundRoutingTimeToMinutes(90));
+    assertEquals(22, Utils.roundRoutingTimeToMinutes(1307));
+    assertEquals(60, Utils.roundRoutingTimeToMinutes(3599));
+    assertEquals(60, Utils.roundRoutingTimeToMinutes(3600));
+  }
+}


### PR DESCRIPTION
## What changed

Round compact Android routing durations to the nearest minute through a shared helper. This keeps the route preview and navigation menu consistent with route-variant labels on the map.

Previously, a duration of 1307 seconds was truncated to 21 minutes in the bottom panel while the map label rounded it to 22 minutes. Both now display 22 minutes. Arrival clock calculations continue to use the unrounded duration.

Added unit tests for the minute-rounding boundaries and the reported 1307-second case.

## Testing

- `ANDROID_HOME=/home/jared/Android/Sdk ./gradlew testFdroidDebugUnitTest --tests app.organicmaps.util.UtilsTest`
- `ANDROID_HOME=/home/jared/Android/Sdk ./gradlew testFdroidDebugUnitTest lintFdroidDebug`

LLM tools were used to help analyze the inconsistent formatting and implement this change.