### PR TITLE
[ios] Fix HTML description layout

### DIFF
--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		A10000000000000000000055 /* TTSLanguageSettingsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000058 /* TTSLanguageSettingsModels.swift */; };
 		A10000000000000000000056 /* TTSLanguageSettingsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000059 /* TTSLanguageSettingsPresenter.swift */; };
 		A630D1EA207CA95900976DEA /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = A630D1E8207CA95900976DEA /* Localizable.stringsdict */; };
+		B26883EF0814407A8B1D73AF /* PlacePageUserDescriptionWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4584F20AAF794B9683B14087 /* PlacePageUserDescriptionWebViewTests.swift */; };
 		BB25B1A71FB32767007276FA /* transit_colors.txt in Resources */ = {isa = PBXBuildFile; fileRef = BB25B1A51FB32767007276FA /* transit_colors.txt */; };
 		BB7626B61E85599C0031D71C /* icudt78l.dat in Resources */ = {isa = PBXBuildFile; fileRef = BB7626B41E8559980031D71C /* icudt78l.dat */; };
 		DB05F1CC1BF340DE002C974C /* drules_default.bin in Resources */ = {isa = PBXBuildFile; fileRef = DB05F1BC1BF340DE002C974C /* drules_default.bin */; };
@@ -829,6 +830,7 @@
 		408645FB21495EB1000A4A1D /* categories_cuisines.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = categories_cuisines.txt; path = ../../data/categories_cuisines.txt; sourceTree = "<group>"; };
 		451950391B7A3E070085DA05 /* patterns.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = patterns.txt; path = ../../data/patterns.txt; sourceTree = "<group>"; };
 		452FCA3A1B6A3DF7007019AB /* colors.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = colors.txt; path = ../../data/colors.txt; sourceTree = "<group>"; };
+		4584F20AAF794B9683B14087 /* PlacePageUserDescriptionWebViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacePageUserDescriptionWebViewTests.swift; sourceTree = "<group>"; };
 		47AEF83F2231249E00D20538 /* categories_brands.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = categories_brands.txt; path = ../../data/categories_brands.txt; sourceTree = SOURCE_ROOT; };
 		4A300ED31C6DCFD400140018 /* countries-strings */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "countries-strings"; path = "../../data/countries-strings"; sourceTree = "<group>"; };
 		4B4153B42BF9695500EE4B02 /* MWMTextToSpeechTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MWMTextToSpeechTests.mm; sourceTree = "<group>"; };
@@ -2179,9 +2181,18 @@
 		ED810EC02D566E6F00ECDE2C /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				E79F77A472014212B40FDE97 /* PlacePageTests */,
 				ED810EC32D566E7600ECDE2C /* SearchOnMapTests */,
 			);
 			path = UI;
