### PR TITLE
[drape_frontend] Fix MessageQueue cancel race

### DIFF
--- a/libs/drape_frontend/base_renderer.cpp
+++ b/libs/drape_frontend/base_renderer.cpp
@@ -113,7 +113,8 @@ void BaseRenderer::SetRenderingEnabled(bool const isEnabled)
     // here we set up value only if rendering disabled
     m_isEnabled = false;
 
-    // if renderer thread is waiting for message let it go
+    // Let the renderer thread out of its message wait so that it reaches CheckRenderingEnabled().
+    // The cancellation is sticky, so it also covers a thread that has not started waiting yet.
     CancelMessageWaiting();
   }
 

--- a/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
+++ b/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRC
   area_shape_tests.cpp
   clip_splines_builder_tests.cpp
   frame_values_tests.cpp
+  message_queue_tests.cpp
   navigator_test.cpp
   path_text_test.cpp
   rainbow_line_gpu_test.cpp

--- a/libs/drape_frontend/drape_frontend_tests/message_queue_tests.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/message_queue_tests.cpp
@@ -1,0 +1,150 @@
+#include "testing/testing.hpp"
+
+#include "drape_frontend/message_queue.hpp"
+
+#include <chrono>
+#include <future>
+
+namespace message_queue_tests
+{
+using namespace std::chrono_literals;
+
+class TestMessage : public df::Message
+{
+public:
+  TestMessage(int id, Type type) : m_id(id), m_type(type) {}
+  Type GetType() const override { return m_type; }
+
+  int const m_id;
+
+private:
+  Type const m_type;
+};
+
+int PopId(df::MessageQueue & queue)
+{
+  auto const msg = queue.PopMessage(false /* waitForMessage */);
+  TEST(msg != nullptr, ());
+  return static_cast<TestMessage *>(msg.get())->m_id;
+}
+
+drape_ptr<df::Message> WaitForResult(df::MessageQueue & queue, std::future<drape_ptr<df::Message>> & result)
+{
+  auto const status = result.wait_for(5s);
+  if (status != std::future_status::ready)
+    queue.CancelWait();
+  TEST(status == std::future_status::ready, ());
+  return result.get();
+}
+
+UNIT_TEST(MessageQueue_CancelBeforeWait)
+{
+  df::MessageQueue queue;
+  queue.CancelWait();
+
+  auto result = std::async(std::launch::async, [&queue] { return queue.PopMessage(true); });
+  TEST(WaitForResult(queue, result) == nullptr, ());
+}
+
+UNIT_TEST(MessageQueue_CancelSurvivesNonBlockingPop)
+{
+  df::MessageQueue queue;
+  queue.CancelWait();
+  TEST(queue.PopMessage(false) == nullptr, ());
+
+  auto result = std::async(std::launch::async, [&queue] { return queue.PopMessage(true); });
+  TEST(WaitForResult(queue, result) == nullptr, ());
+}
+
+// A queued message wins over a pending cancellation and consumes it: the wait did end, so callers must
+// not expect the cancellation to resurface as a later nullptr.
+UNIT_TEST(MessageQueue_MessageWinsOverPendingCancel)
+{
+  df::MessageQueue queue;
+  queue.PushMessage(make_unique_dp<TestMessage>(1, df::Message::Type::Invalidate), df::MessagePriority::Normal);
+  queue.CancelWait();
+
+  auto const msg = queue.PopMessage(true);
+  TEST(msg != nullptr, ());
+  TEST_EQUAL(static_cast<TestMessage *>(msg.get())->m_id, 1, ());
+
+  auto result = std::async(std::launch::async, [&queue] { return queue.PopMessage(true); });
+  TEST(result.wait_for(200ms) == std::future_status::timeout, ());
+  queue.CancelWait();
+  TEST(WaitForResult(queue, result) == nullptr, ());
+}
+
+UNIT_TEST(MessageQueue_CancelRacingWithWait)
+{
+  df::MessageQueue queue;
+  std::promise<void> started;
+  auto result = std::async(std::launch::async, [&queue, &started]
+  {
+    started.set_value();
+    return queue.PopMessage(true);
+  });
+  started.get_future().wait();
+  queue.CancelWait();
+
+  TEST(WaitForResult(queue, result) == nullptr, ());
+}
+
+UNIT_TEST(MessageQueue_PushRacingWithWait)
+{
+  df::MessageQueue queue;
+  std::promise<void> started;
+  auto result = std::async(std::launch::async, [&queue, &started]
+  {
+    started.set_value();
+    return queue.PopMessage(true);
+  });
+  started.get_future().wait();
+  queue.PushMessage(make_unique_dp<df::Message>(), df::MessagePriority::Normal);
+
+  TEST(WaitForResult(queue, result) != nullptr, ());
+}
+
+// UberHighSingleton jumps the whole queue and is deduplicated by message type, High overtakes Normal but
+// stays behind UberHighSingleton, and Low is drained only after everything else.
+UNIT_TEST(MessageQueue_PriorityOrder)
+{
+  using Type = df::Message::Type;
+  df::MessageQueue queue;
+  queue.PushMessage(make_unique_dp<TestMessage>(1, Type::Invalidate), df::MessagePriority::Normal);
+  queue.PushMessage(make_unique_dp<TestMessage>(2, Type::Invalidate), df::MessagePriority::Low);
+  queue.PushMessage(make_unique_dp<TestMessage>(3, Type::Invalidate), df::MessagePriority::High);
+  queue.PushMessage(make_unique_dp<TestMessage>(4, Type::UpdateReadManager), df::MessagePriority::UberHighSingleton);
+  queue.PushMessage(make_unique_dp<TestMessage>(5, Type::FlushTile), df::MessagePriority::UberHighSingleton);
+  queue.PushMessage(make_unique_dp<TestMessage>(6, Type::UpdateReadManager), df::MessagePriority::UberHighSingleton);
+
+  TEST_EQUAL(PopId(queue), 5, ());
+  TEST_EQUAL(PopId(queue), 4, ());
+  TEST_EQUAL(PopId(queue), 3, ());
+  TEST_EQUAL(PopId(queue), 1, ());
+  TEST_EQUAL(PopId(queue), 2, ());
+  TEST(queue.PopMessage(false) == nullptr, ());
+}
+
+// Filtering drops matching messages both from the queue and on arrival, until it is disabled;
+// InstantFilter makes a single pass and leaves no filter installed.
+UNIT_TEST(MessageQueue_Filtering)
+{
+  using Type = df::Message::Type;
+  auto isInvalidate = [](ref_ptr<df::Message> m) { return m->GetType() == Type::Invalidate; };
+
+  df::MessageQueue queue;
+  queue.PushMessage(make_unique_dp<TestMessage>(1, Type::Invalidate), df::MessagePriority::Normal);
+  queue.PushMessage(make_unique_dp<TestMessage>(2, Type::FlushTile), df::MessagePriority::Normal);
+
+  queue.EnableMessageFiltering(isInvalidate);
+  queue.PushMessage(make_unique_dp<TestMessage>(3, Type::Invalidate), df::MessagePriority::Normal);
+  TEST_EQUAL(PopId(queue), 2, ());
+  TEST(queue.PopMessage(false) == nullptr, ());
+
+  queue.DisableMessageFiltering();
+  queue.PushMessage(make_unique_dp<TestMessage>(4, Type::Invalidate), df::MessagePriority::Normal);
+  queue.InstantFilter(isInvalidate);
+  queue.PushMessage(make_unique_dp<TestMessage>(5, Type::Invalidate), df::MessagePriority::Normal);
+  TEST_EQUAL(PopId(queue), 5, ());
+}
+}  // namespace message_queue_tests

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -2605,8 +2605,10 @@ void FrontendRenderer::AddUserEvent(drape_ptr<UserEvent> && event)
     return;
 #endif
   m_userEventStream.AddEvent(std::move(event));
