### PR TITLE
[editor] Keep unrepresentable schedules in the advanced editor

### DIFF
--- a/libs/editor/editor_tests/ui2oh_test.cpp
+++ b/libs/editor/editor_tests/ui2oh_test.cpp
@@ -557,7 +557,6 @@ UNIT_TEST(OpeningHours2TimeTableSet_onlyRepresentableSchedulesUseSimpleMode)
            "Mo-Su (sunrise+01:00)-sunset",
            "sunrise-sunset",
            "Mo-Fr 08:00-18:00; Sa sunrise-sunset",
-           "Mo-Fr 08:00-18:00, Sa 10:00-14:00",
            "Mo-Fr 08:00-18:00 || Sa 10:00-14:00",
        })
   {
@@ -691,4 +690,32 @@ UNIT_TEST(OpeningHours2TimeTableSet_overnightCombinationsStayInAdvancedMode)
   TEST(MakeTimeTableSet(disjoint, tts), ());
   TEST_EQUAL(tts.Size(), 1, ());
   TEST_EQUAL(tts.Front().GetOpeningDays().size(), 1, ());
+}
+
+// An additive rule over days disjoint from every preceding rule is equivalent
+// to an overriding one, so the simple editor represents it losslessly; place
+// pages then render it structured instead of as raw text.
+UNIT_TEST(OpeningHours2TimeTableSet_disjointAdditiveRules)
+{
+  {
+    TestLosslessRoundTrip("Mo-Fr 08:00-18:00, Sa 10:00-14:00");
+
+    OpeningHours oh("Mo-Fr 08:00-18:00, Sa 10:00-14:00");
+    TEST(oh.IsValid(), ());
+    TimeTableSet tts;
+    TEST(MakeTimeTableSet(oh, tts), ());
+    TEST_EQUAL(tts.Size(), 2, ());
+    TEST_EQUAL(tts.Get(0).GetOpeningDays().size(), 5, ());
+    TEST_EQUAL(tts.Get(1).GetOpeningDays().size(), 1, ());
+  }
+
+  // Overlapping days or a closed additive rule change semantics under the
+  // overriding model: keep them in the advanced editor.
+  for (std::string_view const value : {"Mo-Fr 08:00-18:00, Mo 10:00-14:00", "Mo-Fr 08:00-18:00, Sa off"})
+  {
+    OpeningHours const oh(value);
+    TEST(oh.IsValid(), (value));
+    TimeTableSet tts;
+    TEST(!MakeTimeTableSet(oh, tts), (value));
+  }
 }

