### PR TITLE
[kml] Validate coordinates on GeoJSON, GPX and KML import

### DIFF
--- a/libs/kml/kml_tests/geojson_tests.cpp
+++ b/libs/kml/kml_tests/geojson_tests.cpp
@@ -11,6 +11,8 @@
 
 #include "coding/string_utf8_multilang.hpp"
 
+#include <limits>
+
 namespace geojson_tests
 {
 kml::FileData GenerateKmlFileData();
@@ -914,6 +916,36 @@ UNIT_TEST(GeoJson_Parse_Elevation)
   TEST_EQUAL(flat.m_tracksData.size(), 1, ());
   for (auto const & pt : flat.m_tracksData[0].m_geometry.m_lines[0])
     TEST_EQUAL(pt.GetAltitude(), geometry::kInvalidAltitude, ());
+
+  // A Z coordinate on a rejected position does not turn surviving 2D positions into sea-level points.
+  std::string_view constexpr inputInvalidPositionZ = R"({
+  "type": "FeatureCollection",
+  "features": [{
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+      "type": "LineString",
+      "coordinates": [[8.0, 47.0], [181.0, 47.1, 100], [8.2, 47.2]]
+    }
+  }]
+})";
+  auto const invalidPositionZ = LoadGeojsonFromString(inputInvalidPositionZ);
+  TEST_EQUAL(invalidPositionZ.m_tracksData.size(), 1, ());
+  for (auto const & pt : invalidPositionZ.m_tracksData[0].m_geometry.m_lines[0])
+    TEST_EQUAL(pt.GetAltitude(), geometry::kInvalidAltitude, ());
+
+  std::string_view constexpr inputExtremeZ = R"({
+  "type": "FeatureCollection",
+  "features": [{
+    "type": "Feature",
+    "properties": {},
+    "geometry": {"type": "LineString", "coordinates": [[8.0, 47.0, 1e300], [8.1, 47.1, -1e300]]}
+  }]
+})";
+  auto const extremeZ = LoadGeojsonFromString(inputExtremeZ);
+  auto const & extremeLine = extremeZ.m_tracksData[0].m_geometry.m_lines[0];
+  TEST_EQUAL(extremeLine[0].GetAltitude(), std::numeric_limits<geometry::Altitude>::max(), ());
+  TEST_EQUAL(extremeLine[1].GetAltitude(), geometry::kInvalidAltitude + 1, ());
 }
 
 UNIT_TEST(GeoJson_Writer_Elevation_Mixed)
@@ -1086,6 +1118,108 @@ UNIT_TEST(GeoJson_Parse_Timestamps_CountMismatch)
   kml::FileData const data = LoadGeojsonFromString(input);
   TEST_EQUAL(data.m_tracksData.size(), 1, ());
   TEST(!data.m_tracksData[0].m_geometry.HasTimestamps(), ());