-  if (IsInInfinityWaiting())
-    CancelMessageWaiting();
+  // User events bypass the message queue, so a renderer parked in a blocking PopMessage() after a few
+  // idle frames would not see this one. CancelWait() is sticky, so the wake-up also lands when the event
+  // arrives just before the renderer starts waiting.
+  CancelMessageWaiting();
 }
 
 void FrontendRenderer::PositionChanged(m2::PointD const & position, bool hasPosition)

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -1895,10 +1895,9 @@ void FrontendRenderer::RenderFrame()
 #if defined(OMIM_OS_DESKTOP)
     EmitGraphicsReady();
 #endif
-    // Process a message or wait for a message.
-    // IsRenderingEnabled() can return false in case of rendering disabling and we must prevent
-    // possibility of infinity waiting in ProcessSingleMessage.
-    ProcessSingleMessage(IsRenderingEnabled());
+    // Process a message, or park until one arrives. SetRenderingEnabled(false) and CloseQueue() both
+    // cancel the wait, and the cancellation is sticky, so this cannot block indefinitely.
+    ProcessSingleMessage();
     m_frameData.m_forceFullRedrawNextFrame = true;
     m_frameData.m_timer.Reset();
     m_frameData.m_inactiveFramesCounter = 0;

--- a/libs/drape_frontend/message_acceptor.cpp
+++ b/libs/drape_frontend/message_acceptor.cpp
@@ -4,14 +4,9 @@
 
 namespace df
 {
-MessageAcceptor::MessageAcceptor() : m_infinityWaiting(false) {}
-
 bool MessageAcceptor::ProcessSingleMessage(bool waitForMessage)
 {
-  m_infinityWaiting = waitForMessage;
   drape_ptr<Message> message = m_messageQueue.PopMessage(waitForMessage);
-  m_infinityWaiting = false;
-
   if (message == nullptr)
     return false;
 
@@ -42,17 +37,12 @@ void MessageAcceptor::PostMessage(drape_ptr<Message> && message, MessagePriority
 void MessageAcceptor::CloseQueue()
 {
   m_messageQueue.CancelWait();
-  m_messageQueue.ClearQuery();
+  m_messageQueue.Clear();
 }
 
 void MessageAcceptor::CancelMessageWaiting()
 {
   m_messageQueue.CancelWait();
-}
-
-bool MessageAcceptor::IsInInfinityWaiting() const
-{
-  return m_infinityWaiting;
 }
 
 #ifdef DEBUG_MESSAGE_QUEUE

--- a/libs/drape_frontend/message_acceptor.hpp
+++ b/libs/drape_frontend/message_acceptor.hpp
@@ -4,10 +4,6 @@
 
 #include "drape/pointers.hpp"
 
-#include <atomic>
-#include <functional>
-#include <mutex>
-
 namespace df
 {
 class Message;
@@ -15,7 +11,7 @@ class Message;
 class MessageAcceptor
 {
 protected:
-  MessageAcceptor();
+  MessageAcceptor() = default;
   virtual ~MessageAcceptor() = default;
 
   virtual void AcceptMessage(ref_ptr<Message> message) = 0;
@@ -26,8 +22,6 @@ protected:
   void CancelMessageWaiting();
 
   void CloseQueue();
-
-  bool IsInInfinityWaiting() const;
 
 #ifdef DEBUG_MESSAGE_QUEUE
   bool IsQueueEmpty() const;
@@ -44,6 +38,5 @@ private:
   void PostMessage(drape_ptr<Message> && message, MessagePriority priority);
 
   MessageQueue m_messageQueue;
-  std::atomic<bool> m_infinityWaiting;
 };
 }  // namespace df

--- a/libs/drape_frontend/message_queue.cpp
+++ b/libs/drape_frontend/message_queue.cpp
@@ -1,16 +1,9 @@
 #include "drape_frontend/message_queue.hpp"
 
 #include "base/assert.hpp"
-#include "base/stl_helpers.hpp"
 
 namespace df
 {
-MessageQueue::~MessageQueue()
-{
-  CancelWait();
-  ClearQuery();
-}
-
 drape_ptr<Message> MessageQueue::PopMessage(bool waitForMessage)
 {
   std::unique_lock<std::mutex> lock(m_mutex);
@@ -145,8 +138,9 @@ void MessageQueue::CancelWait()
   m_condition.notify_one();
 }
 
-void MessageQueue::ClearQuery()
+void MessageQueue::Clear()
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   m_messages.clear();
   m_lowPriorityMessages.clear();
 }

--- a/libs/drape_frontend/message_queue.cpp
+++ b/libs/drape_frontend/message_queue.cpp
@@ -5,8 +5,6 @@
 
 namespace df
 {
-MessageQueue::MessageQueue() : m_isWaiting(false) {}
-
 MessageQueue::~MessageQueue()
 {
   CancelWait();
@@ -16,11 +14,10 @@ MessageQueue::~MessageQueue()
 drape_ptr<Message> MessageQueue::PopMessage(bool waitForMessage)
 {
   std::unique_lock<std::mutex> lock(m_mutex);
-  if (waitForMessage && m_messages.empty() && m_lowPriorityMessages.empty())
+  if (waitForMessage)
   {
-    m_isWaiting = true;
-    m_condition.wait(lock, [this]() { return !m_isWaiting; });
-    m_isWaiting = false;
+    m_condition.wait(lock, [this] { return m_cancelPending || !m_messages.empty() || !m_lowPriorityMessages.empty(); });
+    m_cancelPending = false;
   }
 
   drape_ptr<Message> msg;
@@ -85,7 +82,7 @@ void MessageQueue::PushMessage(drape_ptr<Message> && message, MessagePriority pr
   default: ASSERT(false, ("Unknown message priority type"));
   }
 
-  CancelWaitImpl();
+  m_condition.notify_one();
 }
 
 void MessageQueue::FilterMessagesImpl()
@@ -144,16 +141,8 @@ size_t MessageQueue::GetSize() const
 void MessageQueue::CancelWait()
 {
   std::lock_guard<std::mutex> lock(m_mutex);
-  CancelWaitImpl();
-}
-
-void MessageQueue::CancelWaitImpl()
-{
-  if (m_isWaiting)
-  {
-    m_isWaiting = false;
-    m_condition.notify_all();
-  }
+  m_cancelPending = true;
+  m_condition.notify_one();
 }
 
 void MessageQueue::ClearQuery()

--- a/libs/drape_frontend/message_queue.hpp
+++ b/libs/drape_frontend/message_queue.hpp
@@ -17,9 +17,6 @@ namespace df
 class MessageQueue
 {
 public:
-  MessageQueue() = default;
-  ~MessageQueue();
-
   // Returns the highest priority message, or nullptr if the queue is empty and waitForMessage is
   // false, or if the wait was interrupted by CancelWait(). A queued message wins over a pending
   // cancellation and consumes it, so a cancelled wait is not guaranteed to be observed as a nullptr.
@@ -27,7 +24,7 @@ public:
   void PushMessage(drape_ptr<Message> && message, MessagePriority priority);
   // Interrupts the current or the next PopMessage(true). A PopMessage(false) leaves it pending.
   void CancelWait();
-  void ClearQuery();
+  void Clear();
 
   using FilterMessageFn = std::function<bool(ref_ptr<Message>)>;
   void EnableMessageFiltering(FilterMessageFn && filter);

--- a/libs/drape_frontend/message_queue.hpp
+++ b/libs/drape_frontend/message_queue.hpp
@@ -12,15 +12,20 @@
 
 namespace df
 {
+// The queue has a single consumer: only one thread may call PopMessage(), since one cancellation
+// flag and notify_one() cannot serve several waiters.
 class MessageQueue
 {
 public:
-  MessageQueue();
+  MessageQueue() = default;
   ~MessageQueue();
 
-  // If the queue is empty then it returns nullptr or wait for a message.
+  // Returns the highest priority message, or nullptr if the queue is empty and waitForMessage is
+  // false, or if the wait was interrupted by CancelWait(). A queued message wins over a pending
+  // cancellation and consumes it, so a cancelled wait is not guaranteed to be observed as a nullptr.
   drape_ptr<Message> PopMessage(bool waitForMessage);
   void PushMessage(drape_ptr<Message> && message, MessagePriority priority);
+  // Interrupts the current or the next PopMessage(true). A PopMessage(false) leaves it pending.
   void CancelWait();
   void ClearQuery();
 
@@ -36,11 +41,12 @@ public:
 
 private:
   void FilterMessagesImpl();
-  void CancelWaitImpl();
 
   mutable std::mutex m_mutex;
   std::condition_variable m_condition;
-  bool m_isWaiting;
+  // Makes a cancellation observable even if it precedes PopMessage(). Consumed by every
+  // PopMessage(true), including one that returns a queued message without waiting.
+  bool m_cancelPending = false;
   using TMessageNode = std::pair<drape_ptr<Message>, MessagePriority>;
   std::deque<TMessageNode> m_messages;
   std::deque<drape_ptr<Message>> m_lowPriorityMessages;


### PR DESCRIPTION
Two commits.

**1. Cancel race.** `CancelWait()` could run after the renderer selected a blocking queue pop but
before `PopMessage(true)` acquired the queue lock. The old implementation only recorded cancellation
while already waiting, so the cancel was lost and the render thread could then sleep indefinitely,
leaving a caller blocked in `SetRenderingEnabled()`.

Cancellation is now kept pending until a pop actually waits, with cancellation plus queue contents as
the condition-variable predicate; the redundant `m_isWaiting` state is gone. Clearing the flag on
*every* pop would instead let a non-blocking pop swallow a cancel meant for the next blocking one —
`FrontendRenderer::RenderFrame()` does exactly those pops — which would leave the queue's contract
dependent on how callers interleave them. That contract is now documented, including the fact that a
queued message wins over a pending cancellation and consumes it.

**2. Teardown race and lost user-event wakeups.**

- `Clear()` (was `ClearQuery()`) mutated both deques with no lock, while `CloseQueue()` runs it
  *before* the render thread is joined — racing the consumer's `pop_front()` and any `PushMessage()`
  that slipped past `ThreadsCommutator`'s cancelled-routine check. Now locked. The custom destructor
  then adds nothing over the implicit one: waking a thread still parked in `PopMessage()` cannot make
  destroying its mutex and condition variable safe, and teardown already cancels and joins.
- `AddUserEvent()` guarded its wake-up with `IsInInfinityWaiting()`, which the renderer sets at the
  *end* of a frame while user events are drained at its *start*. An event arriving in between got no
  wake-up, so a single isolated input (zoom button, `MakeFrameActive`, a lone tap just as the map
  settles) could be ignored until something else woke the queue. Sticky cancellation makes the
  unconditional call correct, retiring `m_infinityWaiting`, its accessor and its constructor.

Net: +2 lines in the queue, −18 in its callers, plus tests.

New `message_queue_tests.cpp`, run in CI by the `ci-drape` / `ci-drape-xcode` presets: cancellation
before, during and across a wait; message precedence over a pending cancellation; and priority
ordering (`UberHighSingleton` dedup by type, `High` over `Normal`, `Low` drained last).
`MessageQueue_CancelBeforeWait` hangs on `master`; `MessageQueue_CancelSurvivesNonBlockingPop` fails
without the first commit.

Tested:

- Full Debug `drape_frontend_tests` with offscreen Qt, plus focused `MessageQueue_*`; each commit
  builds and passes on its own
- `desktop` and `dev_sandbox`
- `assembleGoogleDebug -Parm64`
- iOS Simulator archive (arm64)

LLM tools were used to review, test, and refine this change.