--- a/libs/editor/editor_tests/ui2oh_test.cpp
+++ b/libs/editor/editor_tests/ui2oh_test.cpp
@@ -359,21 +359,14 @@ UNIT_TEST(OpeningHours2TimeTableSet_off)
                ());
   }
   {
+    // The exclusion starts where the opening time does: representing it would
+    // require shrinking the opening time, which a time table cannot express.
     OpeningHours oh("Mo-Fr 11:00-17:00; Sa-Su 12:00-16:00; Mo-Fr 11:00-13:00 off");
     TEST(oh.IsValid(), ());
 
     TimeTableSet tts;
 
-    TEST(MakeTimeTableSet(oh, tts), ());
-    TEST_EQUAL(tts.Size(), 2, ());
-
-    auto const tt = tts.Get(0);
-    TEST_EQUAL(tts.GetUnhandledDays(), OpeningDays(), ());
-
-    TEST_EQUAL(tt.GetOpeningTime().GetStart().GetHourMinutes().GetHoursCount(), 11, ());
-    TEST_EQUAL(tt.GetOpeningTime().GetEnd().GetHourMinutes().GetHoursCount(), 17, ());
-    TEST_EQUAL(tt.GetExcludeTime()[0].GetStart().GetHourMinutes().GetHoursCount(), 11, ());
-    TEST_EQUAL(tt.GetExcludeTime()[0].GetEnd().GetHourMinutes().GetHoursCount(), 13, ());
+    TEST(!MakeTimeTableSet(oh, tts), ());
   }
   {
     OpeningHours oh("Mo off; Tu-Su 09:00-17:00");
@@ -583,5 +576,93 @@ UNIT_TEST(OpeningHours2TimeTableSet_onlyRepresentableSchedulesUseSimpleMode)
        })
   {
     TestLosslessRoundTrip(value);
+  }
+}
+
+// A closed rule overrides everything it intersects; losing any part of it on
+// save would reopen closed hours.
+UNIT_TEST(OpeningHours2TimeTableSet_closedOverridesApplyEverywhere)
+{
+  {
+    // A trailing constant "off" closes the whole week: not representable.
+    OpeningHours oh("Mo-Fr 08:00-18:00; off");
+    TEST(oh.IsValid(), ());
+    TimeTableSet tts;
+    TEST(!MakeTimeTableSet(oh, tts), ());
+  }
+  {
+    // A whole-week override closes both time tables: nothing left to edit.
+    OpeningHours oh("Mo-Fr 08:00-18:00; Sa-Su 10:00-16:00; Mo-Su off");
+    TEST(oh.IsValid(), ());
+    TimeTableSet tts;
+    TEST(!MakeTimeTableSet(oh, tts), ());
+  }
+  {
+    // A selectorless closed rule applies to the whole week.
+    TestLosslessRoundTrip("Mo-Fr 08:00-18:00; 13:00-14:00 off");
+
+    OpeningHours oh("Mo-Fr 08:00-18:00; 13:00-14:00 off");
+    TEST(oh.IsValid(), ());
+    TimeTableSet tts;
+    TEST(MakeTimeTableSet(oh, tts), ());
+    TEST_EQUAL(tts.Size(), 1, ());
+
+    auto const tt = tts.Front();
+    TEST_EQUAL(tt.GetExcludeTime().size(), 1, ());
+    TEST_EQUAL(tt.GetExcludeTime()[0].GetStart().GetHourMinutes().GetHoursCount(), 13, ());
+    TEST_EQUAL(tt.GetExcludeTime()[0].GetEnd().GetHourMinutes().GetHoursCount(), 14, ());
+  }
+  {
+    // The override reaches the second time table, not only the first one.
+    TestLosslessRoundTrip("Mo-Fr 08:00-18:00; Sa-Su 10:00-16:00; Sa 12:00-13:00 off");
+
+    OpeningHours oh("Mo-Fr 08:00-18:00; Sa-Su 10:00-16:00; Sa 12:00-13:00 off");
+    TEST(oh.IsValid(), ());
+    TimeTableSet tts;
+    TEST(MakeTimeTableSet(oh, tts), ());
+    TEST_EQUAL(tts.Size(), 3, ());
+
+    TEST_EQUAL(tts.Get(0).GetOpeningDays().size(), 5, ());
+    // Saturday is split out of Sa-Su and carries the exclusion.
+    TEST_EQUAL(tts.Get(1).GetOpeningDays().size(), 1, ());
+    TEST_EQUAL(tts.Get(2).GetOpeningDays().size(), 1, ());
+    TEST_EQUAL(tts.Get(2).GetExcludeTime().size(), 1, ());
+  }
+  {
+    // The override closes a whole time table, but not the whole week.
+    TestLosslessRoundTrip("Mo-Fr 08:00-18:00; Sa-Su 10:00-16:00; Sa-Su 10:00-16:00 off");
+
+    OpeningHours oh("Mo-Fr 08:00-18:00; Sa-Su 10:00-16:00; Sa-Su 10:00-16:00 off");
+    TimeTableSet tts;
+    TEST(MakeTimeTableSet(oh, tts), ());
+    TEST_EQUAL(tts.Size(), 1, ());
+    TEST_EQUAL(tts.GetUnhandledDays(), OpeningDays({osmoh::Weekday::Saturday, osmoh::Weekday::Sunday}), ());
+  }
+  {
+    // The override closes a part of a time table completely.
+    TestLosslessRoundTrip("Mo-Fr 08:00-18:00; Mo 08:00-18:00 off");
+
+    OpeningHours oh("Mo-Fr 08:00-18:00; Mo 08:00-18:00 off");
+    TimeTableSet tts;
+    TEST(MakeTimeTableSet(oh, tts), ());
+    TEST_EQUAL(tts.Size(), 1, ());
+    TEST_EQUAL(tts.Get(0).GetOpeningDays(),
+               OpeningDays({osmoh::Weekday::Tuesday, osmoh::Weekday::Wednesday, osmoh::Weekday::Thursday,
+                            osmoh::Weekday::Friday}),
+               ());
+  }
+
+  // A closed span that only overlaps the opening one would reopen closed hours:
+  // excluding it as is leaves a zero-length span, which means open all day.
+  for (std::string_view const value : {
+           "Mo-Fr 08:00-18:00; Mo 07:00-12:00 off",
+           "Mo-Fr 08:00-18:00; Mo 12:00-20:00 off",
+           "Mo-Fr 08:00-18:00; Mo-Fr 08:00-18:00 off",
+       })
+  {
+    OpeningHours const oh(value);
+    TEST(oh.IsValid(), (value));
+    TimeTableSet tts;
+    TEST(!MakeTimeTableSet(oh, tts), (value));
   }
 }

--- a/libs/editor/editor_tests/ui2oh_test.cpp
+++ b/libs/editor/editor_tests/ui2oh_test.cpp
@@ -2,12 +2,37 @@
 
 #include "editor/ui2oh.hpp"
 
