### PR TITLE
[editor] Write only the OSM tags the user actually edited

### DIFF
--- a/libs/editor/CMakeLists.txt
+++ b/libs/editor/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SRC
   osm_auth.hpp
   osm_editor.cpp
   osm_editor.hpp
+  osm_tag_policy.cpp
+  osm_tag_policy.hpp
   server_api.cpp
   server_api.hpp
   ui2oh.cpp

--- a/libs/editor/editor_config.cpp
+++ b/libs/editor/editor_config.cpp
@@ -131,6 +131,15 @@ std::vector<pugi::xml_node> GetPrioritizedTypes(pugi::xml_node const & node)
 }
 }  // namespace
 
+std::vector<feature::Metadata::EType> GetEditableMetadataFields()
+{
+  std::vector<feature::Metadata::EType> fields;
+  fields.reserve(kNamesToFMD.size());
+  for (auto const & [name, type] : kNamesToFMD)
+    fields.push_back(type);
+  return fields;
+}
+
 bool EditorConfig::GetTypeDescription(std::vector<std::string> classificatorTypes,
                                       TypeAggregatedDescription & outDesc) const
 {

--- a/libs/editor/editor_config.hpp
+++ b/libs/editor/editor_config.hpp
@@ -29,6 +29,10 @@ struct TypeAggregatedDescription
   bool m_cuisine = false;
 };
 
+/// @returns every metadata field data/editor.config can make editable. Exposed so that tests can
+/// check the whole editable set is covered elsewhere, see editor/osm_tag_policy.hpp.
+std::vector<feature::Metadata::EType> GetEditableMetadataFields();
+
 class EditorConfig
 {
 public:

--- a/libs/editor/editor_tests/CMakeLists.txt
+++ b/libs/editor/editor_tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRC
   opening_hours_ui_test.cpp
   osm_editor_test.cpp
   osm_editor_test.hpp
+  osm_tag_policy_test.cpp
   ui2oh_test.cpp
   xml_feature_test.cpp
 )

--- a/libs/editor/editor_tests/osm_tag_policy_test.cpp
+++ b/libs/editor/editor_tests/osm_tag_policy_test.cpp
@@ -6,6 +6,7 @@
 
 #include "indexer/classificator.hpp"
 #include "indexer/classificator_loader.hpp"
+#include "indexer/edit_journal.hpp"
 #include "indexer/editable_map_object.hpp"
 #include "indexer/feature_meta.hpp"
 
@@ -999,6 +1000,35 @@ UNIT_TEST(OsmTagPolicy_WriteDoesNotDuplicateTheUsersValue)
   TEST_EQUAL(ApplyFieldEdit(feature, "cuisine", "pizza", "klingon").m_status, FieldWriteStatus::Written, ());
 
   TEST_EQUAL(TagOrNone(feature, "cuisine"), "klingon", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteReplaysTwoEditsOfOneField)
+{
+  // The user changed one field twice, so the upload applies the net change (edit_journal.hpp).
+  osm::EditJournal journal;
+  journal.AddTagChange("phone", "+1 5552222", "+1 5553333");
+  journal.AddTagChange("phone", "+1 5553333", "+1 5554444");
+
+  auto const changes = osm::CollapseTagChanges(journal.GetJournal());
+  TEST_EQUAL(changes.size(), 1, ());
+  auto const & change = changes.front();
+
+  auto feature = MakeNode({{"phone", "+1 5551111"}, {"mobile", "+1 5552222"}});
+  TEST_EQUAL(ApplyFieldEdit(feature, change.key, change.old_value, change.new_value).m_status,
+             FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "mobile"), "+1 5554444", ());
+  TEST_EQUAL(TagOrNone(feature, "phone"), "+1 5551111", ());
+
+  // The upload went through but its response was lost, so the same journal is replayed against the
+  // object it produced. There is nothing left to do, and no changeset is worth sending.
+  TEST_EQUAL(ApplyFieldEdit(feature, change.key, change.old_value, change.new_value).m_status,
+             FieldWriteStatus::NothingToDo, ());
+  TEST_EQUAL(TagOrNone(feature, "mobile"), "+1 5554444", ());
+  TEST_EQUAL(TagOrNone(feature, "phone"), "+1 5551111", ());
+
+  // Replaying the entries one by one instead would report a conflict on a field nobody else touched.
+  auto uploaded = MakeNode({{"phone", "+1 5551111"}, {"mobile", "+1 5554444"}});
+  TEST_EQUAL(ApplyFieldEdit(uploaded, "phone", "+1 5552222", "+1 5553333").m_status, FieldWriteStatus::Ambiguous, ());
 }
 
 UNIT_TEST(OsmTagPolicy_WriteAgreesWithTheGenerator)

