### PR TITLE
[drape] Apply visual scale to routing anchor on use

### DIFF
--- a/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
+++ b/libs/drape_frontend/drape_frontend_tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRC
   clip_splines_builder_tests.cpp
   frame_values_tests.cpp
   message_queue_tests.cpp
+  my_position_controller_tests.cpp
   navigator_test.cpp
   path_text_test.cpp
   rainbow_line_gpu_test.cpp

--- a/libs/drape_frontend/drape_frontend_tests/my_position_controller_tests.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/my_position_controller_tests.cpp
@@ -1,0 +1,87 @@
+#include "testing/testing.hpp"
+
+#include "drape_frontend/drape_frontend_tests/visual_params_fixture.hpp"
+
+#include "drape_frontend/arrow3d.hpp"
+#include "drape_frontend/drape_hints.hpp"
+#include "drape_frontend/my_position_controller.hpp"
+#include "drape_frontend/visual_params.hpp"
+
+#include "platform/location.hpp"
+
+#include "geometry/rect2d.hpp"
+#include "geometry/screenbase.hpp"
+
+namespace my_position_controller_tests
+{
+using df::test_support::VisualParamsFixture;
+
+// Other tests in this binary rely on the visual scale set by VisualParamsFixture.
+class ScopedVisualScale
+{
+public:
+  explicit ScopedVisualScale(double vs) : m_prev(df::VisualParams::Instance().GetVisualScale())
+  {
+    df::VisualParams::Instance().SetVisualScale(vs);
+  }
+  ~ScopedVisualScale() { df::VisualParams::Instance().SetVisualScale(m_prev); }
+
+private:
+  double const m_prev;
+};
+
+m2::RectD const kViewport(0.0, 0.0, 600.0, 800.0);
+
+// Returns the bottom offset of the position anchor in routing mode, in device pixels.
+double GetRoutingOffsetY(df::MyPositionController & controller)
+{
+  m2::PointD anchor = m2::PointD::Zero();
+  controller.CorrectScalePoint(anchor);
+  return kViewport.maxY() - anchor.y;
+}
+
+// The routing anchor must follow the visual scale, which changes at runtime when the map is moved
+// to a display with another scale (CarPlay/Android Auto connect and disconnect).
+UNIT_CLASS_TEST(VisualParamsFixture, MyPositionController_RoutingOffsetFollowsVisualScale)
+{
+  df::MyPositionController::Params params(location::FollowAndRotate, 0.0 /* timeInBackground */, df::Hints{},
+                                          true /* isRoutingActive */, false /* isAutozoomEnabled */,
+                                          [](location::EMyPositionMode, bool) {});
+  df::MyPositionController controller(std::move(params), nullptr /* notifier */);
+  controller.SetVisibleViewport(kViewport);
+
+  // A position is needed to leave PendingPosition for FollowAndRotate, where the routing anchor is used.
+  location::GpsInfo info;
+  info.m_latitude = 0.0;
+  info.m_longitude = 0.0;
+  info.m_horizontalAccuracy = 10.0;
+  controller.OnLocationUpdate(info, true /* isNavigable */, ScreenBase());
+  TEST(controller.GetCurrentMode() == location::FollowAndRotate, (controller.GetCurrentMode()));
+
+  double const visualScale = df::VisualParams::Instance().GetVisualScale();
+  double constexpr kChangedVisualScale = 3.0;
+
+  // The default offset is fully derived from the visual scale.
+  double const defaultOffset = GetRoutingOffsetY(controller);
+  TEST_GREATER(defaultOffset, 0.0, ());
+  {
+    ScopedVisualScale const guard(kChangedVisualScale);
+    TEST_ALMOST_EQUAL_ABS(GetRoutingOffsetY(controller), defaultOffset * kChangedVisualScale / visualScale, 1e-9, ());
+  }
+  TEST_ALMOST_EQUAL_ABS(GetRoutingOffsetY(controller), defaultOffset, 1e-9, ());
+
+  // An offset reported by the UI is in device pixels and is not scaled, but the arrow's size on top of it is.
+  int constexpr kUiOffset = 5;
+  controller.UpdateRoutingOffsetY(false /* useDefault */, kUiOffset);
+  double const uiOffset = GetRoutingOffsetY(controller);
+  TEST_ALMOST_EQUAL_ABS(uiOffset, kUiOffset + df::Arrow3d::GetMaxBottomSize() * visualScale, 1e-9, ());
+  {
+    ScopedVisualScale const guard(kChangedVisualScale);
+    TEST_ALMOST_EQUAL_ABS(GetRoutingOffsetY(controller),
+                          kUiOffset + df::Arrow3d::GetMaxBottomSize() * kChangedVisualScale, 1e-9, ());
+  }
+
+  controller.UpdateRoutingOffsetY(true /* useDefault */, 0 /* offsetY */);
+  TEST_ALMOST_EQUAL_ABS(GetRoutingOffsetY(controller), defaultOffset, 1e-9, ());
+}
+}  // namespace my_position_controller_tests

--- a/libs/drape_frontend/frontend_renderer.cpp
+++ b/libs/drape_frontend/frontend_renderer.cpp
@@ -683,6 +683,7 @@ void FrontendRenderer::AcceptMessage(ref_ptr<Message> message)
     // changes, so re-resolve it here before all tiles are re-requested in UpdateAll.
     ResolveZoomLevel(m_userEventStream.GetCurrentScreen());
     UpdateAll<VisualScaleChangedMessage>();
