### PR TITLE
[editor] Persist and finalize an upload before reporting it done

### DIFF
--- a/libs/editor/changeset_wrapper.cpp
+++ b/libs/editor/changeset_wrapper.cpp
@@ -29,6 +29,8 @@ bool OsmFeatureHasTags(pugi::xml_node const & osmFt)
   return osmFt.child("tag");
 }
 
+constexpr char const * kDefaultChangesetComment = "Editing objects with Organic Maps";
+
 std::string_view constexpr kVowels = "aeiouy";
 
 std::string_view constexpr kMainTags[] = {"amenity",   "shop",    "tourism", "historic", "craft",
@@ -101,22 +103,46 @@ namespace osm
 ChangesetWrapper::ChangesetWrapper(std::string const & keySecret, ServerApi06::KeyValueTags comments) noexcept
   : m_changesetComments(std::move(comments))
   , m_api(OsmOAuth::ServerAuth(keySecret))
-{}
+{
+  // Finish() replaces it with the detailed description. Setting it upfront leaves an interrupted
+  // upload with a labelled changeset instead of a bare one.
+  m_changesetComments.emplace("comment", kDefaultChangesetComment);
+}
 
 ChangesetWrapper::~ChangesetWrapper()
 {
-  if (m_changesetId)
+  // Best effort for early returns only, a no-op after an explicit Finish().
+  Finish();
+}
+
+void ChangesetWrapper::Finish()
+{
+  if (m_changesetId == kInvalidChangesetId)
+    return;
+
+  // Attempt everything below exactly once: a retry from the destructor would only add another
+  // network timeout to the time the upload takes to report itself finished.
+  auto const changesetId = m_changesetId;
+  m_changesetId = kInvalidChangesetId;
+
+  try
   {
-    try
-    {
-      m_changesetComments["comment"] = GetDescription();
-      m_api.UpdateChangeSet(m_changesetId, m_changesetComments);
-      m_api.CloseChangeSet(m_changesetId);
-    }
-    catch (std::exception const & ex)
-    {
-      LOG(LWARNING, (ex.what()));
-    }
+    m_changesetComments["comment"] = GetDescription();
+    m_api.UpdateChangeSet(changesetId, m_changesetComments);
+  }
+  catch (std::exception const & ex)
+  {
+    LOG(LWARNING, ("Failed to update changeset", changesetId, "description:", ex.what()));
+  }
+
+  // Close in any case: a changeset left open blocks the next one and expires only in an hour.
+  try
+  {
+    m_api.CloseChangeSet(changesetId);
+  }
+  catch (std::exception const & ex)
+  {
+    LOG(LWARNING, ("Failed to close changeset", changesetId, ":", ex.what()));
   }
 }
 

--- a/libs/editor/changeset_wrapper.hpp
+++ b/libs/editor/changeset_wrapper.hpp
@@ -55,6 +55,12 @@ public:
   /// Allows to see exception details in OSM changesets for easier debugging.
   void SetErrorDescription(std::string const & error);
 
+  /// Writes the changeset description and closes the changeset. Does not throw: a failed
+  /// description update still attempts the close. Idempotent, and a no-op when no changeset was
+  /// ever created. Call it explicitly before reporting the upload as finished; the destructor
+  /// only covers early returns.
+  void Finish();
+
 private:
   /// Unfortunately, pugi can't return xml_documents from methods.
   /// Throws exceptions from above list.

--- a/libs/editor/editor_tests/CMakeLists.txt
+++ b/libs/editor/editor_tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(editor_tests)
 
 set(SRC
+  changeset_wrapper_test.cpp
   config_loader_test.cpp
   editor_config_test.cpp
   editor_notes_test.cpp

--- a/libs/editor/editor_tests/changeset_wrapper_test.cpp
+++ b/libs/editor/editor_tests/changeset_wrapper_test.cpp
@@ -1,0 +1,16 @@
+#include "testing/testing.hpp"
+
+#include "editor/changeset_wrapper.hpp"
+
+namespace changeset_wrapper_test
+{
+// A wrapper that never opened a changeset must not contact the server, so Finish() is a no-op and
+// the destructor may call it again. Any regression here would hang or fail this test on the network.
+UNIT_TEST(ChangesetWrapper_FinishWithoutChangesetIsIdempotent)
+{
+  osm::ChangesetWrapper changeset("" /* keySecret */, {{"created_by", "Organic Maps unit test"}});
+  changeset.Finish();
+  changeset.Finish();
+  // The destructor calls Finish() once more.
+}
+}  // namespace changeset_wrapper_test

--- a/libs/editor/editor_tests/osm_editor_test.cpp
+++ b/libs/editor/editor_tests/osm_editor_test.cpp
@@ -64,12 +64,16 @@ class OptionalSaveStorage : public editor::InMemoryStorage
 public:
   void AllowSave(bool allow) { m_allowSave = allow; }
 
+  /// Number of successful writes, to check that a batch save writes exactly once.
+  size_t GetSaveCount() const { return m_saveCount; }
+
   // StorageBase overrides:
   bool Save(pugi::xml_document const & doc) override
   {
     if (!m_allowSave)
       return false;
 
+    ++m_saveCount;
     return InMemoryStorage::Save(doc);
   }
 
@@ -78,11 +82,13 @@ public:
     if (!m_allowSave)
       return false;
 
+    ++m_saveCount;
     return InMemoryStorage::Reset();
   }
 
 private:
   bool m_allowSave = true;
+  size_t m_saveCount = 0;
 };
 
 class ScopedOptionalSaveStorage
@@ -101,6 +107,7 @@ public:
   }
 
   void AllowSave(bool allow) { m_storage->AllowSave(allow); }
+  size_t GetSaveCount() const { return m_storage->GetSaveCount(); }
 
 private:
   OptionalSaveStorage * m_storage = new OptionalSaveStorage;