--- a/libs/editor/editor_tests/osm_tag_policy_test.cpp
+++ b/libs/editor/editor_tests/osm_tag_policy_test.cpp
@@ -1,0 +1,1037 @@
+#include "testing/testing.hpp"
+
+#include "editor/editor_config.hpp"
+#include "editor/osm_tag_policy.hpp"
+#include "editor/xml_feature.hpp"
+
+#include "indexer/classificator.hpp"
+#include "indexer/classificator_loader.hpp"
+#include "indexer/editable_map_object.hpp"
+#include "indexer/feature_meta.hpp"
+
+#include "coding/string_utf8_multilang.hpp"
+
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace osm_tag_policy_test
+{
+using editor::ApplyFieldEdit;
+using editor::Canonicalize;
+using editor::FieldWriteStatus;
+using editor::HasCanonicalForm;
+using editor::HasFieldPolicy;
+using editor::ValuesEquivalent;
+using editor::XMLFeature;
+
+XMLFeature MakeNode(std::vector<std::pair<std::string, std::string>> const & tags)
+{
+  XMLFeature feature(XMLFeature::Type::Node);
+  for (auto const & [key, value] : tags)
+    feature.SetTagValue(key, value);
+  return feature;
+}
+
+// @returns the value of @a key, or "-" if the tag is absent, so that both can be tested at once.
+std::string TagOrNone(XMLFeature const & feature, std::string_view key)
+{
+  return feature.HasTag(key) ? feature.GetTagValue(key) : "-";
+}
+
+// @returns every journal key the editor can produce, taken from the code that produces them
+// (EditableMapObject::LogDiffInJournal): the editable metadata fields, the keys the diff writes
+// itself, and one key per name language.
+std::vector<std::string> EditableFields()
+{
+  std::vector<std::string> keys;
+  for (auto const type : editor::GetEditableMetadataFields())
+    keys.emplace_back(feature::ToString(type));
+
+  for (auto const key : osm::kDirectJournalKeys)
+    keys.emplace_back(key);
+
+  for (auto const & language : StringUtf8Multilang::GetSupportedLanguages())
+    keys.emplace_back(StringUtf8Multilang::GetOSMTagByCode(StringUtf8Multilang::GetLangIndex(language.m_code)));
+
+  return keys;
+}
+
+UNIT_TEST(OsmTagPolicy_CanonicalizeIdentity)
+{
+  TEST_EQUAL(Canonicalize("name", "Café Ätsch"), "Café Ätsch", ());
+  TEST_EQUAL(Canonicalize("name:de", "Freiburg"), "Freiburg", ());
+  TEST_EQUAL(Canonicalize("addr:housenumber", "12 a"), "12 a", ());
+  TEST_EQUAL(Canonicalize("addr:street", "Улица Ленина"), "Улица Ленина", ());
+  TEST_EQUAL(Canonicalize("phone", "+1 555 1234"), "+1 555 1234", ());
+  TEST_EQUAL(Canonicalize("email", "a@b.com"), "a@b.com", ());
+  TEST_EQUAL(Canonicalize("opening_hours", "Mo-Fr 8:00-17:00"), "Mo-Fr 8:00-17:00", ());
+  // Not editable, and unknown keys are passed through unchanged.
+  TEST_EQUAL(Canonicalize("nonexistent_tag", "whatever"), "whatever", ());
+}
+
+UNIT_TEST(OsmTagPolicy_CanonicalizeWebsite)
+{
+  // The generator strips a trailing slash right after the host, and nothing else.
+  TEST_EQUAL(Canonicalize("website", "https://organicmaps.app/"), "https://organicmaps.app", ());
+  TEST_EQUAL(Canonicalize("website", "https://organicmaps.app"), "https://organicmaps.app", ());
+  TEST_EQUAL(Canonicalize("website", "organicmaps.app/"), "organicmaps.app", ());
+  TEST_EQUAL(Canonicalize("website", "organicmaps.app/news/"), "organicmaps.app/news/", ());
+  TEST_EQUAL(Canonicalize("website:menu", "https://organicmaps.app/"), "https://organicmaps.app", ());
+  // The editor's own input formatter adds a missing protocol; canonicalization must not, or every
+  // protocol-less website in OSM would look like a third-party edit.
+  TEST_EQUAL(Canonicalize("website", "organicmaps.app"), "organicmaps.app", ());
+}
+
+UNIT_TEST(OsmTagPolicy_CanonicalizeInternet)
+{
+  TEST_EQUAL(Canonicalize("internet_access", "wlan"), "wlan", ());
+  TEST_EQUAL(Canonicalize("internet_access", "WLAN"), "wlan", ());
+  TEST_EQUAL(Canonicalize("internet_access", "free"), "wlan", ());
+  TEST_EQUAL(Canonicalize("internet_access", "wifi"), "wlan", ());
+  TEST_EQUAL(Canonicalize("internet_access", "public"), "wlan", ());
+  TEST_EQUAL(Canonicalize("internet_access", "terminal"), "terminal", ());
+  // The generator drops what it cannot parse, so the MWM holds nothing and the two compare equal.
+  TEST_EQUAL(Canonicalize("internet_access", "terminal;wlan"), "", ());
+  TEST_EQUAL(Canonicalize("internet_access", "customers"), "", ());
+}
+
+UNIT_TEST(OsmTagPolicy_CanonicalizeNumbers)
+{
+  TEST_EQUAL(Canonicalize("height", "12"), "12", ());
+  TEST_EQUAL(Canonicalize("height", "2 m"), "2", ());
+  TEST_EQUAL(Canonicalize("height", "40'"), "12.2", ("Imperial units are converted to metres."));
+  TEST_EQUAL(Canonicalize("height", "0"), "", ());
+
+  TEST_EQUAL(Canonicalize("building:levels", "3.0"), "3", ());
+  TEST_EQUAL(Canonicalize("building:levels", "４"), "4", ("Full width digits."));
+  TEST_EQUAL(Canonicalize("building:levels", "2-5"), "2", ());
+  TEST_EQUAL(Canonicalize("building:levels", "many"), "", ());
+
+  TEST_EQUAL(Canonicalize("level", "１"), "1", ("Full width digits."));
+  TEST_EQUAL(Canonicalize("level", "1;2"), "1;2", ("A level can be a list or a range."));
+
+  TEST_EQUAL(Canonicalize("stars", "5"), "5", ());
+  TEST_EQUAL(Canonicalize("stars", "8"), "", ());
+}
+
+UNIT_TEST(OsmTagPolicy_CanonicalizeYesNo)
+{
+  TEST_EQUAL(Canonicalize("self_service", "Yes"), "yes", ());
+  TEST_EQUAL(Canonicalize("self_service", "partially"), "partially", ());
+  TEST_EQUAL(Canonicalize("self_service", "limited"), "", ());
+  TEST_EQUAL(Canonicalize("outdoor_seating", "YES"), "yes", ());
+  TEST_EQUAL(Canonicalize("drive_through", "No"), "no", ());
+  TEST_EQUAL(Canonicalize("drive_through", "only"), "", ());
+}
+
+UNIT_TEST(OsmTagPolicy_CanonicalizeSocial)
+{
+  TEST_EQUAL(Canonicalize("contact:facebook", "https://facebook.com/organicmaps"), "organicmaps", ());
+  TEST_EQUAL(Canonicalize("contact:facebook", "organicmaps"), "organicmaps", ());
+  TEST_EQUAL(Canonicalize("contact:instagram", "https://instagram.com/organicmaps"), "organicmaps", ());
+  TEST_EQUAL(Canonicalize("contact:twitter", "https://twitter.com/organicmaps"), "organicmaps", ());
+  TEST_EQUAL(Canonicalize("contact:twitter", "@organicmaps"), "organicmaps", ());
+  TEST_EQUAL(Canonicalize("contact:vk", "https://vk.com/organicmaps"), "organicmaps", ());
+}
+
+UNIT_TEST(OsmTagPolicy_CanonicalizeCuisine)
+{
+  classificator::Load();
+
+  // A set: sorted, deduplicated, and everything OM has no classifier type for is dropped.
+  TEST_EQUAL(Canonicalize("cuisine", "pizza;burger"), "burger;pizza", ());
+  TEST_EQUAL(Canonicalize("cuisine", "burger;pizza"), "burger;pizza", ());
+  TEST_EQUAL(Canonicalize("cuisine", " pizza ; burger "), "burger;pizza", ());
+  TEST_EQUAL(Canonicalize("cuisine", "pizza;pizza"), "pizza", ());
+  TEST_EQUAL(Canonicalize("cuisine", "pizza;klingon"), "pizza", ());
+  TEST_EQUAL(Canonicalize("cuisine", "klingon"), "", ());
+
+  // Every token is normalized the way the generator normalizes it before the classifier lookup, or
+  // the map would show a cuisine the editor cannot find in the tag it came from.
+  TEST_EQUAL(Canonicalize("cuisine", "BBQ"), "barbecue", ());
+  TEST_EQUAL(Canonicalize("cuisine", "barbeque"), "barbecue", ());
+  TEST_EQUAL(Canonicalize("cuisine", "doughnut"), "donut", ());
+  TEST_EQUAL(Canonicalize("cuisine", "steak"), "steak_house", ());
+  TEST_EQUAL(Canonicalize("cuisine", "coffee"), "coffee_shop", ());
+  TEST_EQUAL(Canonicalize("cuisine", "Ice Cream"), "ice_cream", ());
+  TEST_EQUAL(Canonicalize("cuisine", "Ice   Cream"), "ice_cream", ("Repeated spaces are collapsed."));
+  TEST_EQUAL(Canonicalize("cuisine", "pizza,burger"), "burger;pizza", ("A comma separates as well."));
+  TEST_EQUAL(Canonicalize("cuisine", "Pizza, BBQ"), "barbecue;pizza", ());
+}
+
+UNIT_TEST(OsmTagPolicy_CanonicalizeRealWorldValues)
+{
+  classificator::Load();
+
+  // A canonicalizer that drops a value the generator keeps makes the field uneditable on every object
+  // that spells it that way: the map shows a value no tag of OM's canonical view holds, so nothing
+  // matches what the user saw and the edit is refused. Cuisine was exactly that gap, and only a human
+  // reviewer noticed - so the fields OM normalizes on import are pinned here against values OSM
+  // really holds, in both directions.
+  struct Value
+  {
+    std::string_view m_key;
+    std::string_view m_raw;
+    std::string_view m_canonical;
+  };
+
+  Value const kKept[] = {
+      // Only a slash right after the host is stripped, and only from a lower-cased scheme - which is
+      // what the map shows, so the editor must not tidy it either.
+      {"website", "https://organicmaps.app", "https://organicmaps.app"},
+      {"website", "http://www.example.com/", "http://www.example.com"},
+      {"website", "www.example.com", "www.example.com"},
+      {"website", "example.com/menu/", "example.com/menu/"},
+      {"website", "https://example.com/a/b", "https://example.com/a/b"},
+      {"website", "https://example.com?x=1", "https://example.com?x=1"},
+      {"website", "https://example.com/#anchor", "https://example.com/#anchor"},
+      {"website", "HTTPS://EXAMPLE.COM/", "HTTPS://EXAMPLE.COM/"},
+
+      {"internet_access", "wlan", "wlan"},
+      {"internet_access", "WLAN", "wlan"},
+      {"internet_access", "yes", "yes"},
+      {"internet_access", "no", "no"},
+      {"internet_access", "wired", "wired"},
+      {"internet_access", "terminal", "terminal"},
+      {"internet_access", "free", "wlan"},
+      {"internet_access", "wifi", "wlan"},
+      {"internet_access", "public", "wlan"},
+
+      // A height is metres, however OSM spelled it.
+      {"height", "12", "12"},
+      {"height", "12.5", "12.5"},
+      {"height", "2 m", "2"},
+      {"height", "2m", "2"},
+      {"height", "3.5 metres", "3.5"},
+      {"height", "12 m (39 ft)", "12"},
+      {"height", "40'", "12.2"},
+      {"height", "6'6\"", "2"},
+      {"height", "10 ft", "3"},
+      {"height", "1,5", "1"},
+
+      {"building:levels", "1", "1"},
+      {"building:levels", "3.0", "3"},
+      {"building:levels", "2.5", "2.5"},
+      {"building:levels", "0", "0"},
+      {"building:levels", "２", "2"},
+      {"building:levels", "2-5", "2"},
+      {"building:levels", "1;2", "1"},
+
+      // A level keeps its list or range, with full width digits normalized.
+      {"level", "0", "0"},
+      {"level", "-1", "-1"},
+      {"level", "0.5", "0.5"},
+      {"level", "1;2", "1;2"},
+      {"level", "3-5", "3-5"},
+      {"level", "１", "1"},
+
+      {"stars", "1", "1"},
+      {"stars", "5", "5"},
+      {"stars", "7", "7"},
+      {"stars", "3S", "3"},
+      {"stars", "4,5", "4"},
+
+      {"drive_through", "yes", "yes"},
+      {"drive_through", "no", "no"},
+      {"drive_through", "Yes", "yes"},
+      {"self_service", "yes", "yes"},
+      {"self_service", "no", "no"},
+      {"self_service", "only", "only"},
+      {"self_service", "partially", "partially"},
+      {"outdoor_seating", "yes", "yes"},
+      {"outdoor_seating", "no", "no"},
+
+      // Every spelling the generator folds, and both separators it splits on.
+      {"cuisine", "pizza", "pizza"},
+      {"cuisine", "ice_cream", "ice_cream"},
+      {"cuisine", "Ice Cream", "ice_cream"},
+      {"cuisine", "BBQ", "barbecue"},
+      {"cuisine", "barbeque", "barbecue"},
+      {"cuisine", "doughnut", "donut"},
+      {"cuisine", "steak", "steak_house"},
+      {"cuisine", "coffee", "coffee_shop"},
+      {"cuisine", "pizza;pasta;italian", "italian;pasta;pizza"},
+      {"cuisine", "italian,pizza", "italian;pizza"},
+      {"cuisine", "Pizza, Pasta", "pasta;pizza"},
+      {"cuisine", "pizza;klingon", "pizza"},
+  };
+
+  for (auto const & [key, raw, canonical] : kKept)
+  {
+    TEST_EQUAL(Canonicalize(key, raw), canonical, (key, raw));
+    TEST_EQUAL(Canonicalize(key, canonical), canonical, ("Canonicalization must be idempotent", key, raw));
+  }
+
+  // Values the generator drops as well, so the map shows nothing for them. The field is then not
+  // editable on such an object: the writer has no source to match and refuses rather than overwriting
+  // a value OM never showed.
+  std::pair<std::string_view, std::string_view> const kDropped[] = {
+      {"internet_access", "customers"},
+      {"internet_access", "limited"},
+      {"internet_access", "service"},
+      {"internet_access", "wlan;terminal"},
+      {"height", "~10"},
+      {"building:levels", "many"},
+      {"building:levels", "168"},
+      {"stars", "0"},
+      {"stars", "8"},
+      {"stars", "10"},
+      {"drive_through", "only"},
+      {"self_service", "limited"},
+      {"outdoor_seating", "seasonal"},
+      {"cuisine", "Fish & Chips"},
+      {"cuisine", "klingon"},
+      // OM's classifier spells this one "hotdog" and neither side folds the OSM spelling into it, so
+      // the map shows no cuisine at all for such a POI and the field cannot be edited on it. Folding
+      // it belongs to the classifier rather than here: it would change what the generator writes.
+      {"cuisine", "hot_dog"},
+  };
+
+  for (auto const & [key, raw] : kDropped)
+    TEST(Canonicalize(key, raw).empty(), (key, raw, Canonicalize(key, raw)));
+
+  // Every cuisine OM knows about, taken from the classifier the editor offers them from: a cuisine
+  // the user can pick has to survive canonicalization, or the edit could not be matched to the tag it
+  // came from.
+  std::vector<std::string_view> const kCuisinePath = {"cuisine"};
+  classif().GetObject(classif().GetTypeByPath(kCuisinePath))->ForEachObject([](ClassifObject const & o) {
+    TEST_EQUAL(Canonicalize("cuisine", o.GetName()), o.GetName(), ());
+  });
+
+  // opening_hours is stored verbatim, so what matters is that a real value parses: an unparseable one
+  // falls back to a raw comparison, where a cosmetic server-side rewrite looks like a third-party edit.
+  std::pair<std::string_view, std::string_view> const kOpeningHours[] = {
+      {"Mo-Fr 08:00-17:00", "Mo-Fr 8:00-17:00"},
+      {"Mo-Sa 09:00-20:00; Su off", "Mo-Sa 9:00-20:00;Su off"},
+      {"Mo-Fr 09:00-12:00,13:00-18:00", "Mo-Fr 9:00-12:00,13:00-18:00"},
+      {"Mo-Fr 07:30-19:00; Sa 08:00-13:00", "Mo-Fr 7:30-19:00; Sa 8:00-13:00"},
+      {"Mo-Fr 08:00-17:00; PH off", "Mo-Fr 8:00-17:00; PH off"},
+  };
+
+  for (auto const & [value, rewritten] : kOpeningHours)
+    TEST(ValuesEquivalent("opening_hours", value, rewritten), (value, rewritten));
+
+  // Known limit, the same one the rule order has: the values are compared as they are written, not by
+  // the hours they mean, so an equivalent rewrite is reported as a change.
+  TEST(!ValuesEquivalent("opening_hours", "Mo-Su 00:00-24:00", "24/7"), ());
+}
+
+UNIT_TEST(OsmTagPolicy_Idempotent)
+{
+  classificator::Load();
+
+  // The upload guard compares an already canonical old_value against a canonicalized server value,
+  // so applying the canonicalizer twice must not change anything.
+  std::pair<char const *, char const *> const kValues[] = {
+      {"name", "Café"},
+      {"addr:housenumber", "12 a"},
+      {"phone", "+1 555 1234; +1 555 9999"},
+      {"opening_hours", "Mo-Fr 8:00-17:00"},
+      {"website", "https://organicmaps.app/"},
+      {"website", "organicmaps.app"},
+      {"website:menu", "https://organicmaps.app/menu/"},
+      {"contact:facebook", "https://facebook.com/organicmaps"},
+      {"contact:instagram", "@organicmaps"},
+      {"contact:twitter", "https://twitter.com/organicmaps"},
+      {"contact:vk", "https://vk.com/organicmaps"},
+      {"contact:line", "https://line.me/R/ti/p/organicmaps"},
+      {"internet_access", "Free"},
+      {"internet_access", "terminal;wlan"},
+      {"internet_access", "customers"},
+      {"stars", "5"},
+      {"stars", "8"},
+      {"height", "40'"},
+      {"height", "0"},
+      {"building:levels", "3.0"},
+      {"building:levels", "many"},
+      {"level", "１;2"},
+      {"self_service", "Yes"},
+      {"outdoor_seating", "limited"},
+      {"drive_through", "No"},
+      {"cuisine", "pizza;burger;klingon"},
+      {"cuisine", "BBQ"},
+      {"cuisine", "Ice Cream, doughnut"},
+      {"cuisine", ""},
+  };
+
+  for (auto const & [key, value] : kValues)
+  {
+    auto const once = Canonicalize(key, value);
+    TEST_EQUAL(Canonicalize(key, once), once, (key, value));
+  }
+}
+
+UNIT_TEST(OsmTagPolicy_ValuesEquivalent)
+{
+  classificator::Load();
+
+  TEST(ValuesEquivalent("website", "https://organicmaps.app/", "https://organicmaps.app"), ());
+  TEST(!ValuesEquivalent("website", "https://organicmaps.app", "https://organicmaps.org"), ());
+  TEST(ValuesEquivalent("internet_access", "free", "wlan"), ());
+  TEST(ValuesEquivalent("height", "40'", "12.2"), ());
+  TEST(ValuesEquivalent("cuisine", "pizza;burger", "burger;pizza"), ());
+  TEST(ValuesEquivalent("cuisine", "pizza;klingon", "pizza"), ("Unknown cuisines are not in the map."));
+  TEST(ValuesEquivalent("cuisine", "BBQ", "barbecue"), ("The generator folds the spelling."));
+  TEST(!ValuesEquivalent("phone", "+1 555 1234", "+1 555 9999"), ());
+
+  // A field whose value is a set of values is compared as a set, so that a server-side reordering is
+  // not reported as a change.
+  TEST(ValuesEquivalent("phone", "+1 555 1234;+1 555 9999", "+1 555 9999; +1 555 1234"), ());
+  TEST(!ValuesEquivalent("phone", "+1 555 1234;+1 555 9999", "+1 555 9999"), ());
+  TEST(ValuesEquivalent("email", "a@b.com;c@d.com", "c@d.com;a@b.com"), ());
+}
+
+UNIT_TEST(OsmTagPolicy_OpeningHoursEquivalent)
+{
+  // Compared through the parser, so a cosmetic rewrite is not a change.
+  TEST(ValuesEquivalent("opening_hours", "Mo-Fr 8:00-17:00", "Mo-Fr 08:00-17:00"), ());
+  TEST(!ValuesEquivalent("opening_hours", "Mo-Fr 8:00-17:00", "Mo-Fr 8:00-18:00"), ());
+
+  // Both sides unparseable: fall back to a raw comparison.
+  TEST(ValuesEquivalent("opening_hours", "whenever we feel like it", "whenever we feel like it"), ());
+  TEST(!ValuesEquivalent("opening_hours", "whenever we feel like it", "Mo-Fr 8:00-17:00"), ());
+  // One side unparseable: raw comparison too, so a fix is reported as a change.
+  TEST(!ValuesEquivalent("opening_hours", "Mo-Fr 8:00-17:00", "Mo-Fr 8:00-17:00 xx"), ());
+
+  // Known limit: rule order is significant in the OSM grammar, so reordering is not equal.
+  TEST(!ValuesEquivalent("opening_hours", "Sa off; Mo-Fr 8:00-17:00", "Mo-Fr 8:00-17:00; Sa off"), ());
+}
+
+UNIT_TEST(OsmTagPolicy_Completeness)
+{
+  // Every editable field must have a policy entry: a missing one silently compares the OSM and the
+  // MWM value domains against each other. The upload path asserts the same thing for every key it
+  // actually writes (Editor::UpdateXMLFeatureTags).
+  for (auto const & key : EditableFields())
+    TEST(HasFieldPolicy(key), ("No policy for the editable field", key));
+}
+
+UNIT_TEST(OsmTagPolicy_NoCanonicalForm)
+{
+  // Exactly these fields hold an MWM value that no single OSM tag carries: a housenumber composed
+  // from addr:conscriptionnumber/addr:streetnumber, a street name taken from OM's street matching,
+  // and two fields whose generator validator is gated on the feature type. For them the writer has
+  // nothing to match an edit against and applies it to the journal key.
+  std::set<std::string_view> const kNoCanonicalForm = {"addr:housenumber", "addr:street", "operator", "ele"};
+
+  for (auto const & key : EditableFields())
+    TEST_EQUAL(HasCanonicalForm(key), !kNoCanonicalForm.contains(key), (key));
+}
+
+UNIT_TEST(OsmTagPolicy_WriteUpdatesTheAliasThatHeldTheValue)
+{
+  // The tag that holds the value the user saw is the tag the generator picked, so updating it in
+  // place is what makes the new value win the next import as well.
+  auto feature = MakeNode({{"mobile", "+1 5551234"}});
+  auto const result = ApplyFieldEdit(feature, "phone", "+1 5551234", "+1 5559999");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "mobile"), "+1 5559999", ());
+  TEST_EQUAL(TagOrNone(feature, "phone"), "-", ("OM does not move a value between alias keys."));
+}
+
+UNIT_TEST(OsmTagPolicy_WriteLeavesOtherAliasesAlone)
+{
+  // A phone number in another alias that OM never showed the user is not theirs to change: the
+  // object keeps stating both claims, and the one the map shows is the one that was edited.
+  auto feature = MakeNode({{"phone", "+1 5551234"}, {"contact:mobile", "+1 5555678"}});
+  auto const result = ApplyFieldEdit(feature, "phone", "+1 5551234", "+1 5559999");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "phone"), "+1 5559999", ());
+  TEST_EQUAL(TagOrNone(feature, "contact:mobile"), "+1 5555678", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteUpdatesABareSocialInPlace)
+{
+  // The duplicate-tag bug fixed at its source: writing "contact:facebook" here would leave the bare
+  // key behind, and the object would state two contradicting handles.
+  auto feature = MakeNode({{"facebook", "organicmaps"}});
+  auto const result = ApplyFieldEdit(feature, "contact:facebook", "organicmaps", "openstreetmap");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "facebook"), "openstreetmap", ());
+  TEST_EQUAL(TagOrNone(feature, "contact:facebook"), "-", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteAliasWifi)
+{
+  // "wifi" is the one alias OM does not write back into: its vocabulary is not internet_access's, so
+  // a matched value is migrated to the canonical key instead of staying where it was.
+  auto feature = MakeNode({{"internet_access", "wlan"}, {"wifi", "free"}});
+  auto const result = ApplyFieldEdit(feature, "internet_access", "wlan", "wired");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "internet_access"), "wired", ());
+  TEST_EQUAL(TagOrNone(feature, "wifi"), "-", ());
+
+  // The same migration when "wifi" is the only key that holds the field.
+  auto bare = MakeNode({{"wifi", "wlan"}});
+  TEST_EQUAL(ApplyFieldEdit(bare, "internet_access", "wlan", "wired").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(bare, "internet_access"), "wired", ());
+  TEST_EQUAL(TagOrNone(bare, "wifi"), "-", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteDoesNotTidyContradictingAliases)
+{
+  // Two keys already state different websites. OM edits the one the user saw - which is the one the
+  // generator reads, since that is where the edited value came from - and leaves the other alone,
+  // even though the object stays contradictory.
+  auto feature = MakeNode({{"url", "http://a.com"}, {"contact:website", "http://b.com"}});
+  auto const result = ApplyFieldEdit(feature, "website", "http://b.com", "http://c.com");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "contact:website"), "http://c.com", ());
+  TEST_EQUAL(TagOrNone(feature, "url"), "http://a.com", ());
+  TEST_EQUAL(TagOrNone(feature, "website"), "-", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteDoesNotTouchOtherKeys)
+{
+  // The metadata reader matches "operator" by prefix; the writer must not, or it would delete a
+  // wikidata id.
+  auto feature = MakeNode({{"operator", "Old"}, {"operator:wikidata", "Q42"}, {"name", "Shop"}});
+  auto const result = ApplyFieldEdit(feature, "operator", "Old", "New");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "operator"), "New", ());
+  TEST_EQUAL(TagOrNone(feature, "operator:wikidata"), "Q42", ());
+  TEST_EQUAL(TagOrNone(feature, "name"), "Shop", ());
+}
+
+UNIT_TEST(OsmTagPolicy_ClearRemovesOnlyTheValueTheUserSaw)
+{
+  // The cost of writing only what OM can see: the numbers the user was never shown stay, and one of
+  // them becomes what the map shows next. Deleting them would delete data the user never asked
+  // about, which is the more damaging of the two failures - so the clear says that it left a value
+  // behind instead of reporting a plain success the user would see contradicted on the next update.
+  auto feature = MakeNode({{"phone", "+1 5551234"}, {"contact:phone", "+1 5555678"}, {"mobile", "+1 5559999"}});
+  auto const result = ApplyFieldEdit(feature, "phone", "+1 5551234", "");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::ClearedButStillStated, ());
+  TEST_EQUAL(result.m_serverValue, "+1 5555678", ("The value the map will show for the field."));
+  TEST_EQUAL(TagOrNone(feature, "phone"), "-", ());
+  TEST_EQUAL(TagOrNone(feature, "contact:phone"), "+1 5555678", ());
+  TEST_EQUAL(TagOrNone(feature, "mobile"), "+1 5559999", ());
+
+  // Nothing is left that the map can show, so the field really is gone.
+  auto alone = MakeNode({{"mobile", "+1 5551234"}});
+  TEST_EQUAL(ApplyFieldEdit(alone, "phone", "+1 5551234", "").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(alone, "mobile"), "-", ());
+}
+
+UNIT_TEST(OsmTagPolicy_ClearKeepsWhatOMCannotRepresent)
+{
+  classificator::Load();
+
+  // Clearing takes away the cuisines the user saw; "klingon" has no classifier type, was never
+  // shown, and is not theirs to delete.
+  auto feature = MakeNode({{"cuisine", "pizza;klingon"}});
+  TEST_EQUAL(ApplyFieldEdit(feature, "cuisine", "pizza", "").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "cuisine"), "klingon", ());
+
+  // Nothing is left over, so the tag goes.
+  auto known = MakeNode({{"cuisine", "pizza;burger"}});
+  TEST_EQUAL(ApplyFieldEdit(known, "cuisine", "burger;pizza", "").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(known, "cuisine"), "-", ());
+
+  // Taking one of several cuisines away leaves the others, tag and all.
+  auto one = MakeNode({{"cuisine", "pizza;burger"}});
+  TEST_EQUAL(ApplyFieldEdit(one, "cuisine", "burger;pizza", "pizza").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(one, "cuisine"), "pizza", ());
+}
+
+UNIT_TEST(OsmTagPolicy_ClearKeepsAnUnparseableValue)
+{
+  // The map shows nothing for a handle OM cannot parse, so clearing the field did not ask for its
+  // removal - it is not a source and the clear does not reach it. The field is gone as far as the
+  // user is concerned, so this is a plain success, unlike a clear that leaves a readable value.
+  auto feature = MakeNode({{"contact:facebook", "Organic Maps Page"}, {"facebook", "organicmaps"}});
+  auto const result = ApplyFieldEdit(feature, "contact:facebook", "organicmaps", "");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "contact:facebook"), "Organic Maps Page", ());
+  TEST_EQUAL(TagOrNone(feature, "facebook"), "-", ());
+}
+
+UNIT_TEST(OsmTagPolicy_ClearAnAbsentFieldDoesNothing)
+{
+  auto feature = MakeNode({{"name", "Shop"}});
+  auto const result = ApplyFieldEdit(feature, "phone", "+1 5551234", "");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::NothingToDo, ("The end state the user asked for holds."));
+  TEST_EQUAL(TagOrNone(feature, "phone"), "-", ());
+}
+
+UNIT_TEST(OsmTagPolicy_ClearAValueTheUserDidNotSee)
+{
+  // Somebody changed the number after the user's map snapshot: deleting it would delete a value they
+  // never saw, so the field is refused and the server value is reported for the upload guard.
+  auto feature = MakeNode({{"phone", "+1 5559999"}});
+  auto const result = ApplyFieldEdit(feature, "phone", "+1 5551234", "");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Unrepresentable, ());
+  TEST_EQUAL(result.m_serverValue, "+1 5559999", ());
+  TEST_EQUAL(TagOrNone(feature, "phone"), "+1 5559999", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WritePostcodeUpdatesTheTagThatHeldIt)
+{
+  // F6's hazard - a left-behind "postal_code" winning the import race - cannot arise: the tag OM
+  // edits is the one that won it, because that is where the edited value came from.
+  auto feature = MakeNode({{"postal_code", "12345"}, {"contact:postcode", "54321"}});
+  auto const result = ApplyFieldEdit(feature, "addr:postcode", "12345", "99999");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "postal_code"), "99999", ());
+  TEST_EQUAL(TagOrNone(feature, "contact:postcode"), "54321", ());
+  TEST_EQUAL(TagOrNone(feature, "addr:postcode"), "-", ());
+
+  // The same claim stated twice is edited twice, or the copy left behind could resurrect the old
+  // value on the next import. The postcode OM never showed stays, so the clear says so.
+  auto cleared = MakeNode({{"addr:postcode", "12345"}, {"contact:postcode", "54321"}, {"postal_code", "12345"}});
+  auto const clearResult = ApplyFieldEdit(cleared, "addr:postcode", "12345", "");
+  TEST_EQUAL(clearResult.m_status, FieldWriteStatus::ClearedButStillStated, ());
+  TEST_EQUAL(clearResult.m_serverValue, "54321", ());
+  TEST_EQUAL(TagOrNone(cleared, "addr:postcode"), "-", ());
+  TEST_EQUAL(TagOrNone(cleared, "postal_code"), "-", ());
+  TEST_EQUAL(TagOrNone(cleared, "contact:postcode"), "54321", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteUpdatesEveryTagThatHeldTheValue)
+{
+  auto feature = MakeNode({{"addr:postcode", "12345"}, {"postal_code", "12345"}});
+  auto const result = ApplyFieldEdit(feature, "addr:postcode", "12345", "99999");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "addr:postcode"), "99999", ());
+  TEST_EQUAL(TagOrNone(feature, "postal_code"), "99999", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteRefusesWhenNothingHoldsTheValue)
+{
+  // Somebody else changed the phone number, or OM cannot model how the map produced it. The writer
+  // cannot tell the two apart, so it writes nothing and reports the server value.
+  auto feature = MakeNode({{"phone", "+1 5551111"}});
+  auto const result = ApplyFieldEdit(feature, "phone", "+1 5551234", "+1 5559999");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Unrepresentable, ());
+  TEST_EQUAL(result.m_serverValue, "+1 5551111", ());
+  TEST_EQUAL(TagOrNone(feature, "phone"), "+1 5551111", ("The user's edit is dropped, not misapplied."));
+}
+
+UNIT_TEST(OsmTagPolicy_WriteRefusesWhenTheAliasesDisagree)
+{
+  // Nothing holds the value the user saw and the two keys state different numbers, so there is no
+  // single server value the upload guard could reconcile the field against.
+  auto feature = MakeNode({{"phone", "+1 5551111"}, {"mobile", "+1 5552222"}});
+  auto const result = ApplyFieldEdit(feature, "phone", "+1 5551234", "+1 5559999");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Ambiguous, ());
+  TEST(result.m_serverValue.empty(), (result.m_serverValue));
+  TEST_EQUAL(TagOrNone(feature, "phone"), "+1 5551111", ());
+  TEST_EQUAL(TagOrNone(feature, "mobile"), "+1 5552222", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteStreetUpdatesContactStreetInPlace)
+{
+  auto feature = MakeNode({{"contact:street", "Hauptstraße"}});
+  auto const result = ApplyFieldEdit(feature, "addr:street", "Hauptstraße", "Nebenstraße");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "contact:street"), "Nebenstraße", ());
+  TEST_EQUAL(TagOrNone(feature, "addr:street"), "-", ());
+
+  auto tagged = MakeNode({{"addr:street", "Hauptstraße"}});
+  TEST_EQUAL(ApplyFieldEdit(tagged, "addr:street", "Hauptstraße", "Nebenstraße").m_status, FieldWriteStatus::Written,
+             ());
+  TEST_EQUAL(TagOrNone(tagged, "addr:street"), "Nebenstraße", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteStreetWithNoSourceIsStillWritten)
+{
+  // A street name comes from OM's street matching, not from the tag, so a missing source classifies
+  // nothing: the edit is applied to the journal key rather than refused. Adding a street to an object
+  // that has none is the most valuable street edit there is.
+  auto absent = MakeNode({{"name", "Shop"}});
+  TEST_EQUAL(ApplyFieldEdit(absent, "addr:street", "Hauptstraße", "Nebenstraße").m_status, FieldWriteStatus::Written,
+             ());
+  TEST_EQUAL(TagOrNone(absent, "addr:street"), "Nebenstraße", ());
+
+  // The tag spells the street differently from the feature OM matched the object to.
+  auto differs = MakeNode({{"addr:street", "Hauptstr."}});
+  TEST_EQUAL(ApplyFieldEdit(differs, "addr:street", "Hauptstraße", "Nebenstraße").m_status, FieldWriteStatus::Written,
+             ());
+  TEST_EQUAL(TagOrNone(differs, "addr:street"), "Nebenstraße", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteOperatorOnANonQualifyingType)
+{
+  // The generator's operator validator is gated on the feature type, so the map shows nothing for
+  // this object and the field has no canonical form: the tag is overwritten, as it was before.
+  auto feature = MakeNode({{"operator", "Old"}});
+  auto const result = ApplyFieldEdit(feature, "operator", "", "New");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "operator"), "New", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteHouseNumberWithNoComponents)
+{
+  // Without the component tags nothing is composed, so the housenumber is an ordinary value whatever
+  // it looks like: "2/2" and "2/a" are house numbers in their own right in Russia and elsewhere, and
+  // OM must not read a Czech-style composition into them and invent the tags it is made of.
+  auto slashed = MakeNode({{"addr:housenumber", "2/2"}});
+  TEST_EQUAL(ApplyFieldEdit(slashed, "addr:housenumber", "2/2", "2/3").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(slashed, "addr:housenumber"), "2/3", ());
+  TEST_EQUAL(TagOrNone(slashed, "addr:conscriptionnumber"), "-", ());
+  TEST_EQUAL(TagOrNone(slashed, "addr:streetnumber"), "-", ());
+
+  // Including when the slash goes away.
+  TEST_EQUAL(ApplyFieldEdit(slashed, "addr:housenumber", "2/3", "5").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(slashed, "addr:housenumber"), "5", ());
+  TEST_EQUAL(TagOrNone(slashed, "addr:conscriptionnumber"), "-", ());
+  TEST_EQUAL(TagOrNone(slashed, "addr:streetnumber"), "-", ());
+
+  auto lettered = MakeNode({{"addr:housenumber", "2/a"}});
+  TEST_EQUAL(ApplyFieldEdit(lettered, "addr:housenumber", "2/a", "2/b").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(lettered, "addr:housenumber"), "2/b", ());
+  TEST_EQUAL(TagOrNone(lettered, "addr:conscriptionnumber"), "-", ());
+  TEST_EQUAL(TagOrNone(lettered, "addr:streetnumber"), "-", ());
+
+  auto plain = MakeNode({{"addr:housenumber", "12"}});
+  TEST_EQUAL(ApplyFieldEdit(plain, "addr:housenumber", "12", "14").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(plain, "addr:housenumber"), "14", ());
+
+  // "contact:housenumber" is read by the generator when there is no "addr:housenumber", so it is an
+  // alias and is updated in place - without it OM would lose an edit it can make today.
+  auto contact = MakeNode({{"contact:housenumber", "12"}});
+  TEST_EQUAL(ApplyFieldEdit(contact, "addr:housenumber", "12", "14").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(contact, "contact:housenumber"), "14", ());
+  TEST_EQUAL(TagOrNone(contact, "addr:housenumber"), "-", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteHouseNumberUpdatesItsComponents)
+{
+  // A Czech-style address: the generator composes the housenumber out of the two component tags, so
+  // the MWM value can be held by no tag at all. The edit is written by inverting the composition -
+  // leaving the components as they were would keep the object stating the old address, and would put
+  // it back on the map as soon as the new housenumber lost its '/'.
+  auto composed = MakeNode({{"addr:conscriptionnumber", "223"}, {"addr:streetnumber", "5"}});
+  TEST_EQUAL(ApplyFieldEdit(composed, "addr:housenumber", "223/5", "123/6").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(composed, "addr:housenumber"), "123/6", ());
+  TEST_EQUAL(TagOrNone(composed, "addr:conscriptionnumber"), "123", ());
+  TEST_EQUAL(TagOrNone(composed, "addr:streetnumber"), "6", ());
+
+  // The same when a tag holds the composed value as well.
+  auto tagged =
+      MakeNode({{"addr:housenumber", "123/45"}, {"addr:conscriptionnumber", "123"}, {"addr:streetnumber", "45"}});
+  TEST_EQUAL(ApplyFieldEdit(tagged, "addr:housenumber", "123/45", "123/46").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(tagged, "addr:housenumber"), "123/46", ());
+  TEST_EQUAL(TagOrNone(tagged, "addr:conscriptionnumber"), "123", ());
+  TEST_EQUAL(TagOrNone(tagged, "addr:streetnumber"), "46", ());
+
+  // Replaying the same edit changes nothing, components and all.
+  TEST_EQUAL(ApplyFieldEdit(tagged, "addr:housenumber", "123/45", "123/46").m_status, FieldWriteStatus::NothingToDo,
+             ());
+  TEST_EQUAL(TagOrNone(tagged, "addr:streetnumber"), "46", ());
+
+  // A housenumber the components contradict is still theirs to fix: the composition is what the map
+  // showed, so writing it splits into the components as usual.
+  auto contradicting =
+      MakeNode({{"addr:housenumber", "99"}, {"addr:conscriptionnumber", "223"}, {"addr:streetnumber", "5"}});
+  TEST_EQUAL(ApplyFieldEdit(contradicting, "addr:housenumber", "223/5", "123/6").m_status, FieldWriteStatus::Written,
+             ());
+  TEST_EQUAL(TagOrNone(contradicting, "addr:housenumber"), "123/6", ());
+  TEST_EQUAL(TagOrNone(contradicting, "addr:conscriptionnumber"), "123", ());
+  TEST_EQUAL(TagOrNone(contradicting, "addr:streetnumber"), "6", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteHouseNumberTheGeneratorWouldRecompose)
+{
+  // What is left of the refusal once the composition can be inverted: a value that is not a
+  // composition of two halves, which the generator would override on the next import.
+  auto composed = MakeNode({{"addr:conscriptionnumber", "223"}, {"addr:streetnumber", "5"}});
+  TEST_EQUAL(ApplyFieldEdit(composed, "addr:housenumber", "223/5", "123").m_status, FieldWriteStatus::Unrepresentable,
+             ());
+  TEST_EQUAL(TagOrNone(composed, "addr:housenumber"), "-", ());
+  TEST_EQUAL(TagOrNone(composed, "addr:conscriptionnumber"), "223", ());
+
+  TEST_EQUAL(ApplyFieldEdit(composed, "addr:housenumber", "223/5", "1/2/3").m_status, FieldWriteStatus::Unrepresentable,
+             ("Two slashes are not a composition of two halves."));
+  TEST_EQUAL(ApplyFieldEdit(composed, "addr:housenumber", "223/5", "223/").m_status, FieldWriteStatus::Unrepresentable,
+             ("An empty half would delete a component."));
+
+  // "addr:provisionalnumber" holds a conscription number that has not been assigned yet, which OM
+  // neither invents nor changes, and writing "addr:conscriptionnumber" next to it would leave the
+  // two racing for the same half of the value.
+  auto provisional =
+      MakeNode({{"addr:housenumber", "223/5"}, {"addr:provisionalnumber", "223"}, {"addr:streetnumber", "5"}});
+  TEST_EQUAL(ApplyFieldEdit(provisional, "addr:housenumber", "223/5", "123/6").m_status,
+             FieldWriteStatus::Unrepresentable, ());
+  TEST_EQUAL(TagOrNone(provisional, "addr:housenumber"), "223/5", ());
+  TEST_EQUAL(TagOrNone(provisional, "addr:provisionalnumber"), "223", ());
+  TEST_EQUAL(TagOrNone(provisional, "addr:conscriptionnumber"), "-", ());
+
+  // Clearing is repopulated from the components, so it is refused as well.
+  TEST_EQUAL(ApplyFieldEdit(composed, "addr:housenumber", "223/5", "").m_status, FieldWriteStatus::Unrepresentable, ());
+
+  // One component is enough to repopulate a cleared housenumber - and is not OM's to complete, so
+  // everything else is an ordinary write.
+  auto lone = MakeNode({{"addr:housenumber", "223"}, {"addr:conscriptionnumber", "223"}});
+  TEST_EQUAL(ApplyFieldEdit(lone, "addr:housenumber", "223", "").m_status, FieldWriteStatus::Unrepresentable, ());
+  TEST_EQUAL(TagOrNone(lone, "addr:housenumber"), "223", ());
+
+  TEST_EQUAL(ApplyFieldEdit(lone, "addr:housenumber", "223", "224/6").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(lone, "addr:housenumber"), "224/6", ());
+  TEST_EQUAL(TagOrNone(lone, "addr:conscriptionnumber"), "223", ());
+  TEST_EQUAL(TagOrNone(lone, "addr:streetnumber"), "-", ("A missing component is not invented."));
+}
+
+UNIT_TEST(OsmTagPolicy_WriteNewTag)
+{
+  auto feature = MakeNode({{"name", "Shop"}});
+  TEST_EQUAL(ApplyFieldEdit(feature, "website", "", "https://organicmaps.app").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "website"), "https://organicmaps.app", ());
+
+  // A key with no policy entry is written as it is named.
+  TEST_EQUAL(ApplyFieldEdit(feature, "brand", "", "Organic Maps").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "brand"), "Organic Maps", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteLocalizedName)
+{
+  // "name:<lang>" shares the policy of "name" but is a key of its own.
+  auto feature = MakeNode({{"name", "Freiburg"}});
+  TEST_EQUAL(ApplyFieldEdit(feature, "name:de", "", "Freiburg im Breisgau").m_status, FieldWriteStatus::Written, ());
+
+  TEST_EQUAL(TagOrNone(feature, "name:de"), "Freiburg im Breisgau", ());
+  TEST_EQUAL(TagOrNone(feature, "name"), "Freiburg", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteAComposedOldName)
+{
+  // The generator joins a name with its dated variants into one MWM value (osm2type.cpp), so no tag
+  // holds what the map showed: the edit is refused instead of being written into "old_name", where
+  // the variant would be appended to it again. Without a variant the field is edited as usual.
+  auto composed = MakeNode({{"old_name", "Leningrad"}, {"old_name:1920", "Petrograd"}});
+  TEST_EQUAL(ApplyFieldEdit(composed, "old_name", "Leningrad;Petrograd", "Sankt-Peterburg").m_status,
+             FieldWriteStatus::Unrepresentable, ());
+  TEST_EQUAL(TagOrNone(composed, "old_name"), "Leningrad", ());
+  TEST_EQUAL(TagOrNone(composed, "old_name:1920"), "Petrograd", ());
+
+  auto plain = MakeNode({{"old_name", "Leningrad"}});
+  TEST_EQUAL(ApplyFieldEdit(plain, "old_name", "Leningrad", "Petrograd").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(plain, "old_name"), "Petrograd", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteIntoAnOccupiedKey)
+{
+  classificator::Load();
+
+  // The map showed nothing and a key already holds a value: the user is adding a claim to a field
+  // whose values add up, not replacing the one they never saw. A place really can serve two cuisines.
+  auto joined = MakeNode({{"cuisine", "klingon"}});
+  TEST_EQUAL(ApplyFieldEdit(joined, "cuisine", "", "pizza").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(joined, "cuisine"), "klingon;pizza", ());
+
+  // A phone number states one fact: the user filling the field in meant this is the number, so a
+  // second one that appeared after their map snapshot is a third-party conflict rather than
+  // something to co-list, and overwriting it would destroy what OM never showed.
+  auto occupied = MakeNode({{"phone", "+1 5551111"}});
+  auto const result = ApplyFieldEdit(occupied, "phone", "", "+1 5559999");
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Unrepresentable, ());
+  TEST_EQUAL(result.m_serverValue, "+1 5551111", ());
+  TEST_EQUAL(TagOrNone(occupied, "phone"), "+1 5551111", ());
+
+  // The same for a field that is one indivisible value.
+  auto social = MakeNode({{"contact:facebook", "organicmaps"}});
+  auto const socialResult = ApplyFieldEdit(social, "contact:facebook", "", "openstreetmap");
+  TEST_EQUAL(socialResult.m_status, FieldWriteStatus::Unrepresentable, ());
+  TEST_EQUAL(socialResult.m_serverValue, "organicmaps", ());
+  TEST_EQUAL(TagOrNone(social, "contact:facebook"), "organicmaps", ());
+
+  // Same when the value is one OM cannot read at all.
+  auto junk = MakeNode({{"contact:facebook", "Organic Maps Page"}});
+  TEST_EQUAL(ApplyFieldEdit(junk, "contact:facebook", "", "openstreetmap").m_status, FieldWriteStatus::Unrepresentable,
+             ());
+  TEST_EQUAL(TagOrNone(junk, "contact:facebook"), "Organic Maps Page", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteReplayIsANoOp)
+{
+  // The upload went through and its response was lost, so the journal is replayed against an object
+  // that already holds the value. Nothing holds the old value any more, but that is not a conflict.
+  auto feature = MakeNode({{"mobile", "+1 5559999"}});
+  auto const result = ApplyFieldEdit(feature, "phone", "+1 5551234", "+1 5559999");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::NothingToDo, ());
+  TEST_EQUAL(TagOrNone(feature, "mobile"), "+1 5559999", ());
+  TEST_EQUAL(TagOrNone(feature, "phone"), "-", ());
+
+  // The same for an addition: the key the user filled in already says it.
+  auto added = MakeNode({{"mobile", "+1 5559999"}});
+  TEST_EQUAL(ApplyFieldEdit(added, "phone", "", "+1 5559999").m_status, FieldWriteStatus::NothingToDo, ());
+  TEST_EQUAL(TagOrNone(added, "phone"), "-", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteKeepsUntouchedCuisineTokens)
+{
+  classificator::Load();
+
+  // "klingon" has no classifier type, so OM never showed it and it is not in the delta at all.
+  auto feature = MakeNode({{"cuisine", "pizza;klingon"}});
+  TEST_EQUAL(ApplyFieldEdit(feature, "cuisine", "pizza", "pizza;burger").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "cuisine"), "pizza;klingon;burger", ());
+
+  // A token nobody touched keeps its place and its spelling, however OSM spelled it.
+  auto spelled = MakeNode({{"cuisine", "Ice Cream;pizza"}});
+  TEST_EQUAL(ApplyFieldEdit(spelled, "cuisine", "ice_cream;pizza", "ice_cream;pizza;burger").m_status,
+             FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(spelled, "cuisine"), "Ice Cream;pizza;burger", ());
+
+  // Only the token the user took away goes.
+  auto removed = MakeNode({{"cuisine", "pizza;burger;klingon"}});
+  TEST_EQUAL(ApplyFieldEdit(removed, "cuisine", "burger;pizza", "pizza").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(removed, "cuisine"), "pizza;klingon", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteEditsACommaSeparatedCuisineList)
+{
+  classificator::Load();
+
+  // The generator splits a cuisine on ',' as well as on ';', so OM has to split the raw value the
+  // same way: a cuisine listed after a comma is a token of its own, and taking it away has to remove
+  // it rather than leave the whole value untouched. What is written back uses the ';' that every
+  // multi-valued OSM tag is read with.
+  auto feature = MakeNode({{"cuisine", "Pizza, BBQ, klingon"}});
+  TEST_EQUAL(ApplyFieldEdit(feature, "cuisine", "barbecue;pizza", "pizza").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "cuisine"), "Pizza;klingon", ());
+
+  auto added = MakeNode({{"cuisine", "Pizza, BBQ"}});
+  TEST_EQUAL(ApplyFieldEdit(added, "cuisine", "barbecue;pizza", "barbecue;pizza;burger").m_status,
+             FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(added, "cuisine"), "Pizza;BBQ;burger", ());
+
+  auto cleared = MakeNode({{"cuisine", "Pizza, BBQ"}});
+  TEST_EQUAL(ApplyFieldEdit(cleared, "cuisine", "barbecue;pizza", "").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(cleared, "cuisine"), "-", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteMatchesACuisineTheGeneratorRenamed)
+{
+  classificator::Load();
+
+  // The map shows "barbecue" for "cuisine=BBQ". Without the generator's own token normalization the
+  // raw token would match nothing, and the cuisine the user deleted would come back on the next map
+  // update.
+  auto feature = MakeNode({{"cuisine", "BBQ"}});
+  TEST_EQUAL(ApplyFieldEdit(feature, "cuisine", "barbecue", "pizza").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "cuisine"), "pizza", ());
+
+  auto listed = MakeNode({{"cuisine", "pizza;BBQ"}});
+  TEST_EQUAL(ApplyFieldEdit(listed, "cuisine", "barbecue;pizza", "pizza").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(listed, "cuisine"), "pizza", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteReplacesOnePhoneNumber)
+{
+  auto feature = MakeNode({{"phone", "+1 5551234;+1 5555678"}});
+  auto const result = ApplyFieldEdit(feature, "phone", "+1 5551234;+1 5555678", "+1 5551234;+1 5559999");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "phone"), "+1 5551234;+1 5559999", ("The untouched number is kept verbatim."));
+}
+
+UNIT_TEST(OsmTagPolicy_WriteCarriesUnknownInternetTokens)
+{
+  // Both tokens are in OM's vocabulary on their own, but the generator drops a multi-value outright,
+  // so the map showed nothing here and the user replaced nothing: their value joins the list.
+  auto feature = MakeNode({{"internet_access", "terminal;wlan"}});
+  auto const result = ApplyFieldEdit(feature, "internet_access", "", "wired");
+
+  TEST_EQUAL(result.m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "internet_access"), "terminal;wlan;wired", ());
+
+  // A token that is already there in another spelling is not added twice, and a write that would
+  // change nothing is not a write.
+  auto present = MakeNode({{"internet_access", "terminal;Free"}});
+  TEST_EQUAL(ApplyFieldEdit(present, "internet_access", "", "wlan").m_status, FieldWriteStatus::NothingToDo, ());
+  TEST_EQUAL(TagOrNone(present, "internet_access"), "terminal;Free", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteTokenDeltaIsIdempotent)
+{
+  classificator::Load();
+
+  // Applying the same edit twice - which is what a replayed upload does - changes nothing the second
+  // time, because a token that is gone is not removed again and one that is there is not added again.
+  auto feature = MakeNode({{"cuisine", "pizza;klingon"}});
+  TEST_EQUAL(ApplyFieldEdit(feature, "cuisine", "pizza", "pizza;burger").m_status, FieldWriteStatus::Written, ());
+  auto const once = TagOrNone(feature, "cuisine");
+
+  TEST_EQUAL(ApplyFieldEdit(feature, "cuisine", "pizza", "pizza;burger").m_status, FieldWriteStatus::NothingToDo, ());
+  TEST_EQUAL(TagOrNone(feature, "cuisine"), once, ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteNeverGainsAList)
+{
+  // A field whose value is one indivisible unit is matched and replaced whole, so a residue OSM
+  // should not have held in the first place (the "4" here) goes with it.
+  auto feature = MakeNode({{"stars", "3;4"}});
+  TEST_EQUAL(ApplyFieldEdit(feature, "stars", "3", "5").m_status, FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(feature, "stars"), "5", ());
+
+  auto website = MakeNode({{"website", "http://a.com;http://b.com"}});
+  TEST_EQUAL(ApplyFieldEdit(website, "website", "http://a.com;http://b.com", "http://c.com").m_status,
+             FieldWriteStatus::Written, ());
+  TEST_EQUAL(TagOrNone(website, "website"), "http://c.com", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteDoesNotDuplicateTheUsersValue)
+{
+  classificator::Load();
+
+  // The user's value already covers a token the raw value holds.
+  auto feature = MakeNode({{"cuisine", "pizza;klingon"}});
+  TEST_EQUAL(ApplyFieldEdit(feature, "cuisine", "pizza", "klingon").m_status, FieldWriteStatus::Written, ());
+
+  TEST_EQUAL(TagOrNone(feature, "cuisine"), "klingon", ());
+}
+
+UNIT_TEST(OsmTagPolicy_WriteAgreesWithTheGenerator)
+{
+  classificator::Load();
+
+  // The whole model rests on the editor and the generator agreeing on what a value means: write an
+  // edit into a raw OSM value, canonicalize the result, and the map must show what the user asked
+  // for.
+  struct Edit
+  {
+    std::string_view m_key;
+    std::string_view m_raw;
+    std::string_view m_base;
+    std::string_view m_newValue;
+  };
+
+  Edit const kEdits[] = {
+      {"cuisine", "BBQ", "barbecue", "pizza"},
+      {"cuisine", "Ice Cream;pizza", "ice_cream;pizza", "ice_cream;pizza;burger"},
+      {"cuisine", "Pizza, BBQ", "barbecue;pizza", "barbecue;pizza;burger"},
+      {"phone", "+1 5551234;+1 5555678", "+1 5551234;+1 5555678", "+1 5551234;+1 5559999"},
+      {"website", "https://a.com/", "https://a.com", "https://b.com/"},
+      {"internet_access", "wifi", "wlan", "wired"},
+      {"height", "40'", "12.2", "15"},
+      {"stars", "3", "3", "5"},
+  };
+
+  for (auto const & [key, raw, base, newValue] : kEdits)
+  {
+    auto feature = MakeNode({{std::string{key}, std::string{raw}}});
+    TEST_EQUAL(ApplyFieldEdit(feature, key, base, newValue).m_status, FieldWriteStatus::Written, (key, raw));
+    TEST(ValuesEquivalent(key, TagOrNone(feature, key), newValue), (key, raw, TagOrNone(feature, key)));
+  }
+}
+}  // namespace osm_tag_policy_test

--- a/libs/editor/osm_editor.cpp
+++ b/libs/editor/osm_editor.cpp
@@ -1220,38 +1220,34 @@ bool Editor::IsFeatureUploadedImpl(FeaturesContainer const & features, MwmId con
 
 void Editor::UpdateXMLFeatureTags(editor::XMLFeature & feature, std::vector<JournalEntry> const & journal)
 {
-  for (JournalEntry const & entry : journal)
-  {
-    switch (entry.journalEntryType)
-    {
-    case JournalEntryType::TagModification:
-    {
-      TagModData const & tagModData = std::get<TagModData>(entry.data);
-      // Every journal key needs a tag policy, otherwise its values are compared in the wrong domain.
-      ASSERT(editor::HasFieldPolicy(tagModData.key), ("No tag policy for the edited field", tagModData.key));
+  ASSERT(journal.empty() || journal.front().journalEntryType != JournalEntryType::LegacyObject,
+         ("Legacy Objects are not editable"));
 
-      auto const result = editor::ApplyFieldEdit(feature, tagModData.key, tagModData.old_value, tagModData.new_value);
-      // A refused field is left out of the upload and the rest is still uploaded: the fields that did
-      // apply are worth more than a dropped changeset. Same for a field that was cleared but is still
-      // stated by a tag OM never showed the user. Reporting either to the user needs the upload guard,
-      // which is not here yet.
-      switch (result.m_status)
-      {
-      case editor::FieldWriteStatus::Ambiguous:
-      case editor::FieldWriteStatus::Unrepresentable:
-        LOG(LWARNING,
-            ("Edit of", tagModData.key, "not applied:", result.m_status, "server value:", result.m_serverValue));
-        break;
-      case editor::FieldWriteStatus::ClearedButStillStated:
-        LOG(LWARNING, ("Edit of", tagModData.key, "cleared the value the user saw, but the object still states",
-                       result.m_serverValue));
-        break;
-      default: LOG(LDEBUG, ("Edit of", tagModData.key, ":", result.m_status));
-      }
+  // The upload applies the net change of the journal, not every step the user took through the UI:
+  // two edits of one field would otherwise be replayed one after the other, and the second one would
+  // look for a value the first one has just replaced.
+  for (TagModData const & tagModData : CollapseTagChanges(journal))
+  {
+    // Every journal key needs a tag policy, otherwise its values are compared in the wrong domain.
+    ASSERT(editor::HasFieldPolicy(tagModData.key), ("No tag policy for the edited field", tagModData.key));
+
+    auto const result = editor::ApplyFieldEdit(feature, tagModData.key, tagModData.old_value, tagModData.new_value);
+    // A refused field is left out of the upload and the rest is still uploaded: the fields that did
+    // apply are worth more than a dropped changeset. Same for a field that was cleared but is still
+    // stated by a tag OM never showed the user. Reporting either to the user needs the upload guard,
+    // which is not here yet.
+    switch (result.m_status)
+    {
+    case editor::FieldWriteStatus::Ambiguous:
+    case editor::FieldWriteStatus::Unrepresentable:
+      LOG(LWARNING,
+          ("Edit of", tagModData.key, "not applied:", result.m_status, "server value:", result.m_serverValue));
       break;
-    }
-    case JournalEntryType::ObjectCreated: break;
-    case JournalEntryType::LegacyObject: ASSERT_FAIL(("Legacy Objects are not editable")); break;
+    case editor::FieldWriteStatus::ClearedButStillStated:
+      LOG(LWARNING, ("Edit of", tagModData.key, "cleared the value the user saw, but the object still states",
+                     result.m_serverValue));
+      break;
+    default: LOG(LDEBUG, ("Edit of", tagModData.key, ":", result.m_status));
     }
   }
 }

--- a/libs/editor/osm_editor.cpp
+++ b/libs/editor/osm_editor.cpp
@@ -3,6 +3,7 @@
 #include "editor/changeset_wrapper.hpp"
 #include "editor/edits_migration.hpp"
 #include "editor/osm_auth.hpp"
+#include "editor/osm_tag_policy.hpp"
 #include "editor/xml_feature.hpp"
 
 #include "opening_hours/opening_hours.hpp"
@@ -1226,7 +1227,27 @@ void Editor::UpdateXMLFeatureTags(editor::XMLFeature & feature, std::vector<Jour
     case JournalEntryType::TagModification:
     {
       TagModData const & tagModData = std::get<TagModData>(entry.data);
-      feature.UpdateOSMTag(tagModData.key, tagModData.new_value);
+      // Every journal key needs a tag policy, otherwise its values are compared in the wrong domain.
+      ASSERT(editor::HasFieldPolicy(tagModData.key), ("No tag policy for the edited field", tagModData.key));
+
+      auto const result = editor::ApplyFieldEdit(feature, tagModData.key, tagModData.old_value, tagModData.new_value);
+      // A refused field is left out of the upload and the rest is still uploaded: the fields that did
+      // apply are worth more than a dropped changeset. Same for a field that was cleared but is still
+      // stated by a tag OM never showed the user. Reporting either to the user needs the upload guard,
+      // which is not here yet.
+      switch (result.m_status)
+      {
+      case editor::FieldWriteStatus::Ambiguous:
+      case editor::FieldWriteStatus::Unrepresentable:
+        LOG(LWARNING,
+            ("Edit of", tagModData.key, "not applied:", result.m_status, "server value:", result.m_serverValue));
+        break;
+      case editor::FieldWriteStatus::ClearedButStillStated:
+        LOG(LWARNING, ("Edit of", tagModData.key, "cleared the value the user saw, but the object still states",
+                       result.m_serverValue));
+        break;
+      default: LOG(LDEBUG, ("Edit of", tagModData.key, ":", result.m_status));
+      }
       break;
     }
     case JournalEntryType::ObjectCreated: break;

--- a/libs/editor/osm_tag_policy.cpp
+++ b/libs/editor/osm_tag_policy.cpp
@@ -1,0 +1,641 @@
+#include "editor/osm_tag_policy.hpp"
+
+#include "editor/xml_feature.hpp"
+
+#include "indexer/classificator.hpp"
+#include "indexer/osm_value_format.hpp"
+#include "indexer/validate_and_format_contacts.hpp"
+
+#include "opening_hours/opening_hours.hpp"
+
+#include "base/assert.hpp"
+#include "base/stl_helpers.hpp"
+#include "base/string_utils.hpp"
+
+#include <span>
+#include <vector>
+
+namespace editor
+{
+namespace
+{
+std::string_view constexpr kOpeningHoursKey = "opening_hours";
+std::string_view constexpr kCuisineKey = "cuisine";
+std::string_view constexpr kHouseNumberKey = "addr:housenumber";
+std::string_view constexpr kLocalNamePrefix = "name:";
+
+// OSM separates the values of a multi-valued tag with ';'. A cuisine is also split on ',' - by the
+// generator (osm2type.cpp), so the editor has to do the same or a cuisine listed after a comma would
+// not be a token of its own and could not be taken away.
+constexpr char const * kTokenSeparators = ";";
+constexpr char const * kCuisineTokenSeparators = ",;";
+
+using Canonicalizer = std::string (*)(std::string const &);
+
+// Identity: the generator stores this tag verbatim today (osm2meta.cpp).
+// If import-time normalization is ever added for this field - trimming,
+// case folding, Unicode normalization, reformatting - add the same function
+// here. The upload guard compares old_value, which is in the MWM value
+// domain, against the canonicalized server value; if the two stop agreeing,
+// ordinary edits start being reported as third-party conflicts.
+std::string Identity(std::string const & v)
+{
+  return v;
+}
+
+// The generator normalizes every cuisine token (osm::NormalizeCuisineToken) and OM keeps the ones it
+// has a classifier type for, losing the rest, so the MWM value is a set rather than a string. Sorted
+// instead of following the classifier's type order: reproducing that order is not needed to tell an
+// edit from a reformatting, and both sides are canonicalized.
+std::string CanonicalizeCuisines(std::string const & v)
+{
+  Classificator const & cl = classif();
+  std::vector<std::string> known;
+  for (std::string_view const token : strings::Tokenize(v, kCuisineTokenSeparators))
+  {
+    auto normalized = osm::NormalizeCuisineToken(std::string{token});
+    if (!normalized.empty() && cl.GetTypeByPathSafe({kCuisineKey, normalized}) != Classificator::INVALID_TYPE)
+      known.push_back(std::move(normalized));
+  }
+  base::SortUnique(known);
+  return strings::JoinStrings(known, kTokenSeparators);
+}
+
+// One of the OSM keys that can hold a field.
+struct FieldAlias
+{
+  std::string_view m_key;
+
+  // OM never writes back into this key, because its value vocabulary is not the field's: "wifi=wired"
+  // is nonsense, and data/replaced_tags.txt rewrites "wifi=yes|free|no" into "internet_access" before
+  // the generator sees the object. A value matched here is migrated instead - written to the field's
+  // first key, with this key removed - which is the one place where OM touches a tag other than the
+  // one it edited.
+  bool m_migrateOnWrite = false;
+};
+
+struct FieldPolicy
+{
+  // Raw OSM value -> MWM value, for the whole tag value. See Identity above for the fields the
+  // generator stores verbatim.
+  Canonicalizer m_canonicalize = &Identity;
+
+  // Raw token -> canonical token, for a field whose OSM value is a set of independent values. Null
+  // means the value is one indivisible unit: it is matched and replaced whole. An empty result means
+  // OM cannot represent the token, so it never matches anything the user saw and is therefore never
+  // removed.
+  Canonicalizer m_canonicalizeToken = nullptr;
+
+  // What the raw value's tokens are separated by. Must be what the field's canonicalizer splits on,
+  // or a token it sees would not be a token here and could not be taken away.
+  char const * m_tokenSeparators = kTokenSeparators;
+
+  // The field's values add up, so a value that is already there and was never shown to the user - it
+  // appeared after the map snapshot, or OM cannot read it - is joined rather than replaced: a place
+  // really can serve several cuisines. Where the field states one fact instead, a phone number or an
+  // email address, a second value is a third-party conflict and the edit is refused.
+  bool m_additive = false;
+
+  // Every OSM key that can hold this field. OM edits whichever of them holds the value the user saw
+  // and leaves the rest alone; the first entry is used only to create the tag when the field is
+  // absent from the object entirely. Empty means the field lives in the journal key only. Which keys
+  // can hold a field is fixed by what folds them on import (the metadata reader, or the generator for
+  // the addr:* groups).
+  std::span<FieldAlias const> m_aliases;
+
+  // The MWM value is not what one OSM tag holds - a composed housenumber, a street name taken from
+  // OM's street matching, a validator gated on the feature type. There is nothing to match an edit
+  // against, so the writer falls back to the journal key, see HasCanonicalForm().
+  bool m_noCanonicalForm = false;
+};
+
+// These aliases come from the generator (osm2type.cpp), not from Metadata::TypeFromString, which
+// folds none of them.
+FieldAlias constexpr kStreetAliases[] = {{"addr:street"}, {"contact:street"}};
+FieldAlias constexpr kHouseNumberAliases[] = {{"addr:housenumber"}, {"contact:housenumber"}};
+FieldAlias constexpr kPostcodeAliases[] = {{"addr:postcode"}, {"contact:postcode"}, {"postal_code"}};
+
+FieldAlias constexpr kPhoneAliases[] = {{"phone"}, {"contact:phone"}, {"contact:mobile"}, {"mobile"}};
+FieldAlias constexpr kFaxAliases[] = {{"fax"}, {"contact:fax"}};
+FieldAlias constexpr kEmailAliases[] = {{"email"}, {"contact:email"}};
+FieldAlias constexpr kWebsiteAliases[] = {{"website"}, {"contact:website"}, {"url"}};
+FieldAlias constexpr kFacebookAliases[] = {{"contact:facebook"}, {"facebook"}};
+FieldAlias constexpr kInstagramAliases[] = {{"contact:instagram"}, {"instagram"}};
+FieldAlias constexpr kTwitterAliases[] = {{"contact:twitter"}, {"twitter"}};
+FieldAlias constexpr kVkAliases[] = {{"contact:vk"}, {"vk"}};
+FieldAlias constexpr kInternetAliases[] = {{"internet_access"}, {.m_key = "wifi", .m_migrateOnWrite = true}};
+
+// The generator composes a housenumber from these (osm2type.cpp): with both a conscription (or
+// provisional) number and a street number present it overrides an addr:housenumber that holds no
+// '/', and with only one of them present it fills an empty addr:housenumber. They are components of
+// the value, not spellings of it, so they must never be aliases: reading one as the housenumber
+// would show half an address, and deleting one on write would corrupt it. What OM does write is the
+// composition it can invert, see ClassifyHouseNumberWrite().
+std::string_view constexpr kConscriptionNumberKey = "addr:conscriptionnumber";
+std::string_view constexpr kProvisionalNumberKey = "addr:provisionalnumber";
+std::string_view constexpr kStreetNumberKey = "addr:streetnumber";
+
+struct FieldEntry
+{
+  std::string_view m_key;
+  FieldPolicy m_policy;
+};
+
+// Every editable field needs an entry, including the ones stored verbatim - see Identity above and
+// the completeness test in editor_tests. A field that is not editable has no entry and falls back to
+// the identity policy: its value is compared and written under the key that names it.
+FieldEntry constexpr kFieldPolicies[] = {
+    // Names. "name:<lang>" is resolved by prefix, see FindFieldPolicy().
+    {"name", {}},
+    {"int_name", {}},
+    {"alt_name", {}},
+    {"old_name", {}},
+
+    // Address.
+    //
+    // A housenumber is composed on import, so the MWM value "123/45" can be held by no tag at all -
+    // no canonical form. See kConscriptionNumberKey for the components and ClassifyHouseNumberWrite()
+    // for how a write is split back into them, or refused where it cannot be.
+    {kHouseNumberKey, {.m_aliases = kHouseNumberAliases, .m_noCanonicalForm = true}},
+    // A street name does not come from the tag at all: it is the default name of the street feature
+    // the object was matched to (ReverseGeocoder::GetFeatureStreetName), which exists even when the
+    // object carries no addr:street and can differ from the tag text.
+    {"addr:street", {.m_aliases = kStreetAliases, .m_noCanonicalForm = true}},
+    // "postal_code" means more than an address postcode elsewhere in OSM, but not on anything OM can
+    // edit: every type that offers a postcode field is address-bearing, no boundary, place or highway
+    // type is among them, and settlements are disabled in data/editor.config outright.
+    {"addr:postcode", {.m_aliases = kPostcodeAliases}},
+    {"addr:flats", {}},
+
+    // Verbatim on import, but compared semantically by ValuesEquivalent().
+    {kOpeningHoursKey, {}},
+
+    // OSM lists several numbers or addresses in one tag, separated by ';', and each of them is a
+    // value in its own right: the editor changes the one the user changed and leaves the rest alone.
+    // Not additive, though: the user filling in a phone number meant this is the number, so a second
+    // one that appeared meanwhile is a conflict rather than something to co-list.
+    {"phone", {.m_canonicalizeToken = &Identity, .m_aliases = kPhoneAliases}},
+    // Not editable today (data/editor.config marks it editable="no"), listed for parity with phone.
+    {"fax", {.m_canonicalizeToken = &Identity, .m_aliases = kFaxAliases}},
+    {"email", {.m_canonicalizeToken = &Identity, .m_aliases = kEmailAliases}},
+
+    {"denomination", {}},
+    // The generator's validator for these two is gated on the feature type (osm2meta.cpp), so there
+    // is no canonical form a pure function can produce.
+    {"operator", {.m_noCanonicalForm = true}},
+    {"ele", {.m_noCanonicalForm = true}},
+    // The generator rewrites a Wikipedia URL into "lang:Title", but the field is not editable
+    // (data/editor.config keeps it commented out) so it cannot appear in a journal. If it becomes
+    // editable, move ValidateAndFormat_wikipedia into indexer/osm_value_format.hpp and use it here.
+    {"wikipedia", {}},
+
+    {"website", {.m_canonicalize = &osm::ValidateAndFormat_url, .m_aliases = kWebsiteAliases}},
+    {"website:menu", {.m_canonicalize = &osm::ValidateAndFormat_url}},
+
+    {"contact:facebook", {.m_canonicalize = &osm::ValidateAndFormat_facebook, .m_aliases = kFacebookAliases}},
+    {"contact:instagram", {.m_canonicalize = &osm::ValidateAndFormat_instagram, .m_aliases = kInstagramAliases}},
+    {"contact:twitter", {.m_canonicalize = &osm::ValidateAndFormat_twitter, .m_aliases = kTwitterAliases}},
+    {"contact:vk", {.m_canonicalize = &osm::ValidateAndFormat_vk, .m_aliases = kVkAliases}},
+    {"contact:line", {.m_canonicalize = &osm::ValidateAndFormat_contactLine}},
+
+    // The generator drops a multi-value outright, so the whole-value canonicalizer stays a whitelist
+    // of single values and the map shows nothing for "internet_access=terminal;wlan". The tag still
+    // legally holds a list, so the writer adds to it rather than overwriting claims OM cannot read.
+    {"internet_access",
+     {.m_canonicalize = &osm::ValidateAndFormat_internet,
+      .m_canonicalizeToken = &osm::ValidateAndFormat_internet,
+      .m_additive = true,
+      .m_aliases = kInternetAliases}},
+
+    {"stars", {.m_canonicalize = &osm::ValidateAndFormat_stars}},
+    {"height", {.m_canonicalize = &osm::ValidateAndFormat_height}},
+    {"building:levels", {.m_canonicalize = &osm::ValidateAndFormat_building_levels}},
+    // A level holds "1;2" or "3-5", but the user edits it as one string and the generator normalizes
+    // it as one string, so it is not a set of independent values.
+    {"level", {.m_canonicalize = &osm::ValidateAndFormat_level}},
+    {"drive_through", {.m_canonicalize = &osm::ValidateAndFormat_drive_through}},
+    {"self_service", {.m_canonicalize = &osm::ValidateAndFormat_self_service}},
+    {"outdoor_seating", {.m_canonicalize = &osm::ValidateAndFormat_outdoor_seating}},
+
+    {kCuisineKey,
+     {.m_canonicalize = &CanonicalizeCuisines,
+      .m_canonicalizeToken = &osm::NormalizeCuisineToken,
+      .m_tokenSeparators = kCuisineTokenSeparators,
+      .m_additive = true}},
+    // Derived from the vegetarian/vegan cuisine types, so the value is "yes" or nothing.
+    {"diet:vegetarian", {}},
+    {"diet:vegan", {}},
+};
+
+FieldPolicy const * FindFieldPolicy(std::string_view journalKey)
+{
+  if (journalKey.starts_with(kLocalNamePrefix))
+    journalKey = "name";
+
+  for (auto const & entry : kFieldPolicies)
+    if (entry.m_key == journalKey)
+      return &entry.m_policy;
+
+  return nullptr;
+}
+
+FieldPolicy const & GetFieldPolicy(std::string_view journalKey)
+{
+  static FieldPolicy const kDefault{};
+  auto const * policy = FindFieldPolicy(journalKey);
+  return policy ? *policy : kDefault;
+}
+
+std::vector<std::string_view> SplitAndTrim(FieldPolicy const & policy, std::string_view value)
+{
+  std::vector<std::string_view> tokens;
+  for (std::string_view token : strings::Tokenize(value, policy.m_tokenSeparators))
+  {
+    strings::Trim(token);
+    if (!token.empty())
+      tokens.push_back(token);
+  }
+  return tokens;
+}
+
+/// @returns the canonical form of one token, or the token itself where OM has no vocabulary for it.
+/// An unrepresentable token is never equal to a value the user saw, so it is never taken away, and it
+/// is still recognized as a duplicate of itself.
+std::string TokenKey(FieldPolicy const & policy, std::string_view token)
+{
+  ASSERT(policy.m_canonicalizeToken, ("Only a field whose value is a set of values has tokens."));
+
+  auto key = policy.m_canonicalizeToken(std::string{token});
+  return key.empty() ? std::string{token} : key;
+}
+
+std::vector<std::string> TokenKeys(FieldPolicy const & policy, std::string_view value)
+{
+  std::vector<std::string> keys;
+  for (auto const token : SplitAndTrim(policy, value))
+    keys.push_back(TokenKey(policy, token));
+  return keys;
+}
+
+/// @returns @a raw with the tokens the user took away removed and the ones they added appended. The
+/// journal has no per-token entries, so the delta is derived: what @a base holds and @a newValue does
+/// not is gone, what @a newValue holds and @a base does not is new. A token nobody touched keeps its
+/// place and its spelling, and a token OM cannot represent is in neither set, so it survives both
+/// directions. A replaced token loses its position, which is preferable to guessing which addition
+/// belongs to which removal.
+std::string ApplyTokenDelta(FieldPolicy const & policy, std::string_view raw, std::string_view base,
+                            std::string_view newValue)
+{
+  auto const baseTokens = TokenKeys(policy, base);
+  auto const newTokens = TokenKeys(policy, newValue);
+
+  std::vector<std::string> out;
+  std::vector<std::string> present;
+  for (auto const token : SplitAndTrim(policy, raw))
+  {
+    auto key = TokenKey(policy, token);
+    if (base::IsExist(baseTokens, key) && !base::IsExist(newTokens, key))
+      continue;
+
+    out.emplace_back(token);
+    present.push_back(std::move(key));
+  }
+
+  for (auto const token : SplitAndTrim(policy, newValue))
+  {
+    auto key = TokenKey(policy, token);
+    if (base::IsExist(baseTokens, key) || base::IsExist(present, key))
+      continue;
+
+    out.emplace_back(token);
+    present.push_back(std::move(key));
+  }
+
+  // ';' is what every multi-valued OSM tag is read with, so a value that also allows ',' is written
+  // back with the one separator both sides agree on.
+  return strings::JoinStrings(out, kTokenSeparators);
+}
+
+/// Writes @a value into @a key, or removes the tag when @a value is empty.
+/// @returns true if the feature changed - a write that changes nothing is not a write, which is what
+/// makes a replay of an already uploaded edit report NothingToDo.
+bool WriteTag(XMLFeature & feature, std::string_view key, std::string_view value)
+{
+  strings::Trim(value);  // XMLFeature::SetTagValue trims as well, so compare what would be stored.
+
+  if (value.empty())
+  {
+    if (!feature.HasTag(key))
+      return false;
+
+    feature.RemoveTag(key);
+    return true;
+  }
+
+  if (feature.HasTag(key) && feature.GetTagValue(key) == value)
+    return false;
+
+  feature.SetTagValue(key, value);
+  return true;
+}
+
+/// Writes @a value into the tag @a source, or migrates it to the field's first key for an alias OM
+/// must not write back into (FieldAlias::m_migrateOnWrite). @returns true if the feature changed.
+bool WriteToSource(XMLFeature & feature, std::span<FieldAlias const> aliases, FieldAlias const & source,
+                   std::string_view value)
+{
+  if (!source.m_migrateOnWrite)
+    return WriteTag(feature, source.m_key, value);
+
+  bool changed = WriteTag(feature, source.m_key, {});
+  changed |= WriteTag(feature, aliases.front().m_key, value);
+  return changed;
+}
+
+/// @returns a value the object still states for the field - what the map can show for it after the
+/// write. Empty when no tag holds the field any more, or when what is left is not something OM can
+/// read and therefore never appears on the map.
+std::string StatedValue(XMLFeature const & feature, std::span<FieldAlias const> aliases, std::string_view journalKey)
+{
+  for (auto const & alias : aliases)
+  {
+    if (!feature.HasTag(alias.m_key))
+      continue;
+
+    auto canonical = Canonicalize(journalKey, feature.GetTagValue(alias.m_key));
+    if (!canonical.empty())
+      return canonical;
+  }
+  return {};
+}
+
+// What the generator's housenumber composition does to a write, for an object that carries the
+// components it composes from.
+struct HouseNumberWrite
+{
+  bool m_refuse = false;
+  // The halves the new value is split back into, empty unless the object states both components.
+  std::string_view m_conscriptionNumber;
+  std::string_view m_streetNumber;
+};
+
+/// Decides how @a newValue can be written as the housenumber of @a feature, given what the generator
+/// composes (osm2type.cpp): with both a conscription (or provisional) number and a street number
+/// present it overrides an addr:housenumber that holds no '/', and with one of them present it fills
+/// an empty one.
+///
+/// The components exist on the object or they do not. Where they do not, "addr:housenumber" is an
+/// ordinary literal value whatever it looks like - "2/2" and "2/a" are house numbers in their own
+/// right in Russia and elsewhere - and OM must never invent a component tag for it. Where they do,
+/// the MWM value is the composition, so the only value OM can write is one that splits back into the
+/// same two components, which are then updated with it; anything the composition would override or
+/// refill is refused instead of being silently reverted on the next import.
+///
+/// "addr:provisionalnumber" holds a conscription number that has not been assigned yet. OM neither
+/// invents nor changes one, and writing "addr:conscriptionnumber" next to it would leave the two
+/// racing for the same half of the value, so such an object is refused.
+HouseNumberWrite ClassifyHouseNumberWrite(XMLFeature const & feature, std::string_view newValue)
+{
+  bool const hasProvisionalNumber = feature.HasTag(kProvisionalNumberKey);
+  bool const hasConscriptionNumber = feature.HasTag(kConscriptionNumberKey) || hasProvisionalNumber;
+  bool const hasStreetNumber = feature.HasTag(kStreetNumberKey);
+
+  if (!hasConscriptionNumber && !hasStreetNumber)
+    return {};
+
+  if (!hasConscriptionNumber || !hasStreetNumber)
+  {
+    // One component fills an empty housenumber, so a cleared value comes straight back. The value
+    // itself is not composed, so everything else is an ordinary write, and the lone component is not
+    // OM's to complete.
+    return {.m_refuse = newValue.empty()};
+  }
+
+  if (hasProvisionalNumber)
+    return {.m_refuse = true};
+
+  // Anything that is not two halves is overridden by the composition on the next import.
+  auto const slash = newValue.find('/');
+  if (slash == std::string_view::npos || newValue.find('/', slash + 1) != std::string_view::npos)
+    return {.m_refuse = true};
+
+  auto conscriptionNumber = newValue.substr(0, slash);
+  auto streetNumber = newValue.substr(slash + 1);
+  strings::Trim(conscriptionNumber);
+  strings::Trim(streetNumber);
+  if (conscriptionNumber.empty() || streetNumber.empty())
+    return {.m_refuse = true};
+
+  return {.m_conscriptionNumber = conscriptionNumber, .m_streetNumber = streetNumber};
+}
+}  // namespace
+
+std::string Canonicalize(std::string_view journalKey, std::string_view rawValue)
+{
+  return GetFieldPolicy(journalKey).m_canonicalize(std::string{rawValue});
+}
+
+bool ValuesEquivalent(std::string_view journalKey, std::string_view a, std::string_view b)
+{
+  if (journalKey == kOpeningHoursKey)
+  {
+    osmoh::OpeningHours const lhs{a}, rhs{b};
+    // Rule order is significant in the OSM grammar, so "Sa off; Mo-Fr 8-17" is not equal to
+    // "Mo-Fr 8-17; Sa off". Reporting such a rewrite as a change is conservative and intended.
+    if (lhs.IsValid() && rhs.IsValid())
+      return lhs == rhs;
+    return a == b;
+  }
+
+  auto const canonicalA = Canonicalize(journalKey, a);
+  auto const canonicalB = Canonicalize(journalKey, b);
+  if (canonicalA == canonicalB)
+    return true;
+
+  // The value is a set of independent values, so the order the server lists them in is not a change.
+  auto const & policy = GetFieldPolicy(journalKey);
+  if (!policy.m_canonicalizeToken)
+    return false;
+
+  auto tokensA = SplitAndTrim(policy, canonicalA);
+  auto tokensB = SplitAndTrim(policy, canonicalB);
+  base::SortUnique(tokensA);
+  base::SortUnique(tokensB);
+  return tokensA == tokensB;
+}
+
+bool HasFieldPolicy(std::string_view journalKey)
+{
+  return FindFieldPolicy(journalKey) != nullptr;
+}
+
+bool HasCanonicalForm(std::string_view journalKey)
+{
+  return !GetFieldPolicy(journalKey).m_noCanonicalForm;
+}
+
+FieldWriteResult ApplyFieldEdit(XMLFeature & feature, std::string_view journalKey, std::string_view base,
+                                std::string_view newValue)
+{
+  ASSERT(!journalKey.empty(), ());
+
+  auto const & policy = GetFieldPolicy(journalKey);
+  // Every OSM key that can hold this field; the first one is where the tag is created if none does.
+  FieldAlias const journalKeyAlias{journalKey};
+  std::span<FieldAlias const> aliases{&journalKeyAlias, 1};
+  if (!policy.m_aliases.empty())
+  {
+    ASSERT_EQUAL(policy.m_aliases.front().m_key, journalKey, ("The journal names a field by the key OM creates."));
+    aliases = policy.m_aliases;
+  }
+
+  // Where this object states the field, and what it states, for the upload guard to reconcile
+  // against. Two aliases holding different values leave the guard nothing to reconcile to.
+  std::vector<FieldAlias> sources;
+  std::string serverValue;
+  bool sourcesDisagree = false;
+  for (auto const & alias : aliases)
+  {
+    if (!feature.HasTag(alias.m_key))
+      continue;
+    sources.push_back(alias);
+
+    auto canonical = Canonicalize(journalKey, feature.GetTagValue(alias.m_key));
+    if (canonical.empty())
+      continue;
+
+    if (serverValue.empty())
+      serverValue = std::move(canonical);
+    else if (!ValuesEquivalent(journalKey, serverValue, canonical))
+      sourcesDisagree = true;
+  }
+
+  // A housenumber the object composes from tags of its own is written as those tags too, or refused
+  // where the composition would take the write back. This is a fact read off the generator, not
+  // doubt, so it overrules the fallback below.
+  HouseNumberWrite composition;
+  if (journalKey == kHouseNumberKey)
+  {
+    composition = ClassifyHouseNumberWrite(feature, newValue);
+    if (composition.m_refuse)
+      return {FieldWriteStatus::Unrepresentable, std::move(serverValue)};
+  }
+
+  // The components are written with the value they were split from: leaving them behind would keep
+  // the object stating the old address, and the composition would put it back as soon as the new
+  // housenumber lost its '/'.
+  auto const writeComponents = [&feature, &composition]
+  {
+    if (composition.m_conscriptionNumber.empty())
+      return false;
+
+    ASSERT(feature.HasTag(kConscriptionNumberKey) && feature.HasTag(kStreetNumberKey),
+           ("A component is only ever updated, never invented: an object without them holds a plain "
+            "housenumber, whatever it looks like."));
+
+    bool changed = WriteTag(feature, kConscriptionNumberKey, composition.m_conscriptionNumber);
+    changed |= WriteTag(feature, kStreetNumberKey, composition.m_streetNumber);
+    return changed;
+  };
+
+  // Turns "the feature changed" into the field's verdict. A clear that another alias survives is not
+  // a plain success: OM took away what the map showed the user, and the next import shows what is
+  // left, so the caller can tell them the field did not go away.
+  auto const finish = [&](bool changed) -> FieldWriteResult
+  {
+    if (!changed)
+      return {FieldWriteStatus::NothingToDo, std::move(serverValue)};
+
+    if (newValue.empty())
+      if (auto stated = StatedValue(feature, aliases, journalKey); !stated.empty())
+        return {FieldWriteStatus::ClearedButStillStated, std::move(stated)};
+
+    return {FieldWriteStatus::Written, std::move(serverValue)};
+  };
+
+  // A replay of our own upload, or somebody who made the same edit: the object already says it.
+  // Checked before the source is located, because after a successful upload nothing holds `base` any
+  // more and the field would look like a third-party conflict forever.
+  if (!newValue.empty())
+  {
+    for (auto const & source : sources)
+      if (ValuesEquivalent(journalKey, feature.GetTagValue(source.m_key), newValue))
+        return {FieldWriteStatus::NothingToDo, std::move(serverValue)};
+  }
+  else if (sources.empty())
+  {
+    // Clearing a field the object does not state: the end state the user asked for already holds.
+    return {FieldWriteStatus::NothingToDo, {}};
+  }
+
+  // The tags that hold the value OM showed the user - the ones the generator picked, since that is
+  // where `base` came from. Empty when the user is adding where the map showed them nothing.
+  std::vector<FieldAlias> matched;
+  if (!base.empty())
+    for (auto const & source : sources)
+      if (ValuesEquivalent(journalKey, feature.GetTagValue(source.m_key), base))
+        matched.push_back(source);
+
+  if (matched.empty())
+  {
+    // Nothing holds the field: the one place where the order of the aliases decides anything.
+    if (base.empty() && sources.empty())
+    {
+      bool changed = WriteTag(feature, aliases.front().m_key, newValue);
+      changed |= writeComponents();
+      return finish(changed);
+    }
+
+    // Something holds the field and the map did not show it: OM cannot read it, or it appeared after
+    // the user's map snapshot. Where the field's values add up, a token joins the claims instead of
+    // overwriting one that was never seen; where it states one fact, the two claims are a conflict.
+    if (base.empty() && policy.m_canonicalizeToken && policy.m_additive)
+    {
+      auto const & source = sources.front();
+      auto const out = ApplyTokenDelta(policy, feature.GetTagValue(source.m_key), base, newValue);
+      return finish(WriteToSource(feature, aliases, source, out));
+    }
+
+    // The MWM value is not what a tag holds, so a missing source classifies nothing: apply the edit
+    // to the journal key, which is what the editor did for every field before source matching.
+    if (policy.m_noCanonicalForm)
+    {
+      bool changed = WriteTag(feature, journalKey, newValue);
+      changed |= writeComponents();
+      return finish(changed);
+    }
+
+    // Neither the value the user saw nor a single server value to reconcile it with.
+    if (sourcesDisagree)
+      return {FieldWriteStatus::Ambiguous, {}};
+
+    return {FieldWriteStatus::Unrepresentable, std::move(serverValue)};
+  }
+
+  // Every matching source holds exactly the value the user was editing, so the same delta applies to
+  // each of them. Updating only one would leave a stale copy that can win the next import race.
+  bool changed = writeComponents();
+  for (auto const & source : matched)
+  {
+    auto const out = policy.m_canonicalizeToken
+                       ? ApplyTokenDelta(policy, feature.GetTagValue(source.m_key), base, newValue)
+                       : std::string{newValue};
+    changed |= WriteToSource(feature, aliases, source, out);
+  }
+
+  return finish(changed);
+}
+
+std::string DebugPrint(FieldWriteStatus status)
+{
+  switch (status)
+  {
+  case FieldWriteStatus::Written: return "Written";
+  case FieldWriteStatus::NothingToDo: return "NothingToDo";
+  case FieldWriteStatus::ClearedButStillStated: return "ClearedButStillStated";
+  case FieldWriteStatus::Ambiguous: return "Ambiguous";
+  case FieldWriteStatus::Unrepresentable: return "Unrepresentable";
+  }
+  UNREACHABLE();
+}
+}  // namespace editor

--- a/libs/editor/osm_tag_policy.hpp
+++ b/libs/editor/osm_tag_policy.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace editor
+{
+class XMLFeature;
+
+// Per-field knowledge about the OSM tags the editor writes: which keys can hold a field (its
+// aliases), and how a raw OSM value maps into the MWM value domain.
+//
+// The editor's journal stores values as they appear in the MWM, which is not always what OSM holds:
+// data/replaced_tags.txt rewrites whole tags, generator/osm2type.cpp normalizes and composes some of
+// them, and generator/osm2meta.cpp strips a trailing slash from a website, turns "40'" into "12.2"
+// and drops what it cannot parse. Comparing the two domains directly reports ordinary edits as
+// third-party conflicts, so everything that has to compare them goes through Canonicalize() here.
+
+/// Maps a raw OSM value of the field named by @a journalKey into the MWM value domain: the value the
+/// map ends up showing, not the output of any single stage of the import. Idempotent. Returns an
+/// empty string for a value the map does not keep, and the value verbatim for a key with no policy
+/// entry.
+std::string Canonicalize(std::string_view journalKey, std::string_view rawValue);
+
+/// True if two raw OSM values mean the same thing for this field. opening_hours is compared
+/// semantically ("8:00" == "08:00"), a field whose value is a ';'-separated set (a phone list,
+/// cuisines) as a set, so that a reordering is not a change, and every other field as canonicalized
+/// strings.
+bool ValuesEquivalent(std::string_view journalKey, std::string_view a, std::string_view b);
+
+/// True if the field has an explicit policy entry. Every editable field must have one, otherwise
+/// its values are compared in the wrong domain - see the completeness test in editor_tests.
+bool HasFieldPolicy(std::string_view journalKey);
+
+/// True if the MWM value of the field is what a single OSM tag holds, so that Canonicalize() can map
+/// a server value into the same domain. Where it is not - a composed housenumber, a street name that
+/// comes from OM's street matching, a validator gated on the feature type - there is nothing to match
+/// an edit against, so ApplyFieldEdit() applies it instead of refusing: a difference it cannot
+/// classify is far more likely to be a formatting variant than a third-party edit.
+bool HasCanonicalForm(std::string_view journalKey);
+
+enum class FieldWriteStatus
+{
+  Written,      // a tag was added, changed or removed; the upload is worth sending
+  NothingToDo,  // the object already says what the user asked for: a replay, or an absent field cleared
+  // The field was cleared and another tag still holds a value for it - one OM never showed the user
+  // and therefore must not delete. The write went through, but the field will not look cleared: the
+  // value left behind is what the map shows on the next import.
+  ClearedButStillStated,
+  Ambiguous,        // the field's sources disagree and none of them holds the value the user saw
+  Unrepresentable,  // no tag holds the value the user saw, the write would destroy something OM never
+                    // showed, or the generator would compose the value back over it
+};
+
+struct FieldWriteResult
+{
+  FieldWriteStatus m_status = FieldWriteStatus::NothingToDo;
+  /// Canonical value of the field as the feature holds it, for the upload guard to reconcile a
+  /// conflict against - and, for ClearedButStillStated, the value the clear left behind. Empty when
+  /// the field is absent, when the sources disagree (Ambiguous), and when the value is composed
+  /// rather than held by a tag.
+  std::string m_serverValue;
+};
+
+/// Applies one field edit to @a feature by changing the tag - or the token inside a tag - that holds
+/// @a base, the value OM showed the user. Every other tag is left untouched: OM never moves a value
+/// between alias keys and never deletes an alias it did not edit. Two exceptions the import forces:
+/// an alias whose value vocabulary is not the field's is migrated to the field's own key, and a
+/// housenumber the object composes from tags of its own is written by splitting it back into the very
+/// tags it was composed from - never into tags the object does not already carry. An empty
+/// @a newValue clears the field, taking away what the user saw and leaving whatever OM's canonical
+/// view does not represent. Writes nothing and reports why when the source cannot be located, see
+/// FieldWriteStatus.
+FieldWriteResult ApplyFieldEdit(XMLFeature & feature, std::string_view journalKey, std::string_view base,
+                                std::string_view newValue);
+
+std::string DebugPrint(FieldWriteStatus status);
+}  // namespace editor

--- a/libs/editor/xml_feature.cpp
+++ b/libs/editor/xml_feature.cpp
@@ -599,41 +599,6 @@ void XMLFeature::RemoveTag(string_view key)
     GetRootNode().remove_child(tag);
 }
 
-void XMLFeature::UpdateOSMTag(std::string_view key, std::string_view value)
-{
-  if (value.empty())
-    RemoveTag(key);
-
-  else
-  {
-    // TODO(mgsergio): Get these alt tags from the config.
-    base::StringIL const alternativeTags[] = {{"phone", "contact:phone", "contact:mobile", "mobile"},
-                                              {"website", "contact:website", "url"},
-                                              {"fax", "contact:fax"},
-                                              {"email", "contact:email"}};
-
-    // Avoid duplication for similar alternative osm tags.
-    for (auto const & alt : alternativeTags)
-    {
-      auto it = alt.begin();
-      ASSERT(it != alt.end(), ());
-      if (key == *it)
-      {
-        for (auto const & tag : alt)
-        {
-          // Reuse already existing tag if it's present.
-          if (HasTag(tag))
-          {
-            SetTagValue(tag, value);
-            return;
-          }
-        }
-      }
-    }
-    SetTagValue(key, value);
-  }
-}
-
 string XMLFeature::GetAttribute(string const & key) const
 {
   return GetRootNode().attribute(key.data()).value();

--- a/libs/editor/xml_feature.hpp
+++ b/libs/editor/xml_feature.hpp
@@ -174,9 +174,6 @@ public:
   void SetTagValue(std::string_view key, std::string_view value);
   void RemoveTag(std::string_view key);
 
-  /// Wrapper for SetTagValue and RemoveTag, avoids duplication for similar alternative osm tags
-  void UpdateOSMTag(std::string_view key, std::string_view value);
-
   std::string GetAttribute(std::string const & key) const;
   void SetAttribute(std::string const & key, std::string const & value);
 

--- a/libs/indexer/edit_journal.cpp
+++ b/libs/indexer/edit_journal.cpp
@@ -112,6 +112,28 @@ std::string EditJournal::ToString(osm::JournalEntryType journalEntryType)
   UNREACHABLE();
 }
 
+std::vector<TagModData> CollapseTagChanges(std::vector<JournalEntry> const & journal)
+{
+  std::vector<TagModData> collapsed;
+  for (JournalEntry const & entry : journal)
+  {
+    if (entry.journalEntryType != JournalEntryType::TagModification)
+      continue;
+
+    TagModData const & tagModData = std::get<TagModData>(entry.data);
+    auto const it = std::find_if(collapsed.begin(), collapsed.end(),
+                                 [&tagModData](TagModData const & tag) { return tag.key == tagModData.key; });
+    if (it == collapsed.end())
+      collapsed.push_back(tagModData);
+    else
+      it->new_value = tagModData.new_value;
+  }
+
+  // A field the user brought back to the value it started with is not an edit at all.
+  std::erase_if(collapsed, [](TagModData const & tag) { return tag.old_value == tag.new_value; });
+  return collapsed;
+}
+
 std::optional<JournalEntryType> EditJournal::TypeFromString(std::string const & entryType)
 {
   if (entryType == "TagModification")

--- a/libs/indexer/edit_journal.hpp
+++ b/libs/indexer/edit_journal.hpp
@@ -83,4 +83,11 @@ public:
 
   static std::optional<JournalEntryType> TypeFromString(std::string const & entryType);
 };
+
+/// Collapses @a journal into one modification per key: the first entry's old_value, the last entry's
+/// new_value, keys that ended up where they started dropped, first-appearance order kept. The stored
+/// journal is the user's editing history and is not modified; only the upload path consumes the
+/// collapsed form, which is what makes a replayed upload see the net change instead of looking for a
+/// value an earlier entry has already replaced.
+std::vector<TagModData> CollapseTagChanges(std::vector<JournalEntry> const & journal);
 }  // namespace osm

--- a/libs/indexer/editable_map_object.cpp
+++ b/libs/indexer/editable_map_object.cpp
@@ -709,10 +709,11 @@ void EditableMapObject::LogDiffInJournal(EditableMapObject const & unedited_emo)
 
   // Address
   if (m_street.m_defaultName != unedited_emo.GetStreet().m_defaultName)
-    m_journal.AddTagChange("addr:street", unedited_emo.GetStreet().m_defaultName, m_street.m_defaultName);
+    m_journal.AddTagChange(std::string(kJournalKeyStreet), unedited_emo.GetStreet().m_defaultName,
+                           m_street.m_defaultName);
 
   if (m_houseNumber != unedited_emo.GetHouseNumber())
-    m_journal.AddTagChange("addr:housenumber", unedited_emo.GetHouseNumber(), m_houseNumber);
+    m_journal.AddTagChange(std::string(kJournalKeyHouseNumber), unedited_emo.GetHouseNumber(), m_houseNumber);
 
   // Metadata
   for (uint8_t i = 0; i < static_cast<uint8_t>(feature::Metadata::FMD_COUNT); ++i)
@@ -743,12 +744,12 @@ void EditableMapObject::LogDiffInJournal(EditableMapObject const & unedited_emo)
   std::string new_vegetarian = findAndErase(new_cuisines, "vegetarian");
   std::string old_vegetarian = findAndErase(old_cuisines, "vegetarian");
   if (new_vegetarian != old_vegetarian)
-    m_journal.AddTagChange("diet:vegetarian", old_vegetarian, new_vegetarian);
+    m_journal.AddTagChange(std::string(kJournalKeyVegetarian), old_vegetarian, new_vegetarian);
 
   std::string new_vegan = findAndErase(new_cuisines, "vegan");
   std::string old_vegan = findAndErase(old_cuisines, "vegan");
   if (new_vegan != old_vegan)
-    m_journal.AddTagChange("diet:vegan", old_vegan, new_vegan);
+    m_journal.AddTagChange(std::string(kJournalKeyVegan), old_vegan, new_vegan);
 
   bool cuisinesModified = false;
 
@@ -767,7 +768,7 @@ void EditableMapObject::LogDiffInJournal(EditableMapObject const & unedited_emo)
   }
 
   if (cuisinesModified)
-    m_journal.AddTagChange(std::string(kTagCuisine), strings::JoinStrings(old_cuisines, ";"),
+    m_journal.AddTagChange(std::string(kJournalKeyCuisine), strings::JoinStrings(old_cuisines, ";"),
                            strings::JoinStrings(new_cuisines, ";"));
 }
 

--- a/libs/indexer/editable_map_object.hpp
+++ b/libs/indexer/editable_map_object.hpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace osm
@@ -64,6 +65,20 @@ struct LocalizedStreet
 
   bool operator==(LocalizedStreet const & st) const { return m_defaultName == st.m_defaultName; }
 };
+
+/// @name Journal keys EditableMapObject::LogDiffInJournal() writes on its own, i.e. neither through
+/// feature::Metadata nor as a localized name. The editor needs a tag policy for every journal key
+/// (editor/osm_tag_policy.hpp), so a new one belongs in kDirectJournalKeys too.
+//@{
+inline std::string_view constexpr kJournalKeyStreet = "addr:street";
+inline std::string_view constexpr kJournalKeyHouseNumber = "addr:housenumber";
+inline std::string_view constexpr kJournalKeyCuisine = "cuisine";
+inline std::string_view constexpr kJournalKeyVegetarian = "diet:vegetarian";
+inline std::string_view constexpr kJournalKeyVegan = "diet:vegan";
+
+inline std::string_view constexpr kDirectJournalKeys[] = {kJournalKeyStreet, kJournalKeyHouseNumber, kJournalKeyCuisine,
+                                                          kJournalKeyVegetarian, kJournalKeyVegan};
+//@}
 
 class EditableMapObject : public MapObject
 {

--- a/libs/indexer/indexer_tests/CMakeLists.txt
+++ b/libs/indexer/indexer_tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SRC
   data_source_test.cpp
   drules_format_tests.cpp
   drules_selector_parser_test.cpp
+  edit_journal_test.cpp
   editable_map_object_test.cpp
   feature_covering_test.cpp
   feature_metadata_test.cpp

--- a/libs/indexer/indexer_tests/edit_journal_test.cpp
+++ b/libs/indexer/indexer_tests/edit_journal_test.cpp
@@ -1,0 +1,69 @@
+#include "testing/testing.hpp"
+
+#include "indexer/edit_journal.hpp"
+
+#include <ctime>
+#include <string>
+#include <vector>
+
+namespace edit_journal_test
+{
+using osm::CollapseTagChanges;
+using osm::EditJournal;
+using osm::JournalEntry;
+using osm::TagModData;
+
+std::vector<JournalEntry> MakeJournal(std::vector<TagModData> const & changes)
+{
+  EditJournal journal;
+  for (auto const & change : changes)
+    journal.AddTagChange(change.key, change.old_value, change.new_value);
+  return journal.GetJournal();
+}
+
+UNIT_TEST(EditJournal_CollapseTagChangesKeepsTheNetChange)
+{
+  // The upload has to apply what the user ended up with, not every step they took: the value the map
+  // showed them before the first edit, and the value they left the field at.
+  auto const collapsed =
+      CollapseTagChanges(MakeJournal({{"phone", "+1 5551111", "+1 5552222"}, {"phone", "+1 5552222", "+1 5553333"}}));
+
+  TEST_EQUAL(collapsed.size(), 1, ());
+  TEST_EQUAL(collapsed[0].key, "phone", ());
+  TEST_EQUAL(collapsed[0].old_value, "+1 5551111", ());
+  TEST_EQUAL(collapsed[0].new_value, "+1 5553333", ());
+}
+
+UNIT_TEST(EditJournal_CollapseTagChangesDropsAnUndoneEdit)
+{
+  auto const collapsed =
+      CollapseTagChanges(MakeJournal({{"phone", "+1 5551111", "+1 5552222"}, {"phone", "+1 5552222", "+1 5551111"}}));
+
+  TEST(collapsed.empty(), ("A field left as it was found is not an edit."));
+}
+
+UNIT_TEST(EditJournal_CollapseTagChangesKeepsFirstAppearanceOrder)
+{
+  auto const collapsed = CollapseTagChanges(MakeJournal(
+      {{"phone", "+1 5551111", "+1 5552222"}, {"website", "a.com", "b.com"}, {"phone", "+1 5552222", "+1 5553333"}}));
+
+  TEST_EQUAL(collapsed.size(), 2, ());
+  TEST_EQUAL(collapsed[0].key, "phone", ());
+  TEST_EQUAL(collapsed[0].new_value, "+1 5553333", ());
+  TEST_EQUAL(collapsed[1].key, "website", ());
+  TEST_EQUAL(collapsed[1].new_value, "b.com", ());
+}
+
+UNIT_TEST(EditJournal_CollapseTagChangesIgnoresOtherEntries)
+{
+  EditJournal journal;
+  journal.AddJournalEntry(
+      {osm::JournalEntryType::ObjectCreated, std::time(nullptr), osm::ObjCreateData{0, feature::GeomType::Point, {}}});
+  journal.AddTagChange("phone", "", "+1 5551111");
+
+  auto const collapsed = CollapseTagChanges(journal.GetJournal());
+
+  TEST_EQUAL(collapsed.size(), 1, ());
+  TEST_EQUAL(collapsed[0].key, "phone", ());
+}
+}  // namespace edit_journal_test

--- a/xcode/editor/editor.xcodeproj/project.pbxproj
+++ b/xcode/editor/editor.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		3D489BEF1D4F67E10052AA38 /* editor_storage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D489BED1D4F67E10052AA38 /* editor_storage.cpp */; };
 		3D489BF01D4F67E10052AA38 /* editor_storage.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D489BEE1D4F67E10052AA38 /* editor_storage.hpp */; };
 		671555E820BDC5D3002BA3B4 /* osm_editor_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 671555E620BDC5D3002BA3B4 /* osm_editor_test.cpp */; };