+}
+
+UNIT_TEST(GeoJson_Parse_Timestamps_OutOfRangeNumber)
+{
+  std::string_view constexpr input = R"({
+  "type": "FeatureCollection",
+  "features": [{
+    "type": "Feature",
+    "properties": {"coordTimes": [1e300, -1e300]},
+    "geometry": {"type": "LineString", "coordinates": [[8.0, 47.0], [8.1, 47.1]]}
+  }]
+})";
+
+  auto const data = LoadGeojsonFromString(input);
+  TEST_EQUAL(data.m_tracksData.size(), 1, ());
+  TEST(!data.m_tracksData[0].m_geometry.HasTimestamps(), ());
+}
+
+UNIT_TEST(GeoJson_Parse_InvalidCoordinates)
+{
+  // Positions shorter than [lon, lat] or outside the WGS84 range are skipped: such a point does not
+  // become a bookmark, such a line vertex is dropped together with its timestamp.
+  std::string_view constexpr input = R"({
+  "type": "FeatureCollection",
+  "features": [
+    {"type": "Feature", "properties": {"name": "empty"}, "geometry": {"type": "Point", "coordinates": []}},
+    {"type": "Feature", "properties": {"name": "short"}, "geometry": {"type": "Point", "coordinates": [8.0]}},
+    {"type": "Feature", "properties": {"name": "far"}, "geometry": {"type": "Point", "coordinates": [1e300, 47.0]}},
+    {"type": "Feature", "properties": {"name": "north"}, "geometry": {"type": "Point", "coordinates": [8.0, 91.0]}},
+    {"type": "Feature", "properties": {"name": "ok"}, "geometry": {"type": "Point", "coordinates": [8.0, 47.0]}},
+    {
+      "type": "Feature",
+      "properties": {
+        "coordTimes": ["2026-05-31T12:34:56Z", "2026-05-31T12:35:01Z", "2026-05-31T12:35:06Z", "2026-05-31T12:35:11Z"]
+      },
+      "geometry": {"type": "LineString", "coordinates": [[8.0, 47.0], [181.0, 47.1], [8.2], [8.3, 47.3]]}
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "all invalid"},
+      "geometry": {"type": "LineString", "coordinates": [[181.0, 47.0], [182.0, 47.1]]}
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "one survivor"},
+      "geometry": {"type": "LineString", "coordinates": [[8.0, 47.0], [181.0, 47.1]]}
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "mismatched timestamps",
+        "coordTimes": ["2026-05-31T12:34:56Z", "2026-05-31T12:35:01Z", "2026-05-31T12:35:06Z", "2026-05-31T12:35:11Z"]
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[8.0, 47.0], [181.0, 47.1], [8.2, 47.2], [8.3, 47.3], [8.4, 47.4]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "multi",
+        "coordTimes": [
+          ["2026-05-31T12:40:00Z", "2026-05-31T12:40:05Z"],
+          ["2026-05-31T12:41:00Z", "2026-05-31T12:41:05Z", "2026-05-31T12:41:10Z"]
+        ]
+      },
+      "geometry": {
+        "type": "MultiLineString",
+        "coordinates": [
+          [[181.0, 47.0], [182.0, 47.1]],
+          [[8.0, 47.0], [181.0, 47.1], [8.2, 47.2]]
+        ]
+      }
+    }
+  ]
+})";
+
+  kml::FileData const data = LoadGeojsonFromString(input);
+  TEST_EQUAL(data.m_bookmarksData.size(), 1, ());
+  TEST_EQUAL(kml::GetDefaultStr(data.m_bookmarksData[0].m_name), "ok", ());
+  TEST_EQUAL(data.m_bookmarksData[0].m_point, mercator::FromLatLon(47.0, 8.0), ());
+
+  TEST_EQUAL(data.m_tracksData.size(), 3, ());
+  auto const & geometry = data.m_tracksData[0].m_geometry;
+  kml::TrackGeometry const expectedLine = {{mercator::FromLatLon(47.0, 8.0), geometry::kInvalidAltitude},
+                                           {mercator::FromLatLon(47.3, 8.3), geometry::kInvalidAltitude}};
+  TEST_EQUAL(geometry.m_lines, std::vector<kml::TrackGeometry>{expectedLine}, ());
+  kml::MultiGeometry::TimeT const expectedTimes = {base::StringToTimestamp("2026-05-31T12:34:56Z"),
+                                                   base::StringToTimestamp("2026-05-31T12:35:11Z")};
+  TEST_EQUAL(geometry.m_timestamps, std::vector<kml::MultiGeometry::TimeT>{expectedTimes}, ());
+
+  auto const & mismatch = data.m_tracksData[1].m_geometry;
+  TEST_EQUAL(mismatch.m_lines[0].size(), 4, ());
+  TEST(!mismatch.HasTimestamps(), ());
+
+  auto const & multi = data.m_tracksData[2].m_geometry;
+  TEST_EQUAL(multi.m_lines.size(), 1, ());
+  TEST_EQUAL(multi.m_lines[0].size(), 2, ());
+  kml::MultiGeometry::TimeT const expectedMultiTimes = {base::StringToTimestamp("2026-05-31T12:41:00Z"),
+                                                        base::StringToTimestamp("2026-05-31T12:41:10Z")};
+  TEST_EQUAL(multi.m_timestamps, std::vector<kml::MultiGeometry::TimeT>{expectedMultiTimes}, ());
 }
 
 UNIT_TEST(GeoJson_Parse_Timestamps_MultiLine)

--- a/libs/kml/kml_tests/gpx_tests.cpp
+++ b/libs/kml/kml_tests/gpx_tests.cpp
@@ -11,6 +11,8 @@
 
 #include "platform/platform.hpp"
 
+#include <limits>
+
 namespace gpx_tests
 {
 namespace
@@ -240,6 +242,8 @@ UNIT_TEST(Gpx_Altitude_Issues)
       <trkpt lat="4" lon="4"><ele>2.0</ele></trkpt>
       <trkpt lat="5" lon="5"><ele>Wrong</ele></trkpt>
       <trkpt lat="6" lon="6"><ele>3</ele></trkpt>
+      <trkpt lat="7" lon="7"><ele>1e300</ele></trkpt>
+      <trkpt lat="8" lon="8"><ele>-1e300</ele></trkpt>
     </trkseg>
 </trk>
 </gpx>
@@ -247,13 +251,15 @@ UNIT_TEST(Gpx_Altitude_Issues)
 
   kml::FileData const dataFromText = LoadGpxFromString(input);
   auto const & line = dataFromText.m_tracksData[0].m_geometry.m_lines[0];
-  TEST_EQUAL(line.size(), 6, ());
+  TEST_EQUAL(line.size(), 8, ());
   TEST_EQUAL(line[0], geometry::PointWithAltitude(mercator::FromLatLon(1, 1), geometry::kInvalidAltitude), ());
   TEST_EQUAL(line[1], geometry::PointWithAltitude(mercator::FromLatLon(2, 2), 1), ());
   TEST_EQUAL(line[2], geometry::PointWithAltitude(mercator::FromLatLon(3, 3), geometry::kInvalidAltitude), ());
   TEST_EQUAL(line[3], geometry::PointWithAltitude(mercator::FromLatLon(4, 4), 2), ());
   TEST_EQUAL(line[4], geometry::PointWithAltitude(mercator::FromLatLon(5, 5), geometry::kInvalidAltitude), ());
   TEST_EQUAL(line[5], geometry::PointWithAltitude(mercator::FromLatLon(6, 6), 3), ());
+  TEST_EQUAL(line[6].GetAltitude(), std::numeric_limits<geometry::Altitude>::max(), ());
+  TEST_EQUAL(line[7].GetAltitude(), geometry::kInvalidAltitude + 1, ());
 }
 
 UNIT_TEST(Gpx_Export_MixedAltitudes)