@@ -135,6 +142,26 @@ void SetBuildingLevels(osm::EditableMapObject & emo, std::string s)
 void SetBuildingLevelsToOne(FeatureType & ft)
 {
   EditFeature(ft, [](osm::EditableMapObject & emo) { SetBuildingLevels(emo, "1"); });
+}
+
+/// Same as SetBuildingLevelsToOne, but also fills the edit journal, which in the app is done by
+/// Framework::SaveEditedMapObject and not by the editor itself.
+void SetBuildingLevelsWithJournal(FeatureType & ft, std::string levels)
+{
+  auto & editor = osm::Editor::Instance();
+
+  osm::EditableMapObject unedited;
+  unedited.SetFromFeatureType(ft);
+  unedited.SetEditableProperties(editor.GetEditableProperties(ft));
+
+  osm::EditableMapObject emo = unedited;
+  if (auto journal = editor.GetEditedFeatureJournal(ft.GetID()))
+    emo.SetJournal(std::move(*journal));
+
+  SetBuildingLevels(emo, std::move(levels));
+  emo.LogDiffInJournal(unedited);
+
+  TEST_EQUAL(editor.SaveEditedFeature(emo), osm::Editor::SaveResult::SavedSuccessfully, ());
 }
 
 void CreateCafeAtPoint(m2::PointD const & point, MwmSet::MwmId const & mwmId, osm::EditableMapObject & emo)
@@ -1253,6 +1280,151 @@ void EditorTest::SaveTransactionTest()
   TEST(editor.m_features.Get()->empty(), ());
 }
 