+		AB0C0A0100000000000D0003 /* osm_tag_policy.hpp in Headers */ = {isa = PBXBuildFile; fileRef = AB0C0A0100000000000D0001 /* osm_tag_policy.hpp */; };
+		AB0C0A0100000000000D0004 /* osm_tag_policy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AB0C0A0100000000000D0002 /* osm_tag_policy.cpp */; };
+		AB0C0A0100000000000D0005 /* osm_tag_policy_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AB0C0A0100000000000D0006 /* osm_tag_policy_test.cpp */; };
 		6715560520BEC332002BA3B4 /* osm_editor.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 6715560120BEC330002BA3B4 /* osm_editor.hpp */; };
 		6715560620BEC332002BA3B4 /* edits_migration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6715560220BEC331002BA3B4 /* edits_migration.cpp */; };
 		6715560720BEC332002BA3B4 /* osm_editor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6715560320BEC331002BA3B4 /* osm_editor.cpp */; };
@@ -109,6 +112,9 @@
 		3D489BEE1D4F67E10052AA38 /* editor_storage.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = editor_storage.hpp; sourceTree = "<group>"; };
 		671555E620BDC5D3002BA3B4 /* osm_editor_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = osm_editor_test.cpp; sourceTree = "<group>"; };
 		671555E720BDC5D3002BA3B4 /* osm_editor_test.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = osm_editor_test.hpp; sourceTree = "<group>"; };
+		AB0C0A0100000000000D0001 /* osm_tag_policy.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = osm_tag_policy.hpp; sourceTree = "<group>"; };
+		AB0C0A0100000000000D0002 /* osm_tag_policy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = osm_tag_policy.cpp; sourceTree = "<group>"; };
+		AB0C0A0100000000000D0006 /* osm_tag_policy_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = osm_tag_policy_test.cpp; sourceTree = "<group>"; };
 		6715560120BEC330002BA3B4 /* osm_editor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = osm_editor.hpp; sourceTree = "<group>"; };
 		6715560220BEC331002BA3B4 /* edits_migration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = edits_migration.cpp; sourceTree = "<group>"; };
 		6715560320BEC331002BA3B4 /* osm_editor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = osm_editor.cpp; sourceTree = "<group>"; };
@@ -238,6 +244,8 @@
 				340C20DD1C3E4DFD00111D22 /* osm_auth.hpp */,
 				6715560320BEC331002BA3B4 /* osm_editor.cpp */,
 				6715560120BEC330002BA3B4 /* osm_editor.hpp */,
