### PR TITLE
Actualize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,19 @@
 # Please use android/.gitignore for all Android stuff
 
-syntax: glob
 *~
 .DS_Store
-Makefile
-Makefile.Debug
-Makefile.Release
-object_script.*.Debug
-object_script.*.Release
+/screenlog.0
 compile_commands.json
 
-stxxl.errlog
-stxxl.log
-screenlog.0
-
+# Styles and colors edited by the built-in designer (see qt/build_style)
 data/symbols/*/design/
-data/drules_proto_default_design.bin
+data/drules_design.bin
 data/colors_design.txt
 data/patterns_design.txt
+# User data written by the app (local OSM edits, bookmarks)
 data/bookmarks
 data/edits.xml
+data/settings.ini
 
 # Python compiled files and dependencies
 *.pyc
@@ -27,57 +21,29 @@ uv.lock
 
 # Windows generated files
 *.vcxproj*
-ipch/*
-omim.sdf
-*.vcproj
-*.icproj
 *.sln
-*.idb
 *.user
-*.pro.user*
-*.ncb
-*.suo
-*.aps
+*.pdb
 *.rc
 !qt/res/windows/windows.rc
-*.pdb
-out/
+/out/
 
 # XCode
 xcode/keys/*
-xcode/build/*
-xcode/metadata/review_information/*
 xcode/fastlane/report.xml
 xcode/fastlane/README.md
 iphone/*/*.xcodeproj/*.pbxuser
-iphone/*/*.xcodeproj/*.perspectivev3
 iphone/*/*.xcodeproj/project.xcworkspace/*
-iphone/*/build/*
-tools/emacsmode/build
+!iphone/*/*.xcodeproj/project.xcworkspace/xcshareddata/
 **/DerivedData/*
-**/xcshareddata/*
-!iphone/Maps/Maps.xcodeproj/xcshareddata/xcschemes/OMaps.xcscheme
 **/xcuserdata
-**/xcschemes
+**/xcshareddata/swiftpm/
+**/xcshareddata/IDEWorkspaceChecks.plist
 iphone/**/*.moved-aside
 iphone/**/*.swp
 iphone/**/*.mode1v3
 iphone/**/*.mode2v3
 iphone/**/*.perspectivev3
-
-# Carthage
-iphone/Maps/3party/Carthage/Checkouts
-iphone/Maps/3party/Carthage/Build/Mac/*.bcsymbolmap
-iphone/Maps/3party/Carthage/Build/Mac/*.dSYM
-iphone/Maps/3party/Carthage/Build/tvOS
-iphone/Maps/3party/Carthage/Build/watchOS
-iphone/Maps/3party/Carthage/Build/iOS/*.bcsymbolmap
-iphone/Maps/3party/Carthage/Build/iOS/*.dSYM
-iphone/Maps/3party/Carthage/Build/*.version
-
-# GeneratedFiles
-tools/win/MapsWithMe*
-GeneratedFiles
 
 # data
 data/[0-9][0-9][0-9][0-9][0-9][0-9]
@@ -85,64 +51,30 @@ data/gps_track.dat
 # custom raster background tiles disk cache
 data/bg_tiles/
 # temporary files for downloader
-data/settings.ini
 data/test_data/world_feed_integration_tests_data
 
-# benchmark results
-data/benchmarks/*.trace
-data/benchmarks/iphone3g/*
-data/benchmarks/ipod4/*
-data/benchmarks/ipad/*
-data/benchmarks/mac/*
-data/benchmarks/kindle-fire/*
-data/benchmarks/galaxy-s-2/*
-data/benchmarks/ipad3/*
-data/benchmarks/ipad2/*
-data/benchmarks/iphone5/*
-data/benchmarks/maps/*
+# JetBrains IDEs
+.idea/
+!/android/.idea/
+/android/.idea/*
+# Must stay here: git does not descend into an excluded directory, so android/.gitignore cannot re-include icon.svg
+!/android/.idea/icon.svg
 
-qtc_packaging
+# Visual Studio
+/.vs/
 
-tools/twine/.git
+# VS Code
+/.vscode/*
+!/.vscode/extensions.json
 
-# shader preprocessing moc files
-drape/shader_def.hpp
-drape/shader_def.cpp
-drape_frontend/shader_def.hpp
-drape_frontend/shader_def.cpp
-drape_frontend/drape_frontend_tests/shader_def_for_tests.hpp
-drape_frontend/drape_frontend_tests/shader_def_for_tests.cpp
+# clangd
+/.cache/
 
-tizen/*/Debug/*
-tizen/*/.*
-!tizen/*/.cproject
-!tizen/*/.project
-
-tizen/*/crash-info/*
-.idea/*
-.idea
-!android/.idea/icon.svg
-
-# Private repository files.
-.private_repository_url
-.private_repository_branch
-private.h
-# ignore old android secrets during the transition period to the new project structure
-android/release.keystore
-android/secure.properties
-android/libnotify.properties
-android/google-services.json
-android/google-play.json
-android/firebase-app-distribution.json
-android/firebase-test-lab.json
-android/huawei-appgallery.json
-android/res/xml/network_security_config.xml
-./server/
-iphone/Maps/app.omaps/
-
-*.li
-
+# Qt Designer
 *.autosave
+
+# Vim files
+*.sw?
 
 # CMake
 /cmake-build-*
@@ -151,48 +83,25 @@ build/
 # Per-developer CMake preset overrides (CMakePresets.json is committed).
 CMakeUserPresets.json
 
-qt/res/Info.plist
-
-designer_version.h
-
-# Vim files
-*.sw?
-
-# Build version
-platform/platform_qt_version.cpp
-
 #python modules building
-tools/python/*/build
-tools/python/*/dist
-tools/python/*/*.egg-info
-tools/python/data/*/build
-tools/python/data/*/dist
-tools/python/data/*/*.egg-info
-tools/python/*/venv/
+/tools/python/*/build
+/tools/python/*/dist
+/tools/python/*/*.egg-info
+/tools/python/data/*/build
+/tools/python/data/*/dist
+/tools/python/data/*/*.egg-info
+/tools/python/*/venv/
 
 # Configs
-tools/python/maps_generator/var/etc/map_generator.ini
-tools/python/routing/etc/*.ini
-tools/unix/maps/settings.sh
+/tools/python/maps_generator/var/etc/map_generator.ini
+/tools/python/routing/etc/*.ini
+/tools/unix/maps/settings.sh
 
 # Helpers
 /node_modules/
 /package-lock.json
 
-# Visual Studio
-.vs
-
-# VS Code
-.vscode
-
-# clangd
-.cache
-
-# AppStore metadata
-screenshots/
-android/src/google/play/listings/
-keywords/
-iphone/metadata/**/keywords.txt
-
-# clangd cache
-.cache/clangd/
+# AppStore metadata (Google Play listings are in android/app/.gitignore)
+/screenshots/
+/keywords/
+/iphone/metadata/**/keywords.txt