+			sourceTree = "<group>";
+		};
+		E79F77A472014212B40FDE97 /* PlacePageTests */ = {
+			isa = PBXGroup;
+			children = (
+				4584F20AAF794B9683B14087 /* PlacePageUserDescriptionWebViewTests.swift */,
+			);
+			path = PlacePageTests;
 			sourceTree = "<group>";
 		};
 		ED810EC32D566E7600ECDE2C /* SearchOnMapTests */ = {
@@ -4988,6 +4999,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B26883EF0814407A8B1D73AF /* PlacePageUserDescriptionWebViewTests.swift in Sources */,
 				EDF838C12C00B9D6007E4E67 /* iCloudDirectoryMonitorTests.swift in Sources */,
 				EDF838C02C00B9D0007E4E67 /* DefaultLocalDirectoryMonitorTests.swift in Sources */,
 				ED1ADA332BC6B1B40029209F /* CarPlayServiceTests.swift in Sources */,

--- a/iphone/Maps/Tests/UI/PlacePageTests/PlacePageUserDescriptionWebViewTests.swift
+++ b/iphone/Maps/Tests/UI/PlacePageTests/PlacePageUserDescriptionWebViewTests.swift
@@ -1,0 +1,68 @@
+@testable import Organic_Maps__Debug_
+import XCTest
+
+final class PlacePageUserDescriptionWebViewTests: XCTestCase {
+  private let width: CGFloat = 320
+
+  func test_GivenUnmeasuredHTML_WhenHeightIsRequested_ThenReturnsNonZeroCollapsedHeight() {
+    let webView = PlacePageUserDescriptionWebView(htmlString: "<b>HTML description</b>")
+
+    let expandedHeight = webView.expandedHeight(for: width)
+    XCTAssertGreaterThan(expandedHeight, 0)
+    XCTAssertEqual(expandedHeight, webView.collapsedHeight(for: width))
+  }
+
+  func test_GivenFullDocumentWithoutViewport_WhenHeightIsMeasured_ThenUsesRenderedScale() {
+    let html = """
+      <!doctype html>
+      <html>
+      <head><style>html, body { margin: 0; padding: 0; }</style></head>
+      <body><div style="height: 100px"></div></body>
+      </html>
+    """
+
+    let (_, measuredHeights) = loadHTML(html) { $0 < 70 }
+
+    XCTAssertTrue(measuredHeights.allSatisfy { $0 > 0 && $0 < 70 }, "Measured heights: \(measuredHeights)")
+  }
+
+  func test_GivenAlternatingPooledDocuments_WhenHeightIsMeasured_ThenIgnoresPreviousDocument() {
+    var retainedWebView: PlacePageUserDescriptionWebView?
+    var measuredHeights: [CGFloat]
+
+    (retainedWebView, measuredHeights) = loadHTML("<div style=\"height: 240px\"></div>") { $0 > 200 }
+    XCTAssertTrue(measuredHeights.allSatisfy { $0 > 200 })
+    retainedWebView = nil
+
+    (retainedWebView, measuredHeights) = loadHTML("<div style=\"height: 20px\"></div>") { $0 < 70 }
+    XCTAssertTrue(measuredHeights.allSatisfy { $0 > 0 && $0 < 70 })
+    retainedWebView = nil
+
+    (retainedWebView, measuredHeights) = loadHTML("<div style=\"height: 240px\"></div>") { $0 > 200 }
+    XCTAssertTrue(measuredHeights.allSatisfy { $0 > 200 })
+    withExtendedLifetime(retainedWebView) {}
+  }
+
+  private func loadHTML(_ html: String,
+                        until isExpectedHeight: @escaping (CGFloat) -> Bool) ->
+    (PlacePageUserDescriptionWebView, [CGFloat]) {
+    let expectation = expectation(description: "HTML height measured")
+    let webView = PlacePageUserDescriptionWebView(htmlString: html)
+    var measuredHeights = [CGFloat]()
+    var isFulfilled = false
+    webView.onContentHeightChanged = { [weak webView] in
+      guard let webView else { return }
+      let height = webView.expandedHeight(for: self.width)
+      measuredHeights.append(height)
+      guard !isFulfilled, isExpectedHeight(height) else { return }
+      isFulfilled = true
+      expectation.fulfill()
+    }
+    webView.frame = CGRect(x: 0, y: 0, width: width, height: webView.collapsedHeight(for: width))
+    webView.layoutIfNeeded()
+
+    wait(for: [expectation], timeout: 5)
+    webView.onContentHeightChanged = nil
+    return (webView, measuredHeights)
+  }
+}

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageExpandableDetailsSection/PlacePageUserDescriptionWebView/PlacePageUserDescriptionWebView.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageExpandableDetailsSection/PlacePageUserDescriptionWebView/PlacePageUserDescriptionWebView.swift
@@ -4,6 +4,7 @@ final class PlacePageUserDescriptionWebView: UIView {
   private enum Constants {
     static let previewHeight: CGFloat = 70
     static let baseURL = URL(string: "https://organicmaps.app")
+    static let contentHeightScript = "document.documentElement.getBoundingClientRect().height"
   }
 
   private static let webViewPool = WebViewPool()
@@ -70,9 +71,9 @@ final class PlacePageUserDescriptionWebView: UIView {
     ]
     NSLayoutConstraint.activate(webViewConstraints)
 
-    contentSizeObservation = webView.scrollView.observe(\.contentSize, options: [.new]) { [weak self] scrollView, _ in
+    contentSizeObservation = webView.scrollView.observe(\.contentSize) { [weak self] _, _ in
       guard let self, self.webView === webView else { return }
-      self.applyMeasuredHeight(scrollView.contentSize.height)
+      self.updateContentHeight()
     }
   }
 
@@ -172,19 +173,17 @@ extension PlacePageUserDescriptionWebView: ExpandableTextContainer {
 
   func updateContentHeight() {
     guard let webView else { return }
-    // WebView content height is known only after rendering. Keep this as a lightweight best-effort measurement
-    // instead of adding document-status tracking and extra JavaScript injection points.
-    webView.evaluateJavaScript("document.documentElement.scrollHeight") { [weak self] result, _ in
-      guard let self, self.webView === webView else { return }
-      let domHeight = CGFloat(htmlHeight: result) ?? 0
-      let scrollHeight = webView.scrollView.contentSize.height
-      let height = max(domHeight, scrollHeight)
-      self.applyMeasuredHeight(height)
+    let measuredHTMLString = htmlString
+    // Element bounds are used because scrollHeight/contentSize can be clamped to the current web view viewport and
+    // overestimate short descriptions. contentSize is only a fallback for a failed JS measurement.
+    webView.evaluateJavaScript(Constants.contentHeightScript) { [weak self] result, _ in
+      guard let self, self.webView === webView, self.htmlString == measuredHTMLString else { return }
+      self.applyMeasuredHeight(CGFloat(htmlHeight: result) ?? webView.scrollView.contentSize.height)
     }
   }
 
   func expandedHeight(for _: CGFloat) -> CGFloat {
-    measuredHTMLHeight
+    measuredHTMLHeight > 0 ? measuredHTMLHeight : Constants.previewHeight
   }
 
   func collapsedHeight(for _: CGFloat) -> CGFloat {
@@ -226,6 +225,7 @@ private extension PlacePageUserDescriptionWebView {
       webView.stopLoading()
       webView.navigationDelegate = nil
       webView.removeFromSuperview()
+      webView.loadHTMLString("", baseURL: nil)
       cachedWebView = webView
     }
 

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageExpandableDetailsSection/PlacePageUserDescriptionWebView/PlacePageUserDescriptionWebView.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageExpandableDetailsSection/PlacePageUserDescriptionWebView/PlacePageUserDescriptionWebView.swift
@@ -4,6 +4,12 @@ final class PlacePageUserDescriptionWebView: UIView {
   private enum Constants {
     static let previewHeight: CGFloat = 70
     static let baseURL = URL(string: "https://organicmaps.app")
+    static let contentHeightRatioScript = """
+    (() => {
+      const root = document.documentElement;
+      return root.clientWidth > 0 ? root.getBoundingClientRect().height / root.clientWidth : null;
+    })()
+    """
   }
 
   private static let webViewPool = WebViewPool()
@@ -14,6 +20,8 @@ final class PlacePageUserDescriptionWebView: UIView {
   private var contentSizeObservation: NSKeyValueObservation?
   private var webViewConstraints = [NSLayoutConstraint]()
   private var isLoadingHTMLString = false
+  private var currentNavigation: WKNavigation?
+  private var finishedNavigation: WKNavigation?
   private var measuredHTMLHeight: CGFloat = 0
   private var htmlString: String
   private var networkPolicy: NetworkPolicy
@@ -70,9 +78,9 @@ final class PlacePageUserDescriptionWebView: UIView {
     ]
     NSLayoutConstraint.activate(webViewConstraints)
 
-    contentSizeObservation = webView.scrollView.observe(\.contentSize, options: [.new]) { [weak self] scrollView, _ in
+    contentSizeObservation = webView.scrollView.observe(\.contentSize) { [weak self] _, _ in
       guard let self, self.webView === webView else { return }
-      self.applyMeasuredHeight(scrollView.contentSize.height)
+      self.updateContentHeight()
     }
   }
 
@@ -89,11 +97,16 @@ final class PlacePageUserDescriptionWebView: UIView {
   private func loadHTML(_ htmlString: String) {
     attachWebView()
     guard let webView else { return }
-    self.htmlString = htmlString
-    measuredHTMLHeight = 0
+    // Preserve the last height during same-content trait reloads so the section keeps its layout while re-rendering.
+    if self.htmlString != htmlString {
+      self.htmlString = htmlString
+      measuredHTMLHeight = 0
+    }
     isLoadingHTMLString = true
+    finishedNavigation = nil
     let html = Self.htmlDocumentBuilder.buildHTML(with: htmlString)
-    webView.loadHTMLString(html, baseURL: Constants.baseURL)
+    currentNavigation = webView.loadHTMLString(html, baseURL: Constants.baseURL)
+    assert(currentNavigation != nil, "WebKit refused to start the description load")
   }
 
   private func applyMeasuredHeight(_ height: CGFloat) {
@@ -136,8 +149,9 @@ final class PlacePageUserDescriptionWebView: UIView {
 // MARK: - WKNavigationDelegate
 
 extension PlacePageUserDescriptionWebView: WKNavigationDelegate {
-  func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
-    guard self.webView === webView else { return }
+  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    guard self.webView === webView, let navigation, navigation === currentNavigation else { return }
+    finishedNavigation = navigation
     updateContentHeight()
   }
 
@@ -171,20 +185,20 @@ extension PlacePageUserDescriptionWebView: ExpandableTextContainer {
   }
 
   func updateContentHeight() {
-    guard let webView else { return }
-    // WebView content height is known only after rendering. Keep this as a lightweight best-effort measurement
-    // instead of adding document-status tracking and extra JavaScript injection points.
-    webView.evaluateJavaScript("document.documentElement.scrollHeight") { [weak self] result, _ in
-      guard let self, self.webView === webView else { return }
-      let domHeight = CGFloat(htmlHeight: result) ?? 0
-      let scrollHeight = webView.scrollView.contentSize.height
-      let height = max(domHeight, scrollHeight)
+    guard let webView, let navigation = finishedNavigation else { return }
+    // Root bounds avoid the viewport floor imposed by scrollHeight/contentSize. Normalizing by clientWidth also
+    // converts CSS pixels for full documents without viewport metadata. contentSize is only a failure fallback.
+    webView.evaluateJavaScript(Constants.contentHeightRatioScript) { [weak self] result, _ in
+      guard let self, self.webView === webView, self.finishedNavigation === navigation else { return }
+      let height = CGFloat(javaScriptNumber: result).map { $0 * webView.bounds.width }
+        ?? webView.scrollView.contentSize.height
       self.applyMeasuredHeight(height)
     }
   }
 
   func expandedHeight(for _: CGFloat) -> CGFloat {
-    measuredHTMLHeight
+    // Use the collapsed height until WebKit measures so it has a renderable frame and More stays hidden.
+    measuredHTMLHeight > 0 ? measuredHTMLHeight : Constants.previewHeight
   }
 
   func collapsedHeight(for _: CGFloat) -> CGFloat {
@@ -257,19 +271,11 @@ private extension URL {
   }
 }
 
-// MARK: - CGFloat + HtmlHeight
+// MARK: - CGFloat + JavaScript number
 
 private extension CGFloat {
-  init?(htmlHeight value: Any?) {
-    switch value {
-    case let value as CGFloat:
-      self = value
-    case let value as Double:
-      self = CGFloat(value)
-    case let value as Int:
-      self = CGFloat(value)
-    default:
-      return nil
-    }
+  init?(javaScriptNumber value: Any?) {
+    guard let number = value as? NSNumber else { return nil }
+    self = CGFloat(number.doubleValue)
   }
 }


### PR DESCRIPTION
Closes #13203

HTML bookmark descriptions can start at zero height while WebKit measures asynchronously. Reused pooled WebViews can also report the previous document height, and full HTML documents without viewport metadata use CSS pixels that do not directly match rendered points.

This PR gives unmeasured content a non-zero preview frame, accepts measurements only after the matching `WKNavigation` finishes, and normalizes DOM height by the CSS layout viewport before converting it to WebView points. It also keeps the previous height during same-content theme/Dynamic Type reloads and adds regression coverage for bootstrap, pooled reuse, and full-document scaling.

Testing: not run locally per request; CI runs the iOS builds and Swift style check.

LLM-assisted.