### PR TITLE
[android] Fix map downloads to USB storage failing on close() EPERM

### DIFF
--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -13,6 +13,12 @@ android {
     buildConfig = true
   }
 
+  testOptions {
+    // Turns android.util.Log and friends into no-op stubs on the JVM, so unit tests can
+    // cover code that incidentally logs (e.g. StorageUtils) without an emulator.
+    unitTests.returnDefaultValues = true
+  }
+
   defaultConfig {
     externalNativeBuild {
       def pchFlag = 'OFF'

--- a/android/sdk/src/androidTest/java/app/organicmaps/sdk/util/StorageUtilsTest.java
+++ b/android/sdk/src/androidTest/java/app/organicmaps/sdk/util/StorageUtilsTest.java
@@ -1,0 +1,28 @@
+package app.organicmaps.sdk.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.system.ErrnoException;
+import android.system.OsConstants;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class StorageUtilsTest
+{
+  @Test
+  public void outOfSpaceClassificationUsesErrno()
+  {
+    assertTrue(StorageUtils.isOutOfSpace(errnoFailure(OsConstants.ENOSPC)));
+    assertTrue(StorageUtils.isOutOfSpace(errnoFailure(OsConstants.EDQUOT)));
+    assertFalse(StorageUtils.isOutOfSpace(errnoFailure(OsConstants.EIO)));
+  }
+
+  private static IOException errnoFailure(int errno)
+  {
+    return new IOException("I/O failed", new ErrnoException("test", errno));
+  }
+}

--- a/android/sdk/src/androidTest/java/app/organicmaps/sdk/util/UtilsTest.java
+++ b/android/sdk/src/androidTest/java/app/organicmaps/sdk/util/UtilsTest.java
@@ -1,0 +1,55 @@
+package app.organicmaps.sdk.util;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.system.ErrnoException;
+import android.system.OsConstants;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class UtilsTest
+{
+  @Test
+  public void closeIgnoringEpermIgnoresNestedEperm() throws IOException
+  {
+    final AtomicBoolean closed = new AtomicBoolean();
+    final Closeable file = () ->
+    {
+      closed.set(true);
+      throw errnoFailure(OsConstants.EPERM);
+    };
+    Utils.closeIgnoringEperm(file, "test file");
+    assertTrue(closed.get());
+  }
+
+  @Test
+  public void closeIgnoringEpermPropagatesOtherErrnos()
+  {
+    final IOException failure = errnoFailure(OsConstants.EIO);
+    final Closeable file = () ->
+    {
+      throw failure;
+    };
+    try
+    {
+      Utils.closeIgnoringEperm(file, "test file");
+      fail("EIO must not be ignored");
+    }
+    catch (IOException e)
+    {
+      assertSame(failure, e);
+    }
+  }
+
+  private static IOException errnoFailure(int errno)
+  {
+    return new IOException("I/O failed", new ErrnoException("test", errno));
+  }
+}

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/DownloadResourcesLegacyActivity.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/DownloadResourcesLegacyActivity.cpp
@@ -4,6 +4,7 @@
 
 #include "storage/downloader.hpp"
 #include "storage/storage.hpp"
+#include "storage/storage_helpers.hpp"
 
 #include "platform/downloader_defines.hpp"
 #include "platform/http_request.hpp"
@@ -42,6 +43,7 @@ static std::vector<platform::CountryFile> g_filesToDownload;
 static uint64_t g_totalDownloadedBytes;
 static uint64_t g_totalBytesToDownload;
 static std::shared_ptr<downloader::HttpRequest> g_currentRequest;
+static uint64_t g_downloadGeneration;
 
 }  // namespace
 
@@ -50,6 +52,7 @@ extern "C"
 JNIEXPORT jint Java_app_organicmaps_sdk_DownloadResourcesLegacyActivity_nativeGetBytesToDownload(JNIEnv * env,
                                                                                                  jclass clazz)
 {
+  ++g_downloadGeneration;
   // clear all
   g_filesToDownload.clear();
   g_totalBytesToDownload = 0;
@@ -96,24 +99,24 @@ JNIEXPORT jint Java_app_organicmaps_sdk_DownloadResourcesLegacyActivity_nativeGe
   return res;
 }
 
-static void DownloadFileFinished(std::shared_ptr<jobject> obj, downloader::HttpRequest const & req)
+static void NotifyDownloadFileFinished(std::shared_ptr<jobject> obj, uint64_t generation,
+                                       platform::CountryFile const & downloadedFile, downloader::DownloadStatus status)
 {
   using downloader::DownloadStatus;
 
-  auto const status = req.GetStatus();
-  ASSERT_NOT_EQUAL(status, DownloadStatus::InProgress, ());
+  if (generation != g_downloadGeneration)
+    return;
 
   int errorCode = ERR_DOWNLOAD_ERROR;
   if (status == DownloadStatus::Completed)
     errorCode = ERR_DOWNLOAD_SUCCESS;
 
-  g_currentRequest.reset();
-
   if (errorCode == ERR_DOWNLOAD_SUCCESS)
   {
-    auto const & curFile = g_filesToDownload.back();
-    size_t const sz = curFile.GetRemoteSize();
-    LOG(LDEBUG, ("finished downloading", curFile.GetName(), "size", sz, "bytes"));
+    CHECK(!g_filesToDownload.empty(), ());
+    CHECK_EQUAL(g_filesToDownload.back().GetName(), downloadedFile.GetName(), ());
+    uint64_t const sz = downloadedFile.GetRemoteSize();
+    LOG(LDEBUG, ("finished downloading", downloadedFile.GetName(), "size", sz, "bytes"));
 
     g_totalDownloadedBytes += sz;
     LOG(LDEBUG, ("totalDownloadedBytes:", g_totalDownloadedBytes));
@@ -127,8 +130,40 @@ static void DownloadFileFinished(std::shared_ptr<jobject> obj, downloader::HttpR
   env->CallVoidMethod(*obj, methodID, errorCode);
 }
 
-static void DownloadFileProgress(std::shared_ptr<jobject> listener, downloader::HttpRequest const & req)
+static void DownloadFileFinished(std::shared_ptr<jobject> obj, uint64_t generation, downloader::HttpRequest const & req)
 {
+  using downloader::DownloadStatus;
+
+  auto const status = req.GetStatus();
+  ASSERT_NOT_EQUAL(status, DownloadStatus::InProgress, ());
+  if (generation != g_downloadGeneration)
+    return;
+
+  CHECK(!g_filesToDownload.empty(), ());
+  auto const downloadedFile = g_filesToDownload.back();
+  auto const path = req.GetFilePath();
+  g_currentRequest.reset();
+
+  if (status != DownloadStatus::Completed)
+  {
+    NotifyDownloadFileFinished(std::move(obj), generation, downloadedFile, status);
+    return;
+  }
+
+  GetPlatform().RunTask(Platform::Thread::File, [obj = std::move(obj), generation, downloadedFile, path]() mutable
+  {
+    auto const status = storage::ValidateDownloadedFile(path, downloadedFile.GetHash());
+    GetPlatform().RunTask(Platform::Thread::Gui, [obj = std::move(obj), generation, downloadedFile, status]() mutable
+    { NotifyDownloadFileFinished(std::move(obj), generation, downloadedFile, status); });
+  });
+}
+
+static void DownloadFileProgress(std::shared_ptr<jobject> listener, uint64_t generation,
+                                 downloader::HttpRequest const & req)
+{
+  if (generation != g_downloadGeneration)
+    return;
+
   JNIEnv * env = jni::GetEnv();
   static jmethodID methodID = jni::GetMethodID(env, *listener, "onProgress", "(I)V");
   env->CallVoidMethod(*listener, methodID,
@@ -149,16 +184,20 @@ JNIEXPORT jint Java_app_organicmaps_sdk_DownloadResourcesLegacyActivity_nativeSt
   auto const & storage = g_framework->GetStorage();
   downloader->SetDataVersion(storage.GetCurrentDataVersion());
 
-  downloader->EnsureMetaConfigReady([&storage, ptr = jni::make_global_ref(listener)]()
+  auto const generation = g_downloadGeneration;
+  downloader->EnsureMetaConfigReady([&storage, ptr = jni::make_global_ref(listener), generation]()
   {
+    if (generation != g_downloadGeneration)
+      return;
+
     auto const & curFile = g_filesToDownload.back();
     auto const fileName = curFile.GetFileName(MapFileType::Map);
     LOG(LINFO, ("Downloading file", fileName));
 
     g_currentRequest.reset(downloader::HttpRequest::GetFile(
         downloader->MakeUrlListLegacy(fileName), storage.GetFilePath(curFile.GetName(), MapFileType::Map),
-        curFile.GetRemoteSize(), std::bind(&DownloadFileFinished, ptr, _1), std::bind(&DownloadFileProgress, ptr, _1),
-        false));
+        curFile.GetRemoteSize(), std::bind(&DownloadFileFinished, ptr, generation, _1),
+        std::bind(&DownloadFileProgress, ptr, generation, _1), false));
   });
 
   return ERR_FILE_IN_PROGRESS;
@@ -168,6 +207,7 @@ JNIEXPORT void Java_app_organicmaps_sdk_DownloadResourcesLegacyActivity_nativeCa
                                                                                                 jclass clazz)
 {
   LOG(LDEBUG, ("cancelCurrentFile, currentRequest=", g_currentRequest));
+  ++g_downloadGeneration;
   g_currentRequest.reset();
 }
 }

--- a/android/sdk/src/main/java/app/organicmaps/sdk/settings/StoragePathManager.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/settings/StoragePathManager.java
@@ -210,8 +210,6 @@ public class StoragePathManager
       return;
     }
 
-    // For writability check use a test dir creation instead of canWrite() to get more information
-    // and avoid possible false negatives.
     if (!StorageUtils.isDirWritable(dir))
     {
       if (Environment.MEDIA_MOUNTED_READ_ONLY.equals(state))

--- a/android/sdk/src/main/java/app/organicmaps/sdk/util/HttpClient.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/util/HttpClient.java
@@ -311,27 +311,38 @@ public final class HttpClient
     }
 
     long bytesWritten = 0;
-    try (RandomAccessFile raf = new RandomAccessFile(targetFile, "rw");
-         okio.BufferedSource source = responseBody.source())
+    try (okio.BufferedSource source = responseBody.source())
     {
-      raf.seek(p.outputFileOffset);
-      // 64 KB buffer: RandomAccessFile.write is unbuffered, so each iteration is a
-      // syscall + JNI crossing. Matches typical 512 KB segment chunks at ~8 iterations.
-      byte[] buffer = new byte[65536];
-      int bytesRead;
-      while ((bytesRead = source.read(buffer)) != -1)
+      final RandomAccessFile raf = new RandomAccessFile(targetFile, "rw");
+      try
       {
-        long remaining = p.outputFileSegmentBytes - bytesWritten;
-        if (bytesRead > remaining)
+        raf.seek(p.outputFileOffset);
+        // 64 KB buffer: RandomAccessFile.write is unbuffered, so each iteration is a
+        // syscall + JNI crossing. Matches typical 512 KB segment chunks at ~8 iterations.
+        byte[] buffer = new byte[65536];
+        int bytesRead;
+        while ((bytesRead = source.read(buffer)) != -1)
         {
-          Logger.w(TAG, "Segment overflow: " + bytesRead + " bytes received, only " + remaining + " expected");
-          p.httpResponseCode = kInconsistentFileSize;
-          return;
+          long remaining = p.outputFileSegmentBytes - bytesWritten;
+          if (bytesRead > remaining)
+          {
+            Logger.w(TAG, "Segment overflow: " + bytesRead + " bytes received, only " + remaining + " expected");
+            p.httpResponseCode = kInconsistentFileSize;
+            return;
+          }
+          raf.write(buffer, 0, bytesRead);
+          bytesWritten += bytesRead;
+          if (hasProgressHandler)
+            nativeOnProgress(nativeCtxPtr, bytesWritten, p.outputFileSegmentBytes);
         }
-        raf.write(buffer, 0, bytesRead);
-        bytesWritten += bytesRead;
-        if (hasProgressHandler)
-          nativeOnProgress(nativeCtxPtr, bytesWritten, p.outputFileSegmentBytes);
+      }
+      finally
+      {
+        // Some FUSE-mounted removable volumes report EPERM from close() although the segment
+        // was written. Retrying cannot fix that volume-specific error, while every errno that
+        // does report lost data (ENOSPC, EIO, EROFS, ...) still fails the segment. Data lost
+        // without any error at all is caught by the BLAKE3 check of the assembled map.
+        Utils.closeIgnoringEperm(raf, p.outputFilePath + " after writing " + bytesWritten + " bytes");
       }
     }
     catch (IOException e)

--- a/android/sdk/src/main/java/app/organicmaps/sdk/util/StorageUtils.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/util/StorageUtils.java
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.DocumentsContract;
+import android.system.OsConstants;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import app.organicmaps.sdk.util.log.Logger;
@@ -15,7 +16,10 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -28,10 +32,9 @@ public class StorageUtils
     final String path = dir.getPath();
     Logger.d(TAG, "Checking for writability " + path);
 
-    // Its better to be conservative here and don't allow to use the storage
-    // if any of the system calls behave unexpectedly,
-    // still we want extra logging to facilitate debugging possible fringe cases,
-    // e.g. https://github.com/organicmaps/organicmaps/issues/2684
+    // Keep the individual checks for diagnostics, but let direct probes decide whether
+    // the operations used by map storage actually work. In particular, canRead() and
+    // canWrite() are only advisory on some document-provider and FUSE-backed volumes.
     boolean success = true;
     if (!dir.isDirectory())
     {
@@ -44,15 +47,9 @@ public class StorageUtils
       success = false;
     }
     if (!dir.canWrite())
-    {
       Logger.w(TAG, "Not writable: " + path);
-      success = false;
-    }
     if (!dir.canRead())
-    {
       Logger.w(TAG, "Not readable: " + path);
-      success = false;
-    }
     if (dir.list() == null)
     {
       Logger.w(TAG, "Not listable: " + path);
@@ -81,7 +78,103 @@ public class StorageUtils
       success = false;
     }
 
+    // Probe the operations map downloads depend on: create, write, close, and read back
+    // a file. EPERM from close() is ignored exactly as the downloader ignores it.
+    final File testFile = new File(dir, "om_test_file");
+    final String testFilePath = testFile.getPath();
+    if (testFile.delete())
+      Logger.i(TAG, "Deleted the existing test file: " + testFilePath);
+    // The timestamp makes the payload differ between runs, so that a stack silently
+    // keeping a previous probe's file instead of the new one fails the read-back.
+    final byte[] payload = (testFilePath + ' ' + System.nanoTime()).getBytes(StandardCharsets.UTF_8);
+    boolean written = false;
+    RandomAccessFile writer = null;
+    try
+    {
+      // The same open mode as the downloader uses; "rw" doesn't truncate, hence setLength().
+      writer = new RandomAccessFile(testFile, "rw");
+      writer.setLength(0);
+      writer.write(payload);
+      written = true;
+    }
+    catch (IOException e)
+    {
+      // A full volume is not an unwritable one: an SD card packed with maps works again
+      // as soon as a map is deleted, while marking it read-only takes it out of the
+      // storage picker for good.
+      if (isOutOfSpace(e))
+        Logger.w(TAG, "No space left for the test file: " + testFilePath, e);
+      else
+      {
+        Logger.w(TAG, "Failed to write the test file: " + testFilePath, e);
+        success = false;
+      }
+    }
+    finally
+    {
+      try
+      {
+        Utils.closeIgnoringEperm(writer, "the written test file " + testFilePath);
+      }
+      catch (IOException e)
+      {
+        // Deferred write errors, a full volume included, are reported by close() on FUSE
+        // and network file systems. The content can't be trusted, so skip the read-back.
+        written = false;
+        if (isOutOfSpace(e))
+          Logger.w(TAG, "No space left to close the test file: " + testFilePath, e);
+        else
+        {
+          Logger.w(TAG, "Failed to close the written test file: " + testFilePath, e);
+          success = false;
+        }
+      }
+    }
+    if (written)
+    {
+      try
+      {
+        if (!fileHasExpectedContent(testFile, payload))
+        {
+          Logger.w(TAG, "Read back different content from the test file: " + testFilePath);
+          success = false;
+        }
+      }
+      catch (IOException e)
+      {
+        Logger.w(TAG, "Failed to read the test file back: " + testFilePath, e);
+        success = false;
+      }
+    }
+    if (testFile.exists() && !testFile.delete())
+    {
+      Logger.w(TAG, "Failed to delete the test file: " + testFilePath);
+      success = false;
+    }
+
     return success;
+  }
+
+  static boolean fileHasExpectedContent(@NonNull File file, @NonNull byte[] expected) throws IOException
+  {
+    final RandomAccessFile reader = new RandomAccessFile(file, "r");
+    try
+    {
+      if (reader.length() != expected.length)
+        return false;
+      final byte[] actual = new byte[expected.length];
+      reader.readFully(actual);
+      return Arrays.equals(expected, actual);
+    }
+    finally
+    {
+      Utils.closeIgnoringEperm(reader, "the read test file " + file.getPath());
+    }
+  }
+
+  static boolean isOutOfSpace(@NonNull IOException error)
+  {
+    return Utils.isErrno(error, OsConstants.ENOSPC) || Utils.isErrno(error, OsConstants.EDQUOT);
   }
 
   @NonNull

