### PR TITLE
[shaders] Locate test shader compilers by absolute path

### DIFF
--- a/libs/shaders/shaders_tests/CMakeLists.txt
+++ b/libs/shaders/shaders_tests/CMakeLists.txt
@@ -1,13 +1,5 @@
 project(shaders_tests)
 
-execute_process(
-  COMMAND rm -rf ${CMAKE_BINARY_DIR}/shaders_compiler
-)
-
-execute_process(
-  COMMAND cp -r ${OMIM_ROOT}/tools/shaders_compiler ${CMAKE_BINARY_DIR}/shaders_compiler
-)
-
 set(SRC
   gl_shaders_desktop_compile_tests.cpp
   gl_program_params_tests.cpp
@@ -16,6 +8,14 @@ set(SRC
 )
 
 omim_add_test(${PROJECT_NAME} ${SRC})
+
+# External GLSL compilers used by gl_shaders_mobile_compile_test. They are only executed, never
+# written to, so the test runs them right from the source tree, no matter which directory it is
+# started from.
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE
+    OMIM_SHADERS_COMPILERS_DIR="${OMIM_ROOT}/tools/shaders_compiler"
+)
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE

--- a/libs/shaders/shaders_tests/gl_shaders_mobile_compile_test.cpp
+++ b/libs/shaders/shaders_tests/gl_shaders_mobile_compile_test.cpp
@@ -23,7 +23,14 @@
 #include <thread>
 #include <vector>
 
+// Absolute path baked in by shaders_tests/CMakeLists.txt, so the test finds the compilers no matter
+// which directory it is started from. The xcode/shaders project does not define it and resolves the
+// compilers bundled into its Resources against the working directory.
+#ifdef OMIM_SHADERS_COMPILERS_DIR
+std::string const kCompilersDir = OMIM_SHADERS_COMPILERS_DIR;
+#else
 std::string const kCompilersDir = "shaders_compiler";
+#endif
 
 #if defined(OMIM_OS_MAC)
 std::string const kMaliCompilerOpenGLES3Dir = "macos/mali_compiler_es3";
@@ -108,10 +115,11 @@ void TestShaders(dp::ApiVersion apiVersion, std::string const & defines, QString
 {
   for (auto const & src : shaders)
   {
-    // From QTemporaryFile documentation (https://doc.qt.io/qt-5/qtemporaryfile.html):
+    // From QTemporaryFile documentation (https://doc.qt.io/qt-6/qtemporaryfile.html):
     // "Specified filenames can contain the following template XXXXXX (six upper case "X" characters),
     // which will be replaced by the auto-generated portion of the filename."
-    QTemporaryFile srcFile(QString("XXXXXX") + ext);
+    // A relative template would be resolved against the working directory.
+    QTemporaryFile srcFile(QDir::tempPath() + "/XXXXXX" + ext);
     TEST(srcFile.open(), ("Temporary file can't be created!"));
     std::string fullSrc;
     if (apiVersion == dp::ApiVersion::OpenGLES3)
@@ -128,7 +136,7 @@ std::string GetCompilerPath(std::string const & compilerName)
 {
   Platform & platform = GetPlatform();
   std::string compilerPath = base::JoinPath(kCompilersDir, compilerName);
-  TEST(platform.IsFileExistsByFullPath(compilerPath), (kCompilersDir, "should present in executable dir"));
+  TEST(platform.IsFileExistsByFullPath(compilerPath), ("Shader compiler path not found:", compilerPath));
   return compilerPath;
 }
 }  // namespace


### PR DESCRIPTION
gl_shaders_mobile_compile_test resolved "shaders_compiler" against the working directory, while its error message claimed the executable directory, so running the test binary from anywhere but the build directory failed. ctest hid this by setting WORKING_DIRECTORY to the build directory.

Bake the location in at configure time, report the resolved path on failure, and copy the compilers with file(COPY) instead of shelling out to rm and cp, which is not portable and silently drops the executable bit on some setups.