+#include <ctime>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 using namespace osmoh;
 using namespace editor;
 using namespace editor::ui;
+
+namespace
+{
+// The simple editor accepts a value only if it can represent it losslessly:
+// check that its meaning survives a conversion round trip over a whole week.
+void TestLosslessRoundTrip(std::string_view value)
+{
+  OpeningHours const oh(value);
+  TEST(oh.IsValid(), (value));
+
+  TimeTableSet tts;
+  TEST(MakeTimeTableSet(oh, tts), (value));
+
+  auto const saved = ToString(MakeOpeningHours(tts));
+  OpeningHours const back(saved);
+  TEST(back.IsValid(), (value, saved));
+
+  // 2020-01-06 00:00 UTC, a Monday.
+  time_t constexpr kWeekStart = 1578268800;
+  for (time_t t = kWeekStart; t < kWeekStart + 7 * 24 * 60 * 60; t += 15 * 60)
+    TEST_EQUAL(oh.IsOpen(t), back.IsOpen(t), (value, saved, t));
+}
+}  // namespace
 
 UNIT_TEST(OpeningHours2TimeTableSet)
 {
@@ -368,23 +393,6 @@ UNIT_TEST(OpeningHours2TimeTableSet_off)
   }
 }
 
-UNIT_TEST(OpeningHours2TimeTableSet_plus)
-{
-  OpeningHours oh("Mo-Su 11:00+");
-  TEST(oh.IsValid(), ());
-
-  TimeTableSet tts;
-
-  TEST(MakeTimeTableSet(oh, tts), ());
-  TEST_EQUAL(tts.Size(), 1, ());
-
-  auto const tt = tts.Get(0);
-  TEST_EQUAL(tts.GetUnhandledDays(), OpeningDays(), ());
-
-  TEST_EQUAL(tt.GetOpeningTime().GetStart().GetHourMinutes().GetHoursCount(), 11, ());
-  TEST_EQUAL(tt.GetOpeningTime().GetEnd().GetHourMinutes().GetHoursCount(), 24, ());
-}
-
 UNIT_TEST(TimeTableSt2OpeningHours)
 {
   {
@@ -536,5 +544,44 @@ UNIT_TEST(TimeTableSt2OpeningHours)
                "Mo, We-Th 08:00-13:00, 14:00-20:00; "
                "Sa 09:00-13:00, 14:00-18:00",
                ());
+  }
+}
+
+UNIT_TEST(OpeningHours2TimeTableSet_onlyRepresentableSchedulesUseSimpleMode)
+{
+  for (std::string_view const value : {
+           "Mo-Fr 08:00-18:00; PH off",
+           "Mo[1] 08:00-18:00",
+           "Mo +1 day 08:00-18:00",
+           "Mo-Fr 08:00-18:00 \"office\"",
+           "Mo-Fr 08:00-18:00 unknown",
+           "24/7 closed",
+           "Mo-Fr 08:00-18:00/02:00",
+           "Mo-Fr 20:00-26:00",
+           "Mo-Su 11:00+",
+           "Mo-Su sunrise-sunset",
+           "Mo-Fr 10:00-sunset",
+           "Mo-Su (sunrise+01:00)-sunset",
+           "sunrise-sunset",
+           "Mo-Fr 08:00-18:00; Sa sunrise-sunset",
+           "Mo-Fr 08:00-18:00, Sa 10:00-14:00",
+           "Mo-Fr 08:00-18:00 || Sa 10:00-14:00",
+       })
+  {
+    OpeningHours const oh(value);
+    TEST(oh.IsValid(), (value));
+    TimeTableSet tts;
+    TEST(!MakeTimeTableSet(oh, tts), (value));
+  }
+
+  for (std::string_view const value : {
+           "24/7",
+           "open",
+           "Mo-Fr 20:00-02:00",
+           "Mo-Fr 08:00-18:00; Sa 10:00-14:00",
+           "Mo-Fr 08:00-24:00",
+       })
+  {
+    TestLosslessRoundTrip(value);
   }
 }

--- a/libs/editor/editor_tests/ui2oh_test.cpp
+++ b/libs/editor/editor_tests/ui2oh_test.cpp
@@ -666,3 +666,29 @@ UNIT_TEST(OpeningHours2TimeTableSet_closedOverridesApplyEverywhere)
     TEST(!MakeTimeTableSet(oh, tts), (value));
   }
 }
