### PR TITLE
[ios][andriod] Handle unavailable track recording elevation data

### DIFF
--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/TrackRecorder.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/TrackRecorder.cpp
@@ -44,10 +44,9 @@ JNIEXPORT void Java_app_organicmaps_sdk_location_TrackRecorder_nativeSetTrackRec
 JNIEXPORT jobject Java_app_organicmaps_sdk_location_TrackRecorder_nativeGetElevationInfo(JNIEnv * env, jclass clazz)
 {
   ASSERT(frm()->IsTrackRecordingEnabled(), ("Track recording is not started"));
-  auto const & elevationInfo = frm()->GetTrackRecordingElevationInfo();
-  if (elevationInfo.IsEmpty())
+  if (frm()->IsTrackRecordingEmpty())
     return nullptr;
-  return ToJavaElevationInfo(env, elevationInfo);
+  return ToJavaElevationInfo(env, frm()->GetTrackRecordingElevationInfo());
 }
 
 JNIEXPORT void Java_app_organicmaps_sdk_location_TrackRecorder_nativeStopTrackRecording(JNIEnv * env, jclass clazz)

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.h
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.h
@@ -30,9 +30,7 @@ typedef void (^TrackRecordingUpdatedHandler)(TrackInfo * _Nonnull trackInfo);
 + (void)saveTrackRecordingWithName:(nonnull NSString *)name;
 + (BOOL)isTrackRecordingEnabled;
 + (BOOL)isTrackRecordingEmpty;
-/// Returns current track recording elevation info.
-/// If the track recording is not in progress, returns empty ElevationProfileData.
-+ (ElevationProfileData * _Nonnull)trackRecordingElevationInfo;
++ (ElevationProfileData * _Nullable)trackRecordingElevationInfo;
 
 @end
 

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
@@ -289,8 +289,11 @@ static Framework::ProductsPopupCloseReason ConvertProductPopupCloseReasonToCore(
   return GetFramework().IsTrackRecordingEmpty();
 }
 
-+ (ElevationProfileData * _Nonnull)trackRecordingElevationInfo
++ (ElevationProfileData * _Nullable)trackRecordingElevationInfo
 {
+  if (GetFramework().IsTrackRecordingEmpty())
+    return nil;
+
   return [[ElevationProfileData alloc] initWithElevationInfo:GetFramework().GetTrackRecordingElevationInfo()];
 }
 

