### PR TITLE
[routing][android] Show the correct roundabout exit on car displays

### DIFF
--- a/.github/workflows/android-check.yaml
+++ b/.github/workflows/android-check.yaml
@@ -156,7 +156,8 @@ jobs:
           script: >-
             ./gradlew -P${{ matrix.arch }} app:test${{ matrix.flavor }} sdk:testDebug
             :wear:testGoogleDebugUnitTest :libs:wear-protocol-gms:testDebugUnitTest
-            :sdk:wear:core:testDebugUnitTest sdk:connectedDebugAndroidTest
+            :sdk:wear:core:testDebugUnitTest :sdk:car:testDebugUnitTest
+            sdk:connectedDebugAndroidTest
 
       - name: Upload ${{ matrix.flavor }} apk
         uses: actions/upload-artifact@v7

--- a/android/sdk/car/build.gradle
+++ b/android/sdk/car/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 
   implementation project(':sdk:widgets:speedlimit')
   implementation project(':sdk:widgets:lanes')
+
+  testImplementation libs.androidx.junit
 }
 
 Publish(project, [

--- a/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingHelpers.java
+++ b/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingHelpers.java
@@ -1,14 +1,13 @@
 package app.organicmaps.sdk.car;
 
+import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
-import androidx.car.app.CarContext;
-import androidx.car.app.model.CarIcon;
 import androidx.car.app.model.Distance;
 import androidx.car.app.navigation.model.LaneDirection;
 import androidx.car.app.navigation.model.Maneuver;
-import androidx.core.graphics.drawable.IconCompat;
 import app.organicmaps.sdk.routing.CarDirection;
 import app.organicmaps.sdk.routing.LaneWay;
+import app.organicmaps.sdk.routing.RoundaboutDirection;
 
 public final class RoutingHelpers
 {
@@ -56,34 +55,39 @@ public final class RoutingHelpers
     return LaneDirection.create(shape, isRecommended);
   }
 
-  @NonNull
-  public static Maneuver createManeuver(@NonNull final CarContext context, @NonNull CarDirection carDirection,
-                                        int roundaboutExitNum)
+  static int getRoundaboutManeuverType(@NonNull CarDirection carDirection, int roundaboutExitNum,
+                                       @NonNull RoundaboutDirection direction,
+                                       @IntRange(from = 0, to = 360) int roundaboutExitAngle, boolean hasRoundaboutExit)
   {
-    final int maneuverType = switch (carDirection)
+    final boolean clockwise = direction == RoundaboutDirection.Clockwise;
+    if (carDirection == CarDirection.LeaveRoundAbout)
+      return clockwise ? Maneuver.TYPE_ROUNDABOUT_EXIT_CW : Maneuver.TYPE_ROUNDABOUT_EXIT_CCW;
+
+    if (!hasRoundaboutExit || roundaboutExitNum <= 0)
+      return clockwise ? Maneuver.TYPE_ROUNDABOUT_ENTER_CW : Maneuver.TYPE_ROUNDABOUT_ENTER_CCW;
+
+    if (roundaboutExitAngle > 0 && direction != RoundaboutDirection.Unknown)
     {
-      case NoTurn, GoStraight -> Maneuver.TYPE_STRAIGHT;
-      case TurnRight -> Maneuver.TYPE_TURN_NORMAL_RIGHT;
-      case TurnSharpRight -> Maneuver.TYPE_TURN_SHARP_RIGHT;
-      case TurnSlightRight -> Maneuver.TYPE_TURN_SLIGHT_RIGHT;
-      case TurnLeft -> Maneuver.TYPE_TURN_NORMAL_LEFT;
-      case TurnSharpLeft -> Maneuver.TYPE_TURN_SHARP_LEFT;
-      case TurnSlightLeft -> Maneuver.TYPE_TURN_SLIGHT_LEFT;
-      case UTurnLeft -> Maneuver.TYPE_U_TURN_LEFT;
-      case UTurnRight -> Maneuver.TYPE_U_TURN_RIGHT;
-      // TODO (AndrewShkrob): add support for CW (clockwise) directions
-      case EnterRoundAbout, LeaveRoundAbout, StayOnRoundAbout -> Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW;
-      case StartAtEndOfStreet -> Maneuver.TYPE_DEPART;
-      case ReachedYourDestination -> Maneuver.TYPE_DESTINATION;
-      case ExitHighwayToLeft -> Maneuver.TYPE_OFF_RAMP_SLIGHT_LEFT;
-      case ExitHighwayToRight -> Maneuver.TYPE_OFF_RAMP_SLIGHT_RIGHT;
-    };
-    final Maneuver.Builder builder = new Maneuver.Builder(maneuverType);
-    if (maneuverType == Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW)
-      builder.setRoundaboutExitNumber(roundaboutExitNum > 0 ? roundaboutExitNum : 1);
-    builder.setIcon(
-        new CarIcon.Builder(IconCompat.createWithResource(context, carDirection.getTurnRes(roundaboutExitNum)))
-            .build());
-    return builder.build();
+      return clockwise ? Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CW_WITH_ANGLE
+                       : Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW_WITH_ANGLE;
+    }
+    return clockwise ? Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CW : Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW;
+  }
+
+  static void setRoundaboutFields(@NonNull Maneuver.Builder builder, int maneuverType, int roundaboutExitNum,
+                                  @IntRange(from = 0, to = 360) int roundaboutExitAngle)
+  {
+    if (maneuverType == Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CW_WITH_ANGLE
+        || maneuverType == Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW_WITH_ANGLE)
+    {
+      builder.setRoundaboutExitNumber(roundaboutExitNum);
+      // A *_WITH_ANGLE type is chosen for a positive angle only, which lint cannot infer.
+      builder.setRoundaboutExitAngle(Math.max(1, roundaboutExitAngle));
+    }
+    else if (maneuverType == Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CW
+             || maneuverType == Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW)
+    {
+      builder.setRoundaboutExitNumber(roundaboutExitNum);
+    }
   }
 }

--- a/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingUtils.java
+++ b/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingUtils.java
@@ -1,8 +1,8 @@
 package app.organicmaps.sdk.car;
 
 import android.graphics.Bitmap;
-import android.text.TextUtils;
 import android.text.style.CharacterStyle;
+import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.car.app.CarContext;
@@ -11,13 +11,16 @@ import androidx.car.app.model.CarIcon;
 import androidx.car.app.model.CarIconSpan;
 import androidx.car.app.navigation.model.Destination;
 import androidx.car.app.navigation.model.Lane;
+import androidx.car.app.navigation.model.Maneuver;
 import androidx.car.app.navigation.model.Step;
 import androidx.car.app.navigation.model.TravelEstimate;
 import androidx.car.app.navigation.model.Trip;
 import androidx.core.graphics.drawable.IconCompat;
 import app.organicmaps.sdk.bookmarks.data.MapObject;
+import app.organicmaps.sdk.routing.CarDirection;
 import app.organicmaps.sdk.routing.LaneInfo;
 import app.organicmaps.sdk.routing.LaneWay;
+import app.organicmaps.sdk.routing.RoundaboutDirection;
 import app.organicmaps.sdk.routing.RoutingInfo;
 import app.organicmaps.sdk.util.Distance;
 import app.organicmaps.sdk.util.Graphics;
@@ -60,7 +63,7 @@ public final class RoutingUtils
 
     // TODO (AndrewShkrob): Use real distance and time estimates
     builder.addStep(createCurrentStep(context, info), createTravelEstimate(info.distToTurn, 0, distanceColor));
-    if (!TextUtils.isEmpty(info.nextStreet))
+    if (info.hasNextNextTurn())
       builder.addStep(createNextStep(context, info), createTravelEstimate(Distance.EMPTY, 0, distanceColor));
     return builder.build();
   }
@@ -73,7 +76,8 @@ public final class RoutingUtils
                                                                info.nextStreetRoadShields, 40f, /* drawOutline */
                                                                false));
     builder.setRoad(info.nextStreet);
-    builder.setManeuver(RoutingHelpers.createManeuver(context, info.carDirection, info.exitNum));
+    builder.setManeuver(createManeuver(context, info.carDirection, info.exitNum, info.roundaboutDirection,
+                                       info.exitAngle, info.hasRoundaboutExit));
     if (info.lanes != null)
     {
       for (final LaneInfo laneInfo : info.lanes)
@@ -99,8 +103,43 @@ public final class RoutingUtils
     builder.setCue(RoadShieldUtils.createStreetTextWithShields(RoutingUtils::createRoadShieldSpan, info.nextNextStreet,
                                                                info.nextNextStreetRoadShields, 40f,
                                                                /* drawOutline */ false));
-    builder.setManeuver(RoutingHelpers.createManeuver(context, info.nextCarDirection, 0));
+    builder.setManeuver(createManeuver(context, info.nextCarDirection, info.nextExitNum, info.nextRoundaboutDirection,
+                                       info.nextExitAngle, info.nextHasRoundaboutExit));
 
+    return builder.build();
+  }
+
+  @NonNull
+  private static Maneuver createManeuver(@NonNull final CarContext context, @NonNull CarDirection carDirection,
+                                         @IntRange(from = 0) int roundaboutExitNum,
+                                         @NonNull RoundaboutDirection roundaboutDirection,
+                                         @IntRange(from = 0, to = 360) int roundaboutExitAngle,
+                                         boolean hasRoundaboutExit)
+  {
+    final int maneuverType = switch (carDirection)
+    {
+      case NoTurn, GoStraight -> Maneuver.TYPE_STRAIGHT;
+      case TurnRight -> Maneuver.TYPE_TURN_NORMAL_RIGHT;
+      case TurnSharpRight -> Maneuver.TYPE_TURN_SHARP_RIGHT;
+      case TurnSlightRight -> Maneuver.TYPE_TURN_SLIGHT_RIGHT;
+      case TurnLeft -> Maneuver.TYPE_TURN_NORMAL_LEFT;
+      case TurnSharpLeft -> Maneuver.TYPE_TURN_SHARP_LEFT;
+      case TurnSlightLeft -> Maneuver.TYPE_TURN_SLIGHT_LEFT;
+      case UTurnLeft -> Maneuver.TYPE_U_TURN_LEFT;
+      case UTurnRight -> Maneuver.TYPE_U_TURN_RIGHT;
+      case EnterRoundAbout, LeaveRoundAbout, StayOnRoundAbout ->
+        RoutingHelpers.getRoundaboutManeuverType(carDirection, roundaboutExitNum, roundaboutDirection,
+                                                 roundaboutExitAngle, hasRoundaboutExit);
+      case StartAtEndOfStreet -> Maneuver.TYPE_DEPART;
+      case ReachedYourDestination -> Maneuver.TYPE_DESTINATION;
+      case ExitHighwayToLeft -> Maneuver.TYPE_OFF_RAMP_SLIGHT_LEFT;
+      case ExitHighwayToRight -> Maneuver.TYPE_OFF_RAMP_SLIGHT_RIGHT;
+    };
+    final Maneuver.Builder builder = new Maneuver.Builder(maneuverType);
+    RoutingHelpers.setRoundaboutFields(builder, maneuverType, roundaboutExitNum, roundaboutExitAngle);
+    builder.setIcon(
+        new CarIcon.Builder(IconCompat.createWithResource(context, carDirection.getTurnRes(roundaboutExitNum)))
+            .build());
     return builder.build();
   }
 