+
+// The simple editing model is linear in wall-clock time: a lone overnight
+// span fits it, but combinations do not survive a round trip.
+UNIT_TEST(OpeningHours2TimeTableSet_overnightCombinationsStayInAdvancedMode)
+{
+  for (std::string_view const value : {
+           "Mo 20:00-02:00, 01:00-04:00",           // wrapped span plus a second span
+           "Mo 20:00-02:00; Mo 21:00-23:00 off",    // exclusion inside a wrapped span
+           "Mo-Fr 08:00-18:00; Sa 23:00-01:00 off"  // wrapping exclusion span
+       })
+  {
+    OpeningHours const oh(value);
+    TEST(oh.IsValid(), (value));
+    TimeTableSet tts;
+    TEST(!MakeTimeTableSet(oh, tts), (value));
+  }
+
+  // A closed rule on disjoint days does not disturb an overnight time table.
+  TestLosslessRoundTrip("Mo 20:00-02:00; Tu 12:00-13:00 off");
+
+  OpeningHours const disjoint("Mo 20:00-02:00; Tu 12:00-13:00 off");
+  TimeTableSet tts;
+  TEST(MakeTimeTableSet(disjoint, tts), ());
+  TEST_EQUAL(tts.Size(), 1, ());
+  TEST_EQUAL(tts.Front().GetOpeningDays().size(), 1, ());
+}