+				AB0C0A0100000000000D0002 /* osm_tag_policy.cpp */,
+				AB0C0A0100000000000D0001 /* osm_tag_policy.hpp */,
 				34FFB34A1C316A7600BFF6C3 /* server_api.cpp */,
 				34FFB34B1C316A7600BFF6C3 /* server_api.hpp */,
 				341138761C15AE42002E3B3E /* ui2oh.cpp */,
@@ -262,6 +270,7 @@
 				3496ABD41DC2034900C5DDBA /* opening_hours_ui_test.cpp */,
 				671555E620BDC5D3002BA3B4 /* osm_editor_test.cpp */,
 				671555E720BDC5D3002BA3B4 /* osm_editor_test.hpp */,
+				AB0C0A0100000000000D0006 /* osm_tag_policy_test.cpp */,
 				3496AC011DC2047D00C5DDBA /* testingmain.cpp */,
 				3496ABD61DC2034900C5DDBA /* ui2oh_test.cpp */,
 				3496ABD81DC2034900C5DDBA /* xml_feature_test.cpp */,
@@ -319,6 +328,7 @@
 				34583BC01C8854C100F94664 /* yes_no_unknown.hpp in Headers */,
 				340C20DF1C3E4DFD00111D22 /* osm_auth.hpp in Headers */,
 				6715560520BEC332002BA3B4 /* osm_editor.hpp in Headers */,