@@ -312,6 +318,41 @@ UNIT_TEST(Gpx_Timestamp_Issues)
   TEST_EQUAL(times[5], base::StringToTimestamp("2024-05-04T19:00:04Z"), ());
   TEST_EQUAL(times[6], base::StringToTimestamp("2024-05-04T19:00:05Z"), ());
   TEST_EQUAL(times[7], base::StringToTimestamp("2024-05-04T19:00:05Z"), ());
+}
+
+UNIT_TEST(Gpx_Track_Invalid_Coordinates)
+{
+  // Waypoints and track points with missing or out-of-range WGS84 coordinates are skipped;
+  // skipped track points do not leave timestamps behind.
+  std::string_view constexpr input = R"(<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1">
+  <wpt lat="95.0" lon="8.0"><name>north</name></wpt>
+  <wpt lat="47.0"><name>missing longitude</name></wpt>
+  <wpt lat="47.0" lon="8.0"><name>ok</name></wpt>
+  <trk>
+    <trkseg>
+      <trkpt lat="47.0" lon="8.0"><time>2026-05-31T12:34:56Z</time></trkpt>
+      <trkpt lat="95.0" lon="8.1"><time>2026-05-31T12:35:01Z</time></trkpt>
+      <trkpt lat="47.2" lon="1e300"><time>2026-05-31T12:35:06Z</time></trkpt>
+      <trkpt lon="8.2"><time>2026-05-31T12:35:08Z</time></trkpt>
+      <trkpt lat="47.3" lon="8.3"><time>2026-05-31T12:35:11Z</time></trkpt>
+    </trkseg>
+  </trk>
+</gpx>
+)";
+
+  kml::FileData const data = LoadGpxFromString(input);
+  TEST_EQUAL(data.m_bookmarksData.size(), 1, ());
+  TEST_EQUAL(kml::GetDefaultStr(data.m_bookmarksData[0].m_name), "ok", ());
+  TEST_EQUAL(data.m_bookmarksData[0].m_point, mercator::FromLatLon(47.0, 8.0), ());
+  TEST_EQUAL(data.m_tracksData.size(), 1, ());
+  auto const & geometry = data.m_tracksData[0].m_geometry;
+  kml::TrackGeometry const expectedLine = {{mercator::FromLatLon(47.0, 8.0), geometry::kInvalidAltitude},
+                                           {mercator::FromLatLon(47.3, 8.3), geometry::kInvalidAltitude}};
+  TEST_EQUAL(geometry.m_lines, std::vector<kml::TrackGeometry>{expectedLine}, ());
+  kml::MultiGeometry::TimeT const expectedTimes = {base::StringToTimestamp("2026-05-31T12:34:56Z"),
+                                                   base::StringToTimestamp("2026-05-31T12:35:11Z")};
+  TEST_EQUAL(geometry.m_timestamps, std::vector<kml::MultiGeometry::TimeT>{expectedTimes}, ());
 }
 
 UNIT_TEST(GoMap)

--- a/libs/kml/kml_tests/serdes_tests.cpp
+++ b/libs/kml/kml_tests/serdes_tests.cpp
@@ -26,6 +26,7 @@
 
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <sstream>
 #include <vector>
 
@@ -984,6 +985,88 @@ UNIT_TEST(Kml_BadTracks)
     TEST_EQUAL(geom.m_lines[0].size(), 2, ());
     TEST_EQUAL(geom.m_lines[0].size(), geom.m_timestamps[0].size(), ());
   }