--- a/android/sdk/src/main/java/app/organicmaps/sdk/util/Utils.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/util/Utils.java
@@ -9,6 +9,8 @@ import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
+import android.system.ErrnoException;
+import android.system.OsConstants;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.view.View;
@@ -308,6 +310,34 @@ public class Utils
         }
       }
     }
+  }
+
+  /**
+   * Closes a file resource, ignoring only the EPERM reported by storage stacks that reject close(). Callers must
+   * independently verify written data; other close errors still make the operation fail.
+   */
+  static void closeIgnoringEperm(@Nullable Closeable closeable, @NonNull String context) throws IOException
+  {
+    if (closeable == null)
+      return;
+    try
+    {
+      closeable.close();
+    }
+    catch (IOException e)
+    {
+      if (!isErrno(e, OsConstants.EPERM))
+        throw e;
+      Logger.w(TAG, "Ignoring EPERM from close() for " + context + ": " + e);
+    }
+  }
+
+  static boolean isErrno(@NonNull Throwable error, int errno)
+  {
+    for (Throwable cause = error; cause != null; cause = cause.getCause())
+      if (cause instanceof ErrnoException && ((ErrnoException) cause).errno == errno)
+        return true;
+    return false;
   }
 
   public static <K, V> String mapPrettyPrint(Map<K, V> map)