+				AB0C0A0100000000000D0003 /* osm_tag_policy.hpp in Headers */,
 				3D3058751D707DBE004AC712 /* config_loader.hpp in Headers */,
 				34527C521C89B1770015050E /* editor_config.hpp in Headers */,
 				675B562820D2706000A521D2 /* editable_feature_source.hpp in Headers */,
@@ -453,6 +463,7 @@
 				341138781C15AE42002E3B3E /* opening_hours_ui.cpp in Sources */,
 				340C20DE1C3E4DFD00111D22 /* osm_auth.cpp in Sources */,
 				6715560720BEC332002BA3B4 /* osm_editor.cpp in Sources */,
+				AB0C0A0100000000000D0004 /* osm_tag_policy.cpp in Sources */,
 				3D052488200F62EE00F24998 /* feature_matcher.cpp in Sources */,
 				3D489BEF1D4F67E10052AA38 /* editor_storage.cpp in Sources */,
 				3411387A1C15AE42002E3B3E /* ui2oh.cpp in Sources */,
@@ -473,6 +484,7 @@
 			files = (
 				3496ABE11DC2035800C5DDBA /* config_loader_test.cpp in Sources */,
 				671555E820BDC5D3002BA3B4 /* osm_editor_test.cpp in Sources */,
+				AB0C0A0100000000000D0005 /* osm_tag_policy_test.cpp in Sources */,
 				3496ABE21DC2035800C5DDBA /* editor_config_test.cpp in Sources */,
 				FACB76B826B89DF700810C9C /* feature_matcher_test.cpp in Sources */,
 				6715560A20BEF0A4002BA3B4 /* new_feature_categories_test.cpp in Sources */,

--- a/xcode/indexer/indexer.xcodeproj/project.pbxproj
+++ b/xcode/indexer/indexer.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		394E1E0B22BBB5EB00E4BC75 /* utils.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 394E1E0922BBB5EB00E4BC75 /* utils.hpp */; };
 		39F376C0207D32450058E8E0 /* cities_boundaries_serdes_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39F376BE207D32410058E8E0 /* cities_boundaries_serdes_tests.cpp */; };
 		39F376C3207D32510058E8E0 /* scale_index_reading_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39F376C1207D324E0058E8E0 /* scale_index_reading_tests.cpp */; };
