### PR TITLE
[generator][indexer] Share OSM value formatters with the editor

### DIFF
--- a/generator/generator_tests/metadata_parser_test.cpp
+++ b/generator/generator_tests/metadata_parser_test.cpp
@@ -632,21 +632,6 @@ UNIT_TEST(Metadata_ValidateAndFormat_ele)
   TEST_EQUAL(tagProc.ValidateAndFormat_ele("11'4\""), "3.45", ());
 }
 
-UNIT_TEST(Metadata_ValidateAndFormat_building_levels)
-{
-  FeatureBuilderParams params;
-  MetadataTagProcessorImpl tp(params);
-  TEST_EQUAL(tp.ValidateAndFormat_building_levels("４"), "4", ());
-  TEST_EQUAL(tp.ValidateAndFormat_building_levels("４floors"), "4", ());
-  TEST_EQUAL(tp.ValidateAndFormat_building_levels("between 1 and ４"), "", ());
-  TEST_EQUAL(tp.ValidateAndFormat_building_levels("0"), "0", ("OSM has many zero-level buildings."));
-  TEST_EQUAL(tp.ValidateAndFormat_building_levels("0.0"), "0", ());
-  TEST_EQUAL(tp.ValidateAndFormat_building_levels(""), "", ());
-  TEST_EQUAL(tp.ValidateAndFormat_building_levels("Level 1"), "", ());
-  TEST_EQUAL(tp.ValidateAndFormat_building_levels("2.51"), "2.5", ());
-  TEST_EQUAL(tp.ValidateAndFormat_building_levels("250"), "", ("Too many levels."));
-}
-
 UNIT_TEST(Metadata_ValidateAndFormat_website)
 {
   FeatureBuilderParams params;
@@ -661,24 +646,4 @@ UNIT_TEST(Metadata_ValidateAndFormat_website)
   p("heritage:website", "https://whc.unesco.org/en/list/1133/");
   TEST_EQUAL(md.Get(Metadata::FMD_HERITAGE_WEBSITE), "https://whc.unesco.org/en/list/1133/", ());
   TEST(md.Get(Metadata::FMD_WEBSITE).empty(), ());
-}
-
-UNIT_TEST(Metadata_ValidateAndFormat_url)
-{
-  std::array<std::pair<char const *, char const *>, 9> constexpr kTests = {{
-      {"a.by", "a.by"},
-      {"http://test.com", "http://test.com"},
-      {"https://test.com", "https://test.com"},
-      {"test.com", "test.com"},
-      {"http://test.com/", "http://test.com"},
-      {"https://test.com/", "https://test.com"},
-      {"test.com/", "test.com"},
-      {"test.com/path", "test.com/path"},
-      {"test.com/path/", "test.com/path/"},
-  }};
-
-  FeatureBuilderParams params;
-  MetadataTagProcessorImpl tp(params);
-  for (auto const & [input, output] : kTests)
-    TEST_EQUAL(tp.ValidateAndFormat_url(input), output, ());
 }

--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -3,27 +3,22 @@
 #include "indexer/classificator.hpp"
 #include "indexer/editable_map_object.hpp"
 #include "indexer/ftypes_matcher.hpp"
+#include "indexer/osm_value_format.hpp"
 
 #include "platform/measurement_utils.hpp"
 
 #include "coding/url.hpp"
 
 #include "base/logging.hpp"
-#include "base/math.hpp"
 #include "base/string_utils.hpp"
 
 #include <algorithm>
 #include <cctype>
-#include <cmath>
-#include <cstdlib>
 #include <optional>
 
 namespace
 {
 using osm::EditableMapObject;
-
-// https://en.wikipedia.org/wiki/List_of_tallest_buildings_in_the_world
-auto constexpr kMaxBuildingLevelsInTheWorld = 167;
 
 bool IsNoNameNoAddressBuilding(FeatureParams const & params)
 {
@@ -32,32 +27,7 @@ bool IsNoNameNoAddressBuilding(FeatureParams const & params)
          params.name.IsEmpty();
 }
 
-bool Prefix2Double(std::string const & str, double & d)
-{
-  char * stop;
-  char const * s = str.c_str();
-  // TODO: Replace with a faster and locale-ignored double conversion.
-  d = std::strtod(s, &stop);
-  return (s != stop && math::is_finite(d));
-}
-
 }  // namespace
