### PR TITLE
[editor] Give features with nothing to upload a terminal status

### DIFF
--- a/libs/editor/editor_tests/osm_editor_test.cpp
+++ b/libs/editor/editor_tests/osm_editor_test.cpp
@@ -15,13 +15,20 @@
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/scales.hpp"
 
+#include "platform/gui_thread.hpp"
+#include "platform/platform.hpp"
 #include "platform/platform_tests_support/async_gui_thread.hpp"
 #include "platform/platform_tests_support/scoped_file.hpp"
 
 #include "base/logging.hpp"
 #include "base/scope_guard.hpp"
+#include "base/task_loop.hpp"
 
+#include <chrono>
+#include <future>
 #include <memory>
+#include <mutex>
+#include <vector>
 
 namespace editor
 {
@@ -105,6 +112,69 @@ public:
 private:
   OptionalSaveStorage * m_storage = new OptionalSaveStorage;
 };
+
+// Editor posts SaveUploadedInformation() to the gui thread, and it is guarded by a thread checker
+// bound to the thread that created the Editor. Collect those tasks instead of running them on a
+// worker, so that the test thread can execute them itself.
+class GuiTaskQueue : public base::TaskLoop
+{
+public:
+  PushResult Push(Task && task) override
+  {
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_tasks.emplace_back(std::move(task));
+    return {true, kNoId};
+  }
+
+  PushResult Push(Task const & task) override
+  {
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_tasks.emplace_back(task);
+    return {true, kNoId};
+  }
+
+  void RunAll()
+  {
+    std::vector<Task> tasks;
+    {
+      std::lock_guard<std::mutex> guard(m_mutex);
+      tasks.swap(m_tasks);
+    }
+    for (auto const & task : tasks)
+      task();
+  }
+
+private:
+  std::mutex m_mutex;
+  std::vector<Task> m_tasks;
+};
+
+/// Uploads pending edits and runs the resulting gui tasks on the calling thread.
+/// @note Features that produce no upload never touch the network: ChangesetWrapper creates a
+/// changeset lazily in Create()/Modify()/Delete() and only closes it if one was created.
+osm::Editor::UploadResult UploadChangesAndWait(osm::Editor & editor)
+{
+  // Pending notes are uploaded to OSM for real, so point the editor at an absent notes file.
+  // Nothing creates it: these tests upload features, not notes.
+  editor.SetNotesForTesting(GetPlatform().WritablePathForFile("test_upload_notes.xml"));
+
+  Platform::ThreadRunner const runner;
+
+  auto * queue = new GuiTaskQueue;
+  GetPlatform().SetGuiThread(std::unique_ptr<base::TaskLoop>(queue));
+  SCOPE_GUARD(resetGuiThread, []() { GetPlatform().SetGuiThread(std::make_unique<platform::GuiThread>()); });
+
+  std::promise<osm::Editor::UploadResult> promise;
+  auto future = promise.get_future();
+  TEST_EQUAL(editor.UploadChanges("dummy_token", {} /* tags */,
+                                  [&promise](osm::Editor::UploadResult result) { promise.set_value(result); }),
+             osm::Editor::UploadStart::Started, ());
+  TEST(future.wait_for(std::chrono::seconds(30)) == std::future_status::ready, ("UploadChanges() has not finished."));
+
+  auto const result = future.get();
+  queue->RunAll();
+  return result;
+}
 
 template <typename Fn>
 void ForEachCafeAtPoint(DataSource & dataSource, m2::PointD const & mercator, Fn && fn)
@@ -724,6 +794,69 @@ void EditorTest::UploadChangesStartResultTest()
   SCOPE_GUARD(resetUploadingFlag, [&editor]() { editor.m_isUploadingNow = false; });
   TEST_EQUAL(editor.UploadChanges({}, {}, callback), osm::Editor::UploadStart::AlreadyUploading, ());
   TEST_EQUAL(callbackCount, 0, ());