--- a/android/sdk/car/src/test/java/app/organicmaps/sdk/car/RoutingHelpersTest.java
+++ b/android/sdk/car/src/test/java/app/organicmaps/sdk/car/RoutingHelpersTest.java
@@ -1,0 +1,84 @@
+package app.organicmaps.sdk.car;
+
+import static org.junit.Assert.assertEquals;
+
+import androidx.car.app.navigation.model.Maneuver;
+import app.organicmaps.sdk.routing.CarDirection;
+import app.organicmaps.sdk.routing.RoundaboutDirection;
+import org.junit.Test;
+
+public class RoutingHelpersTest
+{
+  @Test
+  public void mapsRoundaboutEntryAndExitWithAngle()
+  {
+    assertEquals(Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW_WITH_ANGLE,
+                 type(CarDirection.EnterRoundAbout, 2, RoundaboutDirection.CounterClockwise, 180, true));
+    assertEquals(Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CW_WITH_ANGLE,
+                 type(CarDirection.EnterRoundAbout, 2, RoundaboutDirection.Clockwise, 180, true));
+  }
+
+  @Test
+  public void preservesDirectionWithoutAngle()
+  {
+    assertEquals(Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW,
+                 type(CarDirection.EnterRoundAbout, 2, RoundaboutDirection.CounterClockwise, 0, true));
+    assertEquals(Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CW,
+                 type(CarDirection.EnterRoundAbout, 2, RoundaboutDirection.Clockwise, 0, true));
+    assertEquals(Maneuver.TYPE_ROUNDABOUT_ENTER_CCW,
+                 type(CarDirection.EnterRoundAbout, 1, RoundaboutDirection.CounterClockwise, 0, false));
+    assertEquals(Maneuver.TYPE_ROUNDABOUT_ENTER_CW,
+                 type(CarDirection.EnterRoundAbout, 1, RoundaboutDirection.Clockwise, 0, false));
+  }
+
+  @Test
+  public void omitsAngleWhenExitNumberIsUnavailable()
+  {
+    assertEquals(Maneuver.TYPE_ROUNDABOUT_ENTER_CCW,
+                 type(CarDirection.EnterRoundAbout, 0, RoundaboutDirection.CounterClockwise, 180, true));
+  }
+
+  @Test
+  public void mapsRoundaboutExitAsExitOnly()
+  {
+    assertEquals(Maneuver.TYPE_ROUNDABOUT_EXIT_CCW,
+                 type(CarDirection.LeaveRoundAbout, 2, RoundaboutDirection.CounterClockwise, 180, true));
+    assertEquals(Maneuver.TYPE_ROUNDABOUT_EXIT_CW,
+                 type(CarDirection.LeaveRoundAbout, 2, RoundaboutDirection.Clockwise, 180, true));
+  }
+
+  @Test
+  public void buildsCombinedAndExitOnlyManeuvers()
+  {
+    final Maneuver combined = build(CarDirection.EnterRoundAbout, 2, RoundaboutDirection.CounterClockwise, 180, true);
+    assertEquals(2, combined.getRoundaboutExitNumber());
+    assertEquals(180, combined.getRoundaboutExitAngle());
+
+    final Maneuver exitOnly = build(CarDirection.LeaveRoundAbout, 2, RoundaboutDirection.CounterClockwise, 180, true);
+    assertEquals(0, exitOnly.getRoundaboutExitNumber());
+    assertEquals(0, exitOnly.getRoundaboutExitAngle());
+  }
+
+  @Test
+  public void buildsManeuverWithoutExitNumber()
+  {
+    final Maneuver maneuver = build(CarDirection.EnterRoundAbout, 0, RoundaboutDirection.CounterClockwise, 0, true);
+    assertEquals(Maneuver.TYPE_ROUNDABOUT_ENTER_CCW, maneuver.getType());
+    assertEquals(0, maneuver.getRoundaboutExitNumber());
+  }
+
+  private static int type(CarDirection carDirection, int exitNum, RoundaboutDirection direction, int exitAngle,
+                          boolean hasExit)
+  {
+    return RoutingHelpers.getRoundaboutManeuverType(carDirection, exitNum, direction, exitAngle, hasExit);
+  }
+
+  private static Maneuver build(CarDirection carDirection, int exitNum, RoundaboutDirection direction, int exitAngle,
+                                boolean hasExit)
+  {
+    final int maneuverType = type(carDirection, exitNum, direction, exitAngle, hasExit);
+    final Maneuver.Builder builder = new Maneuver.Builder(maneuverType);
+    RoutingHelpers.setRoundaboutFields(builder, maneuverType, exitNum, exitAngle);
+    return builder.build();
+  }
+}

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -1296,8 +1296,7 @@ JNIEXPORT jobject Java_app_organicmaps_sdk_Framework_nativeGetRouteFollowingInfo
   if (!rm.IsRoutingActive())
     return nullptr;
 
-  routing::FollowingInfo info;
-  rm.GetRouteFollowingInfo(info);
+  auto const info = rm.GetRouteFollowingInfo();
   if (!info.IsValid())
     return nullptr;
 

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/routing/RoutingJni.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/routing/RoutingJni.cpp
@@ -49,6 +49,12 @@ jobject ToJavaPedestrianDirection(JNIEnv * env, routing::turns::PedestrianDirect
   return ToJavaDirection(env, clazz, "Lapp/organicmaps/sdk/routing/PedestrianDirection;", pedestrianDirection);
 }
 