+void EditorTest::SaveUploadedInformationTest()
+{
+  ScopedOptionalSaveStorage optionalSaveStorage;
+  auto & editor = osm::Editor::Instance();
+
+  auto const mwmId = BuildMwm("GB", [](TestMwmBuilder & builder)
+  {
+    builder.Add(TestCafe(m2::PointD(1.0, 1.0), "London Cafe1", "en"));
+    builder.Add(TestCafe(m2::PointD(4.0, 4.0), "London Cafe2", "en"));
+
+    builder.Add(TestPOI(m2::PointD(6.0, 6.0), "Corner Post", "default"));
+  });
+
+  ForEachCafeAtPoint(m_dataSource, m2::PointD(1.0, 1.0),
+                     [](FeatureType & ft) { SetBuildingLevelsWithJournal(ft, "1"); });
+  ForEachCafeAtPoint(m_dataSource, m2::PointD(4.0, 4.0),
+                     [](FeatureType & ft) { SetBuildingLevelsWithJournal(ft, "1"); });
+
+  std::vector<osm::Editor::FeatureUploadResult> results;
+  {
+    auto const features = editor.m_features.Get();
+    auto const & edits = features->at(mwmId);
+    TEST_EQUAL(edits.size(), 2, ());
+    for (auto const & index : edits)
+    {
+      TEST(index.second.m_uploadStatus.empty(), ());
+      TEST(!index.second.m_object.GetJournal().GetJournal().empty(), ());
+      results.push_back({FeatureID(mwmId, index.first), {time(nullptr), "Uploaded", {}}, index.second.m_editRevision});
+    }
+  }
+
+  // A refused write must leave everything pending, so that the upload is retried later.
+  optionalSaveStorage.AllowSave(false);
+  TEST(!editor.SaveUploadedInformation(results), ());
+  for (auto const & index : editor.m_features.Get()->at(mwmId))
+  {
+    TEST(index.second.m_uploadStatus.empty(), ());
+    TEST(!index.second.m_object.GetJournal().GetJournal().empty(), ());
+  }
+
+  optionalSaveStorage.AllowSave(true);
+  auto const savesBeforeBatch = optionalSaveStorage.GetSaveCount();
+  TEST(editor.SaveUploadedInformation(results), ());
+  // Two features, a single edits.xml rewrite.
+  TEST_EQUAL(optionalSaveStorage.GetSaveCount(), savesBeforeBatch + 1, ());
+
+  for (auto const & index : editor.m_features.Get()->at(mwmId))
+  {
+    TEST_EQUAL(index.second.m_uploadStatus, "Uploaded", ());
+    TEST(index.second.m_object.GetJournal().GetJournal().empty(), ());
+  }
+
+  // An upload that produced no results at all must not rewrite anything.
+  auto const savesAfterBatch = optionalSaveStorage.GetSaveCount();
+  TEST(editor.SaveUploadedInformation({}), ());
+  TEST_EQUAL(optionalSaveStorage.GetSaveCount(), savesAfterBatch, ());
+}
+
+void EditorTest::EditRevisionTest()
+{
+  auto & editor = osm::Editor::Instance();
+
+  auto const mwmId = BuildMwm("GB", [](TestMwmBuilder & builder)
+  {
+    builder.Add(TestCafe(m2::PointD(1.0, 1.0), "London Cafe1", "en"));
+    builder.Add(TestCafe(m2::PointD(4.0, 4.0), "London Cafe2", "en"));
+
+    builder.Add(TestPOI(m2::PointD(6.0, 6.0), "Corner Post", "default"));
+  });
+
+  FeatureID editedFid, deletedFid;
+  ForEachCafeAtPoint(m_dataSource, m2::PointD(1.0, 1.0), [&editedFid](FeatureType & ft)
+  {
+    editedFid = ft.GetID();
+    SetBuildingLevelsWithJournal(ft, "1");
+  });
+  ForEachCafeAtPoint(m_dataSource, m2::PointD(4.0, 4.0), [&deletedFid](FeatureType & ft)
+  {
+    deletedFid = ft.GetID();
+    SetBuildingLevelsWithJournal(ft, "1");
+  });
+
+  auto const uploadedRevision = GetEditedFeatureInfo(editedFid).m_editRevision;
+  TEST_NOT_EQUAL(uploadedRevision, 0, ("A newly created entry must carry a revision"));
+
+  // The user edits the feature while its upload is in flight.
+  ForEachCafeAtPoint(m_dataSource, m2::PointD(1.0, 1.0),
+                     [](FeatureType & ft) { SetBuildingLevelsWithJournal(ft, "3"); });
+
+  auto const editedRevision = GetEditedFeatureInfo(editedFid).m_editRevision;
+  TEST_NOT_EQUAL(editedRevision, uploadedRevision, ("An edit must bump the revision"));
+
+  // Applying the stale result would mark the newer edit as uploaded and drop its journal.
+  TEST(editor.SaveUploadedInformation({{editedFid, {time(nullptr), "Uploaded", {}}, uploadedRevision}}), ());
+  {
+    auto const fti = GetEditedFeatureInfo(editedFid);
+    TEST(fti.m_uploadStatus.empty(), ());
+    TEST(!fti.m_object.GetJournal().GetJournal().empty(), ());
+    TEST_EQUAL(fti.m_editRevision, editedRevision, ());
+  }
+
+  // A result for the current revision is applied.
+  TEST(editor.SaveUploadedInformation({{editedFid, {time(nullptr), "Uploaded", {}}, editedRevision}}), ());
+  {
+    auto const fti = GetEditedFeatureInfo(editedFid);
+    TEST_EQUAL(fti.m_uploadStatus, "Uploaded", ());
+    TEST(fti.m_object.GetJournal().GetJournal().empty(), ());
+  }
+
+  // MarkFeatureWithStatus is the only path that mutates an entry in place, so check it bumps too.
+  auto const revisionBeforeDelete = GetEditedFeatureInfo(deletedFid).m_editRevision;
+  editor.DeleteFeature(deletedFid);
+  {
+    auto const fti = GetEditedFeatureInfo(deletedFid);
+    TEST_EQUAL(fti.m_status, FeatureStatus::Deleted, ());
+    TEST_NOT_EQUAL(fti.m_editRevision, revisionBeforeDelete, ("DeleteFeature must bump the revision"));
+  }
+
+  // The result of the modification that was in flight must not mark the deletion as uploaded.
+  TEST(editor.SaveUploadedInformation({{deletedFid, {time(nullptr), "Uploaded", {}}, revisionBeforeDelete}}), ());
+  {
+    auto const fti = GetEditedFeatureInfo(deletedFid);
+    TEST(fti.m_uploadStatus.empty(), ());
+    TEST_EQUAL(fti.m_status, FeatureStatus::Deleted, ());
+  }
+
+  // LoadEdits is reachable mid-upload via OnMapRegistered and rebuilds every entry from disk.
+  // A fresh entry must not inherit a revision that an upload in flight has already captured.
+  auto const revisionBeforeReload = GetEditedFeatureInfo(deletedFid).m_editRevision;
+  TEST(editor.Save(*editor.m_features.Get()), ());
+  editor.LoadEdits();
+  TEST_EQUAL(editor.m_features.Get()->at(mwmId).size(), 2, ());
+  TEST_NOT_EQUAL(GetEditedFeatureInfo(deletedFid).m_editRevision, revisionBeforeReload,
+                 ("A reloaded entry must get a new revision"));
+}
+
+// static
+osm::Editor::FeatureTypeInfo EditorTest::GetEditedFeatureInfo(FeatureID const & fid)
+{
+  auto const features = osm::Editor::Instance().m_features.Get();
+  auto const * fti = osm::Editor::GetFeatureTypeInfo(*features, fid.m_mwmId, fid.m_index);
+  CHECK(fti, ("The editor has no entry for", fid));
+  return *fti;
+}
+
 void EditorTest::Cleanup(platform::LocalCountryFile const & map)
 {
   platform::CountryIndexes::DeleteFromDisk(map);
@@ -1421,6 +1593,16 @@ UNIT_CLASS_TEST(EditorTest, SaveEditedFeatureTest)
 UNIT_CLASS_TEST(EditorTest, SaveTransactionTest)
 {
   EditorTest::SaveTransactionTest();
+}
+
+UNIT_CLASS_TEST(EditorTest, SaveUploadedInformationTest)
+{
+  EditorTest::SaveUploadedInformationTest();
+}
+
+UNIT_CLASS_TEST(EditorTest, EditRevisionTest)
+{
+  EditorTest::EditRevisionTest();
 }
 
 UNIT_CLASS_TEST(EditorTest, LoadEditsXml)

--- a/libs/editor/editor_tests/osm_editor_test.hpp
+++ b/libs/editor/editor_tests/osm_editor_test.hpp
@@ -3,6 +3,7 @@
 #include "generator/generator_tests_support/test_mwm_builder.hpp"
 
 #include "editor/editable_data_source.hpp"
+#include "editor/osm_editor.hpp"
 
 #include "indexer/mwm_set.hpp"
 
@@ -47,9 +48,14 @@ public:
   void LoadMapEditsTest();
   void SaveEditedFeatureTest();
   void SaveTransactionTest();
+  void SaveUploadedInformationTest();
+  void EditRevisionTest();
   void LoadExistingEditsXml();
 
 private:
+  /// @returns a copy of the editor's entry for |fid|.
+  static osm::Editor::FeatureTypeInfo GetEditedFeatureInfo(FeatureID const & fid);
+
   template <typename BuildFn>
   MwmSet::MwmId ConstructTestMwm(BuildFn && fn)
   {

--- a/libs/editor/osm_editor.cpp
+++ b/libs/editor/osm_editor.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <sstream>
 
 #include <pugixml.hpp>
@@ -124,6 +125,13 @@ bool IsObsolete(editor::XMLFeature const & xml, FeatureID const & fid)
          base::TimeTToSecondsSinceEpoch(uploadTime) < GetMwmCreationTimeByMwmId(fid.m_mwmId);
 }
 }  // namespace
