### PR TITLE
[map] Return empty elevation info when track collection is absent

### DIFF
--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/TrackRecorder.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/TrackRecorder.cpp
@@ -44,7 +44,7 @@ JNIEXPORT void Java_app_organicmaps_sdk_location_TrackRecorder_nativeSetTrackRec
 JNIEXPORT jobject Java_app_organicmaps_sdk_location_TrackRecorder_nativeGetElevationInfo(JNIEnv * env, jclass clazz)
 {
   ASSERT(frm()->IsTrackRecordingEnabled(), ("Track recording is not started"));
-  auto const & elevationInfo = frm()->GetTrackRecordingElevationInfo();
+  auto const elevationInfo = frm()->GetTrackRecordingElevationInfo();
   if (elevationInfo.IsEmpty())
     return nullptr;
   return ToJavaElevationInfo(env, elevationInfo);

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1897,7 +1897,7 @@ void Framework::SetTrackRecordingUpdateHandler(TrackRecordingUpdateHandler && tr
     m_trackRecordingUpdateHandler(GpsTracker::Instance().GetTrackStatistics());
 }
 
-ElevationInfo const & Framework::GetTrackRecordingElevationInfo()
+ElevationInfo Framework::GetTrackRecordingElevationInfo()
 {
   return GpsTracker::Instance().GetElevationInfo();
 }

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -452,7 +452,7 @@ public:
   /// Returns the elevation profile data of the currently recorded track.
   /// To get the data on the every track recording state update, this function should be called after receiving the
   /// callback from the `SetTrackRecordingUpdateHandler`.
-  static ElevationInfo const & GetTrackRecordingElevationInfo();
+  static ElevationInfo GetTrackRecordingElevationInfo();
 
   void SetMapStyle(MapStyle mapStyle);
   void MarkMapStyle(MapStyle mapStyle);

--- a/libs/map/gps_track.cpp
+++ b/libs/map/gps_track.cpp
@@ -49,6 +49,7 @@ void GpsTrack::AddPoints(std::vector<location::GpsInfo> const & points)
 }
 
 /// @note These functions are called during recording, so should be synchronized with Collection writer thread.
+/// The collection is created lazily in the worker thread, so it may be absent right after recording has started.
 /// @{
 TrackStatistics GpsTrack::GetTrackStatistics() const
 {
@@ -56,11 +57,10 @@ TrackStatistics GpsTrack::GetTrackStatistics() const
   return m_collection ? m_collection->GetTrackStatistics() : TrackStatistics();
 }
 
-ElevationInfo const & GpsTrack::GetElevationInfo() const
+ElevationInfo GpsTrack::GetElevationInfo() const
 {
   std::lock_guard lg(m_threadGuard);
-  CHECK(m_collection, ());
-  return m_collection->UpdateAndGetElevationInfo();
+  return m_collection ? m_collection->UpdateAndGetElevationInfo() : ElevationInfo();
 }
 /// @}
 

--- a/libs/map/gps_track.hpp
+++ b/libs/map/gps_track.hpp
@@ -32,7 +32,7 @@ public:
 
   /// Returns track statistics
   TrackStatistics GetTrackStatistics() const;
-  ElevationInfo const & GetElevationInfo() const;
+  ElevationInfo GetElevationInfo() const;
 
   /// Clears any previous tracking info
   /// @note Callback is called with 'toRemove' points, if some points were removed.

--- a/libs/map/gps_tracker.cpp
+++ b/libs/map/gps_tracker.cpp
@@ -73,7 +73,7 @@ TrackStatistics GpsTracker::GetTrackStatistics()
   return m_track.GetTrackStatistics();
 }
 
-ElevationInfo const & GpsTracker::GetElevationInfo()
+ElevationInfo GpsTracker::GetElevationInfo()
 {
   return m_track.GetElevationInfo();
 }

--- a/libs/map/gps_tracker.hpp
+++ b/libs/map/gps_tracker.hpp
@@ -18,7 +18,7 @@ public:
   bool IsEmpty() const;
 
   TrackStatistics GetTrackStatistics();
-  ElevationInfo const & GetElevationInfo();
+  ElevationInfo GetElevationInfo();
 
   using TGpsTrackDiffCallback =
       std::function<void(std::vector<std::pair<size_t, location::GpsInfo>> && toAdd,

--- a/libs/map/map_tests/gps_track_test.cpp
+++ b/libs/map/map_tests/gps_track_test.cpp
@@ -142,4 +142,27 @@ UNIT_TEST(GpsTrack_Simple)
     }
   }
 }
+
+UNIT_TEST(GpsTrack_ElevationInfoWithoutCollection)
+{
+  string const filePath = GetGpsTrackFilePath();
+  SCOPE_GUARD(gpsTestFileDeleter, bind(FileWriter::DeleteFileX, filePath));
+  FileWriter::DeleteFileX(filePath);
+
+  double const timestamp = system_clock::to_time_t(system_clock::now());
+
+  GpsTrack track(filePath);
+  track.AddPoint(Make(timestamp, ms::LatLon(53.9, 27.55), 10));
+  track.AddPoint(Make(timestamp + 1, ms::LatLon(53.91, 27.56), 10));
+
+  // The collection is created in the worker thread and only after a callback is set, so the elevation
+  // info must be available (and empty) while the track has no collection yet.
+  TEST(track.GetElevationInfo().IsEmpty(), ());
+
+  GpsTrackCallback callback;
+  track.SetCallback(bind(&GpsTrackCallback::OnUpdate, &callback, placeholders::_1, placeholders::_2));
+  TEST(callback.WaitForCallback(kWaitForCallbackTimeout), ());
+
+  TEST_EQUAL(track.GetElevationInfo().GetSize(), 2, ());
+}
 }  // namespace gps_track_test


### PR DESCRIPTION
`GpsTrack::GetElevationInfo()` aborts on `CHECK(m_collection, ())` when the track recording collection has not been created yet.

The collection is created lazily in the worker thread and only once a callback is set (`GpsTrack::ProcessPoints()`), so between `Framework::StartTrackRecording()` and the first worker pass the recording is already enabled while the collection is still absent. Asking for elevation data in that window kills the app — this is the crash reported in #13289, where iOS shows the track recording place page synchronously from the completion of `TrackRecordingManager.start()`.

The same call also leaked a reference out of the mutex: `GetElevationInfo()` returned `ElevationInfo const &` pointing into `m_collection`, while `m_threadGuard` is released on return — so both platform wrappers read the object unlocked, and the worker thread could meanwhile reach `GpsTrackCollection::Clear()` → `m_elevationInfo.Clear()` and free `m_lines` under the reader. Returning by value copies under the lock and closes that window.

### What changed

- `GpsTrack::GetElevationInfo()` returns an empty `ElevationInfo` when there is no  collection, mirroring `GetTrackStatistics()` right above it, which already treats a missing collection as a valid state.
- Regression test `GpsTrack_ElevationInfoWithoutCollection`.