-
-std::string MetadataTagProcessorImpl::ValidateAndFormat_stars(std::string const & v)
-{
-  if (v.empty())
-    return {};
-
-  // We are accepting stars from 1 to 7.
-  if (v[0] <= '0' || v[0] > '7')
-    return {};
-
-  // Ignore numbers larger than 9.
-  if (v.size() > 1 && ::isdigit(v[1]))
-    return {};
-
-  return std::string(1, v[0]);
-}
 
 std::string MetadataTagProcessorImpl::ValidateAndFormat_operator(std::string const & v) const
 {
@@ -71,28 +41,6 @@ std::string MetadataTagProcessorImpl::ValidateAndFormat_operator(std::string con
   }
 
   return {};
-}
-
-std::string MetadataTagProcessorImpl::ValidateAndFormat_url(std::string const & v)
-{
-  // Remove the last slash if it's after the hostname to beautify URLs in the UI and save a byte of space:
-  // https://www.test.com/ => https://www.test.com
-  // www.test.com/ => www.test.com
-  // www.test.com/path => www.test.com/path
-  // www.test.com/path/ => www.test.com/path/
-  constexpr std::string_view kHttps = "https://";
-  constexpr std::string_view kHttp = "http://";
-  size_t start = 0;
-  if (v.starts_with(kHttps))
-    start = kHttps.size();
-  else if (v.starts_with(kHttp))
-    start = kHttp.size();
-  auto const first = v.find('/', start);
-  if (first == std::string::npos)
-    return v;
-  if (first + 1 == v.size())
-    return std::string{v.begin(), --v.end()};
-  return v;
 }
 
 std::string MetadataTagProcessorImpl::ValidateAndFormat_phone(std::string const & v)