+		AB0C0A0100000000000C0005 /* edit_journal_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AB0C0A0100000000000C0006 /* edit_journal_test.cpp */; };
 		3D489BC61D3D220F0052AA38 /* editable_map_object_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D489BA71D3D1F8A0052AA38 /* editable_map_object_test.cpp */; };
 		3D489BC71D3D22150052AA38 /* features_vector_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D489BA81D3D1F8A0052AA38 /* features_vector_test.cpp */; };
 		3D489BC81D3D22190052AA38 /* string_slice_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D489BA91D3D1F8A0052AA38 /* string_slice_tests.cpp */; };
@@ -243,6 +244,7 @@
 		3D452AF71EE6D9F5009EAB9B /* wheelchair_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = wheelchair_tests.cpp; sourceTree = "<group>"; };
 		3D452AF81EE6D9F5009EAB9B /* feature_names_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = feature_names_test.cpp; sourceTree = "<group>"; };
 		3D452AF91EE6D9F5009EAB9B /* centers_table_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = centers_table_test.cpp; sourceTree = "<group>"; };
+		AB0C0A0100000000000C0006 /* edit_journal_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = edit_journal_test.cpp; sourceTree = "<group>"; };
 		3D489BA71D3D1F8A0052AA38 /* editable_map_object_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = editable_map_object_test.cpp; sourceTree = "<group>"; };
 		3D489BA81D3D1F8A0052AA38 /* features_vector_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = features_vector_test.cpp; sourceTree = "<group>"; };
 		3D489BA91D3D1F8A0052AA38 /* string_slice_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_slice_tests.cpp; sourceTree = "<group>"; };
@@ -487,6 +489,7 @@
 				40DF582C2174979200E4E0FC /* classificator_tests.cpp */,
 				670C61011AB065B100C38A8C /* data_source_test.cpp */,
 				56C74C271C749E8100B71B9F /* drules_selector_parser_test.cpp */,