--- a/libs/editor/ui2oh.cpp
+++ b/libs/editor/ui2oh.cpp
@@ -46,10 +46,6 @@ void SetUpTimeTable(osmoh::TTimespans spans, editor::ui::TimeTable & tt)
 {
   using namespace osmoh;
 
-  // Expand plus: 13:15+ -> 13:15-24:00.
-  for (auto & span : spans)
-    span.ExpandPlus();
-
   std::sort(std::begin(spans), std::end(spans), [](Timespan const & a, Timespan const & b)
   {
     auto const start1 = a.GetStart().GetHourMinutes().GetDuration();
@@ -129,6 +125,58 @@ std::vector<Weekdays> SplitIntoIntervals(editor::ui::OpeningDays const & days)
   }
 
   return result;
+}
+
+bool IsRepresentableInSimpleEditor(osmoh::OpeningHours const & oh)
+{
+  using namespace osmoh;
+
+  if (!oh.IsValid())
+    return false;
+
+  auto const & rules = oh.GetRule();
+  for (size_t i = 0; i < rules.size(); ++i)
+  {
+    auto const & rule = rules[i];
+    if (rule.HasModifierComment() || rule.GetModifier() == RuleSequence::Modifier::Unknown ||
+        rule.GetModifier() == RuleSequence::Modifier::Comment)
+    {
+      return false;
+    }
+    if (rule.IsTwentyFourHours() && rule.GetModifier() == RuleSequence::Modifier::Closed)
+      return false;
+
+    if (rule.HasYears() || rule.HasMonths() || rule.HasWeeks())
+      return false;
+
+    // The timetable set combines its entries as ordinary overriding rules.
+    if (i + 1 < rules.size() && rule.GetAnySeparator() != ";")
+      return false;
+
+    auto const & weekdays = rule.GetWeekdays();
+    if (!weekdays.GetHolidays().empty())
+      return false;
+    for (auto const & range : weekdays.GetWeekdayRanges())
+      if (range.HasNth() || range.HasOffset())
+        return false;
+
+    for (auto const & span : rule.GetTimes())
+    {
+      if (!span.HasStart() || !span.HasEnd() || span.HasPlus() || span.HasPeriod() ||
+          !span.GetStart().IsHoursMinutes() || !span.GetEnd().IsHoursMinutes())
+      {
+        return false;
+      }
+
+      auto const start = span.GetStart().GetHourMinutes().GetDuration();
+      auto const end = span.GetEnd().GetHourMinutes().GetDuration();
+      // Platform pickers expose wall-clock starts and allow 24:00 only as the
+      // end of a day.
+      if (start >= 24_h || end > 24_h)
+        return false;
+    }
+  }
+  return true;
 }
 
 osmoh::Weekdays MakeWeekdays(editor::ui::TimeTable const & tt)
@@ -306,10 +354,7 @@ osmoh::OpeningHours MakeOpeningHours(ui::TimeTableSet const & tts)
 
 bool MakeTimeTableSet(osmoh::OpeningHours const & oh, ui::TimeTableSet & tts)
 {
-  if (!oh.IsValid())
-    return false;
-
-  if (oh.HasYearSelector() || oh.HasWeekSelector() || oh.HasMonthSelector())
+  if (!IsRepresentableInSimpleEditor(oh))
     return false;
 
   tts = ui::TimeTableSet();
@@ -324,11 +369,6 @@ bool MakeTimeTableSet(osmoh::OpeningHours const & oh, ui::TimeTableSet & tts)
 
     ui::TimeTable tt = ui::TimeTable::GetUninitializedTimeTable();
     tt.SetOpeningTime(tt.GetPredefinedOpeningTime());
-
-    // Comments and unknown rules belong to advanced mode.
-    if (rulePart.GetModifier() == osmoh::RuleSequence::Modifier::Unknown ||
-        rulePart.GetModifier() == osmoh::RuleSequence::Modifier::Comment)
-      return false;
 
     if (rulePart.GetModifier() == osmoh::RuleSequence::Modifier::Closed)
     {

--- a/libs/editor/ui2oh.cpp
+++ b/libs/editor/ui2oh.cpp
@@ -14,6 +14,10 @@ using osmoh::operator""_h;
 
 osmoh::Timespan const kTwentyFourHours = {0_h, 24_h};
 
+editor::ui::OpeningDays const kWholeWeek = {
+    osmoh::Weekday::Monday, osmoh::Weekday::Tuesday,  osmoh::Weekday::Wednesday, osmoh::Weekday::Thursday,
+    osmoh::Weekday::Friday, osmoh::Weekday::Saturday, osmoh::Weekday::Sunday};
+
 editor::ui::OpeningDays MakeOpeningDays(osmoh::Weekdays const & wds)
 {
   std::set<osmoh::Weekday> openingDays;
@@ -145,6 +149,7 @@ bool IsRepresentableInSimpleEditor(osmoh::OpeningHours const & oh)
     return false;
 
   auto const & rules = oh.GetRule();
+  editor::ui::OpeningDays coveredDays;
   for (size_t i = 0; i < rules.size(); ++i)
   {
     auto const & rule = rules[i];
@@ -163,8 +168,19 @@ bool IsRepresentableInSimpleEditor(osmoh::OpeningHours const & oh)
       return false;
 
     // The timetable set combines its entries as ordinary overriding rules.
-    if (i + 1 < rules.size() && rule.GetAnySeparator() != ";")
-      return false;
+    // An additive open rule over days disjoint from every preceding rule is
+    // equivalent to an overriding one; a fallback ("||") never is.
+    if (i > 0 && rules[i - 1].GetAnySeparator() != ";")
+    {
+      if (rules[i - 1].GetAnySeparator() != "," || !rule.HasWeekdays() ||
+          rule.GetModifier() == RuleSequence::Modifier::Closed)
+      {
+        return false;
+      }
+      for (auto const day : MakeOpeningDays(rule.GetWeekdays()))
+        if (coveredDays.count(day) != 0)
+          return false;
+    }
 
     auto const & weekdays = rule.GetWeekdays();
     if (!weekdays.GetHolidays().empty())
@@ -194,6 +210,9 @@ bool IsRepresentableInSimpleEditor(osmoh::OpeningHours const & oh)
       if (WrapsMidnight(span) && (rule.GetTimes().size() > 1 || rule.GetModifier() == RuleSequence::Modifier::Closed))
         return false;
     }
+
+    auto const ruleDays = rule.HasWeekdays() ? MakeOpeningDays(rule.GetWeekdays()) : kWholeWeek;
+    coveredDays.insert(ruleDays.begin(), ruleDays.end());
   }
   return true;
 }
@@ -233,10 +252,6 @@ osmoh::TTimespans MakeTimespans(editor::ui::TimeTable const & tt)
 
   return spans;
 }
-
-editor::ui::OpeningDays const kWholeWeek = {
-    osmoh::Weekday::Monday, osmoh::Weekday::Tuesday,  osmoh::Weekday::Wednesday, osmoh::Weekday::Thursday,
-    osmoh::Weekday::Friday, osmoh::Weekday::Saturday, osmoh::Weekday::Sunday};
 
 editor::ui::OpeningDays GetCommonDays(editor::ui::OpeningDays const & a, editor::ui::OpeningDays const & b)
 {

--- a/libs/editor/ui2oh.cpp
+++ b/libs/editor/ui2oh.cpp
@@ -143,7 +143,10 @@ bool IsRepresentableInSimpleEditor(osmoh::OpeningHours const & oh)
     {
       return false;
     }
-    if (rule.IsTwentyFourHours() && rule.GetModifier() == RuleSequence::Modifier::Closed)
+    // A constant rule carries only a modifier ("Mo-Fr 08:00-18:00; off" is
+    // closed the whole week): no time table can represent it, except a constant
+    // open rule -- that is the whole week, 24 hours a day.
+    if (rule.IsEmpty() && !rule.IsTwentyFourHours())
       return false;
 
     if (rule.HasYears() || rule.HasMonths() || rule.HasWeeks())
@@ -231,98 +234,99 @@ osmoh::HourMinutes::TMinutes::rep GetDuration(osmoh::Time const & time)
   return time.GetHourMinutes().GetDurationCount();
 }
 
-bool Includes(osmoh::Timespan const & a, osmoh::Timespan const & b)
+// The result of applying a closed rule's spans to a time table it covers.
+enum class Exclusion
 {
-  return GetDuration(a.GetStart()) <= GetDuration(b.GetStart()) && GetDuration(b.GetEnd()) <= GetDuration(a.GetEnd());
+  Applied,      // The spans became exclude times of the time table.
+  ClosedTable,  // The rule closes the whole opening span.
+  Unsupported   // No time table can express the result.
+};
+
+Exclusion ExcludeTimes(osmoh::TTimespans const & excludeTime, editor::ui::TimeTable & tt)
+{
+  if (tt.IsTwentyFourHours())
+  {
+    tt.SetTwentyFourHours(false);
+    // TODO(mgsergio): Consider TimeTable refactoring:
+    // get rid of separation of TwentyFourHours and OpeningTime.
+    tt.SetOpeningTime(kTwentyFourHours);
+  }
+
+  auto const openStart = GetDuration(tt.GetOpeningTime().GetStart());
+  auto const openEnd = GetDuration(tt.GetOpeningTime().GetEnd());
+
+  for (auto const & span : excludeTime)
+  {
+    auto const start = GetDuration(span.GetStart());
+    auto const end = GetDuration(span.GetEnd());
+
+    // The place is closed outside of its opening time anyway.
+    if (end <= openStart || openEnd <= start)
+      continue;
+
+    if (start <= openStart && openEnd <= end)
+      return Exclusion::ClosedTable;
+
+    // Only a span strictly inside the opening one is an exclude time: an
+    // overlapping one would have to shrink the opening span, and excluding it
+    // as is leaves a zero-length span, which osmoh reads as open all day.
+    if (start <= openStart || openEnd <= end || !tt.AddExcludeTime(span))
+      return Exclusion::Unsupported;
+  }
+
+  return Exclusion::Applied;
 }
 
 bool ExcludeRulePart(osmoh::RuleSequence const & rulePart, editor::ui::TimeTableSet & tts)
 {
-  auto const ttsInitialSize = tts.Size();
-  for (size_t i = 0; i < ttsInitialSize; ++i)
+  // A closed rule with no day selector applies to the whole week, mirroring
+  // the open-rule branch in MakeTimeTableSet.
+  auto const ruleDays = rulePart.HasWeekdays() ? MakeOpeningDays(rulePart.GetWeekdays()) : kWholeWeek;
+  auto const & excludeTime = rulePart.GetTimes();
+
+  // The rule overrides every time table it intersects, so visit them all;
+  // iterating backwards keeps indices valid across Remove() and never
+  // revisits the time tables Append() adds along the way.
+  for (size_t i = tts.Size(); i-- > 0;)
   {
     auto tt = tts.Get(i);
     auto const ttOpeningDays = tt.GetOpeningDays();
-    auto const commonDays = GetCommonDays(ttOpeningDays, MakeOpeningDays(rulePart.GetWeekdays()));
+    auto const commonDays = GetCommonDays(ttOpeningDays, ruleDays);
+    if (commonDays.empty())
+      continue;
 
-    auto const removeCommonDays = [&commonDays](editor::ui::TimeTableSet::Proxy & tt)
-    {
-      for (auto const day : commonDays)
-        VERIFY(tt.RemoveWorkingDay(day), ("Can't remove working day"));
-      VERIFY(tt.Commit(), ("Can't commit changes"));
-    };
-
-    auto const twentyFourHoursGuard = [](editor::ui::TimeTable & tt)
-    {
-      if (tt.IsTwentyFourHours())
-      {
-        tt.SetTwentyFourHours(false);
-        // TODO(mgsergio): Consider TimeTable refactoring:
-        // get rid of separation of TwentyFourHours and OpeningTime.
-        tt.SetOpeningTime(kTwentyFourHours);
-      }
-    };
-
-    auto const & excludeTime = rulePart.GetTimes();
-    // The whole rule matches to the tt.
+    // The rule covers the whole time table.
     if (commonDays.size() == ttOpeningDays.size())
     {
-      // rulePart applies to commonDays in a whole.
-      if (excludeTime.empty())
-        return tts.Remove(i);
+      // A closed rule with no times closes every day it covers.
+      auto const exclusion = excludeTime.empty() ? Exclusion::ClosedTable : ExcludeTimes(excludeTime, tt);
+      if (exclusion == Exclusion::Unsupported)
+        return false;
 
-      twentyFourHoursGuard(tt);
-
-      for (auto const & time : excludeTime)
-      {
-        // Whatever it is, it's already closed at a time out of opening time.
-        if (!Includes(tt.GetOpeningTime(), time))
-          continue;
-
-        // The whole opening time interval should be switched off
-        if (!tt.AddExcludeTime(time))
-          return tts.Remove(i);
-      }
-      VERIFY(tt.Commit(), ("Can't update time table"));
-      return true;
+      if (exclusion == Exclusion::Applied)
+        VERIFY(tt.Commit(), ("Can't update time table"));
+      else if (!tts.Remove(i))
+        return false;  // The last time table is closed, nothing is left to edit.
+      continue;
     }
-    // A rule is applied to a subset of a time table. We should
-    // subtract common parts from tt and add a new time table if needed.
-    if (commonDays.size() != 0)
-    {
-      // rulePart applies to commonDays in a whole.
-      if (excludeTime.empty())
-      {
-        removeCommonDays(tt);
-        continue;
-      }
 
-      twentyFourHoursGuard(tt);
+    // The rule applies to a part of the time table: move the common days into a
+    // time table of their own, unless the rule closes them completely.
+    editor::ui::TimeTable copy = tt;
+    VERIFY(copy.SetOpeningDays(commonDays), ("Can't set opening days"));
 
-      editor::ui::TimeTable copy = tt;
-      VERIFY(copy.SetOpeningDays(commonDays), ("Can't set opening days"));
+    auto const exclusion = excludeTime.empty() ? Exclusion::ClosedTable : ExcludeTimes(excludeTime, copy);
+    if (exclusion == Exclusion::Unsupported)
+      return false;
 
-      auto doAppendRest = true;
-      for (auto const & time : excludeTime)
-      {
-        // Whatever it is, it's already closed at a time out of opening time.
-        if (!Includes(copy.GetOpeningTime(), time))
-          continue;
+    for (auto const day : commonDays)
+      VERIFY(tt.RemoveWorkingDay(day), ("Can't remove working day"));
+    VERIFY(tt.Commit(), ("Can't commit changes"));
 
-        // The whole opening time interval should be switched off
-        if (!copy.AddExcludeTime(time))
-        {
-          doAppendRest = false;
-          break;
-        }
-      }
-
-      removeCommonDays(tt);
-
-      if (doAppendRest)
-        VERIFY(tts.Append(copy), ("Can't add new time table"));
-    }
+    if (exclusion == Exclusion::Applied)
+      VERIFY(tts.Append(copy), ("Can't add new time table"));
   }
+
   return true;
 }
 }  // namespace