+}
+
+UNIT_TEST(Kml_InvalidTrackBeforeValidTrack)
+{
+  std::string_view constexpr input = R"(<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+  <Placemark>
+    <gx:MultiTrack>
+      <gx:Track>
+        <when>2026-01-01T00:00:00Z</when>
+        <gx:coord>181 47 0</gx:coord>
+      </gx:Track>
+      <gx:Track>
+        <when>2026-01-01T00:00:01Z</when>
+        <gx:coord>8 47 0</gx:coord>
+        <when>2026-01-01T00:00:02Z</when>
+        <gx:coord>8.1 47.1 0</gx:coord>
+      </gx:Track>
+    </gx:MultiTrack>
+  </Placemark>
+</kml>)";
+
+  kml::FileData data;
+  TEST_NO_THROW({ kml::DeserializerKml(data).Deserialize(MemReader(input)); }, ());
+  TEST_EQUAL(data.m_tracksData.size(), 1, ());
+  auto const & geometry = data.m_tracksData[0].m_geometry;
+  TEST_EQUAL(geometry.m_lines.size(), 1, ());
+  TEST_EQUAL(geometry.m_lines[0].size(), 2, ());
+  TEST_EQUAL(geometry.m_timestamps[0].size(), 2, ());
+}
+
+UNIT_TEST(Kml_OriginPointWithInvalidLine)
+{
+  std::string_view constexpr input = R"(<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Placemark>
+    <name>origin</name>
+    <MultiGeometry>
+      <Point><coordinates>0,0</coordinates></Point>
+      <LineString><coordinates>181,47 182,48</coordinates></LineString>
+    </MultiGeometry>
+  </Placemark>
+</kml>)";
+
+  kml::FileData data;
+  TEST_NO_THROW({ kml::DeserializerKml(data).Deserialize(MemReader(input)); }, ());
+  TEST_EQUAL(data.m_bookmarksData.size(), 1, ());
+  TEST_EQUAL(data.m_bookmarksData[0].m_point, mercator::FromLatLon(0, 0), ());
+}
+
+UNIT_TEST(Kml_AltitudeClamping)
+{
+  std::string_view constexpr input = R"(<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Placemark>
+    <LineString><coordinates>8.0,47.0,1e300 8.1,47.1,-1e300</coordinates></LineString>
+  </Placemark>
+</kml>)";
+
+  kml::FileData data;
+  TEST_NO_THROW({ kml::DeserializerKml(data).Deserialize(MemReader(input)); }, ());
+  TEST_EQUAL(data.m_tracksData.size(), 1, ());
+  auto const & line = data.m_tracksData[0].m_geometry.m_lines[0];
+  TEST_EQUAL(line[0].GetAltitude(), std::numeric_limits<geometry::Altitude>::max(), ());
+  TEST_EQUAL(line[1].GetAltitude(), geometry::kInvalidAltitude + 1, ());
+}
+
+UNIT_TEST(Kml_InvalidPointCoordinates)
+{
+  // Only placemarks with valid WGS84 coordinates produce bookmarks.
+  std::string_view constexpr input = R"(<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Placemark><name>far</name><Point><coordinates>181.0,47.0</coordinates></Point></Placemark>
+  <Placemark><name>north</name><Point><coordinates>8.0,91.0</coordinates></Point></Placemark>
+  <Placemark><name>ok</name><Point><coordinates>8.0,47.0</coordinates></Point></Placemark>
+</kml>)";
+
+  kml::FileData data;
+  TEST_NO_THROW({ kml::DeserializerKml(data).Deserialize(MemReader(input)); }, ());
+  TEST_EQUAL(data.m_bookmarksData.size(), 1, ());
+  TEST_EQUAL(kml::GetDefaultStr(data.m_bookmarksData[0].m_name), "ok", ());
+  TEST_EQUAL(data.m_bookmarksData[0].m_point, mercator::FromLatLon(47.0, 8.0), ());
 }
 
 namespace