+}
+
+void EditorTest::UploadObsoleteFeatureTest()
+{
+  auto & editor = osm::Editor::Instance();
+  FeatureID featureId;
+
+  auto const mwmId = ConstructTestMwm([](TestMwmBuilder & builder)
+  { builder.Add(TestCafe(m2::PointD(1.0, 1.0), "London Cafe", "en")); });
+
+  // Reporting a place as non-existent marks it obsolete, see Editor::CreateNote().
+  ForEachCafeAtPoint(m_dataSource, m2::PointD(1.0, 1.0), [&editor, &featureId](FeatureType & ft)
+  {
+    featureId = ft.GetID();
+    TEST(editor.MarkFeatureAsObsolete(featureId), ());
+  });
+
+  TEST(editor.HaveMapEditsToUpload(mwmId), ());
+
+  // The note itself is uploaded separately; the obsolete feature only hides the POI locally and
+  // is never sent to OSM, so nothing was actually uploaded even though the feature now has a
+  // terminal status.
+  TEST(UploadChangesAndWait(editor) == osm::Editor::UploadResult::NothingToUpload, ());
+  TEST(!editor.HaveMapEditsToUpload(mwmId), ());
+  TEST(!editor.IsFeatureUploaded(featureId.m_mwmId, featureId.m_index), ());
+  TEST_EQUAL(editor.GetStats().m_uploadedCount, 0, ());
+
+  editor.LoadEdits();
+  TEST(!editor.HaveMapEditsToUpload(mwmId), ());
+  TEST(!editor.IsFeatureUploaded(featureId.m_mwmId, featureId.m_index), ());
+}
+
+void EditorTest::UploadInSyncFeatureTest()
+{
+  auto & editor = osm::Editor::Instance();
+  FeatureID featureId;
+
+  auto const mwmId = ConstructTestMwm([](TestMwmBuilder & builder)
+  { builder.Add(TestCafe(m2::PointD(1.0, 1.0), "London Cafe", "en")); });
+
+  // A modified feature with an empty journal is already in sync with OSM.
+  ForEachCafeAtPoint(m_dataSource, m2::PointD(1.0, 1.0), [&editor, &featureId](FeatureType & ft)
+  {
+    featureId = ft.GetID();
+    auto editableFeatures = std::make_shared<osm::Editor::FeaturesContainer>(*editor.m_features.Get());
+    editor.MarkFeatureWithStatus(*editableFeatures, featureId, FeatureStatus::Modified);
+    TEST(editor.SaveTransaction(editableFeatures), ());
+  });
+
+  TEST(editor.HaveMapEditsToUpload(mwmId), ());
+
+  // UploadChanges() reports this unexpected state with LOG(LERROR), which aborts in Debug builds.
+  base::ScopedLogAbortLevelChanger const logAbortLevel(LCRITICAL);
+
+  // Nothing is sent to OSM here either, so the result must not look like a real upload.
+  TEST(UploadChangesAndWait(editor) == osm::Editor::UploadResult::NothingToUpload, ());
+  TEST(!editor.HaveMapEditsToUpload(mwmId), ());
+  TEST(!editor.IsFeatureUploaded(featureId.m_mwmId, featureId.m_index), ());
+  TEST_EQUAL(editor.GetStats().m_uploadedCount, 0, ());
+
+  editor.LoadEdits();
+  TEST(!editor.HaveMapEditsToUpload(mwmId), ());
+  TEST(!editor.IsFeatureUploaded(featureId.m_mwmId, featureId.m_index), ());
 }
 
 void EditorTest::GetStatsTest()
@@ -1386,6 +1519,16 @@ UNIT_CLASS_TEST(EditorTest, HaveMapEditsToUploadTest)
 UNIT_CLASS_TEST(EditorTest, UploadChangesStartResultTest)
 {
   EditorTest::UploadChangesStartResultTest();
+}
+
+UNIT_CLASS_TEST(EditorTest, UploadObsoleteFeatureTest)
+{
+  EditorTest::UploadObsoleteFeatureTest();
+}
+
+UNIT_CLASS_TEST(EditorTest, UploadInSyncFeatureTest)
+{
+  EditorTest::UploadInSyncFeatureTest();
 }
 
 UNIT_CLASS_TEST(EditorTest, GetStatsTest)

--- a/libs/editor/editor_tests/osm_editor_test.hpp
+++ b/libs/editor/editor_tests/osm_editor_test.hpp
@@ -40,6 +40,8 @@ public:
   void HaveMapEditsOrNotesToUploadTest();
   void HaveMapEditsToUploadTest();
   void UploadChangesStartResultTest();
+  void UploadObsoleteFeatureTest();
+  void UploadInSyncFeatureTest();
   void GetStatsTest();
   void IsCreatedFeatureTest();
   void ForEachFeatureInMwmRectAndScaleTest();

--- a/libs/editor/osm_editor.cpp
+++ b/libs/editor/osm_editor.cpp
@@ -47,6 +47,7 @@ constexpr char const * kObsoleteSection = "obsolete";
 constexpr char const * kAddrStreetTag = "addr:street";
 
 constexpr char const * kUploaded = "Uploaded";
+constexpr char const * kNoUploadNeeded = "No upload needed";
 constexpr char const * kDeletedFromOSMServer = "Deleted from OSM by someone";
 constexpr char const * kNeedsRetry = "Needs Retry";
 constexpr char const * kMatchedFeatureIsEmpty = "Matched feature has no tags";