+
+// static
+uint64_t Editor::NextEditRevision()
+{
+  static std::atomic<uint64_t> counter{0};
+  return counter.fetch_add(1, std::memory_order_relaxed) + 1;
+}
 
 Editor::Editor() : m_configLoader(m_config)
 {
@@ -604,222 +612,265 @@ Editor::UploadStart Editor::UploadChanges(string const & oauthToken, ChangesetTa
   GetPlatform().RunTask(Platform::Thread::Network,
                         [this, oauthToken, tags = std::move(tags), callback = std::move(callback)]()
   {
-    SCOPE_GUARD(resetUploadingFlag, [this]() { m_isUploadingNow = false; });
-
+    std::vector<FeatureUploadResult> results;
     int uploadedFeaturesCount = 0, pendingFeaturesCount = 0;
-    ChangesetWrapper changeset(oauthToken, std::move(tags));
 
-    auto const features = m_features.Get();
-    LOG(LINFO, ("Features =", features->size()));
-
-    for (auto const & id : *features)
+    // The thread pool runs tasks without a try/catch of its own, so an exception escaping this
+    // lambda terminates the process without unwinding and not even a scope guard would run.
+    try
     {
-      if (!id.first.IsAlive())
-        continue;
+      ChangesetWrapper changeset(oauthToken, std::move(tags));
 
-      for (auto const & index : id.second)
+      auto const features = m_features.Get();
+      LOG(LINFO, ("Features =", features->size()));
+
+      for (auto const & id : *features)
       {
-        FeatureTypeInfo const & fti = index.second;
-        // Do not process already uploaded features or those failed permanently.
-        if (!NeedsUpload(fti.m_uploadStatus))
+        if (!id.first.IsAlive())
           continue;
 
-        // TODO(a): Use UploadInfo as part of FeatureTypeInfo.
-        UploadInfo uploadInfo = {fti.m_uploadAttemptTimestamp, fti.m_uploadStatus, fti.m_uploadError};
-
-        LOG(LDEBUG, ("Content of editJournal:\n", fti.m_object.GetJournal().JournalToString()));
-
-        // Don't use new editor for Legacy Objects
-        auto const & journalHistory = fti.m_object.GetJournal().GetJournalHistory();
-        bool const useNewEditor =
-            journalHistory.empty() || journalHistory.front().journalEntryType != JournalEntryType::LegacyObject;
-
-        auto const GetMapObject = [this](FeatureTypeInfo const & ti)
+        for (auto const & index : id.second)
         {
-          auto res = GetOriginalMapObject(ti.m_object.GetID());
-          if (!res)
+          FeatureTypeInfo const & fti = index.second;
+          // Do not process already uploaded features or those failed permanently.
+          if (!NeedsUpload(fti.m_uploadStatus))
+            continue;
+
+          // TODO(a): Use UploadInfo as part of FeatureTypeInfo.
+          UploadInfo uploadInfo = {fti.m_uploadAttemptTimestamp, fti.m_uploadStatus, fti.m_uploadError};
+
+          LOG(LDEBUG, ("Content of editJournal:\n", fti.m_object.GetJournal().JournalToString()));
+
+          // Don't use new editor for Legacy Objects
+          auto const & journalHistory = fti.m_object.GetJournal().GetJournalHistory();
+          bool const useNewEditor =
+              journalHistory.empty() || journalHistory.front().journalEntryType != JournalEntryType::LegacyObject;
+
+          auto const GetMapObject = [this](FeatureTypeInfo const & ti)
           {
-            LOG(LERROR, ("A feature:", ti.m_object, "cannot be loaded."));
-            GetPlatform().RunTask(Platform::Thread::Gui,
-                                  [this, id = ti.m_object.GetID()]() { RemoveFeatureIfExists(id); });
-          }
-          return res;
-        };
+            auto res = GetOriginalMapObject(ti.m_object.GetID());
+            if (!res)
+            {
+              LOG(LERROR, ("A feature:", ti.m_object, "cannot be loaded."));
+              GetPlatform().RunTask(Platform::Thread::Gui,
+                                    [this, id = ti.m_object.GetID()]() { RemoveFeatureIfExists(id); });
+            }
+            return res;
+          };
 
-        try
-        {
-          if (useNewEditor)
+          try
           {
-            switch (fti.m_status)
+            if (useNewEditor)
             {
-            case FeatureStatus::Untouched: CHECK(false, (fti.m_object)); continue;
-            case FeatureStatus::Obsolete: continue;  // Obsolete features will be deleted by OSMers.
-            case FeatureStatus::Created:             // fallthrough
-            case FeatureStatus::Modified:
-            {
-              auto const & journal = fti.m_object.GetJournal().GetJournal();
-
-              switch (fti.m_object.GetEditingLifecycle())
+              switch (fti.m_status)
               {
-              case EditingLifecycle::CREATED:
+              case FeatureStatus::Untouched: CHECK(false, (fti.m_object)); continue;
+              case FeatureStatus::Obsolete: continue;  // Obsolete features will be deleted by OSMers.
+              case FeatureStatus::Created:             // fallthrough
+              case FeatureStatus::Modified:
               {
-                // Generate XMLFeature for new object
-                JournalEntry const & createEntry = journal.front();
-                ASSERT(createEntry.journalEntryType == JournalEntryType::ObjectCreated,
-                       ("First item should have type ObjectCreated"));
-                ObjCreateData const & objCreateData = std::get<ObjCreateData>(createEntry.data);
-                XMLFeature feature =
-                    editor::TypeToXML(objCreateData.type, objCreateData.geomType, objCreateData.mercator);
+                auto const & journal = fti.m_object.GetJournal().GetJournal();
 
-                // Check if place already exists
-                bool mergeSameLocation = false;
-                try
+                switch (fti.m_object.GetEditingLifecycle())
                 {
-                  XMLFeature osmFeature = changeset.GetMatchingNodeFeatureFromOSM(objCreateData.mercator);
-                  if (objCreateData.mercator == osmFeature.GetMercatorCenter())
+                case EditingLifecycle::CREATED:
+                {
+                  // Generate XMLFeature for new object
+                  JournalEntry const & createEntry = journal.front();
+                  ASSERT(createEntry.journalEntryType == JournalEntryType::ObjectCreated,
+                         ("First item should have type ObjectCreated"));
+                  ObjCreateData const & objCreateData = std::get<ObjCreateData>(createEntry.data);
+                  XMLFeature feature =
+                      editor::TypeToXML(objCreateData.type, objCreateData.geomType, objCreateData.mercator);
+
+                  // Check if place already exists
+                  bool mergeSameLocation = false;
+                  try
                   {
-                    changeset.AddChangesetTag("info:merged_same_location", "yes");
-                    feature = osmFeature;
-                    mergeSameLocation = true;
+                    XMLFeature osmFeature = changeset.GetMatchingNodeFeatureFromOSM(objCreateData.mercator);
+                    if (objCreateData.mercator == osmFeature.GetMercatorCenter())
+                    {
+                      changeset.AddChangesetTag("info:merged_same_location", "yes");
+                      feature = osmFeature;
+                      mergeSameLocation = true;
+                    }
+                    else
+                    {
+                      changeset.AddChangesetTag("info:feature_close_by", "yes");
+                    }
                   }
+                  catch (ChangesetWrapper::OsmObjectWasDeletedException const &)
+                  {}
+                  catch (ChangesetWrapper::EmptyFeatureException const &)
+                  {}
+
+                  // Add tags to XMLFeature
+                  UpdateXMLFeatureTags(feature, journal);
+
+                  // Upload XMLFeature to OSM
+                  LOG(LDEBUG, ("CREATE Feature (newEditor)", feature));
+                  if (!mergeSameLocation)
+                    changeset.Create(feature);
                   else
-                  {
-                    changeset.AddChangesetTag("info:feature_close_by", "yes");
-                  }
+                    changeset.Modify(feature);
+                  break;
                 }
-                catch (ChangesetWrapper::OsmObjectWasDeletedException const &)
-                {}
-                catch (ChangesetWrapper::EmptyFeatureException const &)
-                {}
 
-                // Add tags to XMLFeature
-                UpdateXMLFeatureTags(feature, journal);
+                case EditingLifecycle::MODIFIED:
+                {
+                  // Load existing OSM object (Throws, see catch below)
+                  XMLFeature feature = GetMatchingFeatureFromOSM(changeset, fti.m_object);
 
-                // Upload XMLFeature to OSM
-                LOG(LDEBUG, ("CREATE Feature (newEditor)", feature));
-                if (!mergeSameLocation)
-                  changeset.Create(feature);
-                else
+                  // Update tags of XMLFeature
+                  UpdateXMLFeatureTags(feature, journal);
+
+                  // Upload XMLFeature to OSM
+                  LOG(LDEBUG, ("MODIFIED Feature (newEditor)", feature));
                   changeset.Modify(feature);
+                  break;
+                }
+
+                case EditingLifecycle::IN_SYNC:
+                {
+                  LOG(LERROR, ("IN_SYNC should not be here:", fti.m_object));
+                  continue;
+                }
+                }
                 break;
               }
-
-              case EditingLifecycle::MODIFIED:
+              case FeatureStatus::Deleted:
               {
-                // Load existing OSM object (Throws, see catch below)
-                XMLFeature feature = GetMatchingFeatureFromOSM(changeset, fti.m_object);
-
-                // Update tags of XMLFeature
-                UpdateXMLFeatureTags(feature, journal);
-
-                // Upload XMLFeature to OSM
-                LOG(LDEBUG, ("MODIFIED Feature (newEditor)", feature));
-                changeset.Modify(feature);
-                break;
-              }
-
-              case EditingLifecycle::IN_SYNC:
-              {
-                LOG(LERROR, ("IN_SYNC should not be here:", fti.m_object));
-                continue;
-              }
+                if (auto moPtr = GetMapObject(fti))
+                  changeset.Delete(GetMatchingFeatureFromOSM(changeset, *moPtr));
+                else
+                  continue;
               }
               break;
+              }
             }
-            case FeatureStatus::Deleted:
-            {
-              if (auto moPtr = GetMapObject(fti))
-                changeset.Delete(GetMatchingFeatureFromOSM(changeset, *moPtr));
-              else
-                continue;
-            }
-            break;
-            }
+
+            uploadInfo.m_uploadStatus = kUploaded;
+            uploadInfo.m_uploadError.clear();
+            ++uploadedFeaturesCount;
+          }
+          catch (ChangesetWrapper::OsmObjectWasDeletedException const & ex)
+          {
+            uploadInfo.m_uploadStatus = kDeletedFromOSMServer;
+            uploadInfo.m_uploadError = ex.Msg();
+            LOG(LWARNING, (ex.what()));
+            changeset.SetErrorDescription(ex.Msg());
+          }
+          catch (ChangesetWrapper::EmptyFeatureException const & ex)
+          {
+            uploadInfo.m_uploadStatus = kMatchedFeatureIsEmpty;
+            uploadInfo.m_uploadError = ex.Msg();
+            LOG(LWARNING, (ex.what()));
+            changeset.SetErrorDescription(ex.Msg());
+          }
+          catch (RootException const & ex)
+          {
+            uploadInfo.m_uploadStatus = kNeedsRetry;
+            uploadInfo.m_uploadError = ex.Msg();
+            ++pendingFeaturesCount;
+            LOG(LWARNING, (ex.what()));
+            changeset.SetErrorDescription(ex.Msg());
           }
 
-          uploadInfo.m_uploadStatus = kUploaded;
-          uploadInfo.m_uploadError.clear();
-          ++uploadedFeaturesCount;
-        }
-        catch (ChangesetWrapper::OsmObjectWasDeletedException const & ex)
-        {
-          uploadInfo.m_uploadStatus = kDeletedFromOSMServer;
-          uploadInfo.m_uploadError = ex.Msg();
-          LOG(LWARNING, (ex.what()));
-          changeset.SetErrorDescription(ex.Msg());
-        }
-        catch (ChangesetWrapper::EmptyFeatureException const & ex)
-        {
-          uploadInfo.m_uploadStatus = kMatchedFeatureIsEmpty;
-          uploadInfo.m_uploadError = ex.Msg();
-          LOG(LWARNING, (ex.what()));
-          changeset.SetErrorDescription(ex.Msg());
-        }
-        catch (RootException const & ex)
-        {
-          uploadInfo.m_uploadStatus = kNeedsRetry;
-          uploadInfo.m_uploadError = ex.Msg();
-          ++pendingFeaturesCount;
-          LOG(LWARNING, (ex.what()));
-          changeset.SetErrorDescription(ex.Msg());
-        }
+          // TODO(AlexZ): Use timestamp from the server.
+          uploadInfo.m_uploadAttemptTimestamp = time(nullptr);
 
-        // TODO(AlexZ): Use timestamp from the server.
-        uploadInfo.m_uploadAttemptTimestamp = time(nullptr);
-
-        /// @todo I suspect that some (last) features can be uploaded several times.
-        /// UploadChanges -> async update here -> m_isUploadingNow = false, new UploadChanges,
-        /// actual SaveUploadedInformation (on Gui) is called after the new upload.
-        GetPlatform().RunTask(Platform::Thread::Gui, [this, id = fti.m_object.GetID(), uploadInfo]()
-        {
-          // Call Save every time we modify each feature's information.
-          SaveUploadedInformation(id, uploadInfo);
-        });
+          results.push_back({fti.m_object.GetID(), std::move(uploadInfo), fti.m_editRevision});
+        }
       }
+
+      // Finalize the changeset before the upload reports itself as finished.
+      changeset.Finish();
+    }
+    catch (std::exception const & ex)
+    {
+      LOG(LERROR, ("Uploading changes has failed:", ex.what()));
+      pendingFeaturesCount = std::max(pendingFeaturesCount, 1);
+      // Features collected before the throw were really uploaded, save them anyway.
     }
 
-    if (callback)
+    bool posted = false;
+    // Covers the narrow case of the post below throwing: the caller is waiting for the callback
+    // and a new upload cannot start until the flag is cleared.
+    SCOPE_GUARD(signalFailure, [&]()
     {
-      UploadResult result = UploadResult::NothingToUpload;
-      // Report an error while any feature is still pending, so that callers retry the rest.
-      // Permanently failed ones (deleted from OSM, empty match) are excluded by NeedsUpload() from
-      // the next upload and must not trigger one.
-      if (pendingFeaturesCount)
-        result = UploadResult::Error;
-      else if (uploadedFeaturesCount)
-        result = UploadResult::Success;
-      callback(result);
-    }
+      if (posted)
+        return;
+      m_isUploadingNow = false;
+      if (callback)
+        callback(UploadResult::Error);
+    });
+
+    // Persist the results before reporting the upload as finished, so that iOS holds its
+    // background task assertion and Android keeps the worker alive until edits.xml is written.
+    // Clearing m_isUploadingNow after the save also stops a second upload from re-sending
+    // features whose status is still queued.
+    GetPlatform().RunTask(Platform::Thread::Gui,
+                          [this, results = std::move(results), callback, uploadedFeaturesCount, pendingFeaturesCount]()
+    {
+      bool const saved = SaveUploadedInformation(results);
+      m_isUploadingNow = false;
+
+      if (callback)
+      {
+        UploadResult result = UploadResult::NothingToUpload;
+        // Report an error while any feature is still pending, so that callers retry the rest.
+        // Permanently failed ones (deleted from OSM, empty match) are excluded by NeedsUpload() from
+        // the next upload and must not trigger one. A failed save leaves everything pending too.
+        if (!saved || pendingFeaturesCount)
+          result = UploadResult::Error;
+        else if (uploadedFeaturesCount)
+          result = UploadResult::Success;
+        callback(result);
+      }
+    });
+    // After the post, not before: the post itself can throw.
+    posted = true;
   });
 
   return UploadStart::Started;
 }
 