@@ -166,42 +114,6 @@ std::string MetadataTagProcessorImpl::ValidateAndFormat_postcode(std::string con
 
 std::string MetadataTagProcessorImpl::ValidateAndFormat_flats(std::string const & v)
 {
-  return v;
-}
-
-std::string MetadataTagProcessorImpl::ValidateAndFormat_internet(std::string v)
-{
-  strings::AsciiToLower(v);
-  if (v == "wlan" || v == "wired" || v == "terminal" || v == "yes" || v == "no")
-    return v;
-  // Process additional top tags.
-  if (v == "free" || v == "wifi" || v == "public")
-    return "wlan";
-  return {};
-}
-
-std::string MetadataTagProcessorImpl::ValidateAndFormat_height(std::string const & v)
-{
-  return measurement_utils::OSMDistanceToMetersString(v, false /*supportZeroAndNegativeValues*/, 1);
-}
-
-std::string MetadataTagProcessorImpl::ValidateAndFormat_building_levels(std::string v)
-{
-  // Some mappers use full width unicode digits. We can handle that.
-  strings::NormalizeDigits(v);
-  // value of building_levels is only one number
-  double levels;
-  if (Prefix2Double(v, levels) && levels >= 0 && levels <= kMaxBuildingLevelsInTheWorld)
-    return strings::to_string_dac(levels, 1);
-
-  return {};
-}
-
-std::string MetadataTagProcessorImpl::ValidateAndFormat_level(std::string v)
-{
-  // Some mappers use full width unicode digits. We can handle that.
-  strings::NormalizeDigits(v);
-  // value of level can be more than one number, so e.g. "1;2" or "3-5"
   return v;
 }
 
@@ -301,30 +213,6 @@ std::string MetadataTagProcessorImpl::ValidateAndFormat_capacity(std::string con
 std::string MetadataTagProcessorImpl::ValidateAndFormat_local_ref(std::string const & v)
 {
   return v;
-}
-
-std::string MetadataTagProcessorImpl::ValidateAndFormat_drive_through(std::string v)
-{
-  strings::AsciiToLower(v);
-  if (v == "yes" || v == "no")
-    return v;
-  return {};
-}
-
-std::string MetadataTagProcessorImpl::ValidateAndFormat_self_service(std::string v)
-{
-  strings::AsciiToLower(v);
-  if (v == "yes" || v == "only" || v == "partially" || v == "no")
-    return v;
-  return {};
-}
-
-std::string MetadataTagProcessorImpl::ValidateAndFormat_outdoor_seating(std::string v)
-{
-  strings::AsciiToLower(v);
-  if (v == "yes" || v == "no")
-    return v;
-  return {};
 }
 
 std::string MetadataTagProcessorImpl::ValidateAndFormat_duration(std::string const & v) const
@@ -483,21 +371,21 @@ void MetadataTagProcessor::operator()(std::string const & k, std::string const &
   case Metadata::FMD_OPEN_HOURS: valid = ValidateAndFormat_opening_hours(v); break;
   case Metadata::FMD_FAX_NUMBER:  // The same validator as for phone.
   case Metadata::FMD_PHONE_NUMBER: valid = ValidateAndFormat_phone(v); break;
-  case Metadata::FMD_STARS: valid = ValidateAndFormat_stars(v); break;
+  case Metadata::FMD_STARS: valid = osm::ValidateAndFormat_stars(v); break;
   case Metadata::FMD_OPERATOR:
     if (!m_operatorF.Add(getLang()))
       return;
     valid = ValidateAndFormat_operator(v);
     break;
-  case Metadata::FMD_WEBSITE: valid = ValidateAndFormat_url(v); break;
-  case Metadata::FMD_HERITAGE_WEBSITE: valid = ValidateAndFormat_url(v); break;
-  case Metadata::FMD_WEBSITE_MENU: valid = ValidateAndFormat_url(v); break;
+  case Metadata::FMD_WEBSITE: valid = osm::ValidateAndFormat_url(v); break;
+  case Metadata::FMD_HERITAGE_WEBSITE: valid = osm::ValidateAndFormat_url(v); break;
+  case Metadata::FMD_WEBSITE_MENU: valid = osm::ValidateAndFormat_url(v); break;
   case Metadata::FMD_CONTACT_FACEBOOK: valid = osm::ValidateAndFormat_facebook(v); break;
   case Metadata::FMD_CONTACT_INSTAGRAM: valid = osm::ValidateAndFormat_instagram(v); break;
   case Metadata::FMD_CONTACT_TWITTER: valid = osm::ValidateAndFormat_twitter(v); break;
   case Metadata::FMD_CONTACT_VK: valid = osm::ValidateAndFormat_vk(v); break;
   case Metadata::FMD_CONTACT_LINE: valid = osm::ValidateAndFormat_contactLine(v); break;
-  case Metadata::FMD_INTERNET: valid = ValidateAndFormat_internet(v); break;
+  case Metadata::FMD_INTERNET: valid = osm::ValidateAndFormat_internet(v); break;
   case Metadata::FMD_ELE: valid = ValidateAndFormat_ele(v); break;
   case Metadata::FMD_DESTINATION: valid = ValidateAndFormat_destination(v); break;
   case Metadata::FMD_DESTINATION_REF: valid = ValidateAndFormat_destination_ref(v); break;
@@ -511,11 +399,11 @@ void MetadataTagProcessor::operator()(std::string const & k, std::string const &
   case Metadata::FMD_WIKIMEDIA_COMMONS: valid = ValidateAndFormat_wikimedia_commons(v); break;
   case Metadata::FMD_FLATS: valid = ValidateAndFormat_flats(v); break;
   case Metadata::FMD_MIN_HEIGHT:  // The same validator as for height.
-  case Metadata::FMD_HEIGHT: valid = ValidateAndFormat_height(v); break;
+  case Metadata::FMD_HEIGHT: valid = osm::ValidateAndFormat_height(v); break;
   case Metadata::FMD_DENOMINATION: valid = ValidateAndFormat_denomination(v); break;
   case Metadata::FMD_BUILDING_MIN_LEVEL:  // The same validator as for building_levels.
-  case Metadata::FMD_BUILDING_LEVELS: valid = ValidateAndFormat_building_levels(v); break;
-  case Metadata::FMD_LEVEL: valid = ValidateAndFormat_level(v); break;
+  case Metadata::FMD_BUILDING_LEVELS: valid = osm::ValidateAndFormat_building_levels(v); break;
+  case Metadata::FMD_LEVEL: valid = osm::ValidateAndFormat_level(v); break;
   case Metadata::FMD_AIRPORT_IATA: valid = ValidateAndFormat_airport_iata(v); break;
   case Metadata::FMD_BRAND:
     if (!m_brandF.Add(getLang()))
@@ -525,9 +413,9 @@ void MetadataTagProcessor::operator()(std::string const & k, std::string const &
   case Metadata::FMD_DURATION: valid = ValidateAndFormat_duration(v); break;
   case Metadata::FMD_CAPACITY: valid = ValidateAndFormat_capacity(v); break;
   case Metadata::FMD_LOCAL_REF: valid = ValidateAndFormat_local_ref(v); break;
-  case Metadata::FMD_DRIVE_THROUGH: valid = ValidateAndFormat_drive_through(v); break;
-  case Metadata::FMD_SELF_SERVICE: valid = ValidateAndFormat_self_service(v); break;
-  case Metadata::FMD_OUTDOOR_SEATING: valid = ValidateAndFormat_outdoor_seating(v); break;
+  case Metadata::FMD_DRIVE_THROUGH: valid = osm::ValidateAndFormat_drive_through(v); break;
+  case Metadata::FMD_SELF_SERVICE: valid = osm::ValidateAndFormat_self_service(v); break;
+  case Metadata::FMD_OUTDOOR_SEATING: valid = osm::ValidateAndFormat_outdoor_seating(v); break;
   case Metadata::FMD_NETWORK: valid = ValidateAndFormat_operator(v); break;
   // Metadata types we do not get from OSM.
   case Metadata::FMD_CUISINE:

--- a/generator/osm2meta.hpp
+++ b/generator/osm2meta.hpp
@@ -10,9 +10,7 @@ struct MetadataTagProcessorImpl
   MetadataTagProcessorImpl(FeatureBuilderParams & params) : m_params(params) {}
 
   std::string ValidateAndFormat_maxspeed(std::string const & v) const;
-  static std::string ValidateAndFormat_stars(std::string const & v);
   std::string ValidateAndFormat_operator(std::string const & v) const;
-  static std::string ValidateAndFormat_url(std::string const & v);
   static std::string ValidateAndFormat_phone(std::string const & v);
   static std::string ValidateAndFormat_opening_hours(std::string const & v);
   std::string ValidateAndFormat_ele(std::string const & v) const;
@@ -26,10 +24,6 @@ struct MetadataTagProcessorImpl
   static std::string ValidateAndFormat_email(std::string const & v);
   static std::string ValidateAndFormat_postcode(std::string const & v);
   static std::string ValidateAndFormat_flats(std::string const & v);
-  static std::string ValidateAndFormat_internet(std::string v);
-  static std::string ValidateAndFormat_height(std::string const & v);
-  static std::string ValidateAndFormat_building_levels(std::string v);
-  static std::string ValidateAndFormat_level(std::string v);
   static std::string ValidateAndFormat_denomination(std::string const & v);
   static std::string ValidateAndFormat_wikipedia(std::string v);
   static std::string ValidateAndFormat_wikimedia_commons(std::string v);
@@ -37,9 +31,6 @@ struct MetadataTagProcessorImpl
   static std::string ValidateAndFormat_brand(std::string const & v);
   std::string ValidateAndFormat_duration(std::string const & v) const;
   static std::string ValidateAndFormat_capacity(std::string const & v);
-  static std::string ValidateAndFormat_drive_through(std::string v);
-  static std::string ValidateAndFormat_self_service(std::string v);
-  static std::string ValidateAndFormat_outdoor_seating(std::string v);
 
 protected:
   FeatureBuilderParams & m_params;

--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -11,6 +11,7 @@
 #include "indexer/classificator.hpp"
 #include "indexer/feature_impl.hpp"
 #include "indexer/ftypes_matcher.hpp"
+#include "indexer/osm_value_format.hpp"
 
 #include "platform/platform.hpp"
 
@@ -869,40 +870,17 @@ void PreprocessElement(OsmElement * p, CalculateOriginFnT const & calcOrg)
   p->AddTag("_path_grade", DeterminePathGrade(p));
 
   string const kCuisineKey = "cuisine";
-  auto cuisines = p->GetTag(kCuisineKey);
+  auto const cuisines = p->GetTag(kCuisineKey);
   if (!cuisines.empty())
   {
-    strings::MakeLowerCaseInplace(cuisines);
-    strings::SimpleTokenizer iter(cuisines, ",;");
-    auto const collapse = [](char c, string & str)
-    {
-      auto const comparator = [c](char lhs, char rhs) { return lhs == rhs && lhs == c; };
-      str.erase(unique(str.begin(), str.end(), comparator), str.end());
-    };
-
     bool first = true;
-    while (iter)
+    // The editor has to normalize an edited cuisine the same way, or it cannot tell which token of
+    // the raw OSM value the user was looking at.
+    strings::Tokenize(cuisines, ",;", [&](std::string_view token)
     {
-      string normalized(*iter);
-      strings::Trim(normalized, " ");
-      collapse(' ', normalized);
-      replace(normalized.begin(), normalized.end(), ' ', '_');
-
+      auto const normalized = osm::NormalizeCuisineToken(string{token});
       if (normalized.empty())
-      {
-        ++iter;
-        continue;
-      }
-
-      // Avoid duplication for some cuisines.
-      if (normalized == "bbq" || normalized == "barbeque")
-        normalized = "barbecue";
-      else if (normalized == "doughnut")
-        normalized = "donut";
-      else if (normalized == "steak")
-        normalized = "steak_house";
-      else if (normalized == "coffee")
-        normalized = "coffee_shop";
+        return;
 
       if (first)
         p->UpdateTag(kCuisineKey, normalized);
@@ -910,8 +888,7 @@ void PreprocessElement(OsmElement * p, CalculateOriginFnT const & calcOrg)
         p->AddTag(kCuisineKey, normalized);
 
       first = false;
-      ++iter;
-    }
+    });
   }
 
   string const kAerodromeTypeKey = "aerodrome:type";

--- a/libs/indexer/CMakeLists.txt
+++ b/libs/indexer/CMakeLists.txt
@@ -97,6 +97,8 @@ set(SRC
   metadata_serdes.hpp
   mwm_set.cpp
   mwm_set.hpp
+  osm_value_format.cpp
+  osm_value_format.hpp
   postcodes_matcher.cpp  # it's in indexer EditableMapObject depends on postcodes_matcher
   postcodes_matcher.hpp  # it's in indexer EditableMapObject depends on postcodes_matcher
   rank_table.cpp

--- a/libs/indexer/indexer_tests/CMakeLists.txt
+++ b/libs/indexer/indexer_tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SRC
   interval_index_test.cpp
   metadata_serdes_tests.cpp
   mwm_set_test.cpp
+  osm_value_format_tests.cpp
   postcodes_matcher_tests.cpp
   rank_table_test.cpp
   read_features_tests.cpp

--- a/libs/indexer/indexer_tests/osm_value_format_tests.cpp
+++ b/libs/indexer/indexer_tests/osm_value_format_tests.cpp
@@ -1,0 +1,64 @@
+#include "testing/testing.hpp"
+
+#include "indexer/osm_value_format.hpp"
+
+#include <array>
+#include <string>
+#include <utility>
+
+UNIT_TEST(OsmValueFormat_building_levels)
+{
+  TEST_EQUAL(osm::ValidateAndFormat_building_levels("４"), "4", ());
+  TEST_EQUAL(osm::ValidateAndFormat_building_levels("４floors"), "4", ());
+  TEST_EQUAL(osm::ValidateAndFormat_building_levels("between 1 and ４"), "", ());
+  TEST_EQUAL(osm::ValidateAndFormat_building_levels("0"), "0", ("OSM has many zero-level buildings."));
+  TEST_EQUAL(osm::ValidateAndFormat_building_levels("0.0"), "0", ());
+  TEST_EQUAL(osm::ValidateAndFormat_building_levels(""), "", ());
+  TEST_EQUAL(osm::ValidateAndFormat_building_levels("Level 1"), "", ());
+  TEST_EQUAL(osm::ValidateAndFormat_building_levels("2.51"), "2.5", ());
+  TEST_EQUAL(osm::ValidateAndFormat_building_levels("250"), "", ("Too many levels."));
+}
+
+UNIT_TEST(OsmValueFormat_url)
+{
+  std::array<std::pair<char const *, char const *>, 9> constexpr kTests = {{
+      {"a.by", "a.by"},
+      {"http://test.com", "http://test.com"},
+      {"https://test.com", "https://test.com"},
+      {"test.com", "test.com"},
+      {"http://test.com/", "http://test.com"},
+      {"https://test.com/", "https://test.com"},
+      {"test.com/", "test.com"},
+      {"test.com/path", "test.com/path"},
+      {"test.com/path/", "test.com/path/"},
+  }};
+
+  for (auto const & [input, output] : kTests)
+    TEST_EQUAL(osm::ValidateAndFormat_url(input), output, ());
+}
+
+UNIT_TEST(OsmValueFormat_stars)
+{
+  TEST_EQUAL(osm::ValidateAndFormat_stars(""), "", ());
+  TEST_EQUAL(osm::ValidateAndFormat_stars("0"), "", ());
+  TEST_EQUAL(osm::ValidateAndFormat_stars("5"), "5", ());
+  TEST_EQUAL(osm::ValidateAndFormat_stars("7"), "7", ());
+  TEST_EQUAL(osm::ValidateAndFormat_stars("8"), "", ());
+  TEST_EQUAL(osm::ValidateAndFormat_stars("55"), "", ("A second digit means a larger number."));
+  TEST_EQUAL(osm::ValidateAndFormat_stars("5S"), "5", ("Superior rating, the star count still counts."));
+  TEST_EQUAL(osm::ValidateAndFormat_stars("5\xEF\xBC\x95"), "5", ("A fullwidth digit is not a digit here."));
+}
+
+UNIT_TEST(OsmValueFormat_NormalizeCuisineToken)
+{
+  TEST_EQUAL(osm::NormalizeCuisineToken(""), "", ());
+  TEST_EQUAL(osm::NormalizeCuisineToken("   "), "", ());
+  TEST_EQUAL(osm::NormalizeCuisineToken("  Pizza  "), "pizza", ());
+  TEST_EQUAL(osm::NormalizeCuisineToken("ICE   CREAM"), "ice_cream", ());
+  TEST_EQUAL(osm::NormalizeCuisineToken("BBQ"), "barbecue", ());
+  TEST_EQUAL(osm::NormalizeCuisineToken("barbeque"), "barbecue", ());
+  TEST_EQUAL(osm::NormalizeCuisineToken("doughnut"), "donut", ());
+  TEST_EQUAL(osm::NormalizeCuisineToken("Steak"), "steak_house", ());
+  TEST_EQUAL(osm::NormalizeCuisineToken("coffee"), "coffee_shop", ());
+  TEST_EQUAL(osm::NormalizeCuisineToken(osm::NormalizeCuisineToken("  BBQ ")), "barbecue", ("Idempotent."));
+}

--- a/libs/indexer/osm_value_format.cpp
+++ b/libs/indexer/osm_value_format.cpp
@@ -1,0 +1,154 @@
+#include "indexer/osm_value_format.hpp"
+
+#include "platform/measurement_utils.hpp"
+
+#include "base/math.hpp"
+#include "base/string_utils.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <string_view>
+
+namespace osm
+{
+namespace
+{
+// https://en.wikipedia.org/wiki/List_of_tallest_buildings_in_the_world
+auto constexpr kMaxBuildingLevelsInTheWorld = 167;
+
+bool Prefix2Double(std::string const & str, double & d)
+{
+  char * stop;
+  char const * s = str.c_str();
+  // TODO: Replace with a faster and locale-ignored double conversion.
+  d = std::strtod(s, &stop);
+  return (s != stop && math::is_finite(d));
+}
+}  // namespace
+
+std::string ValidateAndFormat_stars(std::string const & v)
+{
+  if (v.empty())
+    return {};
+
+  // We are accepting stars from 1 to 7.
+  if (v[0] <= '0' || v[0] > '7')
+    return {};
+
+  // Ignore numbers larger than 9.
+  if (v.size() > 1 && '0' <= v[1] && v[1] <= '9')
+    return {};
+
+  return std::string(1, v[0]);
+}
+
+std::string ValidateAndFormat_url(std::string const & v)
+{
+  // Remove the last slash if it's after the hostname to beautify URLs in the UI and save a byte of space:
+  // https://www.test.com/ => https://www.test.com
+  // www.test.com/ => www.test.com
+  // www.test.com/path => www.test.com/path
+  // www.test.com/path/ => www.test.com/path/
+  constexpr std::string_view kHttps = "https://";
+  constexpr std::string_view kHttp = "http://";
+  size_t start = 0;
+  if (v.starts_with(kHttps))
+    start = kHttps.size();
+  else if (v.starts_with(kHttp))
+    start = kHttp.size();
+  auto const first = v.find('/', start);
+  if (first == std::string::npos)
+    return v;
+  if (first + 1 == v.size())
+    return std::string{v.begin(), --v.end()};
+  return v;
+}
+
+std::string ValidateAndFormat_internet(std::string const & v)
+{
+  std::string res = v;
+  strings::AsciiToLower(res);
+  if (res == "wlan" || res == "wired" || res == "terminal" || res == "yes" || res == "no")
+    return res;
+  // Process additional top tags.
+  if (res == "free" || res == "wifi" || res == "public")
+    return "wlan";
+  return {};
+}
+
+std::string ValidateAndFormat_height(std::string const & v)
+{
+  return measurement_utils::OSMDistanceToMetersString(v, false /*supportZeroAndNegativeValues*/, 1);
+}
+
+std::string ValidateAndFormat_building_levels(std::string const & v)
+{
+  // Some mappers use full width unicode digits. We can handle that.
+  std::string res = v;
+  strings::NormalizeDigits(res);
+  // value of building_levels is only one number
+  double levels;
+  if (Prefix2Double(res, levels) && levels >= 0 && levels <= kMaxBuildingLevelsInTheWorld)
+    return strings::to_string_dac(levels, 1);
+
+  return {};
+}
+
+std::string ValidateAndFormat_level(std::string const & v)
+{
+  // Some mappers use full width unicode digits. We can handle that.
+  std::string res = v;
+  strings::NormalizeDigits(res);
+  // value of level can be more than one number, so e.g. "1;2" or "3-5"
+  return res;
+}
+
+std::string ValidateAndFormat_drive_through(std::string const & v)
+{
+  std::string res = v;
+  strings::AsciiToLower(res);
+  if (res == "yes" || res == "no")
+    return res;
+  return {};
+}
+
+std::string ValidateAndFormat_self_service(std::string const & v)
+{
+  std::string res = v;
+  strings::AsciiToLower(res);
+  if (res == "yes" || res == "only" || res == "partially" || res == "no")
+    return res;
+  return {};
+}
+
+std::string ValidateAndFormat_outdoor_seating(std::string const & v)
+{
+  std::string res = v;
+  strings::AsciiToLower(res);
+  if (res == "yes" || res == "no")
+    return res;
+  return {};
+}
+
+std::string NormalizeCuisineToken(std::string const & v)
+{
+  std::string token = v;
+  strings::MakeLowerCaseInplace(token);
+  strings::Trim(token, " ");
+  auto const isRepeatedSpace = [](char lhs, char rhs) { return lhs == rhs && lhs == ' '; };
+  token.erase(std::unique(token.begin(), token.end(), isRepeatedSpace), token.end());
+  std::replace(token.begin(), token.end(), ' ', '_');
+
+  // Avoid duplication for some cuisines.
+  if (token == "bbq" || token == "barbeque")
+    return "barbecue";
+  if (token == "doughnut")
+    return "donut";
+  if (token == "steak")
+    return "steak_house";
+  if (token == "coffee")
+    return "coffee_shop";
+
+  return token;
+}
+}  // namespace osm

--- a/libs/indexer/osm_value_format.hpp
+++ b/libs/indexer/osm_value_format.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+
+namespace osm
+{
+/// @name Pure OSM tag value formatters: a raw OSM value in, the value the map stores out.
+/// The generator applies them on import (generator/osm2meta.cpp), and anything that has to compare a
+/// raw OSM value against what the map shows - the editor, telling a third-party edit from an
+/// import-time reformatting - has to reproduce them. An empty result means the value is dropped on
+/// import. All are idempotent and share one signature, so that a caller can hold them in a table
+/// keyed by the metadata id.
+/// @note These bound what the generator stores, not what a user may type: EditableMapObject's
+/// validators for the same tags are deliberately stricter (see EditableMapObject::IsValidMetadata,
+/// e.g. building levels are 1..50 integers there and 0..167 with fractions here).
+//@{
+std::string ValidateAndFormat_stars(std::string const & v);
+/// @note Not ValidateAndFormat_website() from indexer/validate_and_format_contacts.hpp, which
+/// formats the same tag in the opposite direction: that one prepends a scheme to what a user typed,
+/// this one strips a trailing slash on import.
+std::string ValidateAndFormat_url(std::string const & v);
+std::string ValidateAndFormat_internet(std::string const & v);
+std::string ValidateAndFormat_height(std::string const & v);
+std::string ValidateAndFormat_building_levels(std::string const & v);
+std::string ValidateAndFormat_level(std::string const & v);
+std::string ValidateAndFormat_drive_through(std::string const & v);
+std::string ValidateAndFormat_self_service(std::string const & v);
+std::string ValidateAndFormat_outdoor_seating(std::string const & v);
+//@}
+
+/// One cuisine token, normalized exactly as the generator does before it looks the classifier type up
+/// (generator/osm2type.cpp): lower-cased, with repeated spaces collapsed and every space turned into
+/// an underscore, and the duplicate spellings folded ("bbq" and "barbeque" into "barbecue",
+/// "doughnut" into "donut", "steak" into "steak_house", "coffee" into "coffee_shop"). The caller
+/// splits the tag value on ',' and ';' and drops the tokens that normalize to nothing.
+std::string NormalizeCuisineToken(std::string const & v);
+}  // namespace osm

--- a/libs/indexer/validate_and_format_contacts.hpp
+++ b/libs/indexer/validate_and_format_contacts.hpp
@@ -6,6 +6,9 @@
 
 namespace osm
 {
+/// Prepends a scheme to a website a user typed. @note Not ValidateAndFormat_url() from
+/// indexer/osm_value_format.hpp, which formats the same tag in the opposite direction: that one
+/// strips a trailing slash off a raw OSM value on import.
 std::string ValidateAndFormat_website(std::string const & v);
 std::string ValidateAndFormat_facebook(std::string const & v);
 std::string ValidateAndFormat_instagram(std::string const & v);

--- a/xcode/indexer/indexer.xcodeproj/project.pbxproj
+++ b/xcode/indexer/indexer.xcodeproj/project.pbxproj
@@ -168,6 +168,8 @@
 		F6DF5F311CD0FD9A00A87154 /* categories_index.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F6DF5F301CD0FD9A00A87154 /* categories_index.hpp */; };
 		F6F1DABE1F13D8B4006A69B7 /* ftraits.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F6F1DABD1F13D8B4006A69B7 /* ftraits.hpp */; };
 		FA67C84926BB35A400B33DCA /* bounds.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40C3C090205BF9F400CED188 /* bounds.hpp */; };
+		AB0C0A0100000000000C0003 /* osm_value_format.hpp in Headers */ = {isa = PBXBuildFile; fileRef = AB0C0A0100000000000C0001 /* osm_value_format.hpp */; };
+		AB0C0A0100000000000C0004 /* osm_value_format.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AB0C0A0100000000000C0002 /* osm_value_format.cpp */; };
 		FA7F9B84273F32680093EA08 /* validate_and_format_contacts.hpp in Headers */ = {isa = PBXBuildFile; fileRef = FA7F9B82273F32680093EA08 /* validate_and_format_contacts.hpp */; };
 		FA7F9B85273F32680093EA08 /* validate_and_format_contacts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FA7F9B83273F32680093EA08 /* validate_and_format_contacts.cpp */; };
 		FACB7C0B26B9176500810C9C /* brands_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 406970A121AEF2F10024DDB2 /* brands_tests.cpp */; };