@@ -364,9 +368,6 @@ bool MakeTimeTableSet(osmoh::OpeningHours const & oh, ui::TimeTableSet & tts)
   bool first = true;
   for (auto const & rulePart : oh.GetRule())
   {
-    if (rulePart.IsEmpty())
-      continue;
-
     ui::TimeTable tt = ui::TimeTable::GetUninitializedTimeTable();
     tt.SetOpeningTime(tt.GetPredefinedOpeningTime());
 

--- a/libs/editor/ui2oh.cpp
+++ b/libs/editor/ui2oh.cpp
@@ -127,6 +127,16 @@ std::vector<Weekdays> SplitIntoIntervals(editor::ui::OpeningDays const & days)
   return result;
 }
 
+osmoh::HourMinutes::TMinutes::rep GetDuration(osmoh::Time const & time)
+{
+  return time.GetHourMinutes().GetDurationCount();
+}
+
+bool WrapsMidnight(osmoh::Timespan const & span)
+{
+  return GetDuration(span.GetEnd()) <= GetDuration(span.GetStart());
+}
+
 bool IsRepresentableInSimpleEditor(osmoh::OpeningHours const & oh)
 {
   using namespace osmoh;
@@ -176,6 +186,12 @@ bool IsRepresentableInSimpleEditor(osmoh::OpeningHours const & oh)
       // Platform pickers expose wall-clock starts and allow 24:00 only as the
       // end of a day.
       if (start >= 24_h || end > 24_h)
+        return false;
+
+      // SetUpTimeTable's interval model and ExcludeTimes() are linear in
+      // wall-clock time: keep a lone overnight span editable, but reject one
+      // combined with other spans or used as an exclusion.
+      if (WrapsMidnight(span) && (rule.GetTimes().size() > 1 || rule.GetModifier() == RuleSequence::Modifier::Closed))
         return false;
     }
   }