+				AB0C0A0100000000000C0006 /* edit_journal_test.cpp */,
 				3D489BA71D3D1F8A0052AA38 /* editable_map_object_test.cpp */,
 				56C74C281C749E8100B71B9F /* feature_metadata_test.cpp */,
 				3D452AF81EE6D9F5009EAB9B /* feature_names_test.cpp */,
@@ -901,6 +904,7 @@
 				670BAA9C1D0B06E1000302DA /* data_source_test.cpp in Sources */,
 				670BAA9B1D0B06E1000302DA /* index_builder_test.cpp in Sources */,
 				670C612C1AB0663400C38A8C /* testingmain.cpp in Sources */,
+				AB0C0A0100000000000C0005 /* edit_journal_test.cpp in Sources */,
 				3D489BC61D3D220F0052AA38 /* editable_map_object_test.cpp in Sources */,
 				670BAA8D1D0B069A000302DA /* succinct_trie_test.cpp in Sources */,
 				670BAA951D0B06E1000302DA /* cell_coverer_test.cpp in Sources */,


### PR DESCRIPTION
Stacked on #13340, which shares the generator's value formatters with the editor. Review that one first; GitHub will retarget this to `master` when it merges.

Groundwork for #13331, where Organic Maps was reverting other mappers' edits.