+jobject ToJavaRoundaboutDirection(JNIEnv * env, routing::turns::RoundaboutDirection direction)
+{
+  static jclass const clazz = jni::GetGlobalClassRef(env, "app/organicmaps/sdk/routing/RoundaboutDirection");
+  return ToJavaEnum(env, clazz, "Lapp/organicmaps/sdk/routing/RoundaboutDirection;", DebugPrint(direction).c_str());
+}
+
 jobject ToJavaLaneWay(JNIEnv * env, routing::turns::lanes::LaneWay const & laneWay)
 {
   static jclass const clazz = jni::GetGlobalClassRef(env, "app/organicmaps/sdk/routing/LaneWay");
@@ -235,6 +241,13 @@ jobject CreateRoutingInfo(JNIEnv * env, routing::FollowingInfo const & info, Rou
     "Lapp/organicmaps/sdk/routing/CarDirection;"               // carNextTurnDirection
     "Lapp/organicmaps/sdk/routing/PedestrianDirection;"        // pedestrianDirection
     "I"                                                        // exitNum
+    "I"                                                        // exitAngle
+    "Lapp/organicmaps/sdk/routing/RoundaboutDirection;"        // roundaboutDirection
+    "Z"                                                        // hasRoundaboutExit
+    "I"                                                        // nextExitNum
+    "I"                                                        // nextExitAngle
+    "Lapp/organicmaps/sdk/routing/RoundaboutDirection;"        // nextRoundaboutDirection
+    "Z"                                                        // nextHasRoundaboutExit
     "I"                                                        // totalTime
     "[Lapp/organicmaps/sdk/routing/LaneInfo;"                  // lanes
     "D"                                                        // speedLimitMps
@@ -258,6 +271,13 @@ jobject CreateRoutingInfo(JNIEnv * env, routing::FollowingInfo const & info, Rou
     ToJavaCarDirection(env, info.m_nextTurn),
     ToJavaPedestrianDirection(env, info.m_pedestrianTurn),
     info.m_exitNum,
+    info.m_roundaboutInfo.m_exitAngle,
+    ToJavaRoundaboutDirection(env, info.m_roundaboutInfo.m_direction),
+    static_cast<jboolean>(info.m_roundaboutInfo.m_hasExit),
+    info.m_nextExitNum,
+    info.m_nextRoundaboutInfo.m_exitAngle,
+    ToJavaRoundaboutDirection(env, info.m_nextRoundaboutInfo.m_direction),
+    static_cast<jboolean>(info.m_nextRoundaboutInfo.m_hasExit),
     info.m_time,
     CreateLanesInfo(env, info.m_lanes),
     info.m_speedLimitMps,

--- a/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoundaboutDirection.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoundaboutDirection.java
@@ -1,0 +1,12 @@
+package app.organicmaps.sdk.routing;
+
+/**
+ * Actual direction in which a route traverses a roundabout. Constant names are shared with the
+ * native routing model and must stay synchronized with it.
+ */
+public enum RoundaboutDirection
+{
+  Unknown,
+  Clockwise,
+  CounterClockwise
+}

--- a/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingInfo.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingInfo.java
@@ -1,5 +1,6 @@
 package app.organicmaps.sdk.routing;
 
+import androidx.annotation.IntRange;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -33,7 +34,29 @@ public final class RoutingInfo
   public final CarDirection carDirection;
   @NonNull
   public final CarDirection nextCarDirection;
+  /** One-based exit number for {@link #carDirection}, or 0 when unavailable. */
   public final int exitNum;
+  /** Sweep from the roundabout entrance to the exit, in degrees from 1 to 360, or 0 when unavailable. */
+  @IntRange(from = 0, to = 360)
+  public final int exitAngle;
+  /** Actual circulation direction for the roundabout maneuver. */
+  @NonNull
+  public final RoundaboutDirection roundaboutDirection;
+  /** Whether the route's exit from the roundabout of {@link #carDirection} is known. */
+  public final boolean hasRoundaboutExit;
+  /** One-based exit number for {@link #nextCarDirection}, or 0 when unavailable. */
+  public final int nextExitNum;
+  /**
+   * Sweep from the roundabout entrance to the exit for {@link #nextCarDirection}, in degrees from 1 to 360, or 0
+   * when unavailable.
+   */
+  @IntRange(from = 0, to = 360)
+  public final int nextExitAngle;
+  /** Actual circulation direction for {@link #nextCarDirection}. */
+  @NonNull
+  public final RoundaboutDirection nextRoundaboutDirection;
+  /** Whether the route's exit from the roundabout of {@link #nextCarDirection} is known. */
+  public final boolean nextHasRoundaboutExit;
   @Nullable
   public final LaneInfo[] lanes;
   // For pedestrian routing.
@@ -49,8 +72,11 @@ public final class RoutingInfo
                       @Nullable RoadShieldInfo nextStreetRoadShields, String nextNextStreet,
                       @Nullable RoadShieldInfo nextNextStreetRoadShields, double completionPercent,
                       @NonNull CarDirection carTurnDirection, @NonNull CarDirection carNextTurnDirection,
-                      @NonNull PedestrianDirection pedestrianDirection, int exitNum, int totalTime,
-                      @Nullable LaneInfo[] lanes, double speedLimitMps, boolean speedLimitExceeded,
+                      @NonNull PedestrianDirection pedestrianDirection, int exitNum,
+                      @IntRange(from = 0, to = 360) int exitAngle, @NonNull RoundaboutDirection roundaboutDirection,
+                      boolean hasRoundaboutExit, int nextExitNum, @IntRange(from = 0, to = 360) int nextExitAngle,
+                      @NonNull RoundaboutDirection nextRoundaboutDirection, boolean nextHasRoundaboutExit,
+                      int totalTime, @Nullable LaneInfo[] lanes, double speedLimitMps, boolean speedLimitExceeded,
                       boolean shouldPlayWarningSignal)
   {
     this.distToTarget = distToTarget;
@@ -66,6 +92,13 @@ public final class RoutingInfo
     this.nextCarDirection = carNextTurnDirection;
     this.lanes = lanes;
     this.exitNum = exitNum;
+    this.exitAngle = exitAngle;
+    this.roundaboutDirection = roundaboutDirection;
+    this.hasRoundaboutExit = hasRoundaboutExit;
+    this.nextExitNum = nextExitNum;
+    this.nextExitAngle = nextExitAngle;
+    this.nextRoundaboutDirection = nextRoundaboutDirection;
+    this.nextHasRoundaboutExit = nextHasRoundaboutExit;
     this.pedestrianDirection = pedestrianDirection;
     this.speedLimitMps = speedLimitMps;
     this.speedCamLimitExceeded = speedLimitExceeded;

--- a/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
+++ b/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
@@ -88,8 +88,7 @@
 {
   if (!self.isRoutingActive)
     return nil;
-  routing::FollowingInfo info;
-  self.rm.GetRouteFollowingInfo(info);
+  auto const info = self.rm.GetRouteFollowingInfo();
   if (!info.IsValid())
     return nil;
   CLLocation * lastLocation = [MWMLocationManager lastLocation];

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -502,8 +502,7 @@ using namespace routing;
   if (![MWMRouter isRoutingActive])
     return;
   auto const & rm = GetFramework().GetRoutingManager();
-  routing::FollowingInfo info;
-  rm.GetRouteFollowingInfo(info);
+  auto const info = rm.GetRouteFollowingInfo();
   if (!info.IsValid())
     return;
   auto navManager = [MWMNavigationDashboardManager sharedManager];

--- a/libs/geometry/angles.hpp
+++ b/libs/geometry/angles.hpp
@@ -81,7 +81,7 @@ T TwoVectorsAngle(m2::Point<T> const & p, m2::Point<T> const & p1, m2::Point<T> 
 double AngleIn2PI(double ang);
 
 /// @return Oriented angle (<= PI) from rad1 to rad2.
-/// >0 - clockwise, <0 - counterclockwise
+/// >0 - counterclockwise, <0 - clockwise.
 double GetShortestDistance(double rad1, double rad2);
 
 double GetMiddleAngle(double a1, double a2);

--- a/libs/map/routing_manager.hpp
+++ b/libs/map/routing_manager.hpp
@@ -173,7 +173,7 @@ public:
   /// a tap-area threshold (kTapPixels * |mercatorPerPixel|), swaps it to active and returns true.
   /// No-op when navigation is active (alts aren't drawn then) or there are no alternatives.
   bool TryTapOnAlternativeRoute(m2::PointD const & mercator, double mercatorPerPixel);
-  void GetRouteFollowingInfo(routing::FollowingInfo & info) const { m_routingSession.GetRouteFollowingInfo(info); }
+  routing::FollowingInfo GetRouteFollowingInfo() const { return m_routingSession.GetRouteFollowingInfo(); }
 
   TransitRouteInfo GetTransitRouteInfo() const;
 

--- a/libs/routing/car_directions.cpp
+++ b/libs/routing/car_directions.cpp
@@ -8,14 +8,192 @@
 #include "geometry/angles.hpp"
 #include "geometry/mercator.hpp"
 
+#include "base/math.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <optional>
+
 namespace routing
 {
 using namespace turns;
 using namespace ftypes;
 
+namespace
+{
+bool AddRoundaboutSweep(LoadedPathSegment const & segment, double & sweep)
+{
+  if (!segment.m_roundaboutCenter)
+    return false;
+
+  auto const & center = *segment.m_roundaboutCenter;
+  double previousAngle = ang::AngleTo(center, segment.m_path.front().GetPoint());
+  for (size_t i = 1; i < segment.m_path.size(); ++i)
+  {
+    double const angle = ang::AngleTo(center, segment.m_path[i].GetPoint());
+    sweep += ang::GetShortestDistance(previousAngle, angle);
+    previousAngle = angle;
+  }
+  return true;
+}
+
+RoundaboutDirection DirectionFromRoundaboutSweep(double sweep)
+{
+  if (sweep > 0.0)
+    return RoundaboutDirection::CounterClockwise;
+  if (sweep < 0.0)
+    return RoundaboutDirection::Clockwise;
+  return RoundaboutDirection::Unknown;
+}
+
+struct PathSweep
+{
+  double m_bends = 0.0;   // Summed heading changes along the driven path.
+  double m_length = 0.0;  // Total length of the driven edges.
+  double m_firstEdge = 0.0;
+  double m_lastEdge = 0.0;
+  size_t m_edges = 0;
+};
+
+/// Sums the bends of the driven path over the segments [|first|, |end|). Consecutive edges of a ring
+/// bend in the circulation direction, so the sign of the total gives it without depending on any
+/// single edge, which a straight section or coordinate quantization can turn the wrong way.
+PathSweep CalcRoundaboutPathSweep(TUnpackedPathSegments const & segments, size_t first, size_t end)
+{
+  PathSweep sweep;
+  double previousHeading = 0.0;
+
+  for (size_t i = first; i < end; ++i)
+  {
+    ASSERT(segments[i].m_onRoundabout, (i));
+    auto const & path = segments[i].m_path;
+    for (size_t j = 1; j < path.size(); ++j)
+    {
+      auto const & from = path[j - 1].GetPoint();
+      auto const & to = path[j].GetPoint();
+      ASSERT_NOT_EQUAL(from, to, (i, j));
+
+      double const heading = ang::AngleTo(from, to);
+      if (sweep.m_edges != 0)
+        sweep.m_bends += ang::GetShortestDistance(previousHeading, heading);
+      previousHeading = heading;
+
+      sweep.m_lastEdge = from.Length(to);
+      if (sweep.m_edges == 0)
+        sweep.m_firstEdge = sweep.m_lastEdge;
+      sweep.m_length += sweep.m_lastEdge;
+      ++sweep.m_edges;
+    }
+  }
+
+  return sweep;
+}
+
+/// Approximates the angle swept around a ring from the bends of its driven edges. The heading of an
+/// edge is the ring's tangent at that edge's midpoint, so the bends only cover the path from the
+/// first edge's midpoint to the last one's, falling short by half of each. A ring edge spans an angle
+/// nearly proportional to its chord, so scaling by the fraction of the driven length that the bends
+/// cover adds those two halves back. Mercator is conformal, so the chords need no unprojection. A
+/// single driven edge has no bend to measure and stays unknown.
+uint16_t EstimateExitAngleFromPath(PathSweep const & sweep)
+{
+  if (sweep.m_edges < 2 || sweep.m_bends == 0.0)
+    return 0;
+
+  // Positive whenever m_edges >= 2, because only half of two of the summed edges is subtracted.
+  double const covered = sweep.m_length - (sweep.m_firstEdge + sweep.m_lastEdge) / 2.0;
+  double const degrees = std::abs(math::RadToDeg(sweep.m_bends)) * sweep.m_length / covered;
+  return static_cast<uint16_t>(std::clamp(static_cast<int32_t>(std::lround(degrees)), 1, 360));
+}
+
+/// Returns the circulation shared by the closed roundabout features on [|first|, |end|), Unknown if
+/// none of them is closed, or nullopt when two of them disagree and nothing may be published.
+std::optional<RoundaboutDirection> GetClosedRoundaboutDirection(TUnpackedPathSegments const & segments, size_t first,
+                                                                size_t end)
+{
+  auto direction = RoundaboutDirection::Unknown;
+  for (size_t i = first; i < end; ++i)
+  {
+    auto const current = segments[i].m_roundaboutDirection;
+    if (current == RoundaboutDirection::Unknown)
+      continue;
+    if (direction != RoundaboutDirection::Unknown && direction != current)
+      return {};
+    direction = current;
+  }
+  return direction;
+}
+
+/// Measures the roundabout path over the annotated segments [|first|, |end|). An exact polar sweep
+/// needs a validated ring center on every segment; without one both values are approximated from the
+/// bends of the driven path, which is the common case because most rings are mapped as open ways.
+RoundaboutInfo MeasureRoundaboutRun(TUnpackedPathSegments const & segments, size_t first, size_t end)
+{
+  auto const closedDirection = GetClosedRoundaboutDirection(segments, first, end);
+  if (!closedDirection)
+    return {};
+
+  auto direction = *closedDirection;
+  double sweep = 0.0;
+  for (size_t i = first; i < end; ++i)
+    if (!AddRoundaboutSweep(segments[i], sweep))
+    {
+      auto const path = CalcRoundaboutPathSweep(segments, first, end);
+      auto const pathDirection = DirectionFromRoundaboutSweep(path.m_bends);
+      if (direction == RoundaboutDirection::Unknown)
+        direction = pathDirection;
+      // The bends of a reflex part of a non-convex ring run against its winding. Keep the winding,
+      // which covers the whole ring, and publish no angle rather than one measured backwards.
+      if (direction != pathDirection)
+        return {0 /* m_exitAngle */, direction};
+      return {EstimateExitAngleFromPath(path), direction};
+    }
+
+  // LoadPathAttributes() stores a ring center only together with that ring's winding.
+  ASSERT_NOT_EQUAL(direction, RoundaboutDirection::Unknown, ());
+  // A purely radial run, e.g. an arm mapped as a part of the ring, sweeps no angle at all.
+  if (sweep == 0.0)
+    return {0 /* m_exitAngle */, direction};
+
+  ASSERT_EQUAL(direction, DirectionFromRoundaboutSweep(sweep), ());
+  auto const roundedDegrees = static_cast<int32_t>(std::lround(std::abs(math::RadToDeg(sweep))));
+  return {static_cast<uint16_t>(std::clamp(roundedDegrees, 1, 360)), direction};
+}
+
+}  // namespace
+
 CarDirectionsEngine::CarDirectionsEngine(MwmDataSource & dataSource, std::shared_ptr<NumMwmIds> numMwmIds)
   : DirectionsEngine(dataSource, std::move(numMwmIds))
 {}
+
+RoundaboutInfo CalcRoundaboutInfo(IRoutingResult const & result, size_t outgoingSegmentIndex)
+{
+  auto const & segments = result.GetSegments();
+  ASSERT_GREATER(outgoingSegmentIndex, 0, ());
+  ASSERT_LESS(outgoingSegmentIndex, segments.size(), ());
+  ASSERT(segments[outgoingSegmentIndex - 1].m_onRoundabout, ());
+  ASSERT(!segments[outgoingSegmentIndex].m_onRoundabout, ());
+
+  size_t firstRoundaboutSegment = outgoingSegmentIndex - 1;
+  while (firstRoundaboutSegment > 0 && segments[firstRoundaboutSegment - 1].m_onRoundabout)
+    --firstRoundaboutSegment;
+
+  auto info = MeasureRoundaboutRun(segments, firstRoundaboutSegment, outgoingSegmentIndex);
+  info.m_hasExit = true;
+  return info;
+}
+
+RoundaboutDirection CalcRoundaboutDirection(IRoutingResult const & result, size_t firstRoundaboutSegment)
+{
+  auto const & segments = result.GetSegments();
+  ASSERT_LESS(firstRoundaboutSegment, segments.size(), ());
+  ASSERT(segments[firstRoundaboutSegment].m_onRoundabout, ());
+
+  size_t end = firstRoundaboutSegment;
+  while (end < segments.size() && segments[end].m_onRoundabout)
+    ++end;
+  return MeasureRoundaboutRun(segments, firstRoundaboutSegment, end).m_direction;
+}
 
 void CarDirectionsEngine::FixupTurns(std::vector<RouteSegment> & routeSegments)
 {
@@ -76,8 +254,8 @@ void FixupCarTurns(std::vector<RouteSegment> & routeSegments)
       // It's possible for car to be on roundabout without entering it
       // if route calculation started at roundabout (e.g. if user made full turn on roundabout).
       if (enterRoundAbout != kInvalidEnter)
-        routeSegments[enterRoundAbout].SetTurnExits(exitNum + 1);
-      routeSegments[idx].SetTurnExits(exitNum + 1);  // For LeaveRoundAbout turn.
+        routeSegments[enterRoundAbout].SetRoundaboutExit(exitNum + 1, t.m_roundaboutInfo);
+      routeSegments[idx].SetRoundaboutExit(exitNum + 1, t.m_roundaboutInfo);  // For LeaveRoundAbout turn.
       enterRoundAbout = kInvalidEnter;
       exitNum = 0;
     }
@@ -131,6 +309,13 @@ size_t CarDirectionsEngine::GetTurnDirection(IRoutingResult const & result, size
 
   if (turnItem.m_turn == CarDirection::None)
     GetTurnDirectionBasic(result, outgoingSegmentIndex, numMwmIds, vehicleSettings, turnItem);
+
+  if (turnItem.m_turn == CarDirection::LeaveRoundAbout)
+    turnItem.m_roundaboutInfo = CalcRoundaboutInfo(result, outgoingSegmentIndex);
+  else if (turnItem.m_turn == CarDirection::EnterRoundAbout)
+    // FixupCarTurns replaces this provisional value with the exit's complete metadata unless the route
+    // ends on the ring.
+    turnItem.m_roundaboutInfo.m_direction = CalcRoundaboutDirection(result, outgoingSegmentIndex);
 
   // Lane information.
   if (turnItem.m_turn != CarDirection::None)

--- a/libs/routing/car_directions.hpp
+++ b/libs/routing/car_directions.hpp
@@ -25,6 +25,17 @@ protected:
 
 void FixupCarTurns(std::vector<RouteSegment> & routeSegments);
 
+/// Measures the roundabout path ending at |outgoingSegmentIndex| and sets m_hasExit. A validated ring
+/// center gives an exact polar sweep; otherwise both values come from the bends of the driven path,
+/// and the angle stays 0 when that path has fewer than two edges or contradicts the ring's own
+/// winding.
+turns::RoundaboutInfo CalcRoundaboutInfo(turns::IRoutingResult const & result, size_t outgoingSegmentIndex);
+
+/// Returns the circulation of the roundabout entered at |firstRoundaboutSegment|, measured over the
+/// whole driven part of the ring. FixupCarTurns() replaces it with the exit's complete metadata
+/// unless the route ends on the ring.
+turns::RoundaboutDirection CalcRoundaboutDirection(turns::IRoutingResult const & result, size_t firstRoundaboutSegment);
+
 /*!
  * \brief Finds an U-turn that starts from master segment and returns how many segments it lasts.
  * \returns an index in |segments| that has the opposite direction with master segment

--- a/libs/routing/directions_engine.cpp
+++ b/libs/routing/directions_engine.cpp
@@ -8,6 +8,10 @@
 
 #include "indexer/ftypes_matcher.hpp"
 
+#include "base/assert.hpp"
+
+#include <span>
+
 namespace routing
 {
 using namespace ftypes;
@@ -33,6 +37,17 @@ void LoadLanes(LoadedPathSegment & pathSegment, FeatureType & ft, bool isForward
 {
   auto tag = GetLanesMetadataTag(ft, isForward);
   pathSegment.m_lanes = lanes::ParseLanes(ft.GetMetadata(tag));
+}
+
+turns::RoundaboutDirection InvertRoundaboutDirection(turns::RoundaboutDirection direction)
+{
+  switch (direction)
+  {
+  case turns::RoundaboutDirection::Unknown: return direction;
+  case turns::RoundaboutDirection::Clockwise: return turns::RoundaboutDirection::CounterClockwise;
+  case turns::RoundaboutDirection::CounterClockwise: return turns::RoundaboutDirection::Clockwise;
+  }
+  UNREACHABLE();
 }
 }  // namespace
 
@@ -78,6 +93,34 @@ void DirectionsEngine::LoadPathAttributes(FeatureID const & featureId, LoadedPat
   pathSegment.m_isLink = m_linkChecker(types);
   pathSegment.m_onRoundabout = m_roundAboutChecker(types);
   pathSegment.m_isOneWay = m_onewayChecker(types);
+
+  if (m_vehicleType == VehicleType::Car && pathSegment.m_onRoundabout)
+  {
+    // A roundabout is split into path segments at its junctions. Reuse its closed-feature metadata
+    // so the full geometry is parsed once while car turn annotations are created.
+    if (!m_pathSegments.empty() && m_pathSegments.back().m_segmentRange.GetFeature() == featureId)
+    {
+      pathSegment.m_roundaboutCenter = m_pathSegments.back().m_roundaboutCenter;
+      pathSegment.m_roundaboutDirection = m_pathSegments.back().m_roundaboutDirection;
+      if (m_pathSegments.back().m_segmentRange.IsForward() != isForward)
+        pathSegment.m_roundaboutDirection = InvertRoundaboutDirection(pathSegment.m_roundaboutDirection);
+    }
+    else
+    {
+      // Open features can be parts of one split roundabout; their direction is derived later from
+      // the contiguous driven path because one feature alone has no global winding or center.
+      std::span<m2::PointD const> const geometry = ft->GetPoints(FeatureType::BEST_GEOMETRY);
+      if (geometry.size() >= 4 && geometry.front() == geometry.back())
+      {
+        pathSegment.m_roundaboutDirection = CalcClosedRoundaboutDirection(geometry, isForward);
+        auto const center = ft->GetLimitRect(FeatureType::BEST_GEOMETRY).Center();
+        // A polar sweep is valid only when the whole ring advances monotonically around the pivot.
+        // Non-convex rings can have a bounding-box center outside the ring or behind a reflex edge.
+        if (IsAngularlyMonotonic(geometry, center))
+          pathSegment.m_roundaboutCenter = center;
+      }
+    }
+  }
 
   pathSegment.m_roadNameInfo.m_mwmId = ft->GetID();
   pathSegment.m_roadNameInfo.m_isLink = pathSegment.m_isLink;

--- a/libs/routing/directions_engine_helpers.cpp
+++ b/libs/routing/directions_engine_helpers.cpp
@@ -1,6 +1,12 @@
 #include "routing/directions_engine_helpers.hpp"
 
+#include "geometry/angles.hpp"
 #include "geometry/mercator.hpp"
+
+#include "base/assert.hpp"
+#include "base/math.hpp"
+
+#include <cmath>
 
 namespace routing
 {
@@ -88,5 +94,50 @@ bool IsJoint(IRoadGraph::EdgeListT const & ingoingEdges, IRoadGraph::EdgeListT c
       return true;
   }
   return false;
+}
+
+turns::RoundaboutDirection CalcClosedRoundaboutDirection(std::span<m2::PointD const> points, bool isForward)
+{
+  ASSERT_GREATER_OR_EQUAL(points.size(), 4, ());
+  ASSERT_EQUAL(points.front(), points.back(), ());
+
+  auto const origin = points.front();
+  double twiceArea = 0.0;
+  for (size_t i = 1; i < points.size(); ++i)
+    twiceArea += m2::CrossProduct(points[i - 1] - origin, points[i] - origin);
+
+  if (twiceArea == 0.0)
+    return turns::RoundaboutDirection::Unknown;
+
+  bool counterClockwise = twiceArea > 0.0;
+  if (!isForward)
+    counterClockwise = !counterClockwise;
+  return counterClockwise ? turns::RoundaboutDirection::CounterClockwise : turns::RoundaboutDirection::Clockwise;
+}
+
+bool IsAngularlyMonotonic(std::span<m2::PointD const> points, m2::PointD const & center)
+{
+  ASSERT_GREATER_OR_EQUAL(points.size(), 4, ());
+  ASSERT_EQUAL(points.front(), points.back(), ());
+
+  double previousAngle = ang::AngleTo(center, points.front());
+  double sweep = 0.0;
+  int directionSign = 0;
+  for (size_t i = 1; i < points.size(); ++i)
+  {
+    double const angle = ang::AngleTo(center, points[i]);
+    double const delta = ang::GetShortestDistance(previousAngle, angle);
+    previousAngle = angle;
+    if (delta == 0.0)
+      continue;
+
+    int const deltaSign = delta > 0.0 ? 1 : -1;
+    if (directionSign != 0 && directionSign != deltaSign)
+      return false;
+    directionSign = deltaSign;
+    sweep += delta;
+  }
+
+  return directionSign != 0 && AlmostEqualAbs(std::abs(sweep), 2.0 * math::pi, 1e-6);
 }
 }  // namespace routing

--- a/libs/routing/directions_engine_helpers.hpp
+++ b/libs/routing/directions_engine_helpers.hpp
@@ -8,6 +8,8 @@
 
 #include "geometry/point2d.hpp"
 
+#include <span>
+
 namespace routing
 {
 struct AdjacentEdges
@@ -51,4 +53,13 @@ private:
 /// of a new LoadedPathSegment.
 bool IsJoint(IRoadGraph::EdgeListT const & ingoingEdges, IRoadGraph::EdgeListT const & outgoingEdges,
              Edge const & ingoingRouteEdge, Edge const & outgoingRouteEdge);
+
+/// Returns the circulation of a route over a closed roundabout feature. |isForward| states whether
+/// the route follows the feature's stored point order.
+turns::RoundaboutDirection CalcClosedRoundaboutDirection(std::span<m2::PointD const> points, bool isForward);
+
+/// Returns true when every edge of a closed ring advances in the same angular direction around
+/// |center| and the ring encloses it, i.e. its total sweep is 2*pi. Only then can partial polar
+/// sweeps around that center represent roundabout exit angles.
+bool IsAngularlyMonotonic(std::span<m2::PointD const> points, m2::PointD const & center);
 }  // namespace routing

--- a/libs/routing/following_info.hpp
+++ b/libs/routing/following_info.hpp
@@ -27,29 +27,27 @@ public:
     std::pair<uint16_t, uint16_t> m_junctionInfoPosition;
   };
 
-  FollowingInfo()
-    : m_turn(turns::CarDirection::None)
-    , m_nextTurn(turns::CarDirection::None)
-    , m_exitNum(0)
-    , m_time(0)
-    , m_completionPercent(0)
-    , m_pedestrianTurn(turns::PedestrianDirection::None)
-  {}
+  FollowingInfo() = default;
 
   bool IsValid() const { return m_distToTarget.IsValid(); }
 
   /// @name Formatted covered distance.
   platform::Distance m_distToTarget;
 
-  /// @name Formatted distance to the next turn.
+  /// @name Next turns and formatted distance to the closest one.
   //@{
   platform::Distance m_distToTurn;
-  turns::CarDirection m_turn;
-  /// Turn after m_turn. Returns NoTurn if there is no turns after.
-  turns::CarDirection m_nextTurn;
-  uint32_t m_exitNum;
+  turns::CarDirection m_turn = turns::CarDirection::None;
+  /// Exit number and roundabout details of m_turn.
+  uint32_t m_exitNum = 0;
+  turns::RoundaboutInfo m_roundaboutInfo;
+  /// Turn after m_turn, or CarDirection::None when it should not be displayed.
+  turns::CarDirection m_nextTurn = turns::CarDirection::None;
+  /// Exit number and roundabout details of m_nextTurn.
+  uint32_t m_nextExitNum = 0;
+  turns::RoundaboutInfo m_nextRoundaboutInfo;
   //@}
-  int m_time;
+  int m_time = 0;
   /// Contains lane information on the edge before the turn.
   turns::lanes::LanesInfo m_lanes;
   // m_turnNotifications contains information about the next turn notifications.
@@ -71,11 +69,11 @@ public:
   RoadShieldInfo m_nextNextStreetShields;
 
   // Percentage of the route completion.
-  double m_completionPercent;
+  double m_completionPercent = 0.0;
 
   /// @name Pedestrian direction information
   //@{
-  turns::PedestrianDirection m_pedestrianTurn;
+  turns::PedestrianDirection m_pedestrianTurn = turns::PedestrianDirection::None;
   //@}
 
   // Current speed limit in meters per second.

--- a/libs/routing/loaded_path_segment.hpp
+++ b/libs/routing/loaded_path_segment.hpp
@@ -7,6 +7,7 @@
 
 #include "indexer/ftypes_matcher.hpp"
 
+#include <optional>
 #include <vector>
 
 namespace routing
@@ -25,6 +26,11 @@ struct LoadedPathSegment
   SegmentRange m_segmentRange;
   std::vector<Segment> m_segments; /*!< Traffic segments for |m_path|. */
   ftypes::HighwayClass m_highwayClass = ftypes::HighwayClass::Undefined;
+  // Closed-roundabout metadata retained only while turn annotations are created. The direction is the
+  // circulation as driven, already flipped for a backward traversal. The center is set only when the
+  // whole feature is angularly monotonic around it, so partial polar sweeps around it are valid.
+  std::optional<m2::PointD> m_roundaboutCenter;
+  turns::RoundaboutDirection m_roundaboutDirection = turns::RoundaboutDirection::Unknown;
   bool m_onRoundabout = false;
   bool m_isLink = false;
   bool m_isOneWay = false;

--- a/libs/routing/route.hpp
+++ b/libs/routing/route.hpp
@@ -154,7 +154,11 @@ public:
     m_turn.m_pedestrianTurn = turns::PedestrianDirection::None;
   }
 
-  void SetTurnExits(uint32_t exitNum) { m_turn.m_exitNum = exitNum; }
+  void SetRoundaboutExit(uint32_t exitNum, turns::RoundaboutInfo const & roundaboutInfo)
+  {
+    m_turn.m_exitNum = exitNum;
+    m_turn.m_roundaboutInfo = roundaboutInfo;
+  }
 
   turns::lanes::LanesInfo & GetTurnLanes() { return m_turn.m_lanes; }
 

--- a/libs/routing/routing_session.cpp
+++ b/libs/routing/routing_session.cpp
@@ -424,9 +424,15 @@ FollowingInfo RoutingSession::GetRouteFollowingInfo() const
 
   // The turn after the next one.
   if (m_routingSettings.m_showTurnAfterNext)
-    info.m_nextTurn = m_turnNotificationsMgr.GetSecondTurnNotification();
+  {
+    auto const & nextTurn = m_turnNotificationsMgr.GetSecondTurn();
+    info.m_nextTurn = nextTurn.m_turn;
+    info.m_nextExitNum = nextTurn.m_exitNum;
+    info.m_nextRoundaboutInfo = nextTurn.m_roundaboutInfo;
+  }
 
   info.m_exitNum = turn.m_exitNum;
+  info.m_roundaboutInfo = turn.m_roundaboutInfo;
   info.m_time = static_cast<int>(std::max(kMinimumETASec, m_route->GetCurrentTimeToEndSec()));
 
   RouteSegment::RoadNameInfo currentRoadNameInfo;

--- a/libs/routing/routing_session.cpp
+++ b/libs/routing/routing_session.cpp
@@ -390,23 +390,20 @@ void GetFullRoadName(RouteSegment::RoadNameInfo const & road, FollowingInfo::Roa
   }
 }
 
-void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
+FollowingInfo RoutingSession::GetRouteFollowingInfo() const
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
 
+  FollowingInfo info;
+  // Nothing should be displayed on the screen about turns if the route is not being followed yet.
   if (!IsRouteValid())
-  {
-    // nothing should be displayed on the screen about turns if these lines are executed
-    info = FollowingInfo();
-    return;
-  }
+    return info;
 
   if (!IsNavigable())
   {
-    info = FollowingInfo();
     info.m_distToTarget = platform::Distance::CreateFormatted(m_route->GetTotalDistanceMeters());
     info.m_time = static_cast<int>(std::max(kMinimumETASec, m_route->GetCurrentTimeToEndSec()));
-    return;
+    return info;
   }
 
   info.m_distToTarget = platform::Distance::CreateFormatted(m_route->GetCurrentDistanceToEndMeters());
@@ -428,8 +425,6 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
   // The turn after the next one.
   if (m_routingSettings.m_showTurnAfterNext)
     info.m_nextTurn = m_turnNotificationsMgr.GetSecondTurnNotification();
-  else
-    info.m_nextTurn = routing::turns::CarDirection::None;
 
   info.m_exitNum = turn.m_exitNum;
   info.m_time = static_cast<int>(std::max(kMinimumETASec, m_route->GetCurrentTimeToEndSec()));
@@ -456,6 +451,8 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
   // Pedestrian info.
   info.m_pedestrianTurn =
       (distanceToTurnMeters < kShowPedestrianTurnInMeters) ? turn.m_pedestrianTurn : turns::PedestrianDirection::None;
+
+  return info;
 }
 
 double RoutingSession::GetCompletionPercent() const

--- a/libs/routing/routing_session.hpp
+++ b/libs/routing/routing_session.hpp
@@ -86,7 +86,7 @@ public:
 
   SessionState OnLocationPositionChanged(location::GpsInfo const & info);
   /// @pre Function is called exactly while moving the route. Depends on current time, no pre-caching.
-  void GetRouteFollowingInfo(FollowingInfo & info) const;
+  FollowingInfo GetRouteFollowingInfo() const;
 
   bool MatchLocationToRoute(location::GpsInfo & location, location::RouteMatchingInfo & routeMatchingInfo);
   void MatchLocationToRoadGraph(location::GpsInfo & location);

--- a/libs/routing/routing_tests/turns_generator_test.cpp
+++ b/libs/routing/routing_tests/turns_generator_test.cpp
@@ -3,6 +3,7 @@
 #include "routing/routing_tests/tools.hpp"
 
 #include "routing/car_directions.hpp"
+#include "routing/directions_engine_helpers.hpp"
 #include "routing/loaded_path_segment.hpp"
 #include "routing/route.hpp"
 #include "routing/routing_result_graph.hpp"
@@ -12,12 +13,16 @@
 
 #include "indexer/ftypes_matcher.hpp"
 
+#include "geometry/angles.hpp"
 #include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"
 #include "geometry/point_with_altitude.hpp"
 
 #include "base/macros.hpp"
+#include "base/math.hpp"
 
+#include <cmath>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -123,6 +128,301 @@ UNIT_TEST(TestFixupTurns)
     TEST_EQUAL(routeSegments3[0].GetTurn(), expectedTurnDir3[0], ());
     TEST_EQUAL(routeSegments3[1].GetTurn(), expectedTurnDir3[1], ());
   }
+}
+
+// Angles are in degrees, counter-clockwise from the east.
+m2::PointD PointOnUnitCircle(double degrees)
+{
+  return {cos(math::DegToRad(degrees)), sin(math::DegToRad(degrees))};
+}
+
+vector<m2::PointD> MakeRoundaboutPath(double enterDeg, double exitDeg, bool counterClockwise)
+{
+  // Degrees driven in circulation from the entrance to the exit, in (0, 360].
+  double sweep = counterClockwise ? exitDeg - enterDeg : enterDeg - exitDeg;
+  while (sweep <= 0.0)
+    sweep += 360.0;
+
+  vector<m2::PointD> path = {PointOnUnitCircle(enterDeg)};
+  // -1 keeps the last point of the ring from coinciding with the exit.
+  for (double driven = 30.0; driven < sweep - 1.0; driven += 30.0)
+    path.push_back(PointOnUnitCircle(counterClockwise ? enterDeg + driven : enterDeg - driven));
+  path.push_back(PointOnUnitCircle(exitDeg));
+  return path;
+}
+
+// |roundabout| makes the segment a part of a closed ring centered at the origin. LoadPathAttributes()
+// stores a center only together with that ring's winding, so both are set here, as in production.
+LoadedPathSegment MakeLoadedPathSegment(vector<m2::PointD> const & path, bool roundabout)
+{
+  LoadedPathSegment segment;
+  for (auto const & point : path)
+    segment.m_path.emplace_back(point);
+  segment.m_onRoundabout = roundabout;
+  if (roundabout)
+  {
+    segment.m_roundaboutCenter = m2::PointD::Zero();
+    double sweep = 0.0;
+    for (size_t i = 1; i < path.size(); ++i)
+      sweep += ang::GetShortestDistance(ang::AngleTo(m2::PointD::Zero(), path[i - 1]),
+                                        ang::AngleTo(m2::PointD::Zero(), path[i]));
+    if (sweep != 0.0)
+      segment.m_roundaboutDirection =
+          sweep > 0.0 ? RoundaboutDirection::CounterClockwise : RoundaboutDirection::Clockwise;
+  }
+  return segment;
+}
+
+// Turns a ring segment into a part of an open or split roundabout feature, which has neither.
+void MakeOpenRoundabout(LoadedPathSegment & segment)
+{
+  segment.m_roundaboutCenter.reset();
+  segment.m_roundaboutDirection = RoundaboutDirection::Unknown;
+}
+
+RoundaboutInfo CalcRoundaboutInfoForAngles(double enterDeg, double exitDeg, bool counterClockwise)
+{
+  TUnpackedPathSegments segments = {
+      MakeLoadedPathSegment({PointOnUnitCircle(enterDeg) * 10.0, PointOnUnitCircle(enterDeg)}, false),
+      MakeLoadedPathSegment(MakeRoundaboutPath(enterDeg, exitDeg, counterClockwise), true),
+      MakeLoadedPathSegment({PointOnUnitCircle(exitDeg), PointOnUnitCircle(exitDeg) * 5.0}, false)};
+  RoutingResultTest result(segments);
+  return CalcRoundaboutInfo(result, 2 /* outgoingSegmentIndex */);
+}
+
+void TestRoundaboutExit(double exitDeg, bool counterClockwise, uint16_t expectedAngle)
+{
+  auto const info = CalcRoundaboutInfoForAngles(-90.0 /* enterDeg */, exitDeg, counterClockwise);
+  TEST(info.m_hasExit, (exitDeg, counterClockwise));
+  TEST_EQUAL(info.m_exitAngle, expectedAngle, (exitDeg, counterClockwise));
+  TEST_EQUAL(info.m_direction,
+             counterClockwise ? RoundaboutDirection::CounterClockwise : RoundaboutDirection::Clockwise,
+             (exitDeg, counterClockwise));
+}
+
+UNIT_TEST(TestCalcRoundaboutInfo)
+{
+  // Counter-clockwise circulation: the 1st exit is to the right.
+  TestRoundaboutExit(0.0 /* east */, true, 90);
+  TestRoundaboutExit(90.0 /* north */, true, 180);
+  TestRoundaboutExit(180.0 /* west */, true, 270);
+
+  // Clockwise circulation: the 1st exit is to the left.
+  TestRoundaboutExit(180.0 /* west */, false, 90);
+  TestRoundaboutExit(90.0 /* north */, false, 180);
+  TestRoundaboutExit(0.0 /* east */, false, 270);
+
+  // The whole circle is driven to take the exit back to the approach road.
+  TestRoundaboutExit(-90.0 /* south */, true, 360);
+  TestRoundaboutExit(-90.0 /* south */, false, 360);
+
+  // The entrance and the exit are the neighbouring points of the ring, so a single segment is
+  // driven on it.
+  TestRoundaboutExit(-60.0, true, 30);
+  TestRoundaboutExit(-120.0, false, 30);
+
+  // A non-cardinal exit is rounded to the nearest degree.
+  TestRoundaboutExit(100.4, true, 190);
+  TestRoundaboutExit(79.6, false, 190);
+
+  // Approach and exit headings do not affect the sweep measured on the ring.
+  auto ring = MakeLoadedPathSegment(MakeRoundaboutPath(-90.0, 0.0, true), true);
+  TUnpackedPathSegments segments = {MakeLoadedPathSegment({{-2.0, -1.0}, {0.0, -1.0}}, false), ring,
+                                    MakeLoadedPathSegment({{1.0, 0.0}, {3.0, 1.0}}, false)};
+  RoutingResultTest result(segments);
+  TEST_EQUAL(CalcRoundaboutInfo(result, 2).m_exitAngle, 90, ());
+
+  // Turn annotations split the ring at junctions; every annotated part contributes to the sweep.
+  auto const ringPath = MakeRoundaboutPath(-90.0, 90.0, true);
+  TUnpackedPathSegments splitSegments = {
+      MakeLoadedPathSegment({PointOnUnitCircle(-90.0) * 5.0, ringPath.front()}, false)};
+  for (size_t i = 1; i < ringPath.size(); ++i)
+    splitSegments.push_back(MakeLoadedPathSegment({ringPath[i - 1], ringPath[i]}, true));
+  splitSegments.push_back(MakeLoadedPathSegment({ringPath.back(), PointOnUnitCircle(90.0) * 5.0}, false));
+  auto const splitInfo = CalcRoundaboutInfo(RoutingResultTest(splitSegments), splitSegments.size() - 1);
+  TEST_EQUAL(splitInfo, (RoundaboutInfo{180, RoundaboutDirection::CounterClockwise, true}), ());
+
+  // Both values are derived across segment boundaries even when every part of the roundabout is an
+  // open two-point feature, and the estimated angle matches the sweep measured around a center.
+  for (size_t i = 1; i + 1 < splitSegments.size(); ++i)
+    MakeOpenRoundabout(splitSegments[i]);
+  auto const openSplitInfo = CalcRoundaboutInfo(RoutingResultTest(splitSegments), splitSegments.size() - 1);
+  TEST_EQUAL(openSplitInfo, splitInfo, ());
+
+  MakeOpenRoundabout(segments[1]);
+  TEST_EQUAL(CalcRoundaboutInfo(RoutingResultTest(segments), 2),
+             (RoundaboutInfo{90, RoundaboutDirection::CounterClockwise, true}), ());
+
+  auto clockwiseRing = MakeLoadedPathSegment(MakeRoundaboutPath(-90.0, 180.0, false), true);
+  MakeOpenRoundabout(clockwiseRing);
+  TUnpackedPathSegments clockwiseSegments = {
+      MakeLoadedPathSegment({PointOnUnitCircle(-90.0) * 5.0, clockwiseRing.m_path.front().GetPoint()}, false),
+      clockwiseRing, MakeLoadedPathSegment({PointOnUnitCircle(180.0), PointOnUnitCircle(180.0) * 5.0}, false)};
+  TEST_EQUAL(CalcRoundaboutInfo(RoutingResultTest(clockwiseSegments), 2),
+             (RoundaboutInfo{90, RoundaboutDirection::Clockwise, true}), ());
+
+  // A single driven edge has no bend, so neither value can be derived from the path alone.
+  auto singleEdgeRing = MakeLoadedPathSegment(MakeRoundaboutPath(-90.0, -60.0, true), true);
+  MakeOpenRoundabout(singleEdgeRing);
+  TUnpackedPathSegments singleEdgeSegments = {
+      MakeLoadedPathSegment({PointOnUnitCircle(-90.0) * 5.0, singleEdgeRing.m_path.front().GetPoint()}, false),
+      singleEdgeRing, MakeLoadedPathSegment({PointOnUnitCircle(-60.0), PointOnUnitCircle(-60.0) * 5.0}, false)};
+  TEST_EQUAL(CalcRoundaboutInfo(RoutingResultTest(singleEdgeSegments), 2),
+             (RoundaboutInfo{0, RoundaboutDirection::Unknown, true}), ());
+}
+
+// Drives the same ring twice: once with a validated center, and once as an open feature that has
+// none, so the exact polar sweep and the estimate made from the driven bends can be compared.
+void TestExitAngleWithoutCenter(double exitDeg, bool counterClockwise, uint16_t expectedAngle)
+{
+  TUnpackedPathSegments segments = {
+      MakeLoadedPathSegment({PointOnUnitCircle(-90.0) * 10.0, PointOnUnitCircle(-90.0)}, false),
+      MakeLoadedPathSegment(MakeRoundaboutPath(-90.0 /* enterDeg */, exitDeg, counterClockwise), true),
+      MakeLoadedPathSegment({PointOnUnitCircle(exitDeg), PointOnUnitCircle(exitDeg) * 5.0}, false)};
+  auto const exact = CalcRoundaboutInfo(RoutingResultTest(segments), 2);
+
+  MakeOpenRoundabout(segments[1]);
+  auto const estimated = CalcRoundaboutInfo(RoutingResultTest(segments), 2);
+
+  TEST_EQUAL(estimated.m_direction, exact.m_direction, (exitDeg, counterClockwise));
+  TEST_EQUAL(estimated.m_exitAngle, exact.m_exitAngle, (exitDeg, counterClockwise));
+  TEST_EQUAL(estimated.m_exitAngle, expectedAngle, (exitDeg, counterClockwise));
+}
+
+UNIT_TEST(TestCalcRoundaboutInfoWithoutCenter)
+{
+  // Most roundabouts are mapped as several open ways and have no validated center, so the sweep is
+  // estimated from the bends of the driven path. The helper builds a ring of equal steps, for which
+  // the estimate is exact.
+  TestExitAngleWithoutCenter(0.0 /* east */, true, 90);
+  TestExitAngleWithoutCenter(90.0 /* north */, true, 180);
+  TestExitAngleWithoutCenter(180.0 /* west */, true, 270);
+  TestExitAngleWithoutCenter(180.0 /* west */, false, 90);
+  TestExitAngleWithoutCenter(90.0 /* north */, false, 180);
+  TestExitAngleWithoutCenter(0.0 /* east */, false, 270);
+  TestExitAngleWithoutCenter(-90.0 /* south */, true, 360);
+  TestExitAngleWithoutCenter(-90.0 /* south */, false, 360);
+
+  // The step onto a non-cardinal exit is shorter than the ring's other steps. Weighting the bends by
+  // the chords they span keeps the estimate equal to the sweep measured around a center.
+  TestExitAngleWithoutCenter(100.4, true, 190);
+  TestExitAngleWithoutCenter(79.6, false, 190);
+}
+
+UNIT_TEST(TestClosedRoundaboutGeometry)
+{
+  vector<m2::PointD> const square = {{0.0, 0.0}, {4.0, 0.0}, {4.0, 4.0}, {0.0, 4.0}, {0.0, 0.0}};
+  TEST_EQUAL(CalcClosedRoundaboutDirection(square, true /* isForward */), RoundaboutDirection::CounterClockwise, ());
+  TEST_EQUAL(CalcClosedRoundaboutDirection(square, false /* isForward */), RoundaboutDirection::Clockwise, ());
+  TEST(IsAngularlyMonotonic(square, {2.0, 2.0}), ());
+
+  // The bounding-box center of this counter-clockwise L-shaped ring lies in its concavity. The two
+  // driven reflex edges have a clockwise polar sweep, so the center must not be used for an angle;
+  // the full ring's winding still provides the correct circulation direction.
+  vector<m2::PointD> const concave = {{0.0, 0.0}, {4.0, 0.0}, {4.0, 1.0}, {1.0, 1.0},
+                                      {1.0, 4.0}, {0.0, 4.0}, {0.0, 0.0}};
+  TEST_EQUAL(CalcClosedRoundaboutDirection(concave, true /* isForward */), RoundaboutDirection::CounterClockwise, ());
+  TEST(!IsAngularlyMonotonic(concave, {2.0, 2.0}), ());
+
+  // The route drives the two reflex edges of that ring. Its winding is known from the closed feature,
+  // but the rejected center leaves the angle unavailable.
+  auto ring = MakeLoadedPathSegment({{4.0, 1.0}, {1.0, 1.0}, {1.0, 4.0}}, true);
+  ring.m_roundaboutCenter.reset();
+  ring.m_roundaboutDirection = RoundaboutDirection::CounterClockwise;
+  TUnpackedPathSegments segments = {MakeLoadedPathSegment({{4.0, 0.0}, {4.0, 1.0}}, false), ring,
+                                    MakeLoadedPathSegment({{1.0, 4.0}, {0.0, 4.0}}, false)};
+  TEST_EQUAL(CalcRoundaboutInfo(RoutingResultTest(segments), 2),
+             (RoundaboutInfo{0, RoundaboutDirection::CounterClockwise, true}), ());
+
+  auto radialRing = MakeLoadedPathSegment({{2.0, 0.0}, {1.0, 0.0}}, true);
+  radialRing.m_roundaboutDirection = RoundaboutDirection::CounterClockwise;
+  TUnpackedPathSegments radialSegments = {MakeLoadedPathSegment({{3.0, 0.0}, {2.0, 0.0}}, false), radialRing,
+                                          MakeLoadedPathSegment({{1.0, 0.0}, {1.0, 1.0}}, false)};
+  TEST_EQUAL(CalcRoundaboutInfo(RoutingResultTest(radialSegments), 2),
+             (RoundaboutInfo{0, RoundaboutDirection::CounterClockwise, true}), ());
+}
+
+UNIT_TEST(TestCalcRoundaboutInfoOnMiniRoundabout)
+{
+  // Fountain Street -> Bridge Street through https://www.openstreetmap.org/node/4664432830 from
+  // https://github.com/organicmaps/organicmaps/issues/7039. The generator replaces the mini
+  // roundabout node with a ring and joins the roads to it radially, clockwise here because the UK
+  // has left-hand traffic.
+  m2::PointD const center = mercator::FromLatLon(51.6960299, -2.2181448);
+  auto const armDeg = [&center](double lat, double lon)
+  { return math::RadToDeg(ang::AngleTo(center, mercator::FromLatLon(lat, lon))); };
+
+  double const enter = armDeg(51.6955804, -2.2179469);  // Fountain Street.
+  double const leave = armDeg(51.6964762, -2.2182834);  // Bridge Street.
+  auto const info = CalcRoundaboutInfoForAngles(enter, leave, false);
+  TEST_EQUAL(info.m_exitAngle, 184, ());
+  TEST_EQUAL(info.m_direction, RoundaboutDirection::Clockwise, ());
+}
+
+UNIT_TEST(TestFixupTurnsRoundaboutExit)
+{
+  // The driver enters from the south, passes the exit to the east and takes the next one, to the
+  // north, which is the 2nd one.
+  vector<m2::PointD> path = {PointOnUnitCircle(-90.0) * 5.0};
+  auto const ringPath = MakeRoundaboutPath(-90.0 /* enterDeg */, 90.0 /* north */, true);
+  path.insert(path.end(), ringPath.begin(), ringPath.end());
+  path.push_back(PointOnUnitCircle(90.0) * 5.0);
+  // routeSegments[i] gets path[i + 1], so the exit is the 2nd route segment from the end.
+  size_t const leaveIdx = path.size() - 3;
+  vector<TurnItem> turns(path.size() - 1);
+  for (size_t i = 0; i < turns.size(); ++i)
+    turns[i] = {static_cast<uint32_t>(i + 1), CarDirection::None};
+  turns[1] = {2, CarDirection::EnterRoundAbout};
+  turns[4] = {5, CarDirection::StayOnRoundAbout};  // The exit to the east.
+  turns[leaveIdx] = {static_cast<uint32_t>(leaveIdx + 1), CarDirection::LeaveRoundAbout};
+  turns[leaveIdx].m_roundaboutInfo = {180, RoundaboutDirection::CounterClockwise, true};
+
+  vector<RouteSegment> routeSegments;
+  RouteSegmentsFrom({}, path, turns, {}, routeSegments);
+  FixupCarTurns(routeSegments);
+
+  // Both the entrance and the exit turns carry the same roundabout metadata.
+  for (size_t const idx : {size_t(1), leaveIdx})
+  {
+    TEST_EQUAL(routeSegments[idx].GetTurn().m_exitNum, 2U, (idx));
+    TEST_EQUAL(routeSegments[idx].GetTurn().m_roundaboutInfo,
+               (RoundaboutInfo{180, RoundaboutDirection::CounterClockwise, true}), (idx));
+  }
+  TEST_EQUAL(routeSegments[4].GetTurn().m_turn, CarDirection::None, ());
+}
+
+// A route that ends on the ring has no LeaveRoundAbout for FixupCarTurns() to copy back, so the
+// circulation measured when entering is the only thing car displays get. This is the ENTER_CW/CCW
+// input that RoutingHelpersTest.preservesDirectionWithoutAngle() asserts on the Java side.
+UNIT_TEST(TestRoundaboutDirectionWhenRouteEndsOnRing)
+{
+  auto const ringPath = MakeRoundaboutPath(-90.0 /* enterDeg */, 90.0 /* exitDeg */, true);
+  TUnpackedPathSegments segments = {MakeLoadedPathSegment({PointOnUnitCircle(-90.0) * 5.0, ringPath.front()}, false),
+                                    MakeLoadedPathSegment(ringPath, true)};
+  TEST_EQUAL(CalcRoundaboutDirection(RoutingResultTest(segments), 1), RoundaboutDirection::CounterClockwise, ());
+
+  // An open ring stores no winding, so it comes from the bends of the driven path instead.
+  MakeOpenRoundabout(segments[1]);
+  TEST_EQUAL(CalcRoundaboutDirection(RoutingResultTest(segments), 1), RoundaboutDirection::CounterClockwise, ());
+
+  vector<m2::PointD> path = {PointOnUnitCircle(-90.0) * 5.0};
+  path.insert(path.end(), ringPath.begin(), ringPath.end());
+  vector<TurnItem> turns(path.size() - 1);
+  for (size_t i = 0; i < turns.size(); ++i)
+    turns[i] = {static_cast<uint32_t>(i + 1), CarDirection::None};
+  turns.front() = {1, CarDirection::EnterRoundAbout};
+  turns.front().m_roundaboutInfo.m_direction = RoundaboutDirection::CounterClockwise;
+  turns.back() = {static_cast<uint32_t>(turns.size()), CarDirection::ReachedYourDestination};
+
+  vector<RouteSegment> routeSegments;
+  RouteSegmentsFrom({}, path, turns, {}, routeSegments);
+  FixupCarTurns(routeSegments);
+
+  // Nothing overwrites the entrance: the direction survives without an exit number or an angle.
+  TEST_EQUAL(routeSegments.front().GetTurn().m_turn, CarDirection::EnterRoundAbout, ());
+  TEST_EQUAL(routeSegments.front().GetTurn().m_exitNum, 0U, ());
+  TEST_EQUAL(routeSegments.front().GetTurn().m_roundaboutInfo,
+             (RoundaboutInfo{0, RoundaboutDirection::CounterClockwise, false}), ());
 }
 
 UNIT_TEST(TestGetRoundaboutDirection)

--- a/libs/routing/routing_tests/turns_sound_test.cpp
+++ b/libs/routing/routing_tests/turns_sound_test.cpp
@@ -9,6 +9,8 @@ namespace turns_sound_test
 {
 using namespace std;
 using routing::turns::CarDirection;
+using routing::turns::RoundaboutDirection;
+using routing::turns::RoundaboutInfo;
 using routing::turns::TurnItemDist;
 using routing::turns::sound::NotificationManager;
 using routing::turns::sound::Settings;
@@ -98,13 +100,13 @@ UNIT_TEST(TurnsSound_MetersTest)
   // 1000 meters till the turn. No sound notifications is required.
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 700 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 700.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 699 meters till the turn. It's time to pronounce the first voice notification.
   // Why? The current speed is 30 meters per seconds. According to correctSettingsMeters
@@ -116,13 +118,13 @@ UNIT_TEST(TurnsSound_MetersTest)
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   vector<string> const expectedNotification1 = {{"In 600 meters. Make a right turn."}};
   TEST_EQUAL(turnNotifications, expectedNotification1, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 650 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 650.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   notificationManager.SetSpeedMetersPerSecond(32.);
 
@@ -130,38 +132,38 @@ UNIT_TEST(TurnsSound_MetersTest)
   turns.front().m_distMeters = 150.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 100 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 100.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 99 meters till the turn. It's time to pronounce the second voice notification.
   turns.front().m_distMeters = 99.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   vector<string> const expectedNotification2 = {{"Make a right turn."}};
   TEST_EQUAL(turnNotifications, expectedNotification2, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 99 meters till the turn again. No sound notifications is required.
   turns.front().m_distMeters = 99.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 50 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 50.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 0 meters till the turn. No sound notifications is required.
   turns.front().m_distMeters = 0.;
   notificationManager.GenerateTurnNotifications(turns, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   TEST(notificationManager.IsEnabled(), ());
 }
@@ -341,16 +343,21 @@ UNIT_TEST(TurnsSound_ComposedTurnTest)
                                        {{10 /* idx */, CarDirection::EnterRoundAbout}, 1000. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns1, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 620 meters till the first turn.
   turnNotifications.clear();
-  vector<TurnItemDist> const turns2 = {{{5 /* idx */, CarDirection::TurnRight}, 620. /* m_distMeters */},
-                                       {{10 /* idx */, CarDirection::EnterRoundAbout}, 665. /* m_distMeters */}};
+  vector<TurnItemDist> turns2 = {
+      {{5 /* idx */, CarDirection::TurnRight}, 620. /* m_distMeters */},
+      {{10 /* idx */, CarDirection::EnterRoundAbout, 3 /* m_exitNum */}, 665. /* m_distMeters */}};
+  turns2[1].m_turnItem.m_roundaboutInfo = {270, RoundaboutDirection::Clockwise, true};
   vector<string> const expectedNotification2 = {{"In 600 meters. Turn right."}, {"Then. Enter the roundabout."}};
   notificationManager.GenerateTurnNotifications(turns2, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification2, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::EnterRoundAbout, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::EnterRoundAbout, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_exitNum, 3, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_roundaboutInfo,
+             (RoundaboutInfo{270, RoundaboutDirection::Clockwise, true}), ());
 
   // 300 meters till the first turn.
   turnNotifications.clear();
@@ -358,7 +365,10 @@ UNIT_TEST(TurnsSound_ComposedTurnTest)
                                        {{10 /* idx */, CarDirection::EnterRoundAbout}, 500. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns3, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::EnterRoundAbout, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::EnterRoundAbout, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_exitNum, 3, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_roundaboutInfo,
+             (RoundaboutInfo{270, RoundaboutDirection::Clockwise, true}), ());
 
   // 20 meters till the first turn.
   turnNotifications.clear();
@@ -367,7 +377,7 @@ UNIT_TEST(TurnsSound_ComposedTurnTest)
   vector<string> const expectedNotification4 = {{"Turn right."}, {"Then. In 200 meters. Enter the roundabout."}};
   notificationManager.GenerateTurnNotifications(turns4, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification4, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::EnterRoundAbout, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::EnterRoundAbout, ());
 
   // After the first turn.
   turnNotifications.clear();
@@ -376,7 +386,7 @@ UNIT_TEST(TurnsSound_ComposedTurnTest)
       {{15 /* idx */, CarDirection::ReachedYourDestination}, 1180. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns5, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // Just before the second turn.
   turnNotifications.clear();
@@ -386,7 +396,7 @@ UNIT_TEST(TurnsSound_ComposedTurnTest)
   vector<string> const expectedNotification6 = {{"Enter the roundabout."}};
   notificationManager.GenerateTurnNotifications(turns6, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification6, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 }
 
 UNIT_TEST(TurnsSound_RoundaboutTurnTest)
@@ -417,7 +427,7 @@ UNIT_TEST(TurnsSound_RoundaboutTurnTest)
       {{10 /* idx */, CarDirection::LeaveRoundAbout, 2 /* m_exitNum */}, 2000. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns1, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 620 meters till the first turn.
   vector<TurnItemDist> const turns2 = {
@@ -427,7 +437,7 @@ UNIT_TEST(TurnsSound_RoundaboutTurnTest)
                                                 {"Then. In 1 kilometer. Take the second exit."}};
   notificationManager.GenerateTurnNotifications(turns2, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification2, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 3 meters till the first turn.
   vector<TurnItemDist> const turns3 = {
@@ -437,7 +447,7 @@ UNIT_TEST(TurnsSound_RoundaboutTurnTest)
                                                 {"Then. In 1 kilometer. Take the second exit."}};
   notificationManager.GenerateTurnNotifications(turns3, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification3, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 900 meters till the second turn.
   vector<TurnItemDist> const turns4 = {
@@ -445,7 +455,7 @@ UNIT_TEST(TurnsSound_RoundaboutTurnTest)
       {{15 /* idx */, CarDirection::EnterRoundAbout, 1 /* m_exitNum */}, 1900. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns4, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 300 meters till the second turn.
   vector<TurnItemDist> const turns5 = {
@@ -453,7 +463,7 @@ UNIT_TEST(TurnsSound_RoundaboutTurnTest)
       {{15 /* idx */, CarDirection::EnterRoundAbout, 1 /* m_exitNum */}, 1300. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns5, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 3 meters till the second turn.
   vector<TurnItemDist> const turns6 = {
@@ -462,7 +472,7 @@ UNIT_TEST(TurnsSound_RoundaboutTurnTest)
   vector<string> const expectedNotification6 = {{"Leave the roundabout."}};
   notificationManager.GenerateTurnNotifications(turns6, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification6, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 5 meters till the third turn.
   vector<TurnItemDist> const turns7 = {
@@ -473,7 +483,7 @@ UNIT_TEST(TurnsSound_RoundaboutTurnTest)
   notificationManager.GenerateTurnNotifications(turns7, turnNotifications);  // The first notification fast forwarding.
   notificationManager.GenerateTurnNotifications(turns7, turnNotifications);
   TEST_EQUAL(turnNotifications, expectedNotification7, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 900 meters till the 4th turn.
   notificationManager.Reset();
@@ -482,7 +492,7 @@ UNIT_TEST(TurnsSound_RoundaboutTurnTest)
       {{30 /* idx */, CarDirection::LeaveRoundAbout, 4 /* m_exitNum */}, 1200. /* m_distMeters */}};
   notificationManager.GenerateTurnNotifications(turns8, turnNotifications);
   TEST(turnNotifications.empty(), ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::None, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::None, ());
 
   // 620 meters till the 4th turn.
   vector<TurnItemDist> const turns9 = {
@@ -493,7 +503,7 @@ UNIT_TEST(TurnsSound_RoundaboutTurnTest)
   notificationManager.GenerateTurnNotifications(turns9, turnNotifications,
                                                 routing::RouteSegment::RoadNameInfo("Main street"));
   TEST_EQUAL(turnNotifications, expectedNotification9, ());
-  TEST_EQUAL(notificationManager.GetSecondTurnNotification(), CarDirection::LeaveRoundAbout, ());
+  TEST_EQUAL(notificationManager.GetSecondTurn().m_turn, CarDirection::LeaveRoundAbout, ());
 }
 
 UNIT_TEST(GetJsonBufferTest)

--- a/libs/routing/turns.cpp
+++ b/libs/routing/turns.cpp
@@ -4,6 +4,7 @@
 
 #include "platform/country_file.hpp"
 
+#include "base/assert.hpp"
 #include "base/internal/message.hpp"
 
 #include <algorithm>
@@ -136,12 +137,32 @@ std::string DebugPrint(SegmentRange const & segmentRange)
 
 namespace turns
 {
+std::string DebugPrint(RoundaboutDirection direction)
+{
+  switch (direction)
+  {
+  case RoundaboutDirection::Unknown: return "Unknown";
+  case RoundaboutDirection::Clockwise: return "Clockwise";
+  case RoundaboutDirection::CounterClockwise: return "CounterClockwise";
+  }
+  UNREACHABLE();
+}
+
+std::string DebugPrint(RoundaboutInfo const & info)
+{
+  std::stringstream out;
+  out << "RoundaboutInfo { m_exitAngle = " << info.m_exitAngle << ", m_direction = " << DebugPrint(info.m_direction)
+      << ", m_hasExit = " << info.m_hasExit << " }";
+  return out.str();
+}
+
 std::string DebugPrint(TurnItem const & turnItem)
 {
   std::stringstream out;
   out << "TurnItem "
       << "{ m_index = " << turnItem.m_index << ", m_turn = " << DebugPrint(turnItem.m_turn)
       << ", m_lanes = " << ::DebugPrint(turnItem.m_lanes) << ", m_exitNum = " << turnItem.m_exitNum
+      << ", m_roundaboutInfo = " << DebugPrint(turnItem.m_roundaboutInfo)
       << ", m_pedestrianDir = " << DebugPrint(turnItem.m_pedestrianTurn) << " }";
   return out.str();
 }

--- a/libs/routing/turns.hpp
+++ b/libs/routing/turns.hpp
@@ -9,6 +9,7 @@
 
 #include "geometry/point2d.hpp"
 
+#include <cstdint>
 #include <limits>
 #include <string>
 #include <vector>
@@ -30,6 +31,7 @@ struct SegmentRange
   void Clear();
   bool IsEmpty() const;
   FeatureID const & GetFeature() const;
+  bool IsForward() const { return m_forward; }
   /// \returns true if the instance of SegmentRange is correct.
   bool IsCorrect() const;
   /// \brief Fills |segment| with the first segment of this SegmentRange.
@@ -104,6 +106,32 @@ enum class CarDirection
 
 std::string DebugPrint(CarDirection const l);
 
+enum class RoundaboutDirection : uint8_t
+{
+  Unknown = 0,
+  Clockwise,
+  CounterClockwise
+};
+
+std::string DebugPrint(RoundaboutDirection direction);
+
+struct RoundaboutInfo
+{
+  bool operator==(RoundaboutInfo const &) const = default;
+
+  // Sweep from the roundabout entrance to the exit, rounded to degrees in [1, 360], or 0 when an
+  // angle cannot be derived reliably.
+  uint16_t m_exitAngle = 0;
+  // Circulation as actually driven, measured from geometry and independent of regional traffic rules.
+  RoundaboutDirection m_direction = RoundaboutDirection::Unknown;
+  // True when the route's exit from this roundabout is known. FixupCarTurns() sets it on the entry
+  // maneuver too, so it distinguishes an entry-only maneuver from a paired entry and exit when the
+  // exit angle is unavailable.
+  bool m_hasExit = false;
+};
+
+std::string DebugPrint(RoundaboutInfo const & info);
+
 /*!
  * \warning The values of PedestrianDirectionType shall be synchronized with values in java
  */
@@ -145,7 +173,7 @@ struct TurnItem
   bool operator==(TurnItem const & rhs) const
   {
     return m_index == rhs.m_index && m_turn == rhs.m_turn && m_lanes == rhs.m_lanes && m_exitNum == rhs.m_exitNum &&
-           m_pedestrianTurn == rhs.m_pedestrianTurn;
+           m_roundaboutInfo == rhs.m_roundaboutInfo && m_pedestrianTurn == rhs.m_pedestrianTurn;
   }
 
   bool IsTurnReachedYourDestination() const
@@ -160,6 +188,7 @@ struct TurnItem
   CarDirection m_turn = CarDirection::None; /*!< The turn instruction of the TurnItem */
   lanes::LanesInfo m_lanes;                 /*!< Lane information on the edge before the turn. */
   uint32_t m_exitNum;                       /*!< Number of exit on roundabout. */
+  RoundaboutInfo m_roundaboutInfo;
   /*!
    * \brief m_pedestrianTurn is type of corresponding direction for a pedestrian, or None
    * if there is no pedestrian specific direction

--- a/libs/routing/turns_notification_manager.cpp
+++ b/libs/routing/turns_notification_manager.cpp
@@ -45,8 +45,7 @@ NotificationManager::NotificationManager()
   , m_nextTurnNotificationProgress(PronouncedNotification::Nothing)
   , m_turnNotificationWithThen(false)
   , m_nextTurnIndex(0)
-  , m_secondTurnNotification(CarDirection::None)
-  , m_secondTurnNotificationIndex(0)
+  , m_closestTurnIndex(0)
 {}
 
 // static
@@ -106,7 +105,7 @@ void NotificationManager::GenerateTurnNotifications(std::vector<TurnItemDist> co
                                                     std::vector<std::string> & turnNotifications,
                                                     RouteSegment::RoadNameInfo const & nextStreetInfo)
 {
-  m_secondTurnNotification = GenerateSecondTurnNotification(turns);
+  UpdateSecondTurn(turns);
 
   turnNotifications.clear();
   if (!m_enabled || turns.empty())
@@ -264,8 +263,8 @@ void NotificationManager::Reset()
   m_nextTurnNotificationProgress = PronouncedNotification::Nothing;
   m_nextTurnIndex = 0;
   m_turnNotificationWithThen = false;
-  m_secondTurnNotification = CarDirection::None;
-  m_secondTurnNotificationIndex = 0;
+  m_secondTurn = {};
+  m_closestTurnIndex = 0;
 }
 
 void NotificationManager::FastForwardFirstTurnNotification()
@@ -275,38 +274,40 @@ void NotificationManager::FastForwardFirstTurnNotification()
     m_nextTurnNotificationProgress = PronouncedNotification::First;
 }
 
-CarDirection NotificationManager::GenerateSecondTurnNotification(std::vector<TurnItemDist> const & turns)
+void NotificationManager::UpdateSecondTurn(std::vector<TurnItemDist> const & turns)
 {
   if (turns.size() < 2)
   {
-    m_secondTurnNotificationIndex = 0;
-    return CarDirection::None;
+    m_secondTurn = {};
+    m_closestTurnIndex = 0;
+    return;
   }
 
   TurnItemDist const & firstTurn = turns[0];
   TurnItemDist const & secondTurn = turns[1];
 
-  if (firstTurn.m_turnItem.m_index != m_secondTurnNotificationIndex)
-    m_secondTurnNotificationIndex = 0;  // It's a new closest (first) turn.
-  else if (m_secondTurnNotificationIndex != 0)
-    return secondTurn.m_turnItem.m_turn;  // m_secondTurnNotificationIndex was set to true before.
+  if (m_closestTurnIndex != 0 && firstTurn.m_turnItem.m_index == m_closestTurnIndex)
+    return;
+
+  // The closest turn changed. Drop the cached second turn once; while it stays current, keep it
+  // instead of rebuilding it on every location update.
+  m_secondTurn = {};
+  m_closestTurnIndex = 0;
 
   double const distBetweenTurnsMeters = secondTurn.m_distMeters - firstTurn.m_distMeters;
   ASSERT_LESS_OR_EQUAL(0., distBetweenTurnsMeters, ());
 
   if (distBetweenTurnsMeters > kSecondTurnThresholdDistM)
-    return CarDirection::None;
+    return;
 
   uint32_t const startPronounceDistMeters = m_settings.ComputeTurnDistanceM(m_speedMetersPerSecond) +
                                             m_settings.ComputeDistToPronounceDistM(m_speedMetersPerSecond);
 
   if (firstTurn.m_distMeters <= startPronounceDistMeters)
   {
-    m_secondTurnNotificationIndex = firstTurn.m_turnItem.m_index;
-    return secondTurn.m_turnItem.m_turn;  // It's time to inform about the turn after the next one.
+    m_closestTurnIndex = firstTurn.m_turnItem.m_index;
+    m_secondTurn = secondTurn.m_turnItem;
   }
-
-  return CarDirection::None;
 }
 
 void NotificationManager::SetLocaleWithJsonForTesting(std::string const & json, std::string const & locale)

--- a/libs/routing/turns_notification_manager.hpp
+++ b/libs/routing/turns_notification_manager.hpp
@@ -81,25 +81,9 @@ public:
   /// The method shall be called after creating a new route or after rerouting.
   void Reset();
 
-  /// \brief The method was implemented to display the second turn notification
-  /// in an appropriate moment.
-  /// @return the second closest turn.
-  /// The return value is different form TurnDirection::NoTurn
-  /// if an end user is close enough to the first (current) turn and
-  /// the distance between the closest and the second closest turn is not large.
-  /// (That means a notification about turn after the closest one was pronounced.)
-  /// For example, if while closing to the closest turn was pronounced
-  /// "Turn right. Then turn left." 500 meters before the closest turn, after that moment
-  /// GetSecondTurnNotification returns TurnDirection::TurnLeft if distance to first turn < 500
-  /// meters.
-  /// After the closest composed turn was passed GetSecondTurnNotification returns
-  /// TurnDirection::NoTurn.
-  /// \note If the returning value is TurnDirection::NoTurn no turn shall be displayed.
-  /// \note If GetSecondTurnNotification returns a value different form TurnDirection::NoTurn
-  /// for a turn once it continues returning the same value until the turn is changed.
-  /// \note This method works independent from m_enabled value.
-  /// So it works when the class enable and disable.
-  CarDirection GetSecondTurnNotification() const { return m_secondTurnNotification; }
+  /// Returns the second closest turn after its "Then" notification is issued, or a turn with
+  /// CarDirection::None when it should not be displayed. This state is independent of m_enabled.
+  TurnItem const & GetSecondTurn() const { return m_secondTurn; }
 
 private:
   std::string GenerateTurnText(uint32_t distanceUnits, uint8_t exitNum, bool useThenInsteadOfDistance,
@@ -113,14 +97,8 @@ private:
   /// without pronunciation.
   void FastForwardFirstTurnNotification();
 
-  /// \param turns contains information about the next turns staring from closest turn.
-  /// That means turns[0] is the closest turn (if available).
-  /// @return the second closest turn or TurnDirection::NoTurn.
-  /// \note If GenerateSecondTurnNotification returns a value different form TurnDirection::NoTurn
-  /// for a turn once it will return the same value until the turn is changed.
-  /// \note This method works independent from m_enabled value.
-  /// So it works when the class enable and disable.
-  CarDirection GenerateSecondTurnNotification(std::vector<TurnItemDist> const & turns);
+  /// Updates m_secondTurn from turns, ordered closest first.
+  void UpdateSecondTurn(std::vector<TurnItemDist> const & turns);
 
   /// m_enabled == true when tts is turned on.
   /// Important! Clients (iOS/Android) implies that m_enabled is false by default.
@@ -157,21 +135,16 @@ private:
   /// notification string.
   GetTtsText m_getTtsText;
 
-  /// if m_secondTurnNotification == true it's time to display the second turn notification
-  /// visual informer, and false otherwise.
-  /// m_secondTurnNotification is a direction of the turn after the closest one
-  /// if an end user shall be informed about it. If not, m_secondTurnNotification ==
-  /// TurnDirection::NoTurn
-  CarDirection m_secondTurnNotification = CarDirection::None;
+  /// The turn after the closest one when it is time to display it, or an empty turn otherwise.
+  TurnItem m_secondTurn;
 
-  /// m_secondTurnNotificationIndex is an index of the closest turn on the route polyline
-  /// where m_secondTurnNotification was set to true last time for a turn.
-  /// If the closest turn is changed m_secondTurnNotification is set to 0.
+  /// Index on the route polyline of the closest turn that m_secondTurn was taken for. It is not the
+  /// index of m_secondTurn itself, which the turn item carries.
   /// \note 0 is a valid index. But in this context it could be considered as invalid
   /// because if firstTurnIndex == 0 that means we're at very beginning of the route
   /// and we're about to making a turn. In that case it's no use to inform a user about
   /// the turn after the next one.
-  uint32_t m_secondTurnNotificationIndex;
+  uint32_t m_closestTurnIndex;
 };
 }  // namespace sound
 }  // namespace turns

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -519,8 +519,7 @@ void DrawWidget::SubmitFakeLocationPoint(m2::PointD const & pt)
     /// RoutingSession::OnLocationPositionChanged will be called the last time.
     routingManager.RoutingSession().OnLocationPositionChanged(qt::common::MakeGpsInfo(point));
 
-    routing::FollowingInfo loc;
-    routingManager.GetRouteFollowingInfo(loc);
+    auto const loc = routingManager.GetRouteFollowingInfo();
     if (routingManager.GetCurrentRouterType() == routing::RouterType::Pedestrian)
     {
       LOG(LDEBUG, ("Distance:", loc.m_distToTarget, "Time:", loc.m_time, DebugPrint(loc.m_pedestrianTurn), "in",

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -532,9 +532,13 @@ void DrawWidget::SubmitFakeLocationPoint(m2::PointD const & pt)
         speed = "SpeedLimit: " +
                 measurement_utils::FormatSpeedNumeric(loc.m_speedLimitMps, measurement_utils::Units::Metric);
 
+      std::string roundabout;
+      if (loc.m_roundaboutInfo != routing::turns::RoundaboutInfo())
+        roundabout = DebugPrint(loc.m_roundaboutInfo);
+
       LOG(LDEBUG, ("Distance:", loc.m_distToTarget, "Time:", loc.m_time, speed, GetTurnString(loc.m_turn),
-                   (loc.m_exitNum != 0 ? ":" + std::to_string(loc.m_exitNum) : ""), "in", loc.m_distToTurn.ToString(),
-                   loc.m_nextStreetName.empty() ? "" : "to " + loc.m_nextStreetName));
+                   (loc.m_exitNum != 0 ? ":" + std::to_string(loc.m_exitNum) : ""), roundabout, "in",
+                   loc.m_distToTurn.ToString(), loc.m_nextStreetName.empty() ? "" : "to " + loc.m_nextStreetName));
 
       std::vector<std::string> notifications;
       routingManager.GenerateNotifications(notifications, true /* announceStreets */);

--- a/qt/routing_turns_visualizer.cpp
+++ b/qt/routing_turns_visualizer.cpp
@@ -37,6 +37,19 @@ std::string RoutingTurnsVisualizer::GetId(routing::turns::TurnItem const & turn)
 
   std::string const index = std::to_string(turn.m_index);
 
-  return index + " " + maneuver + (turn.m_exitNum != 0 ? ":" + std::to_string(turn.m_exitNum) : "");
+  // Car displays draw a roundabout from the circulation and the entrance-to-exit sweep, not from the
+  // exit number, so show all three here.
+  std::string roundabout;
+  if (turn.m_exitNum != 0)
+    roundabout = ":" + std::to_string(turn.m_exitNum);
+  auto const & info = turn.m_roundaboutInfo;
+  if (info.m_direction != routing::turns::RoundaboutDirection::Unknown)
+  {
+    roundabout += info.m_direction == routing::turns::RoundaboutDirection::Clockwise ? " CW" : " CCW";
+    if (info.m_exitAngle != 0)
+      roundabout += " " + std::to_string(info.m_exitAngle);
+  }
+
+  return index + " " + maneuver + roundabout;
 }
 }  // namespace qt


### PR DESCRIPTION
Closes #7039.

### What changed

Instrument clusters and head-up displays draw their own roundabout image from the AndroidX maneuver type, the circulation direction and the angular sweep — no icon is sent to them. Every roundabout was reported as a counter-clockwise entry and exit, so clusters drew mirrored or U-turn shaped maneuvers. The route now supplies that geometry instead of a directionless exit number.

Five self-contained commits:

1. **`[routing] Return route following info by value`** — the method filled a caller-provided struct, resetting it on two of its three paths and relying on the caller to pass a fresh one on the third. Pure refactor, no behaviour change.
2. **`[routing] Measure the roundabout circulation and exit angle`** — the measurement itself, described below.
3. **`[routing] Publish roundabout details for both displayed turns`** — carries the three values out of the core for the current and the second displayed turn.
4. **`[android] Show the correct roundabout maneuver on car displays`** — JNI marshalling, the maneuver-type mapping, and CI wiring for the new `sdk:car` tests, which `sdk:testDebug` does not reach.
5. **`[qt] Show roundabout details in the routing debug output`** — makes the native values observable on the desktop.

### How the geometry is measured

A closed roundabout feature gives its circulation from its winding, which stays correct for non-convex rings. Its bounding-box centre is kept only when the whole ring advances monotonically around it, and the driven segments are then summed as an exact polar sweep from the entrance to the exit.

Most roundabouts are not mapped as one closed way. Scanning `junction=roundabout|circular` features in real mwms:

| map | roundabout features | open / split ways | closed rings, centre kept |
|---|---|---|---|
| Zimbabwe | 160 | 0 | 160 |
| Andorra | 472 | 463 (6.7 km of 7.1 km) | 9 |
| minsk-pass | 6 | 5 | 1 |

For split rings both values therefore come from the bends of the driven path. The heading of a ring edge is the ring's tangent at that edge's midpoint, so the summed bends fall short of the swept angle by half of the first and half of the last edge. Weighting by driven length adds them back — `bends * length / (length - (first + last) / 2)` — which is exact for a ring of equal steps (the tests compare it against the centre-based sweep) and, unlike scaling by the mean edge, does not assume they are equal. Measured over 19 704 random rings, mean absolute error 5.96° -> 0.11°, worst 24.9° -> 0.57°. A single driven edge, or bends that run against the ring's own winding (the reflex part of a non-convex ring), leave the angle unknown.

The monotonicity gate rejected **0 of 170** closed rings across those three maps, including one of 572 m and 59 points. It is insurance against concave gyratories, not the working mechanism.

Circulation, positive sweep in `[1, 360]` and the presence of an exit stay three separate values: only that makes an entry-only maneuver distinguishable from a paired entry and exit when the angle is unavailable. Nothing here needs regional traffic-side data, border exceptions, or repeated geometry work during navigation updates.

### Validation

- Every commit builds (`routing_tests` + `desktop`) and passes `routing_tests` on its own.
- `ctest -L omim-test`: 36/36.
- `:sdk:car:testDebugUnitTest`, `:sdk:car:lintDebug`, `:sdk:lintDebug`, `:sdk:testDebug`.
- Native cases: clockwise and counter-clockwise circulation, 30/90/180/190/270/360-degree sweeps, concave and non-monotonic rings, a single driven edge, split annotation, open geometry with and without a centre, non-radial arms, the second turn, and the #7039 mini roundabout.
- **Not tested on a physical instrument cluster or head-up display.** Commit 5 makes the native values visible on the desktop over any roundabout, but the cluster artwork itself still needs a drive.

### Behaviour change worth a second opinion

`RoutingUtils.createTrip` gated the second Android Auto step on `!TextUtils.isEmpty(info.nextStreet)`, while `createNextStep` is built from `nextNextStreet` and `nextCarDirection`. It now uses `info.hasNextNextTurn()`, the predicate the phone UI already uses for the same decision, so the second step no longer appears for a "go straight" second turn or an unnamed next-next road.

### Deliberately not in this PR

- The phone and Android Auto icons still show a symmetric ring glyph with the exit number — all 12 `ic_roundabout_exit_N` drawables share one path, so they convey neither the circulation nor where the exit is. Both values are now available in `RoutingInfo` on the phone side, which unblocks #2281.
- iOS and CarPlay do not read the new values yet: #13416.

