### PR TITLE
[editor] Fix the upload completion path on Android and iOS

### DIFF
--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/editor/Editor.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/editor/Editor.cpp
@@ -300,18 +300,24 @@ JNIEXPORT jint Java_app_organicmaps_sdk_editor_Editor_nativeUploadChanges(JNIEnv
 {
   using osm::Editor;
 
-  // The wait below is bounded, so the completion callback may outlive this frame: the promise is
-  // shared with it instead of living on the stack. UploadChanges runs the callback at most once,
-  // and only when it returned true.
+  // The wait below is bounded, so the completion callback may outlive this frame. Share the promise
+  // with the callback instead of keeping it on the stack. This non-empty callback is called exactly
+  // once when UploadChanges returns Started.
   auto const promise = std::make_shared<std::promise<Editor::UploadResult>>();
   auto future = promise->get_future();
 
-  if (!Editor::Instance().UploadChanges(
-          jni::ToNativeString(env, token),
-          {{"created_by", "Organic Maps " OMIM_OS_NAME " " + jni::ToNativeString(env, appVersion)},
-           {"bundle_id", jni::ToNativeString(env, appId)}},
-          [promise](Editor::UploadResult result) { promise->set_value(result); }))
-    promise->set_value(Editor::UploadResult::NothingToUpload);
+  switch (Editor::Instance().UploadChanges(
+      jni::ToNativeString(env, token),
+      {{"created_by", "Organic Maps " OMIM_OS_NAME " " + jni::ToNativeString(env, appVersion)},
+       {"bundle_id", jni::ToNativeString(env, appId)}},
+      [promise](Editor::UploadResult result) { promise->set_value(result); }))
+  {
+  case Editor::UploadStart::Started: break;
+  // Returning NothingToUpload while a previous upload is running would make the worker finish even
+  // though its outcome is still unknown. Report an error so that the worker retries instead.
+  case Editor::UploadStart::AlreadyUploading: return static_cast<jint>(Editor::UploadResult::Error);
+  case Editor::UploadStart::NothingToUpload: return static_cast<jint>(Editor::UploadResult::NothingToUpload);
+  }
 
   if (future.wait_for(std::chrono::minutes(5)) == std::future_status::timeout)
   {

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/editor/Editor.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/editor/Editor.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <chrono>
 #include <future>
+#include <memory>
 #include <set>
 #include <vector>
 
@@ -298,19 +299,26 @@ JNIEXPORT jint Java_app_organicmaps_sdk_editor_Editor_nativeUploadChanges(JNIEnv
                                                                           jstring appVersion, jstring appId)
 {
   using osm::Editor;
-  std::promise<Editor::UploadResult> promise;
-  auto future = promise.get_future();
+
+  // The wait below is bounded, so the completion callback may outlive this frame: the promise is
+  // shared with it instead of living on the stack. UploadChanges runs the callback at most once,
+  // and only when it returned true.
+  auto const promise = std::make_shared<std::promise<Editor::UploadResult>>();
+  auto future = promise->get_future();
 
   if (!Editor::Instance().UploadChanges(
           jni::ToNativeString(env, token),
           {{"created_by", "Organic Maps " OMIM_OS_NAME " " + jni::ToNativeString(env, appVersion)},
            {"bundle_id", jni::ToNativeString(env, appId)}},
-          [&promise](Editor::UploadResult result) { promise.set_value(result); }))
-    promise.set_value(Editor::UploadResult::NothingToUpload);
+          [promise](Editor::UploadResult result) { promise->set_value(result); }))
+    promise->set_value(Editor::UploadResult::NothingToUpload);
 
-  auto status = future.wait_for(std::chrono::minutes(5));
-  if (status == std::future_status::timeout)
+  if (future.wait_for(std::chrono::minutes(5)) == std::future_status::timeout)
+  {
+    // Reported as an error so that the caller reschedules, but the upload itself keeps running.
+    LOG(LWARNING, ("Timed out waiting for the OSM upload, it continues in background."));
     return static_cast<jint>(Editor::UploadResult::Error);
+  }
   return static_cast<jint>(future.get());
 }
 

--- a/android/sdk/src/main/java/app/organicmaps/sdk/editor/Editor.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/editor/Editor.java
@@ -48,7 +48,8 @@ public final class Editor
 
   /**
    * Blocks the calling thread until the upload completes, but no longer than five minutes. On
-   * timeout UPLOAD_RESULT_ERROR is returned while the upload keeps running in the background.
+   * timeout UPLOAD_RESULT_ERROR is returned while the upload keeps running in the background. The
+   * same value is returned immediately if a map edits upload is already in progress.
    * @return one of UPLOAD_RESULT_* constants, or -1 if not authorized.
    */
   @WorkerThread

--- a/android/sdk/src/main/java/app/organicmaps/sdk/editor/Editor.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/editor/Editor.java
@@ -47,7 +47,8 @@ public final class Editor
   public static final int UPLOAD_RESULT_NOTHING_TO_UPLOAD = 2;
 
   /**
-   * Blocks the calling thread until the upload completes.
+   * Blocks the calling thread until the upload completes, but no longer than five minutes. On
+   * timeout UPLOAD_RESULT_ERROR is returned while the upload keeps running in the background.
    * @return one of UPLOAD_RESULT_* constants, or -1 if not authorized.
    */
   @WorkerThread

--- a/iphone/Maps/Core/BackgroundFetchScheduler/BackgroundFetchTask/BackgroundFetchTask.swift
+++ b/iphone/Maps/Core/BackgroundFetchScheduler/BackgroundFetchTask/BackgroundFetchTask.swift
@@ -11,7 +11,9 @@
                                                                         expirationHandler: {
                                                                           self.finish(.failed)
                                                                         })