@@ -229,11 +245,6 @@ editor::ui::OpeningDays GetCommonDays(editor::ui::OpeningDays const & a, editor:
   return result;
 }
 
-osmoh::HourMinutes::TMinutes::rep GetDuration(osmoh::Time const & time)
-{
-  return time.GetHourMinutes().GetDurationCount();
-}
-
 // The result of applying a closed rule's spans to a time table it covers.
 enum class Exclusion
 {
@@ -251,6 +262,10 @@ Exclusion ExcludeTimes(osmoh::TTimespans const & excludeTime, editor::ui::TimeTa
     // get rid of separation of TwentyFourHours and OpeningTime.
     tt.SetOpeningTime(kTwentyFourHours);
   }
+
+  // Linear exclusion math cannot split an overnight opening span.
+  if (WrapsMidnight(tt.GetOpeningTime()))
+    return Exclusion::Unsupported;
 
   auto const openStart = GetDuration(tt.GetOpeningTime().GetStart());
   auto const openEnd = GetDuration(tt.GetOpeningTime().GetEnd());

--- a/libs/opening_hours/opening_hours_tests/osmoh_tests.cpp
+++ b/libs/opening_hours/opening_hours_tests/osmoh_tests.cpp
@@ -1381,4 +1381,18 @@ UNIT_TEST(OpeningHours_CommentRules)
   }
 }
 
