### PR TITLE
fix(ios): estimated heights for settings section headers/footers

### DIFF
--- a/iphone/Maps/UI/ReusableComponents/MWMTableViewController.m
+++ b/iphone/Maps/UI/ReusableComponents/MWMTableViewController.m
@@ -40,6 +40,16 @@ static CGFloat const kMaxEstimatedTableViewCellHeight = 100.0;
   return UITableViewAutomaticDimension;
 }
 
+- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForHeaderInSection:(NSInteger)section
+{
+  return kMaxEstimatedTableViewCellHeight;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForFooterInSection:(NSInteger)section
+{
+  return kMaxEstimatedTableViewCellHeight;
+}
+
 - (void)viewDidLoad
 {
   [super viewDidLoad];


### PR DESCRIPTION
Provide estimatedHeightForHeader/Footer so self-sizing section footers (e.g. Enable logging) are not clipped.

Note: not built on Linux (no Xcode); please verify on simulator.

Fixes #12976

## Test plan
- [ ] Review diff against issue
- [ ] Run project lint/tests if applicable