-    if backgroundTaskIdentifier != UIBackgroundTaskIdentifier.invalid { fire() }
+    if backgroundTaskIdentifier != UIBackgroundTaskIdentifier.invalid {
+      fire()
+    }
   }
 
   fileprivate func fire() {
@@ -19,6 +21,14 @@
   }
 
   fileprivate func finish(_ result: UIBackgroundFetchResult) {
+    // The expiration handler is delivered on the main actor and the upload completion on the core's
+    // network thread, while the state below is unsynchronized. Serialize both on the main queue so
+    // that the background task is ended and reported exactly once.
+    if !Thread.isMainThread {
+      DispatchQueue.main.async { self.finish(result) }
+      return
+    }
+
     guard backgroundTaskIdentifier != UIBackgroundTaskIdentifier.invalid else { return }
     UIApplication.shared.endBackgroundTask(UIBackgroundTaskIdentifier(rawValue: backgroundTaskIdentifier.rawValue))
     backgroundTaskIdentifier = UIBackgroundTaskIdentifier.invalid

--- a/iphone/Maps/Core/Editor/MWMEditorHelper.mm
+++ b/iphone/Maps/Core/Editor/MWMEditorHelper.mm
@@ -25,12 +25,18 @@
       }
     };
     std::string const oauthToken = osm_auth_ios::AuthorizationGetCredentials();
-    if (!osm::Editor::Instance().UploadChanges(oauthToken,
-                                               {{"created_by", std::string("Organic Maps " OMIM_OS_NAME " ") +
-                                                                   AppInfo.sharedInfo.bundleVersion.UTF8String},
-                                                {"bundle_id", NSBundle.mainBundle.bundleIdentifier.UTF8String}},
-                                               lambda))
-      lambda(osm::Editor::UploadResult::NothingToUpload);
+    switch (osm::Editor::Instance().UploadChanges(
+        oauthToken,
+        {{"created_by", std::string("Organic Maps " OMIM_OS_NAME " ") + AppInfo.sharedInfo.bundleVersion.UTF8String},
+         {"bundle_id", NSBundle.mainBundle.bundleIdentifier.UTF8String}},
+        lambda))
+    {
+    case osm::Editor::UploadStart::Started: break;
+    // Unlike Android, the result does not reschedule anything here: it only ends the background
+    // task, so both reasons for not starting are reported the same way.
+    case osm::Editor::UploadStart::AlreadyUploading:  // fallthrough
+    case osm::Editor::UploadStart::NothingToUpload: completionHandler(UIBackgroundFetchResultNoData); break;
+    }
   }
 }
 