+UNIT_TEST(TimeEvent_NoClockValue)
+{
+  // A sun event has no fixed wall-clock value; platform time pickers must
+  // check IsEvent() instead of reading the zero placeholder as a clock time.
+  OpeningHours const oh("Mo-Su sunrise-sunset");
+  TEST(oh.IsValid(), ());
+  TEST_EQUAL(oh.GetRule().size(), 1, ());
+
+  auto const & span = oh.GetRule().front().GetTimes().front();
+  TEST(span.GetStart().IsEvent(), ());
+  TEST(span.GetEnd().IsEvent(), ());
+  TEST_EQUAL(span.GetStart().GetHoursCount(), 0, ());
+  TEST_EQUAL(span.GetEnd().GetHoursCount(), 0, ());
+}
 }  // namespace osmoh_tests


### PR DESCRIPTION
## What

The simple editor's `ui::TimeTable` model can only represent ordinary
overriding rules with plain wall-clock spans, but `MakeTimeTableSet()`
checked that piecemeal and missed cases where the mismatch silently
corrupts the value on save. This PR makes the simple editor accept only
schedules it can round-trip losslessly and fixes the conversions that
lost data for values it does accept.

Four commits, each with its own regression tests:

1. **Keep unrepresentable schedules in the advanced editor** —
   `IsRepresentableInSimpleEditor()` gates sun events, open-ended spans
   (`11:00+`), holidays (`Su,PH …`), nth/offset weekdays,
   comments/`unknown`, fallback (`||`) rules and constant rules other than
   a plain constant *open* (`24/7`, `open`, which the simple editor has
   always handled), alongside the year/week/month selector checks.
   Such values fall back to the advanced editor, which preserves the raw
   string; both place pages keep showing it and the open/closed status
   keeps working.
2. **Apply closed overrides to every time table** — a trailing constant
   `off`, a selectorless `13:00-14:00 off` and a `Mo-Su off` spanning
   several time tables were all silently lost on save, reopening closed
   hours. A closed span strictly inside an opening span becomes an excluded
   time, one that covers it closes that day, and one that only partially
   overlaps falls back to the advanced editor instead of reopening the
   closed part. One value that used to convert
   (`Mo-Fr 11:00-17:00; …; Mo-Fr 11:00-13:00 off`) is now edited as raw
   text: it was previously saved as open all day, and clipping the opening
   span instead would drop earlier exclusions straddling the new boundary.
3. **Keep overnight-span combinations in the advanced editor** — the
   interval math is linear in wall-clock time, so
   `Mo 20:00-02:00, 01:00-04:00` collapsed to `Mo 01:00-02:00` and an
   `off` inside a wrapped span was dropped; a lone overnight span stays
   editable, combinations fall back.
4. **Accept additive rules over disjoint days** — a plain
   `Mo-Fr 08:00-18:00, Sa 10:00-14:00` is representable (union equals
   override on disjoint days), so it keeps rendering structured on the
   place pages instead of as raw text; overlapping or closed additive
   rules stay in advanced mode. Saving such a value from the simple
   editor spells it with `;`.

## Why

Sun events survive into the timetable, but both platforms marshal it as
plain hours/minutes (Android `JavaTimespan` and iOS
`dateComponentsFromTime` read `GetHoursCount()` — a hardcoded 00:00 for
an event), so opening a POI with `Mo-Su sunrise-sunset` in the simple
editor and saving it untouched rewrote the tag to `Mo-Su 00:00-00:00`
(173 patterns / 2854 objects in the #13107 corpus). The other gated and
fixed classes lose or change data the same way: `11:00+` was saved as
`11:00-24:00`, additive rules came back as overrides, the `PH` part of
`Su,PH` was silently dropped, closed overrides and overnight
combinations were corrupted as described above.

Follow-up to #13107, announced in its description. Related:
#4186 (real sun-event times), #3883 (public-holiday dates).

## How tested

`editor_tests` (four `ui2oh` suites cover the gated classes and every
corruption case above as a rejection or a correct conversion; the accepted
values are asserted to survive a save/load round trip, not merely to enter
simple mode)
and `opening_hours_tests` (the event-clock-value invariant the platform
marshalling relies on) on desktop, on top of merged master.

## Not in this PR

Rebuilding `MakeTimeTableSet` on a canonical per-minute weekly grid,
which would make closed overrides and overnight spans correct by
construction instead of gated, belongs with the planned editor-model
rework.