+    m_myPositionController->UpdatePosition();
     break;
   }
 

--- a/libs/drape_frontend/my_position_controller.cpp
+++ b/libs/drape_frontend/my_position_controller.cpp
@@ -11,6 +11,7 @@
 
 #include "platform/measurement_utils.hpp"
 
+#include "base/assert.hpp"
 #include "base/math.hpp"
 
 #include <algorithm>
@@ -138,7 +139,6 @@ MyPositionController::MyPositionController(Params && params, ref_ptr<DrapeNotifi
   , m_autoScale3d(m_autoScale2d)
   , m_lastGPSBearingTimer(false)
   , m_lastLocationTimestamp(0.0)
-  , m_positionRoutingOffsetY(kPositionRoutingOffsetY * GetVisualScale())
   , m_isDirtyViewport(false)
   , m_isDirtyAutoZoom(false)
   , m_isPendingAnimation(false)
@@ -755,13 +755,19 @@ m2::PointD MyPositionController::GetRotationPixelCenter() const
 
 m2::PointD MyPositionController::GetRoutingRotationPixelCenter() const
 {
-  return {m_visiblePixelRect.Center().x, m_visiblePixelRect.maxY() - m_positionRoutingOffsetY};
+  double const vs = GetVisualScale();
+  double const offsetY =
+      m_routingOffsetY ? *m_routingOffsetY + Arrow3d::GetMaxBottomSize() * vs : kPositionRoutingOffsetY * vs;
+  return {m_visiblePixelRect.Center().x, m_visiblePixelRect.maxY() - offsetY};
 }
 
 void MyPositionController::UpdateRoutingOffsetY(bool useDefault, int offsetY)
 {
-  double const vs = GetVisualScale();
-  m_positionRoutingOffsetY = useDefault ? kPositionRoutingOffsetY * vs : offsetY + Arrow3d::GetMaxBottomSize() * vs;
+  ASSERT(useDefault || offsetY >= 0, (offsetY));
+  if (useDefault)
+    m_routingOffsetY.reset();
+  else
+    m_routingOffsetY = offsetY;
 }
 
 m2::PointD MyPositionController::GetDrawablePosition()

--- a/libs/drape_frontend/my_position_controller.hpp
+++ b/libs/drape_frontend/my_position_controller.hpp
@@ -17,6 +17,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <optional>
 
 namespace df
 {
@@ -195,7 +196,10 @@ private:
 
   m2::RectD m_pixelRect;
   m2::RectD m_visiblePixelRect;
-  double m_positionRoutingOffsetY;
+  // Bottom offset in device pixels as reported by the UI, std::nullopt for the default one.
+  // Scale-dependent parts are applied in GetRoutingRotationPixelCenter(), because the visual scale
+  // can change at runtime (e.g. when the map moves to a car display).
+  std::optional<int> m_routingOffsetY;
 
   bool m_isDirtyViewport;
   bool m_isDirtyAutoZoom;


### PR DESCRIPTION
`MyPositionController` cached the routing anchor offset at whichever visual scale was active when it was initialized or updated. The scale changes at runtime when the map moves between displays (CarPlay, Android Auto, external displays), so the followed position could retain a stale offset.

**Fix.** Store only the UI-provided device-pixel offset and calculate scale-dependent parts when the anchor is read. Refresh the followed model view when `VisualScaleChanged` is delivered, so same-size or DPI-only display switches apply the corrected anchor immediately and message ordering cannot leave it stale.

Follow-up of #13168. `SelectionShape` and `MyPosition` are recreated by `RecacheMapShapes()` on visual-scale changes, while routing auto-scale is recomputed on location updates.

**Testing.**
- Full `drape_frontend_tests` suite in Debug, including a non-unity build.
- `MyPositionController_RoutingOffsetFollowsVisualScale` covers default, UI-provided, changed-scale, and reset-to-default offsets.

**Reproduce in Sim**

1. Build and run Organic Maps on an arm64 iPhone simulator with a 3× display, such as iPhone 17 Pro.
2. Set a simulated location on a road, build a vehicle route, and start navigation.
3. Ensure the app is in routing FollowAndRotate mode—the bug is not visible when the position is centered normally.
4. Open the CarPlay display using Simulator’s I/O → External Displays → CarPlay menu and open Organic Maps there. The default CarPlay simulator display is typically 2×.
5. Keep the simulated location stationary and observe the position arrow’s vertical placement.
6. Close and reopen the CarPlay display several times, letting the map move between the phone and CarPlay.

On the affected build:

- Phone → CarPlay: the routing anchor may remain approximately 100.04 px from the bottom instead of 68.36 px, placing the arrow about 32 px too high.
- CarPlay → phone: the default anchor may remain 208 px from the bottom instead of 312 px, placing it about 104 px too low.
- The precise transition showing the bug depends on render/UI message timing, so repeat the switch if necessary.

Those values come from:
```
CarPlay expected: 5 + 31.68 × 2 = 68.36 px
Stale phone scale: 5 + 31.68 × 3 = 100.04 px

Phone expected: 104 × 3 = 312 px
Stale CarPlay scale: 104 × 2 = 208 px
```
For deterministic confirmation, log or break in MyPositionController::UpdateRoutingOffsetY() on the parent commit:

- When attaching CarPlay, observe it cache the offset using visual scale 3.
- Then observe VisualParams::SetVisualScale(2).
- The cached offset remains based on 3.

In this PR, the anchor should immediately settle at the correct height on every connect and disconnect, without needing a resize or new GPS fix.