--- a/android/app/.gitignore
+++ b/android/app/.gitignore
@@ -2,18 +2,14 @@
 /nativeOutputs
 
 # ignore private keys
-/google-services.json
-/secure.properties
 /release.keystore
 /secure.properties
-/libnotify.properties
 /google-services.json
 /google-play.json
 /firebase-app-distribution.json
 /firebase-test-lab.json
 /huawei-appgallery.json
 /agconnect-services.json
-/src/main/res/xml/network_security_config.xml
 
 # ignore flags symlinks
 /src/main/res/drawable-xhdpi/??.png


### PR DESCRIPTION
Split out of #13316, where anchoring `keywords/` was needed so it would stop matching Boost's `boost/log/keywords/`. The rest of the file turned out to be equally out of date, but none of it belongs in a Boost PR.

## What changed

**Anchored the rules that name root-level paths.** `screenshots/`, `keywords/`, `.vscode`, `.idea`, `.cache` and `out/` were unanchored, so they matched same-named directories anywhere in the tree.

**Dropped rules for tooling that is gone** — each verified absent, not assumed: qmake makefiles (no `.pro` files left), stxxl, Qt Creator, Carthage, `tools/win`, `tools/emacsmode`, `data/benchmarks` for the iPhone 3G, the pre-`libs/` `drape/shader_def.*` paths, the old `tools/twine` location, VS2008-era artifacts, `designer_version.h`, `.private_repository_*` and the Mercurial-era `syntax: glob`.

**Stopped shadowing files that are deliberately committed.** `private.h`, `android/.idea/icon.svg`, `.vscode/extensions.json`, the shared Xcode schemes and android's `network_security_config.xml` are all tracked defaults, so those rules never applied and only misled. The negations meant to re-include them could not work either: git does not descend into an excluded directory, so `!android/.idea/icon.svg` and `!…/OMaps.xcscheme` were inert. They are restructured to re-include the parent directory first.

`private.h` and `network_security_config.xml` are worth calling out — both are committed *public* defaults (`f7f81433c1`, CI overwrites `private.h` from the `PRIVATE_H` secret), so ignoring them was pointless.

**Android secrets** moved to `android/app/.gitignore` long ago where the paths are correct (the root copies were missing `/app`), so the stale copies are dropped, along with two duplicated lines there.

## Deliberate exception

`xcode/keys/*` keeps hiding the seven committed WWDR certificates. That directory holds signing material, so having new files ignored by default is worth the `git add -f` needed for a new certificate.

## Verification

- No tracked file is shadowed by any `.gitignore` in the repo, apart from the WWDR certificates above — previously 7 rules shadowed 14 files.
- Secrets stay ignored: `release.keystore`, `secure.properties`, the `*.json` credentials, `xcode/keys/*.p12`, Play listings.
- Xcode per-user files stay ignored: `contents.xcworkspacedata`, `IDEWorkspaceChecks.plist`, `xcshareddata/swiftpm/`, `xcuserdata`; the shared settings and schemes are visible.
- On a clean checkout the set of ignored files is unchanged: 156 entries before and after, nothing newly exposed.

198 -> 113 lines.