### PR TITLE
[editor] Send a deletion to OSM even if the feature was uploaded

### DIFF
--- a/libs/editor/editor_tests/osm_editor_test.cpp
+++ b/libs/editor/editor_tests/osm_editor_test.cpp
@@ -460,6 +460,62 @@ void EditorTest::DeleteFeatureTest()
   });
 }
 
+void EditorTest::DeleteUploadedFeatureTest()
+{
+  auto & editor = osm::Editor::Instance();
+
+  auto const mwmId = ConstructTestMwm([](TestMwmBuilder & builder)
+  { builder.Add(TestCafe(m2::PointD(1.0, 1.0), "London Cafe", "en")); });
+
+  FeatureID fid;
+  ForEachCafeAtPoint(m_dataSource, m2::PointD(1.0, 1.0), [&fid](FeatureType & ft)
+  {
+    SetBuildingLevelsToOne(ft);
+    fid = ft.GetID();
+  });
+  TEST(editor.HaveMapEditsToUpload(mwmId), ());
+
+  // Pretend that the modification was uploaded to OSM.
+  editor.SaveUploadedInformation(fid, FeatureStatus::Modified, {time(nullptr), "Uploaded", {}});
+  TEST(editor.IsFeatureUploaded(mwmId, fid.m_index), ());
+  TEST(!editor.HaveMapEditsToUpload(mwmId), ());
+
+  // Deleting an already uploaded feature is a new operation and must be uploaded too.
+  editor.DeleteFeature(fid);
+  TEST_EQUAL(editor.GetFeatureStatus(fid), FeatureStatus::Deleted, ());
+  TEST(!editor.IsFeatureUploaded(mwmId, fid.m_index), ());
+  TEST(editor.HaveMapEditsToUpload(mwmId), ());
+}
+
+void EditorTest::StaleUploadResultTest()
+{
+  auto & editor = osm::Editor::Instance();
+
+  auto const mwmId = ConstructTestMwm([](TestMwmBuilder & builder)
+  { builder.Add(TestCafe(m2::PointD(1.0, 1.0), "London Cafe", "en")); });
+
+  FeatureID fid;
+  ForEachCafeAtPoint(m_dataSource, m2::PointD(1.0, 1.0), [&fid](FeatureType & ft)
+  {
+    SetBuildingLevelsToOne(ft);
+    fid = ft.GetID();
+  });
+
+  // The feature is deleted while its modification is still being uploaded.
+  editor.DeleteFeature(fid);
+  TEST(editor.HaveMapEditsToUpload(mwmId), ());
+
+  // The modification's result must not be applied to the deletion, which was not uploaded yet.
+  editor.SaveUploadedInformation(fid, FeatureStatus::Modified, {time(nullptr), "Uploaded", {}});
+  TEST(!editor.IsFeatureUploaded(mwmId, fid.m_index), ());
+  TEST(editor.HaveMapEditsToUpload(mwmId), ());
+
+  // The deletion's own result is applied.
+  editor.SaveUploadedInformation(fid, FeatureStatus::Deleted, {time(nullptr), "Uploaded", {}});
+  TEST(editor.IsFeatureUploaded(mwmId, fid.m_index), ());
+  TEST(!editor.HaveMapEditsToUpload(mwmId), ());
+}
+
 void EditorTest::ClearAllLocalEditsTest()
 {
   auto & editor = osm::Editor::Instance();
@@ -1341,6 +1397,16 @@ UNIT_CLASS_TEST(EditorTest, IsFeatureUploadedTest)
 UNIT_CLASS_TEST(EditorTest, DeleteFeatureTest)
 {
   EditorTest::DeleteFeatureTest();
+}
+
+UNIT_CLASS_TEST(EditorTest, DeleteUploadedFeatureTest)
+{
+  EditorTest::DeleteUploadedFeatureTest();
+}
+
+UNIT_CLASS_TEST(EditorTest, StaleUploadResultTest)
+{
+  EditorTest::StaleUploadResultTest();
 }
 
 UNIT_CLASS_TEST(EditorTest, ClearAllLocalEditsTest)

--- a/libs/editor/editor_tests/osm_editor_test.hpp
+++ b/libs/editor/editor_tests/osm_editor_test.hpp
@@ -33,6 +33,8 @@ public:
   void GetFeatureStatusTest();
   void IsFeatureUploadedTest();
   void DeleteFeatureTest();
+  void DeleteUploadedFeatureTest();
+  void StaleUploadResultTest();
   void ClearAllLocalEditsTest();
   void GetFeaturesByStatusTest();
   void OnMapDeregisteredTest();

--- a/libs/editor/osm_editor.cpp
+++ b/libs/editor/osm_editor.cpp
@@ -301,22 +301,14 @@ void Editor::DeleteFeature(FeatureID const & fid)
 {
   CHECK_THREAD_CHECKER(MainThreadChecker, ());
 
-  auto editableFeatures = make_shared<FeaturesContainer>(*m_features.Get());
-
-  auto const mwm = editableFeatures->find(fid.m_mwmId);
-
-  if (mwm != editableFeatures->end())
+  // A feature created by the user is deleted by removing all traces of it.
+  if (GetFeatureStatus(fid) == FeatureStatus::Created)
   {
-    auto const f = mwm->second.find(fid.m_index);
-    // Created feature is deleted by removing all traces of it.
-    if (f != mwm->second.end() && f->second.m_status == FeatureStatus::Created)
-    {
-      mwm->second.erase(f);
-      SaveTransaction(editableFeatures);
-      return;
-    }
+    RemoveFeature(fid);
+    return;
   }
 
+  auto editableFeatures = make_shared<FeaturesContainer>(*m_features.Get());
   MarkFeatureWithStatus(*editableFeatures, fid, FeatureStatus::Deleted);
   SaveTransaction(editableFeatures);
   Invalidate();
@@ -420,9 +412,8 @@ Editor::SaveResult Editor::SaveEditedFeature(EditableMapObject const & emo)
   fti.m_modificationTimestamp = time(nullptr);
   fti.m_street = emo.GetStreet().m_defaultName;
 
-  // Reset upload status so already uploaded features can be uploaded again after modification.
-  fti.m_uploadStatus = {};
-
+  // The whole entry is replaced, so the upload state of a previous operation on the same feature
+  // is dropped and an already uploaded feature is uploaded again after it was modified.
   auto editableFeatures = make_shared<FeaturesContainer>(*features);
   (*editableFeatures)[fid.m_mwmId][fid.m_index] = std::move(fti);
 
@@ -770,10 +761,11 @@ Editor::UploadStart Editor::UploadChanges(string const & oauthToken, ChangesetTa
         /// @todo I suspect that some (last) features can be uploaded several times.
         /// UploadChanges -> async update here -> m_isUploadingNow = false, new UploadChanges,
         /// actual SaveUploadedInformation (on Gui) is called after the new upload.
-        GetPlatform().RunTask(Platform::Thread::Gui, [this, id = fti.m_object.GetID(), uploadInfo]()
+        GetPlatform().RunTask(Platform::Thread::Gui,
+                              [this, id = fti.m_object.GetID(), status = fti.m_status, uploadInfo]()
         {
           // Call Save every time we modify each feature's information.
-          SaveUploadedInformation(id, uploadInfo);
+          SaveUploadedInformation(id, status, uploadInfo);
         });
       }
     }
@@ -795,7 +787,7 @@ Editor::UploadStart Editor::UploadChanges(string const & oauthToken, ChangesetTa
   return UploadStart::Started;
 }
 
-void Editor::SaveUploadedInformation(FeatureID const & fid, UploadInfo const & uploadInfo)
+void Editor::SaveUploadedInformation(FeatureID const & fid, FeatureStatus uploadedStatus, UploadInfo const & uploadInfo)
 {
   CHECK_THREAD_CHECKER(MainThreadChecker, ());
 
@@ -812,6 +804,12 @@ void Editor::SaveUploadedInformation(FeatureID const & fid, UploadInfo const & u
     return;
 
   auto & fti = index->second;
+  // The user started a new operation on the feature (deleted it, or edited it again) while the
+  // upload was in flight. The result belongs to the previous operation: applying it would mark the
+  // new one as uploaded and it would never be sent to OSM.
+  if (fti.m_status != uploadedStatus)
+    return;
+
   fti.m_uploadAttemptTimestamp = uploadInfo.m_uploadAttemptTimestamp;
   fti.m_uploadStatus = uploadInfo.m_uploadStatus;
   fti.m_uploadError = uploadInfo.m_uploadError;
@@ -1064,19 +1062,20 @@ void Editor::MarkFeatureWithStatus(FeaturesContainer & editableFeatures, Feature
 {
   CHECK_THREAD_CHECKER(MainThreadChecker, ());
 
-  auto & fti = editableFeatures[fid.m_mwmId][fid.m_index];
-
   auto const originalObjectPtr = GetOriginalMapObject(fid);
-
   if (!originalObjectPtr)
   {
     LOG(LERROR, ("A feature with id", fid, "cannot be loaded."));
     return;
   }
 
+  // Deleting or obsoleting a feature starts a new operation on it, so nothing from a previous edit
+  // survives: a leftover "Uploaded" status would keep a deletion from ever being sent to OSM.
+  FeatureTypeInfo fti;
   fti.m_object = *originalObjectPtr;
   fti.m_status = status;
   fti.m_modificationTimestamp = time(nullptr);
+  editableFeatures[fid.m_mwmId][fid.m_index] = std::move(fti);
 }
 
 MwmSet::MwmId Editor::GetMwmIdByMapName(string const & name)

--- a/libs/editor/osm_editor.hpp
+++ b/libs/editor/osm_editor.hpp
@@ -133,7 +133,8 @@ public:
   /// @returns true if a feature was uploaded to osm.
   bool IsFeatureUploaded(MwmId const & mwmId, uint32_t index) const;
 
-  /// Marks feature as "deleted" from MwM file.
+  /// Removes a feature created by the user, or marks an existing OSM feature to be deleted on the
+  /// next upload. In both cases the feature is no longer shown on the map.
   void DeleteFeature(FeatureID const & fid);
 
   /// @returns empty object if feature wasn't edited.
@@ -191,7 +192,7 @@ private:
   struct UploadInfo
   {
     time_t m_uploadAttemptTimestamp = base::INVALID_TIME_STAMP;
-    /// Is empty if upload has never occurred or one of k* constants above otherwise.
+    /// Empty if the upload has never happened, otherwise one of the k* constants in osm_editor.cpp.
     std::string m_uploadStatus;
     std::string m_uploadError;
   };
@@ -204,7 +205,7 @@ private:
     std::string m_street;
     time_t m_modificationTimestamp = base::INVALID_TIME_STAMP;
     time_t m_uploadAttemptTimestamp = base::INVALID_TIME_STAMP;
-    /// Is empty if upload has never occurred or one of k* constants above otherwise.
+    /// Empty if the upload has never happened, otherwise one of the k* constants in osm_editor.cpp.
     std::string m_uploadStatus;
     std::string m_uploadError;
   };
@@ -230,7 +231,9 @@ private:
   /// @returns pointer to m_features[id][index] if exists, nullptr otherwise.
   static FeatureTypeInfo const * GetFeatureTypeInfo(FeaturesContainer const & features, MwmId const & mwmId,
                                                     uint32_t index);
-  void SaveUploadedInformation(FeatureID const & fid, UploadInfo const & fromUploader);
+  /// Applies the result of an upload attempt, unless a new operation has superseded the uploaded
+  /// one in the meantime.
+  void SaveUploadedInformation(FeatureID const & fid, FeatureStatus uploadedStatus, UploadInfo const & fromUploader);
 
   void MarkFeatureWithStatus(FeaturesContainer & editableFeatures, FeatureID const & fid, FeatureStatus status);
 


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #13343 — merge that one first. Resetting the upload state makes an `Obsolete` entry pending, and `UploadChanges()` skips `Obsolete` without assigning a status, so on its own this PR leaves a "place does not exist" report on a previously uploaded POI pending forever. #13343 gives those features a terminal status.

### What changed

`Editor::MarkFeatureWithStatus()` starts a new `Deleted`/`Obsolete` operation on a feature, but it mutated the existing entry in place and kept `m_uploadStatus`, `m_uploadError`, `m_uploadAttemptTimestamp` and `m_street` from the *previous* operation. It now builds a fresh `FeatureTypeInfo` and replaces the entry — the shape `SaveEditedFeature()` already had — so no field can be forgotten.

Two more fixes follow from the same invariant, *a new operation has to be uploaded on its own*:

- **A race could undo the fix.** `SaveUploadedInformation()` matched on `FeatureID` alone, so a result queued to the GUI thread was applied to whatever operation the entry held when it ran: a modification's result arriving after the user deleted that feature marked the *deletion* as uploaded. It now also takes the uploaded `FeatureStatus` and drops a superseded result.
- **The entry is inserted only after the delegate call succeeds.** Previously `editableFeatures[mwm][index]` default-inserted an `Untouched` entry before `GetOriginalMapObject()` was even called, and the early return on failure left it for `Save()` to hit `CHECK(false, ("Not edited features shouldn't be here."))`. That is reachable: `MwmSet::LockValueImpl()` returns `nullptr` on `Reader::TooManyFilesException` *without* deregistering, so the delegate can fail while `MwmId::IsAlive()` is still true.

Cleanups in the same paths: `DeleteFeature()` removes a user-created feature through `RemoveFeature()`, which also invalidates the map (the hand-rolled erase did not, so the POI stayed drawn) and drops the emptied mwm entry; `SaveEditedFeature()`'s `fti.m_uploadStatus = {}` was a no-op on a freshly constructed local, removed with its misleading comment; three stale doc comments corrected.

### Why it matters

User-visible data loss. Edit a POI, upload it, then delete it: the entry keeps `m_uploadStatus == "Uploaded"`, so `NeedsUpload()` and `HaveMapEditsToUpload()` are false and the deletion is never sent. The POI stays on OpenStreetMap forever and the user has no way to notice.

`Editor::DeleteFeature()` is reached from Qt desktop; iOS and Android reach the same helper through "place does not exist" → `MarkFeatureAsObsolete()`.

### How it was tested

- `DeleteUploadedFeatureTest` — edit a feature, mark it uploaded, delete it, assert it is pending again and no longer reported as uploaded. Verified to fail on master.
- `StaleUploadResultTest` — a `Modified` result is refused for a `Deleted` entry, the entry's own `Deleted` result is accepted. Verified to fail without the status check.
- The `Save()` crash was reproduced with a stub failing `Editor::Delegate` and confirmed gone.
- Full `cmake --build` plus `ctest -L omim-test` (documented excludes) — 36/36 passed. `clang-format --dry-run -Werror` clean.

### Not covered here

- Two successive *modifications* still share `FeatureStatus::Modified`, so a result can still be applied to the second edit. Needs the per-entry edit revision from #13345, which supersedes the status check added here.
- A created **and uploaded** feature deleted on desktop is still only erased locally and stays on OSM — the `Deleted` upload path re-reads the original through `GetOriginalMapObject()`, which fails on a created feature's fake index. Separate fix, needs its own test.