The editor's journal stores values as they appear in the **MWM**, which is not always what OSM holds: the generator strips a trailing slash from a website, turns `40'` into `12.2`, folds `contact:phone` into `phone`, normalizes cuisines, and drops what it cannot parse. The old writer ignored all of that and wrote the journal key with the journal value, which is how OM ended up adding a second `contact:facebook` beside an existing `facebook`, writing a landline into `mobile`, and — the reported case — stamping a user's original value back over someone else's correction.

### What changed

A per-field policy table records, for every editable field, how a raw OSM value maps into the MWM domain (using the formatters shared in #13340) and which OSM keys can hold it.

The writer becomes **source matching**: it locates the alias — or the token inside it — whose canonical value is the one the user was shown, changes only that, and leaves every other tag alone. Consequences:

- a value is updated in the key that already held it, so no duplicate contradictory tag is created;
- a tag the user never saw is never deleted;
- when nothing holds the value the user edited, the write is refused instead of overwriting — which is what stops the reverts in #13331;
- `opening_hours` is compared semantically, so `8:00` and `08:00` are not a conflict.

Composed and derived values are handled explicitly rather than guessed at. A house number built from `addr:conscriptionnumber` + `addr:streetnumber` is written back into those components when it can be, and refused when it cannot; a house number that merely *contains* a slash (`2/2`, `2/a` — ordinary in Russia, Ukraine and Poland) is an ordinary value and is never decomposed. `addr:street` comes from the matched street feature rather than the tag, so it falls back to a direct write.

**Coalesce journal entries per field before uploading.** Two edits to one field replayed sequentially made the second read the first's output as server data (`phone=+4;+3;+1`). Entries are now collapsed by key — first `old_value`, last `new_value` — before anything touches XML. The journal itself is unchanged; it stays the audit trail.

### Scope

This is the write side only. It stops the destructive part of #13331 — a replayed upload no longer overwrites a third party's value — but a replay still opens a changeset with an unchanged object (#10219), and the lost-upload-status race that causes replays in the first place (#8448) is untouched. Both are follow-ups.

### Testing

Full tree builds with unity on and off. `ctest -L omim-test` (minus the documented excludes) 36/36 on both. `generator_tests` green throughout: map output is byte-identical. 46 writer tests plus a corpus test that runs every canonicalizer over real OSM values and asserts agreement with the generator.