@@ -382,6 +384,8 @@
 		F6DF5F2C1CD0FC9D00A87154 /* categories_index.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = categories_index.cpp; sourceTree = "<group>"; };
 		F6DF5F301CD0FD9A00A87154 /* categories_index.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = categories_index.hpp; sourceTree = "<group>"; };
 		F6F1DABD1F13D8B4006A69B7 /* ftraits.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ftraits.hpp; sourceTree = "<group>"; };
+		AB0C0A0100000000000C0001 /* osm_value_format.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = osm_value_format.hpp; sourceTree = "<group>"; };
+		AB0C0A0100000000000C0002 /* osm_value_format.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = osm_value_format.cpp; sourceTree = "<group>"; };
 		FA7F9B82273F32680093EA08 /* validate_and_format_contacts.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = validate_and_format_contacts.hpp; sourceTree = "<group>"; };
 		FA7F9B83273F32680093EA08 /* validate_and_format_contacts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_and_format_contacts.cpp; sourceTree = "<group>"; };
 		FACB7C1A26B919AD00810C9C /* libbase.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libbase.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -632,6 +636,8 @@
 				408FE47424FEB95600F5D06D /* metadata_serdes.hpp */,
 				675340E41A3F540F00A0A8C3 /* mwm_set.cpp */,
 				675340E51A3F540F00A0A8C3 /* mwm_set.hpp */,
