### PR TITLE
[ios] Skip invalid compass headings

### DIFF
--- a/iphone/Maps/Core/Location/MWMLocationManager.mm
+++ b/iphone/Maps/Core/Location/MWMLocationManager.mm
@@ -265,7 +265,7 @@ void setShowLocationAlert(BOOL needShow)
 + (CLHeading *)lastHeading
 {
   MWMLocationManager * manager = [self manager];
-  if (!manager.started || !manager.lastHeadingInfo || manager.lastHeadingInfo.headingAccuracy < 0)
+  if (!manager.started || !location_util::isValidHeading(manager.lastHeadingInfo))
     return nil;
   return manager.lastHeadingInfo;
 }
@@ -285,7 +285,10 @@ void setShowLocationAlert(BOOL needShow)
 
 - (void)processHeadingUpdate:(CLHeading *)headingInfo
 {
+  // Stored first, so +lastHeading keeps reflecting the latest (possibly invalid) state.
   self.lastHeadingInfo = headingInfo;
+  if (!location_util::isValidHeading(headingInfo))
+    return;
   GetFramework().OnCompassUpdate(location_util::compassInfoFromHeading(headingInfo));
   for (Observer observer in self.observers)
     if ([observer respondsToSelector:@selector(onHeadingUpdate:)])
@@ -486,6 +489,13 @@ void setShowLocationAlert(BOOL needShow)
 - (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)heading
 {
   [self processHeadingUpdate:heading];
+}
+
+// The calibration HUD is the only way back to valid headings, which are otherwise skipped, but it
+// must not cover the map while driving, where the arrow follows the route rather than the compass.
+- (BOOL)locationManagerShouldDisplayHeadingCalibration:(CLLocationManager *)manager
+{
+  return self.geoMode != GeoMode::VehicleRouting;
 }
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations

--- a/iphone/Maps/Core/Location/location_util.h
+++ b/iphone/Maps/Core/Location/location_util.h
@@ -29,13 +29,17 @@ static location::GpsInfo gpsInfoFromLocation(CLLocation * l, location::TLocation
   return info;
 }
 
+// A negative accuracy means the heading is invalid (both trueHeading and magneticHeading).
+static bool isValidHeading(CLHeading * h)
+{
+  return h != nil && h.headingAccuracy >= 0.0;
+}
+
+// Expects a valid heading, see isValidHeading().
 static location::CompassInfo compassInfoFromHeading(CLHeading * h)
 {
   location::CompassInfo info;
-  if (h.trueHeading >= 0.0)
-    info.m_bearing = math::DegToRad(h.trueHeading);
-  else if (h.headingAccuracy >= 0.0)
-    info.m_bearing = math::DegToRad(h.magneticHeading);
+  info.m_bearing = math::DegToRad(h.trueHeading >= 0.0 ? h.trueHeading : h.magneticHeading);
   return info;
 }
 

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
@@ -199,7 +199,7 @@ extension PlacePageCommonLayout: MWMLocationObserver {
   func onLocationError(_: MWMLocationStatus) {}
 
   private func updateHeading(_ heading: CLLocationDirection) {
-    guard let location = lastLocation, heading > 0 else {
+    guard let location = lastLocation, heading >= 0 else {
       return
     }
 

--- a/libs/platform/location.hpp
+++ b/libs/platform/location.hpp
@@ -60,14 +60,9 @@ public:
   ms::LatLon GetLatLon() const { return {m_latitude, m_longitude}; }
 };
 
-class CompassInfo
+struct CompassInfo
 {
-public:
-  // double m_timestamp;           //!< seconds from 1st Jan 1970
-  // double m_magneticHeading;     //!< positive radians from the magnetic North
-  // double m_trueHeading;         //!< positive radians from the true North
-  // double m_accuracy;            //!< offset from the magnetic to the true North in radians
-  double m_bearing;  //!< positive radians from the true North
+  double m_bearing = 0.0;  //!< positive radians from the true North
 };
 
 static inline bool IsLatValid(double lat)


### PR DESCRIPTION
`compassInfoFromHeading()` left `CompassInfo::m_bearing` uninitialized when Core Location reported an invalid heading (negative `headingAccuracy` and no true heading — the documented "uncalibrated / no fix" state), and `MWMLocationManager` forwarded that indeterminate bearing to the core as the compass direction (undefined behaviour; the garbage value ends up in drape's follow-and-rotate / arrow direction).

Forward a heading to the core and to the observers only when it is valid (one shared `isValidHeading()` predicate, also used by `+lastHeading`, which keeps returning `nil` while the compass is uncalibrated), give `m_bearing` a default value like the other location fields and drop the stale commented-out `CompassInfo` members. The place page direction arrow now also accepts an exactly northern heading (`>= 0`).

Since invalid headings are now dropped instead of forwarded, `locationManagerShouldDisplayHeadingCalibration:` returns YES so iOS can show its heading calibration prompt when the magnetometer is disturbed or uncalibrated — a way back to valid compass values for the users affected by wrong/frozen headings, instead of a silently frozen arrow.

Tested:
- `xcodebuild` of the OMaps scheme for the iOS Simulator (arm64), Debug
- Debug `platform_tests` (`location_test`); `map`, `drape_frontend_tests`, `dev_sandbox` and `assembleGoogleDebug -Parm64` build with the `CompassInfo` change
- The calibration prompt itself cannot be triggered in the simulator; to be verified on a device with a disturbed compass
