### PR TITLE
[windows] Make language and DST overrides portable

### DIFF
--- a/dev_sandbox/main.cpp
+++ b/dev_sandbox/main.cpp
@@ -3,6 +3,7 @@
 #include "map/framework.hpp"
 
 #include "platform/platform.hpp"
+#include "platform/preferred_languages.hpp"
 #include "platform/settings.hpp"
 
 #include "base/logging.hpp"
@@ -38,7 +39,7 @@ DEFINE_string(data_path, "", "Path to data directory.");
 DEFINE_string(log_abort_level, base::ToString(base::GetDefaultLogAbortLevel()),
               "Log messages severity that causes termination.");
 DEFINE_string(resources_path, "", "Path to resources directory.");
-DEFINE_string(lang, "", "Device language.");
+DEFINE_string(lang, "", "Preferred language override.");
 
 #if defined(OMIM_OS_MAC) || defined(OMIM_OS_LINUX) || defined(OMIM_OS_WINDOWS)
 drape_ptr<dp::GraphicsContextFactory> CreateContextFactory(GLFWwindow * window, dp::ApiVersion api, m2::PointU size);
@@ -213,6 +214,9 @@ int main(int argc, char * argv[])
   gflags::SetVersionString(platform.Version());
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
+  if (!FLAGS_lang.empty())
+    languages::SetPreferredLanguageOverride(FLAGS_lang);
+
   if (!FLAGS_resources_path.empty())
     platform.SetResourceDir(FLAGS_resources_path);
   if (!FLAGS_data_path.empty())
@@ -259,9 +263,6 @@ int main(int argc, char * argv[])
   bool outvalue;
   if (!settings::Get(settings::kDeveloperMode, outvalue))
     settings::Set(settings::kDeveloperMode, true);
-
-  if (!FLAGS_lang.empty())
-    (void)::setenv("LANGUAGE", FLAGS_lang.c_str(), 1);
 
   FrameworkParams frameworkParams;
   Framework framework(frameworkParams);

--- a/libs/opening_hours/opening_hours_tests/osmoh_tests.cpp
+++ b/libs/opening_hours/opening_hours_tests/osmoh_tests.cpp
@@ -6,7 +6,9 @@
 
 #include "opening_hours/opening_hours.hpp"
 
-#include <cstdlib>
+#include "timezone/timezone.hpp"
+
+#include <chrono>
 #include <ctime>
 #include <iomanip>
 #include <sstream>
@@ -62,6 +64,13 @@ time_t MakeTimestamp(std::string const & dateTime, char const * fmt = "%Y-%m-%d 
   return mktime(&time);
 }
 
+time_t MakeUtcTimestamp(int year, int month, int day, int hour, int minute)
+{
+  auto const time = std::chrono::sys_days{std::chrono::year{year} / month / day} + std::chrono::hours{hour} +
+                    std::chrono::minutes{minute};
+  return static_cast<time_t>(std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch()).count());
+}
+
 bool Parse(std::string const & str, OpeningHours & oh)
 {
   oh = OpeningHours(str);
@@ -86,6 +95,15 @@ bool IsUnknown(OpeningHours const & oh, std::string const & dateTime)
 std::string FormatTime(time_t t, char const * fmt)
 {
   std::tm const tm = *localtime(&t);
+  char buffer[30];
+  std::strftime(buffer, sizeof(buffer) / sizeof(buffer[0]), fmt, &tm);
+  return std::string(buffer);
+}
+
+std::string FormatZonedTime(time_t t, om::tz::TimeZone const & timeZone, char const * fmt)
+{
+  time_t const zonedTime = om::tz::Convert(t, timeZone);
+  std::tm const tm = *std::gmtime(&zonedTime);
   char buffer[30];
   std::strftime(buffer, sizeof(buffer) / sizeof(buffer[0]), fmt, &tm);
   return std::string(buffer);
@@ -1225,29 +1243,24 @@ UNIT_TEST(OpeningHours_GetInfoHorizonAndDst)
   }
   {
     // Crossing a DST transition must not shift the reported opening time:
-    // Europe/Berlin springs forward on 2026-03-29 02:00 -> 03:00.
-    char const * const oldTz = getenv("TZ");
-    setenv("TZ", "Europe/Berlin", 1);
-    tzset();
+    // UTC+1 with a one-hour jump at 2026-03-29 01:00 UTC models Europe/Berlin's
+    // 02:00 -> 03:00 transition. Keeping it here makes the test independent of
+    // the generated timezone database's year range.
+    om::tz::TimeZone const timeZone{.base_offset = 68, .dst_delta = 60, .transitions = {{87, 60}}};
     {
       OpeningHours const oh("Mo-Su 10:00-18:00");
-      auto const info = oh.GetInfo(MakeTimestamp("2026-03-28 23:00"));
-      TEST_EQUAL(FormatTime(info.nextTimeOpen, "%Y-%m-%d %H:%M"), "2026-03-29 10:00", ());
+      auto const info = oh.GetInfo(MakeUtcTimestamp(2026, 3, 28, 22, 0), timeZone);
+      TEST_EQUAL(FormatZonedTime(info.nextTimeOpen, timeZone, "%Y-%m-%d %H:%M"), "2026-03-29 10:00", ());
     }
     {
       // An opening boundary inside the gap snaps to the first valid instant:
-      // nonexistent 02:30 becomes 03:00, exactly where IsOpen() flips.
+      // nonexistent 02:30 becomes 03:00, exactly where the evaluated state flips.
       OpeningHours const oh("Su 02:30-04:00");
-      auto const info = oh.GetInfo(MakeTimestamp("2026-03-28 12:00"));
-      TEST_EQUAL(FormatTime(info.nextTimeOpen, "%Y-%m-%d %H:%M"), "2026-03-29 03:00", ());
-      TEST(oh.IsOpen(info.nextTimeOpen), ());
-      TEST(!oh.IsOpen(info.nextTimeOpen - 60), ());
+      auto const info = oh.GetInfo(MakeUtcTimestamp(2026, 3, 28, 11, 0), timeZone);
+      TEST_EQUAL(FormatZonedTime(info.nextTimeOpen, timeZone, "%Y-%m-%d %H:%M"), "2026-03-29 03:00", ());
+      TEST_EQUAL(oh.GetInfo(info.nextTimeOpen, timeZone).state, RuleState::Open, ());
+      TEST_EQUAL(oh.GetInfo(info.nextTimeOpen - 60, timeZone).state, RuleState::Closed, ());
     }
-    if (oldTz)
-      setenv("TZ", oldTz, 1);
-    else
-      unsetenv("TZ");
-    tzset();
   }
 }
 