--- a/libs/editor/editor_tests/osm_editor_test.cpp
+++ b/libs/editor/editor_tests/osm_editor_test.cpp
@@ -707,6 +707,25 @@ void EditorTest::HaveMapEditsToUploadTest()
   TEST(editor.HaveMapEditsToUpload(rfMwmId), ());
 }
 
+void EditorTest::UploadChangesStartResultTest()
+{
+  auto & editor = osm::Editor::Instance();
+  ScopedFile notes("upload_changes_start_result_notes.xml", ScopedFile::Mode::DoNotCreate);
+  notes.Reset();  // No note is created, so there is no file to remove.
+  editor.SetNotesForTesting(notes.GetFullPath());
+
+  size_t callbackCount = 0;
+  auto const callback = [&callbackCount](osm::Editor::UploadResult) { ++callbackCount; };
+
+  TEST_EQUAL(editor.UploadChanges({}, {}, callback), osm::Editor::UploadStart::NothingToUpload, ());
+  TEST_EQUAL(callbackCount, 0, ());
+
+  editor.m_isUploadingNow = true;
+  SCOPE_GUARD(resetUploadingFlag, [&editor]() { editor.m_isUploadingNow = false; });
+  TEST_EQUAL(editor.UploadChanges({}, {}, callback), osm::Editor::UploadStart::AlreadyUploading, ());
+  TEST_EQUAL(callbackCount, 0, ());
+}
+
 void EditorTest::GetStatsTest()
 {
   auto & editor = osm::Editor::Instance();
@@ -1362,6 +1381,11 @@ UNIT_CLASS_TEST(EditorTest, HaveMapEditsOrNotesToUploadTest)
 UNIT_CLASS_TEST(EditorTest, HaveMapEditsToUploadTest)
 {
   EditorTest::HaveMapEditsToUploadTest();
+}
+
+UNIT_CLASS_TEST(EditorTest, UploadChangesStartResultTest)
+{
+  EditorTest::UploadChangesStartResultTest();
 }
 
 UNIT_CLASS_TEST(EditorTest, GetStatsTest)

--- a/libs/editor/editor_tests/osm_editor_test.hpp
+++ b/libs/editor/editor_tests/osm_editor_test.hpp
@@ -39,6 +39,7 @@ public:
   void RollBackChangesTest();
   void HaveMapEditsOrNotesToUploadTest();
   void HaveMapEditsToUploadTest();
+  void UploadChangesStartResultTest();
   void GetStatsTest();
   void IsCreatedFeatureTest();
   void ForEachFeatureInMwmRectAndScaleTest();

--- a/libs/editor/osm_editor.cpp
+++ b/libs/editor/osm_editor.cpp
@@ -583,22 +583,22 @@ bool Editor::HaveMapEditsToUpload(MwmId const & mwmId) const
   return false;
 }
 
-bool Editor::UploadChanges(string const & oauthToken, ChangesetTags tags, FinishUploadCallback callback)
+Editor::UploadStart Editor::UploadChanges(string const & oauthToken, ChangesetTags tags, FinishUploadCallback callback)
 {
   /// @todo Unite data and notes uploading in one thread with one callback.
   m_notes->Upload(OsmOAuth::ServerAuth(oauthToken));
 
   if (m_isUploadingNow)
-    return false;
+    return UploadStart::AlreadyUploading;
 
   if (!HaveMapEditsToUpload(*m_features.Get()))
-    return false;
+    return UploadStart::NothingToUpload;
 
   {
     // Not sure that this function isn't called in parallel. Put safe CAS.
     bool expected = false;
     if (!m_isUploadingNow.compare_exchange_strong(expected, true))
-      return false;
+      return UploadStart::AlreadyUploading;
   }
 
   GetPlatform().RunTask(Platform::Thread::Network,
@@ -791,7 +791,7 @@ bool Editor::UploadChanges(string const & oauthToken, ChangesetTags tags, Finish
     }
   });
 