--- a/android/sdk/src/test/java/app/organicmaps/sdk/util/StorageUtilsTest.java
+++ b/android/sdk/src/test/java/app/organicmaps/sdk/util/StorageUtilsTest.java
@@ -1,0 +1,121 @@
+package app.organicmaps.sdk.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+// These tests run on the JVM: isDirWritable() uses only java.io, and Logger calls are
+// no-op stubs there (returnDefaultValues, see build.gradle).
+public class StorageUtilsTest
+{
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void writableDir()
+  {
+    final File dir = tempFolder.getRoot();
+    assertTrue(StorageUtils.isDirWritable(dir));
+    // The probe must clean up after itself.
+    assertFalse(new File(dir, "om_test_dir").exists());
+    assertFalse(new File(dir, "om_test_file").exists());
+  }
+
+  @Test
+  public void nonExistentDir()
+  {
+    assertFalse(StorageUtils.isDirWritable(new File(tempFolder.getRoot(), "missing")));
+  }
+
+  @Test
+  public void fileInsteadOfDir() throws IOException
+  {
+    assertFalse(StorageUtils.isDirWritable(tempFolder.newFile()));
+  }
+
+  @Test
+  public void leftoverProbeArtifactsAreReplaced() throws IOException
+  {
+    final File dir = tempFolder.getRoot();
+    assertTrue(new File(dir, "om_test_dir").mkdir());
+    final File staleFile = new File(dir, "om_test_file");
+    try (FileOutputStream os = new FileOutputStream(staleFile))
+    {
+      os.write("stale content from a previous run".getBytes(StandardCharsets.UTF_8));
+    }
+    assertTrue(StorageUtils.isDirWritable(dir));
+    assertFalse(staleFile.exists());
+    assertFalse(new File(dir, "om_test_dir").exists());
+  }
+
+  @Test
+  public void unwritableTestFile() throws IOException
+  {
+    final File dir = tempFolder.getRoot();
+    // A non-empty directory in place of the probe file can neither be deleted nor written to.
+    // The volume has free space, so this must be reported as not writable.
+    final File blocker = new File(dir, "om_test_file");
+    assertTrue(blocker.mkdir());
+    assertTrue(new File(blocker, "child").createNewFile());
+    assertFalse(StorageUtils.isDirWritable(dir));
+  }
+
+  @Test
+  public void readOnlyDir()
+  {
+    final File dir = tempFolder.getRoot();
+    // Running as root (some CI containers) ignores permission bits -- skip there.
+    Assume.assumeTrue(dir.setWritable(false) && !dir.canWrite());
+    try
+    {
+      assertFalse(StorageUtils.isDirWritable(dir));
+    }
+    finally
+    {
+      // Not asserted: a failure here would replace the real one reported by the test body.
+      dir.setWritable(true);
+    }
+  }
+
+  @Test
+  public void readBackRequiresExactContent() throws IOException
+  {
+    final byte[] expected = "expected probe payload".getBytes(StandardCharsets.UTF_8);
+    final File file = tempFolder.newFile();
+
+    write(file, expected);
+    assertTrue(StorageUtils.fileHasExpectedContent(file, expected));
+
+    final byte[] different = expected.clone();
+    different[different.length / 2] ^= 1;
+    write(file, different);
+    assertFalse(StorageUtils.fileHasExpectedContent(file, expected));
+
+    write(file, Arrays.copyOf(expected, expected.length - 1));
+    assertFalse(StorageUtils.fileHasExpectedContent(file, expected));
+
+    final ByteArrayOutputStream longer = new ByteArrayOutputStream();
+    longer.write(expected);
+    longer.write(0);
+    write(file, longer.toByteArray());
+    assertFalse(StorageUtils.fileHasExpectedContent(file, expected));
+  }
+
+  private static void write(File file, byte[] content) throws IOException
+  {
+    try (FileOutputStream stream = new FileOutputStream(file))
+    {
+      stream.write(content);
+    }
+  }
+}