--- a/libs/platform/preferred_languages.cpp
+++ b/libs/platform/preferred_languages.cpp
@@ -436,12 +436,35 @@ static MSLocale const gLocales[] = {
 
 namespace languages
 {
+namespace
+{
+struct SystemLanguagesState
+{
+  std::string m_override;
+  bool m_initialized = false;
+};
+
+SystemLanguagesState & GetSystemLanguagesState()
+{
+  static SystemLanguagesState state;
+  return state;
+}
+}  // namespace
+
 struct SystemLanguages
 {
   buffer_vector<std::string, 4> m_langs;
 
   SystemLanguages()
   {
+    auto & state = GetSystemLanguagesState();
+    state.m_initialized = true;
+    if (!state.m_override.empty())
+    {
+      m_langs.push_back(state.m_override);
+      return;
+    }
+
     /// @DebugNote
     // Hardcode draw text language.
     // m_langs.push_back("hi");
@@ -522,6 +545,14 @@ struct SystemLanguages
 #endif
   }
 };
+
+void SetPreferredLanguageOverride(std::string_view language)
+{
+  ASSERT(!language.empty(), ());
+  auto & state = GetSystemLanguagesState();
+  ASSERT(!state.m_initialized, ("The language override must be set before the first language lookup"));
+  state.m_override = language;
+}
 
 buffer_vector<std::string, 4> const & GetSystemPreferred()
 {

--- a/libs/platform/preferred_languages.hpp
+++ b/libs/platform/preferred_languages.hpp
@@ -39,6 +39,9 @@ std::string GetCurrentMapLanguage();
 /// Normalize() it for a core language code, or GetTwine() it for a Twine locale.
 std::string SelectMapLanguage(buffer_vector<std::string, 4> const & preferred);
 
+/// Overrides OS language preferences during process startup. Must be called before any language getter.
+void SetPreferredLanguageOverride(std::string_view language);
+
 /// Script a Chinese language tag is written in.
 enum class ChineseScript
 {

--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -44,7 +44,7 @@ DEFINE_string(rects, "",
               "[;lat_leftBottom,lon_leftBottom,lat_rightTop,lon_rightTop]\" or path to a file with "
               "rects in the same format. Each rect defines a place on the map to take screenshot.");
 DEFINE_string(dst_path, "", "Path to a directory to save screenshots.");
-DEFINE_string(lang, "", "Device language.");
+DEFINE_string(lang, "", "Preferred language override.");
 DEFINE_int32(width, 0, "Screenshot width.");
 DEFINE_int32(height, 0, "Screenshot height.");
 DEFINE_double(
@@ -117,6 +117,9 @@ int main(int argc, char * argv[])
   gflags::SetVersionString(platform.Version());
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
+  if (!FLAGS_lang.empty())
+    languages::SetPreferredLanguageOverride(FLAGS_lang);
+
   if (!FLAGS_resources_path.empty())
     platform.SetResourceDir(FLAGS_resources_path);
   if (!FLAGS_data_path.empty())
@@ -170,9 +173,6 @@ int main(int argc, char * argv[])
   if (eulaAccepted)  // User has accepted EULA
   {
     std::unique_ptr<qt::ScreenshotParams> screenshotParams;
-
-    if (!FLAGS_lang.empty())
-      (void)::setenv("LANGUAGE", FLAGS_lang.c_str(), 1);
 
     if (!FLAGS_kml_path.empty() || !FLAGS_points.empty() || !FLAGS_rects.empty())
     {


### PR DESCRIPTION
Follow-up to https://github.com/organicmaps/organicmaps/pull/13107#discussion_r3786658579

- Test the DST transition against a time zone spelled out in the test (UTC+1 with a +1 h jump), instead of mutating the process timezone or reading the bundled database — the bundled transitions are stored as deltas from the generation year, so a regenerated `timezone_info.json` would silently retire the test.
- Apply the desktop `--lang` option through an explicit startup override on every platform, including Windows.
- Avoid adding process-wide `setenv()`/`unsetenv()` compatibility shims.

Tested:
- `cmake --build <build> --target opening_hours_tests platform_tests desktop dev_sandbox`
- `opening_hours_tests --filter='osmoh_tests.cpp::.*'`, `platform_tests --filter='language_test.cpp::.*'`
- Isolated startup-language override probe (`de-CH` -> `de`)
- Negative check: emptying the test's transition table reproduces the pre-fix failure, so the test really exercises the spring-forward gap.

LLM tools were used for review and implementation.