--- a/iphone/Maps/Core/TrackRecorder/TrackRecordingManager.swift
+++ b/iphone/Maps/Core/TrackRecorder/TrackRecordingManager.swift
@@ -16,7 +16,7 @@ enum StopTrackRecordingResult {
 protocol TrackRecordingObservable: AnyObject {
   var recordingState: TrackRecordingState { get }
   var trackRecordingInfo: TrackInfo { get }
-  var trackRecordingElevationProfileData: ElevationProfileData { get }
+  var trackRecordingElevationProfileData: ElevationProfileData? { get }
 
   func addObserver(_ observer: AnyObject, recordingIsActiveDidChangeHandler: @escaping TrackRecordingStateHandler)
   func removeObserver(_ observer: AnyObject)
@@ -24,14 +24,14 @@ protocol TrackRecordingObservable: AnyObject {
 }
 
 /// A handler type for extracting elevation profile data on demand.
-typealias ElevationProfileDataExtractionHandler = () -> ElevationProfileData
+typealias ElevationProfileDataExtractionHandler = () -> ElevationProfileData?
 
 /// A callback type that notifies observers about track recording state changes.
 /// - Parameters:
 ///   - state: The current recording state.
 ///   - info: The current track recording info.
 ///   - elevationProfileExtractor: A closure to fetch elevation profile data lazily.
-typealias TrackRecordingStateHandler = (TrackRecordingState, TrackInfo, ElevationProfileDataExtractionHandler?) -> Void
+typealias TrackRecordingStateHandler = (TrackRecordingState, TrackInfo, ElevationProfileDataExtractionHandler) -> Void
 
 @objcMembers
 final class TrackRecordingManager: NSObject {
@@ -60,8 +60,8 @@ final class TrackRecordingManager: NSObject {
   private var observations: [Observation] = []
   private(set) var trackRecordingInfo: TrackInfo = .empty()
 
-  var trackRecordingElevationProfileData: ElevationProfileData {
-    FrameworkHelper.trackRecordingElevationInfo()
+  var trackRecordingElevationProfileData: ElevationProfileData? {
+    trackRecorder.trackRecordingElevationInfo()
   }
 
   var recordingState: TrackRecordingState {

--- a/iphone/Maps/Tests/Core/TrackRecorder/TrackRecordingManagerTests.swift
+++ b/iphone/Maps/Tests/Core/TrackRecorder/TrackRecordingManagerTests.swift
@@ -112,6 +112,19 @@ final class TrackRecordingManagerTests: XCTestCase {
     XCTAssertFalse(mockTrackRecorder.saveTrackRecordingCalled)
     XCTAssertTrue(trackRecordingManager.recordingState == .inactive)
   }
+
+  func test_GivenElevationInfoIsUnavailable_WhenGetTrackRecordingElevationProfileData_ThenReturnsNil() {
+    mockTrackRecorder.trackRecordingElevationProfileData = nil
+
+    XCTAssertNil(trackRecordingManager.trackRecordingElevationProfileData)
+  }
+
+  func test_GivenElevationInfoIsAvailable_WhenGetTrackRecordingElevationProfileData_ThenReturnsData() {
+    let elevationProfileData = ElevationProfileData()
+    mockTrackRecorder.trackRecordingElevationProfileData = elevationProfileData
+
+    XCTAssertTrue(trackRecordingManager.trackRecordingElevationProfileData === elevationProfileData)
+  }
 }
 
 // MARK: - Mock Classes
@@ -122,6 +135,7 @@ private final class MockTrackRecorder: TrackRecorder {
   static var startTrackRecordingCalled = false
   static var stopTrackRecordingCalled = false
   static var saveTrackRecordingCalled = false
+  static var trackRecordingElevationProfileData: ElevationProfileData?
 
   static func reset() {
     trackRecordingIsEnabled = false
@@ -129,6 +143,7 @@ private final class MockTrackRecorder: TrackRecorder {
     startTrackRecordingCalled = false
     stopTrackRecordingCalled = false
     saveTrackRecordingCalled = false
+    trackRecordingElevationProfileData = nil
   }
 
   static func isTrackRecordingEnabled() -> Bool {
@@ -155,8 +170,8 @@ private final class MockTrackRecorder: TrackRecorder {
 
   static func setTrackRecordingUpdateHandler(_: ((TrackInfo) -> Void)?) {}
 
-  static func trackRecordingElevationInfo() -> ElevationProfileData {
-    ElevationProfileData()
+  static func trackRecordingElevationInfo() -> ElevationProfileData? {
+    trackRecordingElevationProfileData
   }
 }
 

--- a/iphone/Maps/UI/Map/MapViewController.mm
+++ b/iphone/Maps/UI/Map/MapViewController.mm
@@ -1129,7 +1129,7 @@ NSString * const kCategorySelectorSegue = @"MapToCategorySelectorSegue";
   __weak __typeof(self) weakSelf = self;
   [self.trackRecordingManager addObserver:self
         recordingIsActiveDidChangeHandler:^(TrackRecordingState state, TrackInfo * _Nonnull trackInfo,
-                                            ElevationProfileData * _Nonnull (^_Nullable elevationData)()) {
+                                            ElevationProfileData * _Nullable (^elevationData)()) {
           __strong __typeof(weakSelf) self = weakSelf;
           if (!self)
             return;

--- a/iphone/Maps/UI/NavigationDashboard/MWMNavigationDashboardManager.mm
+++ b/iphone/Maps/UI/NavigationDashboard/MWMNavigationDashboardManager.mm
@@ -42,7 +42,7 @@
     _parentViewController = viewController;
     [TrackRecordingManager.shared addObserver:self
             recordingIsActiveDidChangeHandler:^(TrackRecordingState state, TrackInfo * _Nonnull,
-                                                ElevationProfileData * _Nonnull (^_Nullable)()) {
+                                                ElevationProfileData * _Nullable (^)()) {
               __strong __typeof(weakSelf) self = weakSelf;
               if (!self)
                 return;


### PR DESCRIPTION
The app can crash when starting track recording and immediately showing the track recording place page before there is recorded elevation data to display.

Reports started from the 2026.06.24 release. The feature was introduced earlier in commit f3f856d by adding the 
`CHECK(m_collection, ());`
to the 
```cpp
ElevationInfo const & GpsTrack::GetElevationInfo() const
{
  std::lock_guard lg(m_threadGuard);
  CHECK(m_collection, ());
  return m_collection->UpdateAndGetElevationInfo();
}
```

Crash report:

```text
3   Organic Maps 0x00000001054de020 +[MWMFrameworkHelper trackRecordingElevationInfo] + 2068 (MWMFrameworkHelper.mm:294)
4   Organic Maps 0x0000000104baba38 @objc TrackRecordingManager.trackRecordingElevationProfileData.getter + 24 (/<compiler-generated>:63)
5   Organic Maps 0x0000000104c86480 -[MapViewController showTrackRecordingPlacePage] + 164 (MapViewController.mm:1121)
6   Organic Maps 0x0000000104bab138 TrackRecordingManager.start(completion:) + 180 (TrackRecordingManager.swift:122)
7   Organic Maps 0x0000000104afaa34 BottomMenuInteractor.toggleTrackRecording() + 184 (BottomMenuInteractor.swift:99)
8   Organic Maps 0x0000000104afcb04 BottomMenuPresenter.tableView(_:didSelectRowAt:) + 200 (BottomMenuPresenter.swift:168)
9   Organic Maps 0x0000000104afd210 @objc BottomMenuPresenter.tableView(_:didSelectRowAt:) + 136 (/<compiler-generated>:0)
```

<img width="998" height="483" alt="image" src="https://github.com/user-attachments/assets/06925289-9640-4772-ab6d-f25021dbc1eb" />