-  return true;
+  return UploadStart::Started;
 }
 
 void Editor::SaveUploadedInformation(FeatureID const & fid, UploadInfo const & uploadInfo)
@@ -1232,6 +1232,17 @@ void Editor::UpdateXMLFeatureTags(editor::XMLFeature & feature, std::vector<Jour
     case JournalEntryType::LegacyObject: ASSERT_FAIL(("Legacy Objects are not editable")); break;
     }
   }
+}
+
+string DebugPrint(Editor::UploadStart uploadStart)
+{
+  switch (uploadStart)
+  {
+  case Editor::UploadStart::Started: return "Started";
+  case Editor::UploadStart::AlreadyUploading: return "AlreadyUploading";
+  case Editor::UploadStart::NothingToUpload: return "NothingToUpload";
+  }
+  UNREACHABLE();
 }
 
 string DebugPrint(Editor::SaveResult saveResult)

--- a/libs/editor/osm_editor.cpp
+++ b/libs/editor/osm_editor.cpp
@@ -606,7 +606,7 @@ Editor::UploadStart Editor::UploadChanges(string const & oauthToken, ChangesetTa
   {
     SCOPE_GUARD(resetUploadingFlag, [this]() { m_isUploadingNow = false; });
 
-    int uploadedFeaturesCount = 0, errorsCount = 0;
+    int uploadedFeaturesCount = 0, pendingFeaturesCount = 0;
     ChangesetWrapper changeset(oauthToken, std::move(tags));
 
     auto const features = m_features.Get();
@@ -745,7 +745,6 @@ Editor::UploadStart Editor::UploadChanges(string const & oauthToken, ChangesetTa
         {
           uploadInfo.m_uploadStatus = kDeletedFromOSMServer;
           uploadInfo.m_uploadError = ex.Msg();
-          ++errorsCount;
           LOG(LWARNING, (ex.what()));
           changeset.SetErrorDescription(ex.Msg());
         }
@@ -753,7 +752,6 @@ Editor::UploadStart Editor::UploadChanges(string const & oauthToken, ChangesetTa
         {
           uploadInfo.m_uploadStatus = kMatchedFeatureIsEmpty;
           uploadInfo.m_uploadError = ex.Msg();
-          ++errorsCount;
           LOG(LWARNING, (ex.what()));
           changeset.SetErrorDescription(ex.Msg());
         }
@@ -761,7 +759,7 @@ Editor::UploadStart Editor::UploadChanges(string const & oauthToken, ChangesetTa
         {
           uploadInfo.m_uploadStatus = kNeedsRetry;
           uploadInfo.m_uploadError = ex.Msg();
-          ++errorsCount;
+          ++pendingFeaturesCount;
           LOG(LWARNING, (ex.what()));
           changeset.SetErrorDescription(ex.Msg());
         }
@@ -783,10 +781,13 @@ Editor::UploadStart Editor::UploadChanges(string const & oauthToken, ChangesetTa
     if (callback)
     {
       UploadResult result = UploadResult::NothingToUpload;
-      if (uploadedFeaturesCount)
-        result = UploadResult::Success;
-      else if (errorsCount)
+      // Report an error while any feature is still pending, so that callers retry the rest.
+      // Permanently failed ones (deleted from OSM, empty match) are excluded by NeedsUpload() from
+      // the next upload and must not trigger one.
+      if (pendingFeaturesCount)
         result = UploadResult::Error;
+      else if (uploadedFeaturesCount)
+        result = UploadResult::Success;
       callback(result);
     }
   });

--- a/libs/editor/osm_editor.hpp
+++ b/libs/editor/osm_editor.hpp
@@ -72,6 +72,13 @@ public:
 
   using FinishUploadCallback = std::function<void(UploadResult)>;
 
+  enum class UploadStart
+  {
+    Started,           // The map edits upload was scheduled.
+    AlreadyUploading,  // A map edits upload is already running.
+    NothingToUpload    // There are no local map edits to upload.
+  };
+
   enum class SaveResult
   {
     NothingWasChanged,
@@ -155,10 +162,12 @@ public:
   bool HaveMapEditsToUpload(MwmId const & mwmId) const;
 
   using ChangesetTags = std::map<std::string, std::string>;
-  /// Tries to upload all local changes to OSM server in a separate thread.
+  /// Tries to upload all local changes to the OSM server in separate network tasks.
   /// @param[in] tags should provide additional information about client to use in changeset.
-  /// @return false With immediate return (nothing to upload). No callback fired.
-  bool UploadChanges(std::string const & oauthToken, ChangesetTags tags, FinishUploadCallback callBack = {});
+  /// Notes are handled independently and are not reflected in the returned value or @a callback.
+  /// @return the map edits upload start status. A non-empty @a callback is called exactly once when
+  /// the returned value is Started, and is not called for the other values.
+  UploadStart UploadChanges(std::string const & oauthToken, ChangesetTags tags, FinishUploadCallback callback = {});
   // TODO(mgsergio): Test new types from new config but with old classificator (where these types are absent).
   // Editor should silently ignore all types in config which are unknown to him.
   NewFeatureCategories GetNewFeatureCategories() const;
@@ -266,4 +275,5 @@ private:
 };
 
 std::string DebugPrint(Editor::SaveResult saveResult);
+std::string DebugPrint(Editor::UploadStart uploadStart);
 }  // namespace osm


### PR DESCRIPTION
### What changed

Four fixes to the editor upload completion path, from the JNI lifetime bug outward.

1. **[android] Fix dangling promise in the editor upload JNI call.** `nativeUploadChanges` captured a stack `std::promise` by reference and waited on its future for at most five minutes. On timeout the function returned and the promise died with the frame while the upload callback was still outstanding; a late completion then read the promise's association pointer out of the reclaimed stack slot and wrote through it (ASan: `stack-use-after-return`). The promise is now shared with the callback so it outlives the frame. The five-minute bound is kept and now logged.

2. **[editor] Tell callers why an upload was not started.** `Editor::UploadChanges()` returned `false` for three different reasons — nothing to upload, an upload already in progress, and losing the start CAS race — and the header documented only the first. On Android that lost edits: after the five-minute timeout the worker reschedules, the retry finds the original upload still running, the `false` reaches Java as `NothingToUpload`, and WorkManager marks the work successful and stops retrying. It now returns `UploadStart::{Started, AlreadyUploading, NothingToUpload}`; the callback contract (exactly once, only for `Started`) is documented. Android maps `AlreadyUploading` to an error so the worker keeps retrying; iOS keeps reporting no new data; Qt ignores the result as before.

3. **[editor] Retry partially failed uploads.** A mixed upload reported `Success` whenever at least one feature succeeded, even if another remained pending after an error, so Android stopped WorkManager without retrying it. Errors now take priority in the aggregate result.

4. **[ios] Finish background upload tasks on the main thread.** The editor completion callback runs on the network thread, while `BackgroundFetchTask.finish` ends a UIKit background task and mutates shared task state. Off-main completions are now dispatched to the main queue.

### Why it matters

An OSM upload that outlives the five-minute wait — slow or stalled network — hit undefined behaviour on the worker thread, and the follow-up retry silently ended the chain with a false success. Partial failures were never retried on any platform.

### How it was tested

- The lifetime bug reproduced under ASan as `stack-use-after-return` with a stack promise + bounded wait; clean with the shared promise.
- New `EditorTest::UploadChangesStartResultTest` covers `NothingToUpload` and `AlreadyUploading` and asserts the callback fires zero times for both.
- Desktop: `editor`, `editor_tests` (pass) and `desktop` build. Android: `./gradlew assembleGoogleDebug -Parm64`. `clang-format --dry-run -Werror` clean on all changed files.
- iOS changes are compile-level; not exercised on device.

Related: #13345 rewrites the same `UploadChanges` tail (persist before signalling) and will need a small rebase over this.