+				AB0C0A0100000000000C0002 /* osm_value_format.cpp */,
+				AB0C0A0100000000000C0001 /* osm_value_format.hpp */,
 				E906DE391CF44934004C4F5E /* postcodes_matcher.cpp */,
 				E906DE3A1CF44934004C4F5E /* postcodes_matcher.hpp */,
 				347F33721C454242009758CC /* rank_table.cpp */,
@@ -737,6 +743,7 @@
 				DB05F0CD1A3F540F00A0A8C3 /* drules_format.hpp in Headers */,
 				DB05F0CE1A3F540F00A0A8C3 /* drules_struct.hpp in Headers */,
 				FA7F9B84273F32680093EA08 /* validate_and_format_contacts.hpp in Headers */,
+				AB0C0A0100000000000C0003 /* osm_value_format.hpp in Headers */,
 				670C615C1AB0691900C38A8C /* features_offsets_table.hpp in Headers */,
 				6758AED41BB4413000C26E27 /* drules_selector.hpp in Headers */,
 				6753412F1A3F540F00A0A8C3 /* index_builder.hpp in Headers */,
@@ -921,6 +928,7 @@
 				675341121A3F540F00A0A8C3 /* feature_algo.cpp in Sources */,
 				675341211A3F540F00A0A8C3 /* feature_utils.cpp in Sources */,
 				FA7F9B85273F32680093EA08 /* validate_and_format_contacts.cpp in Sources */,