-void Editor::SaveUploadedInformation(FeatureID const & fid, UploadInfo const & uploadInfo)
+bool Editor::SaveUploadedInformation(std::vector<FeatureUploadResult> const & results)
 {
   CHECK_THREAD_CHECKER(MainThreadChecker, ());
 
+  if (results.empty())
+    return true;
+
   auto editableFeatures = make_shared<FeaturesContainer>(*m_features.Get());
 
-  auto id = editableFeatures->find(fid.m_mwmId);
-  // Rare case: feature was deleted at the time of changes uploading.
-  if (id == editableFeatures->end())
-    return;
+  for (auto const & result : results)
+  {
+    auto const id = editableFeatures->find(result.m_fid.m_mwmId);
+    // Rare case: feature was deleted at the time of changes uploading.
+    if (id == editableFeatures->end())
+      continue;
 
-  auto index = id->second.find(fid.m_index);
-  // Rare case: feature was deleted at the time of changes uploading.
-  if (index == id->second.end())
-    return;
+    auto const index = id->second.find(result.m_fid.m_index);
+    // Rare case: feature was deleted at the time of changes uploading.
+    if (index == id->second.end())
+      continue;
 
-  auto & fti = index->second;
-  fti.m_uploadAttemptTimestamp = uploadInfo.m_uploadAttemptTimestamp;
-  fti.m_uploadStatus = uploadInfo.m_uploadStatus;
-  fti.m_uploadError = uploadInfo.m_uploadError;
+    auto & fti = index->second;
+    // The feature was edited while it was uploading. Keep the newer edit pending instead of
+    // marking it uploaded and dropping its journal.
+    if (fti.m_editRevision != result.m_editRevision)
+      continue;
 
-  if (!NeedsUpload(uploadInfo.m_uploadStatus))
-    fti.m_object.ClearJournal();
+    fti.m_uploadAttemptTimestamp = result.m_uploadInfo.m_uploadAttemptTimestamp;
+    fti.m_uploadStatus = result.m_uploadInfo.m_uploadStatus;
+    fti.m_uploadError = result.m_uploadInfo.m_uploadError;
 
-  SaveTransaction(editableFeatures);
+    if (!NeedsUpload(result.m_uploadInfo.m_uploadStatus))
+      fti.m_object.ClearJournal();
+  }
+
+  return SaveTransaction(editableFeatures);
 }
 
 bool Editor::FillFeatureInfo(FeatureStatus status, XMLFeature const & xml, FeatureID const & fid,
@@ -1077,6 +1128,9 @@ void Editor::MarkFeatureWithStatus(FeaturesContainer & editableFeatures, Feature
   fti.m_object = *originalObjectPtr;
   fti.m_status = status;
   fti.m_modificationTimestamp = time(nullptr);
+  // The only path that mutates an existing entry in place. Everywhere else an edit either
+  // constructs a new FeatureTypeInfo (with a fresh revision) or erases the entry altogether.
+  fti.m_editRevision = NextEditRevision();
 }
 
 MwmSet::MwmId Editor::GetMwmIdByMapName(string const & name)

--- a/libs/editor/osm_editor.hpp
+++ b/libs/editor/osm_editor.hpp
@@ -187,6 +187,9 @@ public:
   static bool IsCreatedFeature(FeatureID const & fid);
 
 private:
+  /// @returns the next value of a process-wide monotonic counter. Never returns 0.
+  static uint64_t NextEditRevision();
+
   // TODO(a): Use this structure as part of FeatureTypeInfo.
   struct UploadInfo
   {
@@ -207,6 +210,20 @@ private:
     /// Is empty if upload has never occurred or one of k* constants above otherwise.
     std::string m_uploadStatus;
     std::string m_uploadError;
+    /// Every newly constructed entry gets a unique value, so a stale upload result can never be
+    /// applied to an entry the user has edited, removed or reloaded meanwhile. Paths that mutate
+    /// an entry in place must assign a new value explicitly. In-memory only: a restart loses the
+    /// in-flight upload anyway.
+    uint64_t m_editRevision = NextEditRevision();
+  };
+
+  /// An upload outcome for a single feature, applied after the whole upload has finished.
+  struct FeatureUploadResult
+  {
+    FeatureID m_fid;
+    UploadInfo m_uploadInfo;
+    /// FeatureTypeInfo::m_editRevision as it was when the feature was uploaded.
+    uint64_t m_editRevision = 0;
   };
 
   using FeaturesContainer = std::map<MwmId, std::map<uint32_t, FeatureTypeInfo>>;
@@ -230,7 +247,10 @@ private:
   /// @returns pointer to m_features[id][index] if exists, nullptr otherwise.
   static FeatureTypeInfo const * GetFeatureTypeInfo(FeaturesContainer const & features, MwmId const & mwmId,
                                                     uint32_t index);
-  void SaveUploadedInformation(FeatureID const & fid, UploadInfo const & fromUploader);
+  /// Applies all upload results in a single transaction, skipping features that were removed or
+  /// edited while the upload was in flight.
+  /// @returns false if the results could not be written to disk; nothing is applied in that case.
+  bool SaveUploadedInformation(std::vector<FeatureUploadResult> const & results);
 
   void MarkFeatureWithStatus(FeaturesContainer & editableFeatures, FeatureID const & fid, FeatureStatus status);
 


### PR DESCRIPTION
## What changed

`Editor::UploadChanges` queued each feature's upload status to the GUI thread, then called the
completion callback, and only afterwards let `~ChangesetWrapper` finalize the changeset. That
callback is what tells the platform the work is done: on iOS it reaches `BackgroundFetchTask.finish`
and `endBackgroundTask`, on Android it unblocks `doWork()` and WorkManager releases the process. So
the app announced completion while the changeset was still open and nothing had been written to
`edits.xml`. Frozen or killed in that window, `edits.xml` still says "needs upload" with the journal
intact and the next backgrounding replays the edit.

Corroboration from the #13331 analysis: of 33 Organic Maps changesets touching the 12 reported
objects, 11 were never closed — they auto-expired at exactly 3600 s. Zero of the 17 non-OM
changesets in the same sample did. Android orphans carry no `comment` at all, iOS orphans have the
comment but were not closed.

This PR reorders the tail of the upload to **finalize, persist, then signal**:

1. **The reorder.** Results are collected on the network thread, the changeset is finalized,
   `edits.xml` is written once, and only then is the callback invoked. iOS holds its background-task
   assertion and Android keeps the worker alive until the state is on disk. N `edits.xml` rewrites
   collapse into one, and `m_isUploadingNow` is now cleared *after* the save, which retires the
   `@todo` about the last features being uploaded several times.

2. **Edit revision guard.** Because results are applied in one batch at the end, an edit made while
   the upload was in flight would be marked "Uploaded" and have its journal cleared. Every entry
   carries a revision from a process-wide monotonic counter, captured with the upload and re-checked
   before a result is applied; otherwise the feature stays pending. Entries get a fresh revision when
   they are *constructed*, which covers `LoadEdits` (reachable mid-upload via `OnMapRegistered`) and
   recreation after `ClearAllLocalEdits`. `MarkFeatureWithStatus` is the only path that mutates an
   entry in place and assigns one explicitly. In-memory only — a restart loses the in-flight upload
   anyway.

3. **A failed save blocks completion.** `SaveTransaction` publishes to `m_features` only after `Save`
   succeeds, so a failed write left memory *and* disk pending while the upload had already happened
   on OSM. The batch save returns `bool`; on failure everything stays pending and `UploadResult::Error`
   is reported, which `OsmUploadWork.doWork()` turns into a retry.

4. **`ChangesetWrapper::Finish()`** (first commit). The destructor updated the comment and closed
   inside one `try`, so a failed `UpdateChangeSet` skipped the close entirely. `Finish()` attempts
   the two independently, marks the changeset finished either way so the destructor does not retry
   and double the network timeout, and is called explicitly before the GUI task is posted. Changesets
   also get a generic comment at creation, replaced by the detailed description at finish, so an
   interrupted upload leaves a labelled changeset rather than a bare one — the absence of a comment
   was the process-kill fingerprint on Android.

The network lambda is wrapped in `try`/`catch`. The thread pool runs tasks bare
(`thread_pool_delayed.cpp:156` and `:174`; there is no `try`/`catch` anywhere in that file), so
without it an escaping exception terminates the process without unwinding and no scope guard would
run. Results collected before a throw are still posted rather than dropped.

## Merge order: #13341 was a hard prerequisite

**#13341 has merged**, so this requirement is satisfied. It mattered because the old
`nativeUploadChanges` captured `[&promise]` and `wait_for(5min)` could return while the callback was
outstanding; moving the callback to the GUI thread would have relocated that dangling-promise crash
from a network thread onto the main thread.

`doWork()` runs on a WorkManager executor thread, not the main thread, so blocking it on the future
while the main looper processes the save is not a deadlock. The new liveness dependency is that
`doWork()` returns only after the main looper runs the save task; if the main thread were wedged it
would now stall to the five-minute timeout and report `Error` (a retry) where today it returned
promptly.

## Expected conflict with #13343

#13343 changes the `IN_SYNC` case inside the same `UploadChanges` loop (`continue` → `break`). This
PR moves that loop one level deeper into a `try` block, so a textual conflict is expected. The
resolution is to keep #13343's `break`, which then falls through to the new `results.push_back` the
way it intends. This PR deliberately does not include that change.

#13342 needs a decision rather than re-indentation: it modifies the per-feature
`SaveUploadedInformation(id, status, uploadInfo)` task that this PR replaces with the batch save.
The revision guard added here subsumes its status guard, so the `uploadedStatus` parameter can be
dropped; and because its rewritten `MarkFeatureWithStatus` builds a fresh `FeatureTypeInfo`, the
explicit `m_editRevision = NextEditRevision()` here becomes redundant.

## Where the callback now runs

| Caller | Effect |
|---|---|
| iOS `MWMEditorHelper.mm` → `BackgroundFetchTask.finish` | `endBackgroundTask` and the completion handler now run on main — strictly better, and it removes the unsynchronised access to `backgroundTaskIdentifier` that the main-thread expiration handler also touches |
| Android `Editor.cpp` | Sets a promise consumed by the WorkManager worker thread; the main thread never blocks on it |
| Qt `mainwindow.cpp` | Passes no callback |

## Residual failure mode, stated honestly

The obvious framing is wrong. For the **first** uploaded feature the PUT-to-persist window does not
shrink — it **widens** to cover the rest of the upload, because its status is no longer posted
immediately. What this removes is the **platform-triggered** kill: the announce-then-die inversion
where the app tells iOS or WorkManager it is finished and is then frozen with the write still queued.
That is the class the evidence above points at, and holding the assertion until the write lands
eliminates it.

The trade is that an unrelated mid-upload death now loses more state than today's per-feature posting
did; mitigated by posting whatever results were collected from the catch path.

`Finish()` does not make orphan changesets impossible either — the close itself can fail. It only
buys "the close is attempted before completion is signalled".

## Tests

New in `editor_tests`:

- `EditorTest_EditRevisionTest` — a new entry carries a non-zero revision; an edit bumps it; a result
  carrying the old revision is not applied (status stays empty, journal intact) while one carrying
  the current revision is; `DeleteFeature` (via `MarkFeatureWithStatus`, the only in-place mutation)
  bumps it and a stale "Uploaded" does not overwrite the deletion; `LoadEdits` gives reloaded entries
  new revisions.
- `EditorTest_SaveUploadedInformationTest` — the batch save writes exactly once for two features,
  returns `false` when the storage refuses (`OptionalSaveStorage`) and leaves everything pending, and
  does not write at all for an empty batch.
- `ChangesetWrapper_FinishWithoutChangesetIsIdempotent` — `Finish()` on a wrapper that never opened a
  changeset is a no-op, callable repeatedly, with the destructor calling it once more. A regression
  that made it unconditionally hit the network would fail or hang this test.

Both revision assertions were checked to fail when the corresponding production line is removed.

The ordering itself has no seam today — `UploadChanges` constructs a concrete `ChangesetWrapper` — so
it is reviewed by inspection. End-to-end verification against `master.apis.dev.openstreetmap.org`
(upload foregrounded, then backgrounded mid-upload; changeset carries a comment and is closed) is
still to be done on device.

Locally: full tree built with `CMAKE_UNITY_BUILD` both ON and OFF, `ctest -L omim-test` minus the
documented excludes 36/36 green, `clang-format --dry-run -Werror` clean on every changed file.

## Issues

Addresses the dominant cause of #13331 (edits replayed after a background upload) and the orphan
changesets in #7402; a step towards #8448. Not claimed as a complete fix for any of them — see the
residual failure mode above, and note that a replayed upload still bumps the object version until the
PUT is gated (#10219).