--- a/android/sdk/src/test/java/app/organicmaps/sdk/util/UtilsTest.java
+++ b/android/sdk/src/test/java/app/organicmaps/sdk/util/UtilsTest.java
@@ -1,0 +1,40 @@
+package app.organicmaps.sdk.util;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+
+public class UtilsTest
+{
+  @Test
+  public void closeIgnoringEpermClosesResource() throws IOException
+  {
+    final AtomicBoolean closed = new AtomicBoolean();
+    Utils.closeIgnoringEperm(() -> closed.set(true), "test resource");
+    assertTrue(closed.get());
+  }
+
+  @Test
+  public void closeIgnoringEpermPropagatesOtherIoErrors()
+  {
+    final IOException failure = new IOException("close failed");
+    final Closeable resource = () ->
+    {
+      throw failure;
+    };
+    try
+    {
+      Utils.closeIgnoringEperm(resource, "test resource");
+      fail("A non-EPERM close error must be propagated");
+    }
+    catch (IOException e)
+    {
+      assertSame(failure, e);
+    }
+  }
+}

--- a/libs/platform/http_request.cpp
+++ b/libs/platform/http_request.cpp
@@ -175,9 +175,8 @@ class FileHttpRequest : public HttpRequest
 
   void SaveResumeChunks()
   {
-    // No writer flush needed — each chunk's transport closes its own file handle
-    // before the completion callback fires. Completed chunks are durable on disk
-    // (modulo kernel buffer flushing, same as the historical FileWriter::Flush() path).
+    // A completion callback runs only after that chunk's transport has finished with its
+    // file handle, so the saved resume state never describes a write still in progress.
     m_strategy.SaveChunks(m_progress.m_bytesTotal, m_filePath + RESUME_FILE_EXTENSION);
   }
 