+				AB0C0A0100000000000C0004 /* osm_value_format.cpp in Sources */,
 				46CB685E2CBC17F2003E40AB /* edit_journal.cpp in Sources */,
 				675341231A3F540F00A0A8C3 /* feature_visibility.cpp in Sources */,
 				56C74C221C749E4700B71B9F /* search_delimiters.cpp in Sources */,


### PR DESCRIPTION
Split out of #13339 so the mechanical half can be reviewed on its own. No behaviour change.

The generator does not store an OSM tag value as it finds it: it strips a trailing slash from a website, turns `40'` into `12.2`, folds `BBQ` into `barbecue` and drops what it cannot parse. Anything that has to compare a raw OSM value against what the map shows — the editor's upload path in #13339, for one — needs the same transformation, but it lives in `MetadataTagProcessorImpl`, which the editor cannot reach and which needs a `FeatureBuilderParams` to instantiate.

### What changed

- The nine pure value formatters (`stars`, `url`, `internet`, `height`, `building_levels`, `level`, `drive_through`, `self_service`, `outdoor_seating`) move from `generator/osm2meta.{hpp,cpp}` into the new `libs/indexer/osm_value_format.{hpp,cpp}` as free functions in namespace `osm`, with one shared signature so a caller can hold them in a table.
- Cuisine token normalization moves there too, out of the loop in `generator/osm2type.cpp` that inlined it.
- The pure-formatter tests move with them into `libs/indexer/indexer_tests/osm_value_format_tests.cpp`, so `indexer` covers its own code; `generator/generator_tests/metadata_parser_test.cpp` keeps the tag-driven cases.

Only the formatters the editor has to reproduce move; the rest stay in `MetadataTagProcessorImpl`, including the ones gated on the feature type (`operator`, `ele`, `duration`, `maxspeed`, `airport_iata`), which cannot be free functions at all.

### Testing

Same code, same call sites, same results, so map output is unchanged. Full tree builds with unity on and off; `ctest -L omim-test` minus the documented excludes is green on both. `generator_tests` passing is the acceptance test.