@@ -95,7 +96,8 @@ struct LogHelper
 
 bool NeedsUpload(string const & uploadStatus)
 {
-  return uploadStatus != kUploaded && uploadStatus != kDeletedFromOSMServer && uploadStatus != kMatchedFeatureIsEmpty;
+  return uploadStatus != kUploaded && uploadStatus != kNoUploadNeeded && uploadStatus != kDeletedFromOSMServer &&
+         uploadStatus != kMatchedFeatureIsEmpty;
 }
 
 XMLFeature GetMatchingFeatureFromOSM(osm::ChangesetWrapper & cw, osm::EditableMapObject const & o)
@@ -648,13 +650,19 @@ Editor::UploadStart Editor::UploadChanges(string const & oauthToken, ChangesetTa
 
         try
         {
+          // Obsolete and already-in-sync features below fall through to a terminal status
+          // without anything ever being sent to OSM.
+          bool sentToOsm = true;
           if (useNewEditor)
           {
             switch (fti.m_status)
             {
             case FeatureStatus::Untouched: CHECK(false, (fti.m_object)); continue;
-            case FeatureStatus::Obsolete: continue;  // Obsolete features will be deleted by OSMers.
-            case FeatureStatus::Created:             // fallthrough
+            // The "place does not exist" report is uploaded as a note, and OSMers delete the
+            // feature themselves. Nothing to upload here, but it still needs a terminal status
+            // below, otherwise it is scheduled for upload again on every backgrounding.
+            case FeatureStatus::Obsolete: sentToOsm = false; break;
+            case FeatureStatus::Created:  // fallthrough
             case FeatureStatus::Modified:
             {
               auto const & journal = fti.m_object.GetJournal().GetJournal();
@@ -720,8 +728,12 @@ Editor::UploadStart Editor::UploadChanges(string const & oauthToken, ChangesetTa
 
               case EditingLifecycle::IN_SYNC:
               {
+                // An empty journal means the feature is already in sync with OSM. Nothing to
+                // upload, but it still needs a terminal status below, otherwise it is scheduled
+                // for upload again on every backgrounding.
                 LOG(LERROR, ("IN_SYNC should not be here:", fti.m_object));
-                continue;
+                sentToOsm = false;
+                break;
               }
               }
               break;
@@ -737,9 +749,10 @@ Editor::UploadStart Editor::UploadChanges(string const & oauthToken, ChangesetTa
             }
           }
 
-          uploadInfo.m_uploadStatus = kUploaded;
+          uploadInfo.m_uploadStatus = sentToOsm ? kUploaded : kNoUploadNeeded;
           uploadInfo.m_uploadError.clear();
-          ++uploadedFeaturesCount;
+          if (sentToOsm)
+            ++uploadedFeaturesCount;
         }
         catch (ChangesetWrapper::OsmObjectWasDeletedException const & ex)
         {

--- a/libs/editor/osm_editor.hpp
+++ b/libs/editor/osm_editor.hpp
@@ -162,7 +162,7 @@ public:
   bool HaveMapEditsToUpload(MwmId const & mwmId) const;
 
   using ChangesetTags = std::map<std::string, std::string>;
-  /// Tries to upload all local changes to the OSM server in separate network tasks.
+  /// Tries to upload all local changes to the OSM server asynchronously on the network thread.
   /// @param[in] tags should provide additional information about client to use in changeset.
   /// Notes are handled independently and are not reflected in the returned value or @a callback.
   /// @return the map edits upload start status. A non-empty @a callback is called exactly once when


### PR DESCRIPTION
### What changed

`Editor::UploadChanges()` skipped `FeatureStatus::Obsolete` and `EditingLifecycle::IN_SYNC` with `continue`, bypassing upload-status persistence. Both now reach a distinct `"No upload needed"` terminal status.

`NeedsUpload()` treats that status as terminal, while `IsFeatureUploaded()` and upload statistics remain false. These paths do not call `Create()`, `Modify()`, or `Delete()`, so the lazily created `ChangesetWrapper` never opens a changeset.

Obsolete entries still receive a timestamp, allowing `Editor::LoadEdits()` to discard them after a later map update.

### Why it matters

Reporting a POI as gone marks its feature entry obsolete and uploads the report separately as an OSM note. The feature entry only hides the POI locally, but without a terminal status it remained pending forever and every backgrounding scheduled another no-op upload.

`EditingLifecycle::IN_SYNC` is the defensive counterpart for a modified feature with an empty journal. It remains logged as an error but is finalized instead of retried forever.

### How it was tested

- `UploadObsoleteFeatureTest` and `UploadInSyncFeatureTest` verify `NothingToUpload`, terminal state, zero uploaded statistics, `IsFeatureUploaded() == false`, and the same behavior after reloading edits from storage.
- The no-op paths make no network requests and create no changeset.
- ARM64 unity and non-unity `editor_tests` passed.
- `clang-format --dry-run -Werror` passed on all changed files.