--- a/libs/storage/storage.cpp
+++ b/libs/storage/storage.cpp
@@ -14,7 +14,6 @@
 #include "platform/preferred_languages.hpp"
 #include "platform/settings.hpp"
 
-#include "coding/blake3.hpp"
 #include "coding/file_writer.hpp"
 #include "coding/internal/file_data.hpp"
 
@@ -788,31 +787,13 @@ void Storage::OnDownloadFinished(QueuedCountry const & queuedCountry, DownloadSt
 
   if (status == DownloadStatus::Completed && m_integrityValidationEnabled)
   {
-    /// @todo Can/Should be combined with ApplyDiff routine when we will restore it.
-    /// While this is simple and working solution, I think that Downloader component
-    /// should make this kind of checks (taking the expected hash as input). But now it's
-    /// not so simple as it may seem ..
-
     GetPlatform().RunTask(Platform::Thread::File,
                           [path = GetFileDownloadPath(countryId, fileType), hash = GetCountryFile(countryId).GetHash(),
                            fn = std::move(finishFn)]()
     {
-      DownloadStatus status = DownloadStatus::Completed;
+      auto const status = ValidateDownloadedFile(path, hash);
 
-      if (coding::Blake3::CalculateMwmBase64(path) != hash)
-      {
-        base::DeleteFileX(path);
-        status = DownloadStatus::FailedIntegrityCheck;
-        LOG(LERROR, ("Integrity check error for", path));
-      }
-
-      GetPlatform().RunTask(Platform::Thread::Gui, [fn = std::move(fn), status]()
-      {
-        if (status == DownloadStatus::Completed)
-          LOG(LDEBUG, ("Successful integrity check"));
-
-        fn(status);
-      });
+      GetPlatform().RunTask(Platform::Thread::Gui, [fn = std::move(fn), status]() { fn(status); });
     });
   }
   else

--- a/libs/storage/storage_helpers.cpp
+++ b/libs/storage/storage_helpers.cpp
@@ -5,6 +5,11 @@
 
 #include "platform/platform.hpp"
 
+#include "coding/blake3.hpp"
+#include "coding/internal/file_data.hpp"
+
+#include "base/logging.hpp"
+
 #include "std/target_os.hpp"
 
 namespace storage
@@ -59,6 +64,19 @@ bool IsEnoughSpaceForUpdate(CountryId const & countryId, Storage const & storage
 #else
   return IsEnoughSpaceForDownload(diff + updateInfo.m_maxFileSizeInBytes);
 #endif  // OMIM_OS_IPHONE
+}
+
+downloader::DownloadStatus ValidateDownloadedFile(std::string const & path, std::string const & expectedHash)
+{
+  if (coding::Blake3::CalculateMwmBase64(path) == expectedHash)
+  {
+    LOG(LDEBUG, ("Successful integrity check for", path));
+    return downloader::DownloadStatus::Completed;
+  }
+
+  base::DeleteFileX(path);
+  LOG(LERROR, ("Integrity check error for", path));
+  return downloader::DownloadStatus::FailedIntegrityCheck;
 }
 
 m2::RectD CalcLimitRect(CountryId const & countryId, Storage const & storage,

--- a/libs/storage/storage_helpers.hpp
+++ b/libs/storage/storage_helpers.hpp
@@ -5,9 +5,12 @@
 
 #include "platform/country_defines.hpp"
 #include "platform/country_file.hpp"
+#include "platform/downloader_defines.hpp"
 
 #include "geometry/point2d.hpp"
 #include "geometry/rect2d.hpp"
+
+#include <string>
 
 namespace storage
 {
@@ -25,6 +28,10 @@ bool IsDownloadFailed(Status status);
 bool IsEnoughSpaceForDownload(MwmSize mwmSize);
 bool IsEnoughSpaceForDownload(CountryId const & countryId, Storage const & storage);
 bool IsEnoughSpaceForUpdate(CountryId const & countryId, Storage const & storage);
+
+// Performs blocking I/O. Callers are responsible for running it off the GUI thread.
+// A file that does not match |expectedHash| is deleted before failure is returned.
+downloader::DownloadStatus ValidateDownloadedFile(std::string const & path, std::string const & expectedHash);
 
 /// \brief Calculates limit rect for |countryId| (expandable or not).
 /// \returns bounding box in mercator coordinates.

--- a/libs/storage/storage_tests/CMakeLists.txt
+++ b/libs/storage/storage_tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SRC
   fake_map_files_downloader.hpp
   helpers.cpp
   helpers.hpp
+  map_file_integrity_tests.cpp
   simple_tree_test.cpp
   storage_download_tests.cpp
   storage_tests.cpp

--- a/libs/storage/storage_tests/map_file_integrity_tests.cpp
+++ b/libs/storage/storage_tests/map_file_integrity_tests.cpp
@@ -1,0 +1,37 @@
+#include "testing/testing.hpp"
+
+#include "storage/storage_helpers.hpp"
+
+#include "platform/platform_tests_support/scoped_file.hpp"
+
+#include "coding/blake3.hpp"
+
+#include "base/logging.hpp"
+
+namespace storage
+{
+namespace
+{
+using platform::tests_support::ScopedFile;
+
+UNIT_TEST(MapFileIntegrity_AcceptsMatchingHash)
+{
+  ScopedFile file("valid_download.mwm", "valid map data");
+  auto const hash = coding::Blake3::CalculateMwmBase64(file.GetFullPath());
+
+  TEST_EQUAL(ValidateDownloadedFile(file.GetFullPath(), hash), downloader::DownloadStatus::Completed, ());
+  TEST(file.Exists(), ());
+}
+
+UNIT_TEST(MapFileIntegrity_DeletesMismatchedFile)
+{
+  base::ScopedLogAbortLevelChanger const ignoreErrors(LCRITICAL);
+  ScopedFile file("invalid_download.mwm", "invalid map data");
+
+  TEST_EQUAL(ValidateDownloadedFile(file.GetFullPath(), "wrong hash"), downloader::DownloadStatus::FailedIntegrityCheck,
+             ());
+  TEST(!file.Exists(), ());
+  file.Reset();
+}
+}  // namespace
+}  // namespace storage


### PR DESCRIPTION
Кратко: USB-накопитель успешно записывал данные, но возвращал EPERM при закрытии файла.

## What changed

- Only EPERM from `RandomAccessFile.close()` is ignored after a download segment is written. Every other write or close error, including the ENOSPC, EIO and EROFS that report actually lost data, remains a download failure.
- Regular map downloads and the legacy Android World/WorldCoasts bootstrap now use the same storage-layer BLAKE3 validator. A mismatched download is deleted and reported as `FailedIntegrityCheck`.
- Legacy bootstrap callbacks carry a generation token so cancellation or restart cannot deliver stale progress or completion.
- `StorageUtils.isDirWritable()` retains its real-file probe and now exercises the same operations as map downloads: random-access create/write, close, exact read-back, and cleanup.
- `canRead()` and `canWrite()` remain diagnostic because direct operations are authoritative on document-provider and FUSE-backed volumes. Directory listing and the direct probes remain required.
- Only exact ENOSPC or EDQUOT errors are treated as a full but otherwise usable volume. Other write, close, read, content, and cleanup failures reject the storage.
- Added JVM, Android instrumentation, and C++ tests for close-error policy, errno classification, exact probe content, and map integrity validation.

## Why

Support logs from a Doro QCM6125 running Android 13 with an exFAT USB drive behind FUSE show every close of a write-opened file descriptor failing with EPERM although the writes succeeded. Streaming downloads close a separate `RandomAccessFile` for every segment, so treating that volume-specific close result as a generic write failure makes every mirror and retry fail.

Ignoring every close error would hide real I/O failures, and relying on normal `Storage::OnDownloadFinished()` validation would leave the legacy World/WorldCoasts bootstrap unverified. The policy therefore ignores only EPERM and verifies complete map contents in both download paths.

An earlier revision also called `FileDescriptor.sync()` on every complete segment. That is dropped: a segment is one 512 KB chunk, so it cost ~2000 fsyncs per GB from parallel chunk transports on exactly the slow removable volumes this fixes, and the affected ROM already rejects `flush` with EPERM, so a rejected `fsync` would have re-created the same deterministic failure. It also bought little — a filesystem that loses data honestly reports it at `close()` with an errno that is still propagated, and one that reports nothing is caught by the whole-file BLAKE3 check. No other code path in the repository fsyncs, so this matches the existing durability contract rather than changing it for one platform.

A full volume is deliberately not marked read-only: it becomes usable after a map is deleted, whereas a read-only classification removes it from storage selection.

No GitHub issue; reported through user support logs.

## How it was tested

- `android/gradlew -p android :sdk:testDebug :sdk:compileDebugAndroidTestJavaWithJavac -Parm64`
- `android/gradlew -p android :app:assembleGoogleDebug :sdk:car:assembleDebug :wear:assembleGoogleDebug -Parm64`
- `android/gradlew -p android :sdk:lintDebug -Parm64`
- `cmake --build build-claude --target storage_tests -j 8`
- `build-claude/storage_tests '--filter=MapFileIntegrity_.*'`
- arm64-only iOS Simulator archive of the `OMaps` workspace/scheme, including CarPlay and Metal targets

Both commits were verified to build and pass tests independently. Android instrumentation tests compile locally but were not run without an emulator/device.

Analyzed and implemented with the help of LLM tools (Claude Code and Codex); reviewed and tested by me.