--- a/libs/kml/serdes.cpp
+++ b/libs/kml/serdes.cpp
@@ -639,16 +639,16 @@ bool ParsePoint(std::string_view s, char const * delim, m2::PointD & pt, geometr
     return false;
 
   double lon;
-  if (strings::to_double(*iter, lon) && mercator::ValidLon(lon) && ++iter)
+  if (strings::to_double(*iter, lon) && ++iter)
   {
     double lat;
-    if (strings::to_double(*iter, lat) && mercator::ValidLat(lat))
+    if (strings::to_double(*iter, lat) && IsValidLatLon(lat, lon))
     {
       pt = mercator::FromLatLon(lat, lon);
 
       double rawAltitude;
       if (++iter && strings::to_double(*iter, rawAltitude))
-        altitude = static_cast<geometry::Altitude>(round(rawAltitude));
+        altitude = ToAltitude(rawAltitude);
 
       return true;
     }
@@ -740,11 +740,14 @@ void KmlParser::ResetPoint()
 
 void KmlParser::SetOrigin(std::string const & s)
 {
-  m_geometryType = GEOMETRY_TYPE_POINT;
-
   m2::PointD pt;
   if (ParsePoint(s, ", \n\r\t", pt))
+  {
+    m_geometryType = GEOMETRY_TYPE_POINT;
     m_org = pt;
+  }
+  else
+    LOG(LWARNING, ("Can not parse KML point coordinates from", s));
 }
 
 void KmlParser::ParseAndAddPoints(MultiGeometry::LineT & line, std::string_view s, char const * blockSeparator,
@@ -762,8 +765,7 @@ void KmlParser::ParseAndAddPoints(MultiGeometry::LineT & line, std::string_view 
 
 void KmlParser::ParseLineString(std::string const & s)
 {
-  // If m_org is not empty, then it's still a Bookmark but with track data
-  if (m_org == m2::PointD::Zero())
+  if (m_geometryType != GEOMETRY_TYPE_POINT)
     m_geometryType = GEOMETRY_TYPE_LINE;
 
   MultiGeometry::LineT line;
@@ -813,15 +815,12 @@ bool KmlParser::MakeValid()
 
   if (GEOMETRY_TYPE_POINT == m_geometryType)
   {
-    if (mercator::ValidX(m_org.x) && mercator::ValidY(m_org.y))
-    {
-      // Set default name.
-      if (m_name.empty() && m_featureTypes.empty())
-        m_name[kDefaultLang] = PointToLineString(m_org);
+    // SetOrigin() sets this type only together with a validated m_org.
+    // Set default name.
+    if (m_name.empty() && m_featureTypes.empty())
+      m_name[kDefaultLang] = PointToLineString(m_org);
 
-      return true;
-    }
-    return false;
+    return true;
   }
   else if (GEOMETRY_TYPE_LINE == m_geometryType)
   {
@@ -1094,6 +1093,7 @@ void KmlParser::Pop(std::string_view tag)
     ASSERT(!lines.empty(), ());
     if (lines.back().size() < 2)
     {
+      m_skipTimes.erase(lines.size() - 1);
       lines.pop_back();
       m_geometry.m_timestamps.pop_back();
     }

--- a/libs/kml/serdes_common.cpp
+++ b/libs/kml/serdes_common.cpp
@@ -2,8 +2,13 @@
 
 #include "geometry/mercator.hpp"
 
+#include "base/math.hpp"
 #include "base/stl_helpers.hpp"
 #include "base/string_utils.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
 
 namespace kml
 {
@@ -40,6 +45,24 @@ bool LineHasAltitude(TrackGeometry const & line)
     auto const alt = pt.GetAltitude();
     return alt != geometry::kInvalidAltitude && alt != geometry::kDefaultAltitudeMeters;
   });
+}
+
+// math::is_finite() is not redundant: this TU is compiled with -ffast-math (unlike the one defining
+// it), where the compiler assumes there are no NaNs and mercator::ValidLat(NaN) is true in Release.
+bool IsValidLatLon(double lat, double lon)
+{
+  return math::is_finite(lat) && math::is_finite(lon) && mercator::ValidLat(lat) && mercator::ValidLon(lon);
+}
+
+geometry::Altitude ToAltitude(double altitude)
+{
+  // Also rejects NaN, which has no representable value and would make the conversion below undefined.
+  if (!math::is_finite(altitude))
+    return geometry::kInvalidAltitude;
+
+  double constexpr kMinAltitude = geometry::kInvalidAltitude + 1.0;
+  double constexpr kMaxAltitude = std::numeric_limits<geometry::Altitude>::max();
+  return static_cast<geometry::Altitude>(std::clamp(std::round(altitude), kMinAltitude, kMaxAltitude));
 }
 
 void SaveStringWithCDATA(Writer & writer, std::string_view s)

--- a/libs/kml/serdes_common.hpp
+++ b/libs/kml/serdes_common.hpp
@@ -21,6 +21,14 @@ std::string PointToGxString(geometry::PointWithAltitude const & pt);
 // flat sea-level track isn't bloated with zero altitudes. Mirrors Track::HasAltitudes intent.
 bool LineHasAltitude(TrackGeometry const & line);
 
+// True for a finite WGS84 latitude/longitude pair within the standard coordinate ranges.
+bool IsValidLatLon(double lat, double lon);
+
+// Converts a raw altitude (KML/GPX <ele>, GeoJSON Z) to geometry::Altitude, clamping into the int16
+// range because converting an out-of-range floating-point value to an integer is undefined. Altitude
+// reserves the lowest int16 value as an invalid sentinel, returned for a non-finite input.
+geometry::Altitude ToAltitude(double altitude);
+
 void SaveStringWithCDATA(Writer & writer, std::string_view s);
 
 std::string_view constexpr kIndent0{};

--- a/libs/kml/serdes_geojson.cpp
+++ b/libs/kml/serdes_geojson.cpp
@@ -2,6 +2,7 @@
 #include "kml/color_parser.hpp"
 #include "kml/serdes_common.hpp"
 
+#include "base/math.hpp"
 #include "base/stl_helpers.hpp"
 #include "base/string_utils.hpp"
 #include "base/timer.hpp"
@@ -11,6 +12,8 @@
 #include "geometry/point_with_altitude.hpp"
 
 #include <algorithm>
+#include <cmath>
+#include <limits>
 #include <map>
 #include <string>
 
@@ -21,7 +24,7 @@ namespace geojson
 std::string DebugPrint(GeoJsonGeometryPoint const & c)
 {
   std::ostringstream out;
-  out << "GeoJsonGeometryPoint [coordinates = " << c.coordinates[1] << ", " << c.coordinates[0] << "]";
+  out << "GeoJsonGeometryPoint [coordinates = " << ::DebugPrint(c.coordinates) << "]";
   return out.str();
 }
 
@@ -181,27 +184,53 @@ PredefinedColor FindPredefinedColor(std::string colorName)
 
 }  // namespace geojson
 
-kml::TrackGeometry CoordsToPoints(std::vector<std::vector<double>> const & coords)
+// A GeoJSON position is a [lon, lat, (alt)] array. Shorter arrays and coordinates outside the
+// WGS84 range are skipped like KML import does; they would put garbage into the map otherwise.
+static bool IsValidPosition(std::vector<double> const & c)
+{
+  return c.size() >= 2 && IsValidLatLon(c[1], c[0]);
+}
+
+// Converts positions to track points, skipping invalid ones. The caller supplies either no
+// timestamps or one per position; aligned timestamps are filtered together with their points.
+static kml::TrackGeometry CoordsToPoints(std::vector<std::vector<double>> const & coords,
+                                         kml::MultiGeometry::TimeT & timestamps)
 {
   // Use kDefaultAltitudeMeters (0) — not kInvalidAltitude — for 2D points when
   // other points in the same line carry a Z coordinate. This preserves the
   // elevation chart for mixed 2D/3D tracks (HasAltitudes returns false on the
   // first kInvalidAltitude, so storing it for every partial-fix point would
   // suppress the chart entirely).
-  bool const hasAnyZ = std::any_of(coords.begin(), coords.end(), [](auto const & c) { return c.size() >= 3; });
+  bool const hasAnyZ =
+      std::any_of(coords.begin(), coords.end(), [](auto const & c) { return IsValidPosition(c) && c.size() >= 3; });
   auto const altFallback = hasAnyZ ? geometry::kDefaultAltitudeMeters : geometry::kInvalidAltitude;
 
+  bool const hasTimestamps = !timestamps.empty();
+  ASSERT(!hasTimestamps || timestamps.size() == coords.size(), (timestamps.size(), coords.size()));
+  kml::MultiGeometry::TimeT keptTimestamps;
+  keptTimestamps.reserve(timestamps.size());
   kml::TrackGeometry points;
   points.reserve(coords.size());
-  for (auto const & c : coords)
+  for (size_t i = 0; i < coords.size(); ++i)
   {
+    auto const & c = coords[i];
+    if (!IsValidPosition(c))
+    {
+      LOG(LWARNING, ("Skipping invalid GeoJson position", c));
+      continue;
+    }
+    if (hasTimestamps)
+      keptTimestamps.push_back(timestamps[i]);
+
     auto const pt = mercator::FromLatLon(c[1], c[0]);
     if (c.size() >= 3)
-      points.emplace_back(pt, static_cast<geometry::Altitude>(std::round(c[2])));
+      points.emplace_back(pt, ToAltitude(c[2]));
     else
       points.emplace_back(pt, altFallback);
   }
 
+  if (hasTimestamps)
+    timestamps = std::move(keptTimestamps);
   return points;
 }
 
@@ -210,7 +239,15 @@ kml::TrackGeometry CoordsToPoints(std::vector<std::vector<double>> const & coord
 static time_t GeoJsonParseTimestamp(glz::generic const & value)
 {
   if (value.is_number())
-    return static_cast<time_t>(value.as<double>());
+  {
+    double const seconds = value.as<double>();
+    static_assert(std::numeric_limits<time_t>::is_signed && std::numeric_limits<time_t>::radix == 2);
+    // 2^digits is the exact exclusive upper bound even when time_t::max() is not representable as double.
+    double const bound = std::ldexp(1.0, std::numeric_limits<time_t>::digits);
+    if (!math::is_finite(seconds) || seconds < -bound || seconds >= bound)
+      return base::INVALID_TIME_STAMP;
+    return static_cast<time_t>(seconds);
+  }
   if (value.is_string())
     return base::StringToTimestamp(value.get_string());
   return base::INVALID_TIME_STAMP;
@@ -296,6 +333,11 @@ bool GeoJsonReader::Parse(std::string_view jsonContent)
   {
     if (auto const * point = std::get_if<GeoJsonGeometryPoint>(&feature.geometry))
     {
+      if (point->coordinates.size() < 2)
+      {
+        LOG(LWARNING, ("Skipping GeoJson point with incomplete position", point->coordinates));
+        continue;
+      }
       double longitude = point->coordinates[0];
       double latitude = point->coordinates[1];
 
@@ -341,6 +383,12 @@ bool GeoJsonReader::Parse(std::string_view jsonContent)
           latitude = info.m_lat;
           longitude = info.m_lon;
         }
+      }
+
+      if (!IsValidLatLon(latitude, longitude))
+      {
+        LOG(LWARNING, ("Skipping GeoJson point with invalid coordinates", latitude, longitude));
+        continue;
       }
 
       // Parse description
@@ -434,32 +482,39 @@ bool GeoJsonReader::Parse(std::string_view jsonContent)
       // Convert line(s) coordinates. coordTimes may be a flat array (LineString) or an array
       // of per-line arrays (MultiLineString); see GetCoordTimesValue for the property aliases.
       auto const * coordTimesVal = GetCoordTimesValue(props_json);
-      if (lineGeometry && !lineGeometry->coordinates.empty())
+      auto appendLine = [&track](std::vector<std::vector<double>> const & coords, glz::generic const * timestampsValue)
       {
-        auto const & line = track.m_geometry.m_lines.emplace_back(CoordsToPoints(lineGeometry->coordinates));
+        if (coords.empty())
+          return;
+
         kml::MultiGeometry::TimeT timestamps;
-        if (coordTimesVal)
-          timestamps = ParseTimestampArray(*coordTimesVal);
-        track.m_geometry.m_timestamps.push_back(SanitizeTimestamps(std::move(timestamps), line.size()));
-      }
+        if (timestampsValue)
+          timestamps = SanitizeTimestamps(ParseTimestampArray(*timestampsValue), coords.size());
+
+        auto line = CoordsToPoints(coords, timestamps);
+        if (line.size() < 2)
+          return;
+
+        track.m_geometry.m_lines.push_back(std::move(line));
+        track.m_geometry.m_timestamps.push_back(std::move(timestamps));
+      };
+
+      if (lineGeometry)
+        appendLine(lineGeometry->coordinates, coordTimesVal);
       if (multilineGeometry)
       {
-        // lineIdx tracks the position in coordTimes by geometry index (including empty
-        // segments that are skipped below), so timestamps stay aligned to their line.
+        // lineIdx tracks the position in coordTimes by geometry index (including the segments
+        // that appendLine drops), so timestamps stay aligned to their line.
         for (size_t lineIdx = 0; auto const & coords : multilineGeometry->coordinates)
         {
-          if (!coords.empty())
+          glz::generic const * timestampsValue = nullptr;
+          if (coordTimesVal && coordTimesVal->is_array())
           {
-            auto const & line = track.m_geometry.m_lines.emplace_back(CoordsToPoints(coords));
-            kml::MultiGeometry::TimeT timestamps;
-            if (coordTimesVal && coordTimesVal->is_array())
-            {
-              auto const & arr = coordTimesVal->get_array();
-              if (lineIdx < arr.size())
-                timestamps = ParseTimestampArray(arr[lineIdx]);
-            }
-            track.m_geometry.m_timestamps.push_back(SanitizeTimestamps(std::move(timestamps), line.size()));
+            auto const & arr = coordTimesVal->get_array();
+            if (lineIdx < arr.size())
+              timestampsValue = &arr[lineIdx];
           }
+          appendLine(coords, timestampsValue);
           ++lineIdx;
         }
       }

--- a/libs/kml/serdes_gpx.cpp
+++ b/libs/kml/serdes_gpx.cpp
@@ -11,6 +11,8 @@
 #include "base/stl_helpers.hpp"
 #include "base/string_utils.hpp"
 
+#include <limits>
+
 namespace kml
 {
 namespace gpx
@@ -63,18 +65,25 @@ void GpxParser::ResetPoint()
   m_color = kInvalidColor;
   m_geometry.Clear();
   m_geometryType = GEOMETRY_TYPE_UNKNOWN;
-  m_lat = 0.;
-  m_lon = 0.;
+  ResetCoordinates();
   m_altitude = geometry::kInvalidAltitude;
   m_timestamp = base::INVALID_TIME_STAMP;
+}
+
+// A <wpt>/<trkpt>/<rtept> with a missing or unparseable lat/lon attribute must be skipped instead
+// of silently reusing the previous point's coordinates. AddAttr writes m_lat/m_lon only on a
+// successful parse, so this out-of-range sentinel survives and IsValidLatLon rejects the point.
+void GpxParser::ResetCoordinates()
+{
+  m_lat = std::numeric_limits<double>::max();
+  m_lon = std::numeric_limits<double>::max();
 }
 
 bool GpxParser::MakeValid()
 {
   if (GEOMETRY_TYPE_POINT == m_geometryType)
   {
-    m2::PointD const & pt = m_org.GetPoint();
-    if (mercator::ValidX(pt.x) && mercator::ValidY(pt.y))
+    if (IsValidLatLon(m_lat, m_lon))
     {
       // Set default name.
       if (m_name.empty())
@@ -94,9 +103,15 @@ bool GpxParser::MakeValid()
 bool GpxParser::Push(std::string tag)
 {
   if (tag == gpx::kWpt)
+  {
     m_geometryType = GEOMETRY_TYPE_POINT;
+    ResetCoordinates();
+  }
   else if (tag == gpx::kTrkPt || tag == gpx::kRtePt)
+  {
     m_geometryType = GEOMETRY_TYPE_LINE;
+    ResetCoordinates();
+  }
 
   m_tags.emplace_back(std::move(tag));
 
@@ -241,8 +256,10 @@ void GpxParser::Pop(std::string_view tag)
 
   if (tag == gpx::kTrkPt || tag == gpx::kRtePt)
   {
-    m2::PointD const p = mercator::FromLatLon(m_lat, m_lon);
-    if (m_line.empty() || !AlmostEqualAbs(m_line.back().GetPoint(), p, kMwmPointAccuracy))
+    if (!IsValidLatLon(m_lat, m_lon))
+      LOG(LWARNING, ("Skipping gpx point with invalid coordinates:", m_lat, m_lon));
+    else if (m2::PointD const p = mercator::FromLatLon(m_lat, m_lon);
+             m_line.empty() || !AlmostEqualAbs(m_line.back().GetPoint(), p, kMwmPointAccuracy))
     {
       m_line.emplace_back(p, m_altitude);
 
@@ -270,8 +287,13 @@ void GpxParser::Pop(std::string_view tag)
   }
   else if (tag == gpx::kWpt)
   {
-    m_org.SetPoint(mercator::FromLatLon(m_lat, m_lon));
-    m_org.SetAltitude(m_altitude);
+    if (IsValidLatLon(m_lat, m_lon))
+    {
+      m_org.SetPoint(mercator::FromLatLon(m_lat, m_lon));
+      m_org.SetAltitude(m_altitude);
+    }
+    else
+      LOG(LWARNING, ("Skipping gpx waypoint with invalid coordinates:", m_lat, m_lon));
     m_altitude = geometry::kInvalidAltitude;
   }
 
@@ -412,7 +434,7 @@ void GpxParser::ParseAltitude(std::string const & value)
 {
   double rawAltitude;
   if (strings::to_double(value, rawAltitude))
-    m_altitude = static_cast<geometry::Altitude>(std::round(rawAltitude));
+    m_altitude = ToAltitude(rawAltitude);
   else
     m_altitude = geometry::kInvalidAltitude;
 }

--- a/libs/kml/serdes_gpx.hpp
+++ b/libs/kml/serdes_gpx.hpp
@@ -68,6 +68,7 @@ private:
   };
 
   void ResetPoint();
+  void ResetCoordinates();
   bool MakeValid();
   void ParseColor(std::string_view colorStr);
   void ParseGarminColor(std::string const & value);

--- a/libs/kml/types.hpp
+++ b/libs/kml/types.hpp
@@ -403,8 +403,9 @@ struct BookmarkData
   uint8_t m_viewportScale = 0;
   // Creation timestamp.
   Timestamp m_timestamp = {};
-  // Coordinates in mercator.
-  m2::PointD m_point;
+  // Coordinates in mercator. Value-initialized because m2::PointD's default constructor leaves
+  // its coordinates indeterminate.
+  m2::PointD m_point{};
   // Bound tracks (vector contains local track ids).
   std::vector<LocalId> m_boundTracks;
   // Visibility.


### PR DESCRIPTION
GeoJSON points/line vertices and GPX waypoints/track/route points were accepted without complete raw WGS84 validation. This could import out-of-range positions, read short GeoJSON positions out of bounds, or reuse the previous GPX point when a coordinate attribute was missing. A KML `<Point>` with out-of-range coordinates was imported at (0, 0), because the placemark was committed as a point before its coordinates were parsed.

Invalid positions are now skipped before projection. GeoJSON timestamps are validated against the original positions and filtered with surviving vertices; segments with fewer than two valid points are dropped. KML, GPX, and GeoJSON altitude parsing also shares a bounded conversion, avoiding undefined out-of-range floating-point-to-integer conversions.

`BookmarkData::m_point` is default-initialized too: it was the struct's only uninitialized member, so a bookmark created without a position wrote `NaN,NaN` coordinates into the KML file, which the validation above then drops on reload.

Related: #12587.

Tested:
- Full `kml_tests` suite in Debug and Release
- Full desktop test suite (`ctest -L omim-test`) in Debug
- `map_tests` rebuilt with `-ftrivial-auto-var-init=pattern` (reproduces the uninitialized `m_point` on any platform)
- `clang-format 22.1.8 --dry-run --Werror`
- `git diff --check`
