### PR TITLE
[routing] Pass off-road intermediate stops when driving past them

### DIFF
--- a/libs/routing/route.cpp
+++ b/libs/routing/route.cpp
@@ -22,6 +22,17 @@ namespace
 {
 double constexpr kOnEndToleranceM = 10.0;
 double constexpr kSteetNameLinkMeters = 400.0;
+// Minimum distance from the raw fix to its route projection to treat an off-road intermediate
+// checkpoint as departed: above typical lateral GPS error, below the smallest matching
+// threshold (20 m, pedestrian), so the decision is made while the fix still matches the route.
+// The stop can therefore be passed in [kCheckpointDepartM, m_matchingThresholdM] past its road
+// point: 15-50 m for a car, 15-20 m for a pedestrian -- the tightest window, ~3 fixes at 1 Hz.
+double constexpr kCheckpointDepartM = 15.0;
+// Slack for "the user is at/heading into the stop" check: dist(fix, B) < connector - slack.
+double constexpr kCheckpointStillNearM = 5.0;
+// How far above the plateau the remaining distance may still be when the projection is considered
+// saturated at the road point of the checkpoint. Rounding only: the projection lands exactly on it.
+double constexpr kCheckpointPlateauM = 1.0;
 }  //  namespace
 
 std::string DebugPrint(RouteSegment::RoadNameInfo const & rni)
@@ -642,9 +653,34 @@ bool Route::MatchLocationToRoute(location::GpsInfo & location, location::RouteMa
   return false;
 }
 
-bool Route::IsSubroutePassed(size_t subrouteIdx) const
+double Route::GetSubrouteEndConnectorMeters(SubrouteAttrs const & attrs) const
 {
-  size_t const endSegmentIdx = GetSubrouteAttrs(subrouteIdx).GetEndSegmentIdx();
+  // Ruler-router legs are 1-2 segments of pure fakes (see the layout table in ruler_router.cpp),
+  // so the tail check below would accept them and derive a bogus "connector" spanning the whole
+  // leg. Bail out first; this also keeps |endSegmentIdx| - 3 within the segments.
+  if (attrs.GetSize() < 3)
+    return 0.0;
+
+  size_t const endSegmentIdx = attrs.GetEndSegmentIdx();
+  ASSERT_LESS_OR_EQUAL(endSegmentIdx, m_routeSegments.size(), ());
+  // IndexGraphStarter::AddEnding() ends every subroute with two pure fake segments: the projection
+  // edge A->B and the zero-length standalone B->B, where B is the raw checkpoint and A is its
+  // projection onto a road -- the last drivable point of the subroute. Any other tail keeps the
+  // plain pass rule.
+  if (m_routeSegments[endSegmentIdx - 1].GetSegment().IsRealSegment() ||
+      m_routeSegments[endSegmentIdx - 2].GetSegment().IsRealSegment())
+    return 0.0;
+
+  // |A - B|: the standalone is zero-length, so this is also the remaining-distance plateau of the
+  // subroute. Both properties are pinned by PassCheckpoint_EndingTailInvariant.
+  return mercator::DistanceOnEarth(m_routeSegments[endSegmentIdx - 3].GetJunction().GetPoint(),
+                                   m_routeSegments[endSegmentIdx - 1].GetJunction().GetPoint());
+}
+
+bool Route::IsSubroutePassed(size_t subrouteIdx, m2::PointD const & fixPoint, double fixSpeedMpS) const
+{
+  auto const & attrs = GetSubrouteAttrs(subrouteIdx);
+  size_t const endSegmentIdx = attrs.GetEndSegmentIdx();
   // If all subroutes up to subrouteIdx are empty.
   if (endSegmentIdx == 0)
     return true;
@@ -653,9 +689,38 @@ bool Route::IsSubroutePassed(size_t subrouteIdx) const
   CHECK_LESS(segmentIdx, m_routeSegments.size(), ());
   double const lengthMeters = m_routeSegments[segmentIdx].GetDistFromBeginningMeters();
   double const passedDistanceMeters = m_poly.GetDistanceFromStartMeters();
-  double const finishToleranceM =
-      segmentIdx == m_routeSegments.size() - 1 ? m_routingSettings.m_finishToleranceM : kOnEndToleranceM;
-  return lengthMeters - passedDistanceMeters < finishToleranceM;
+  double const remainingMeters = lengthMeters - passedDistanceMeters;
+
+  if (segmentIdx == m_routeSegments.size() - 1)
+    return remainingMeters < m_routingSettings.m_finishToleranceM;
+
+  double const connectorMeters = GetSubrouteEndConnectorMeters(attrs);
+  if (connectorMeters < kOnEndToleranceM)
+    return remainingMeters < kOnEndToleranceM;
+
+  // The checkpoint sits >= kOnEndToleranceM off the road, so the remaining distance never drops
+  // below the connector length: it plateaus there once the projection saturates at A. Wait for the
+  // plateau -- a lateral GPS error does not move the projection, so it alone can never pass a stop
+  // the user is still driving up to.
+  if (remainingMeters > connectorMeters + kCheckpointPlateauM)
+    return false;
+
+  // Pass the stop only once the raw fix has left A behind and is not at/heading into the stop, so
+  // that a user who really visits the checkpoint keeps it until departure.
+  if (mercator::DistanceOnEarth(fixPoint, m_poly.GetCurrentIter().m_pt) < kCheckpointDepartM)
+    return false;
+
+  // B is the junction of the trailing standalone fake. It is taken from the segments and not from
+  // attrs.GetFinish(), which IndexRouter::AdjustRoute() fills with the route's final destination
+  // instead of the intermediate checkpoint for the leg it rebuilds.
+  auto const & checkpoint = m_routeSegments[segmentIdx].GetJunction().GetPoint();
+  if (mercator::DistanceOnEarth(fixPoint, checkpoint) < connectorMeters - kCheckpointStillNearM)
+    return false;
+
+  // At standstill GPS wander alone can satisfy every distance condition above; require real
+  // movement where the vehicle defines a minimum speed (car only). A fix without speed data
+  // (negative, as location::GpsInfo::HasSpeed()) must not block passing forever.
+  return fixSpeedMpS < 0.0 || fixSpeedMpS >= m_routingSettings.m_minSpeedForRouteRebuildMpS;
 }
 
 std::string Route::DebugPrintTurns() const

--- a/libs/routing/route.hpp
+++ b/libs/routing/route.hpp
@@ -520,7 +520,11 @@ public:
   /// fields accordingly.
   bool MatchLocationToRoute(location::GpsInfo & location, location::RouteMatchingInfo & routeMatchingInfo) const;
 
-  bool IsSubroutePassed(size_t subrouteIdx) const;
+  /// \brief Checks whether the user is past the end of |subrouteIdx|. |fixPoint| and |fixSpeedMpS|
+  /// are the raw (unmatched) position and speed of the fix just handled by MoveIterator(); the
+  /// speed is negative when the fix carries none, exactly as location::GpsInfo::m_speed. They tell
+  /// driving past an off-road intermediate checkpoint from arriving at it.
+  bool IsSubroutePassed(size_t subrouteIdx, m2::PointD const & fixPoint, double fixSpeedMpS) const;
 
   std::string DebugPrintTurns() const;
 
@@ -529,6 +533,11 @@ private:
 
   double GetPolySegAngle(size_t ind) const;
   void GetClosestTurnAfterIdx(size_t segIdx, turns::TurnItem & turn) const;
+
+  /// \returns Length of the trailing pure-fake connector (projection edge A->B + standalone B->B)
+  /// of the subroute, i.e. how far its checkpoint sits off the road, or 0 when the subroute does
+  /// not end with such a tail.
+  double GetSubrouteEndConnectorMeters(SubrouteAttrs const & attrs) const;
 
   /// \returns Estimated time from the beginning.
   double GetCurrentTimeFromBeginSec() const;

--- a/libs/routing/routing_session.cpp
+++ b/libs/routing/routing_session.cpp
@@ -271,7 +271,7 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
     m_moveAwayCounter = 0;
     m_lastDistance = 0.0;
 
-    PassCheckpoints();
+    PassCheckpoints(info);
 
     if (m_checkpoints.IsFinished())
     {
@@ -475,10 +475,11 @@ double RoutingSession::GetCompletionPercent() const
   return percent;
 }
 
-void RoutingSession::PassCheckpoints()
+void RoutingSession::PassCheckpoints(GpsInfo const & info)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
-  while (!m_checkpoints.IsFinished() && m_route->IsSubroutePassed(m_checkpoints.GetPassedIdx()))
+  auto const fixPoint = mercator::FromLatLon(info.m_latitude, info.m_longitude);
+  while (!m_checkpoints.IsFinished() && m_route->IsSubroutePassed(m_checkpoints.GetPassedIdx(), fixPoint, info.m_speed))
   {
     m_route->PassNextSubroute();
     // Keep the active RouteBase in m_lastResult in sync so a later RouteCall (e.g. drape engine

--- a/libs/routing/routing_session.hpp
+++ b/libs/routing/routing_session.hpp
@@ -179,7 +179,7 @@ private:
   void RemoveRoute();
   void RebuildRouteOnTrafficUpdate();
 
-  void PassCheckpoints();
+  void PassCheckpoints(location::GpsInfo const & info);
 
 private:
   std::unique_ptr<AsyncRouter> m_router;

--- a/libs/routing/routing_tests/CMakeLists.txt
+++ b/libs/routing/routing_tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRC
   async_router_test.cpp
   bfs_tests.cpp
   checkpoint_predictor_test.cpp
+  checkpoint_pass_tests.cpp
   coding_test.cpp
   cross_border_graph_tests.cpp
   cross_mwm_connector_test.cpp

--- a/libs/routing/routing_tests/checkpoint_pass_tests.cpp
+++ b/libs/routing/routing_tests/checkpoint_pass_tests.cpp
@@ -1,0 +1,597 @@
+#include "testing/testing.hpp"
+
+#include "routing/routing_tests/index_graph_tools.hpp"
+#include "routing/routing_tests/tools.hpp"
+
+#include "routing/fake_feature_ids.hpp"
+#include "routing/route.hpp"
+#include "routing/router.hpp"
+#include "routing/routing_callbacks.hpp"
+#include "routing/routing_helpers.hpp"
+#include "routing/routing_session.hpp"
+#include "routing/routing_settings.hpp"
+
+#include "traffic/traffic_cache.hpp"
+
+#include "indexer/classificator_loader.hpp"
+
+#include "platform/location.hpp"
+#include "platform/platform.hpp"
+
+#include "geometry/distance_on_sphere.hpp"
+#include "geometry/mercator.hpp"
+#include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace checkpoint_pass_tests
+{
+using namespace routing;
+using namespace std;
+
+double constexpr kDegToM = 111317.0;  // metres per mercator degree at the equator.
+double constexpr kAx = 0.005;         // x of A, the projection of the intermediate stop onto the road.
+
+location::GpsInfo GetGps(double x, double y, double accuracy = 5.0, double speed = 20.0)
+{
+  location::GpsInfo info;
+  info.m_latitude = mercator::YToLat(y);
+  info.m_longitude = mercator::XToLon(x);
+  info.m_horizontalAccuracy = accuracy;
+  info.m_speed = speed;
+  return info;
+}
+
+// Mirror RoutingSession: IsSubroutePassed() judges the raw fix MoveIterator() has just matched.
+bool IsPassed(Route const & route, location::GpsInfo const & info, size_t subrouteIdx = 0)
+{
+  return route.IsSubroutePassed(subrouteIdx, mercator::FromLatLon(info.m_latitude, info.m_longitude), info.m_speed);
+}
+
+bool MoveAndCheckPassed(Route & route, location::GpsInfo const & info, size_t subrouteIdx = 0)
+{
+  return route.MoveIterator(info) && IsPassed(route, info, subrouteIdx);
+}
+
+Segment RealSeg(uint32_t idx)
+{
+  return {0, 0, idx, true};
+}
+
+Segment FakeSeg(uint32_t idx)
+{
+  return {kFakeNumMwmId, FakeFeatureIds::kIndexGraphStarterId, idx, true};
+}
+
+// Production-faithful two-leg route. Road along the equator; A = (0.005, 0); the intermediate
+// stop B sits |connectorM| north of A. Polyline (per IndexGraphStarter::AddEnding + RedressRoute):
+//   start, start, road..., A, B, B, | B, A, road..., finish, finish
+// Leg 0 tail = pure fakes (A->B, B->B); leg 1 head = pure fakes (B->B, B->A).
+struct Fixture
+{
+  explicit Fixture(double connectorM, VehicleType vehicle = VehicleType::Car) : m_b(kAx, connectorM / kDegToM)
+  {
+    m2::PointD const a(kAx, 0.0);
+    m_path = {{0.0, 0.0}, {0.0, 0.0}, {0.001, 0.0}, {0.002, 0.0}, {0.003, 0.0}, {0.004, 0.0}, a, m_b};
+    m_stopIdx = m_path.size();  // polyline index of leg-0 end vertex (the standalone B).
+    m_path.push_back(m_b);      // leg 0 standalone B->B end vertex.
+    m_path.push_back(m_b);      // leg 1 standalone B->B vertex.
+    m_path.insert(m_path.end(), {a, {0.006, 0.0}, {0.007, 0.0}, {0.008, 0.0}, {0.009, 0.0}, {0.01, 0.0}, {0.01, 0.0}});
+
+    vector<Segment> segs;
+    for (uint32_t i = 0; i + 1 < m_path.size(); ++i)
+      segs.push_back(RealSeg(i));
+    segs[m_stopIdx - 2] = FakeSeg(m_stopIdx - 2);  // projection edge A->B
+    segs[m_stopIdx - 1] = FakeSeg(m_stopIdx - 1);  // standalone B->B
+    segs[m_stopIdx] = FakeSeg(m_stopIdx);          // leg 1 standalone B->B
+    segs[m_stopIdx + 1] = FakeSeg(m_stopIdx + 1);  // leg 1 projection edge B->A
+
+    vector<RouteSegment> segments;
+    RouteSegmentsFrom(segs, m_path, {}, {}, segments);
+    FillSegmentInfo(vector<double>(m_path.size() - 1, 0.0), segments);
+
+    m_route.SetRoutingSettings(GetRoutingSettings(vehicle));
+    m_route.SetRouteSegments(std::move(segments));
+    m_route.SetGeometry(m_path.begin(), m_path.end());
+
+    SetSubroutes(m_b);
+  }
+
+  // |leg0Finish| is what SubrouteAttrs reports as the first leg's checkpoint. Every producer fills
+  // it with B, except IndexRouter::AdjustRoute(), which reports the route's final destination for
+  // the leg it rebuilds -- hence the parameter.
+  void SetSubroutes(m2::PointD const & leg0Finish)
+  {
+    auto const wa = [](m2::PointD const & p)
+    { return geometry::PointWithAltitude(p, geometry::kDefaultAltitudeMeters); };
+    m_route.SetSubroutes(
+        vector<Route::SubrouteAttrs>{Route::SubrouteAttrs(wa(m_path.front()), wa(leg0Finish), 0, m_stopIdx),
+                                     Route::SubrouteAttrs(wa(m_b), wa(m_path.back()), m_stopIdx, m_path.size() - 1)});
+  }
+
+  double RemainingToStopM() const
+  {
+    auto const & segments = m_route.GetRouteSegments();
+    return segments[m_stopIdx - 1].GetDistFromBeginningMeters() - m_route.GetCurrentDistanceFromBeginMeters();
+  }
+
+  m2::PointD m_b;
+  vector<m2::PointD> m_path;
+  size_t m_stopIdx = 0;
+  Route m_route;
+};
+
+double MetersPastA(m2::PointD const & pos)
+{
+  return (pos.x - kAx) * kDegToM;
+}
+
+// The router-side guard for the invariant Route::GetSubrouteEndConnectorMeters() relies on: every
+// ending built by IndexGraphStarter::AddEnding() contributes exactly two trailing pure fake
+// segments -- the projection edge A->B and the zero-length standalone B->B -- whose summed length
+// is |A - B|. Fails if the shape of a route ending ever changes.
+UNIT_TEST(PassCheckpoint_EndingTailInvariant)
+{
+  using namespace routing_test;
+  using AlgoT = AStarAlgorithm<Segment, SegmentEdge, RouteWeight>;
+
+  classificator::Load();  // CreateEstimatorForCar reads hwtag types.
+
+  unique_ptr<TestGeometryLoader> loader = make_unique<TestGeometryLoader>();
+  loader->AddRoad(0 /* featureId */, false /* oneWay */, 50.0 /* speed */,
+                  RoadGeometry::Points({{0.0, 0.0}, {3.0, 0.0}}));
+
+  traffic::TrafficCache const trafficCache;
+  shared_ptr<EdgeEstimator> estimator = CreateEstimatorForCar(trafficCache);
+  unique_ptr<WorldGraph> worldGraph = BuildWorldGraph(std::move(loader), estimator, vector<Joint>());
+
+  for (double offY : {0.0, 0.0003, 0.002})  // on-road, ~33 m and ~223 m off-road checkpoints.
+  {
+    m2::PointD const b(1.5, offY);
+    m2::PointD const a(1.5, 0.0);
+    auto const start = MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, m2::PointD(0.5, 0.0), *worldGraph);
+    auto const finish = MakeFakeEnding(0 /* featureId */, 0 /* segmentIdx */, b, *worldGraph);
+    auto starter = MakeStarter(start, finish, *worldGraph);
+
+    vector<Segment> route;
+    double timeSec;
+    TEST_EQUAL(CalculateRoute(*starter, route, timeSec), AlgoT::Result::OK, ("offY =", offY));
+    size_t const n = route.size();
+    TEST_GREATER_OR_EQUAL(n, 3, ("offY =", offY));
+
+    size_t pureFakeTail = 0;
+    for (auto rit = route.rbegin(); rit != route.rend(); ++rit)
+    {
+      Segment real = *rit;
+      if (starter->ConvertToReal(real))
+        break;
+      ++pureFakeTail;
+    }
+    TEST_EQUAL(pureFakeTail, 2, ("Ending must contribute exactly two trailing pure fakes, offY =", offY));
+
+    // The standalone B->B is zero-length and sits at the checkpoint.
+    auto const & lastFrom = starter->GetJunction(route[n - 1], false /* front */);
+    auto const & lastTo = starter->GetJunction(route[n - 1], true /* front */);
+    TEST_EQUAL(lastFrom, lastTo, ("offY =", offY));
+    TEST_ALMOST_EQUAL_ABS(mercator::FromLatLon(lastTo.GetLatLon()).y, b.y, 1e-9, ("offY =", offY));
+
+    // The projection edge runs A->B, where A is the perpendicular foot of B on the road.
+    auto const projFrom = mercator::FromLatLon(starter->GetJunction(route[n - 2], false /* front */).GetLatLon());
+    auto const projTo = mercator::FromLatLon(starter->GetJunction(route[n - 2], true /* front */).GetLatLon());
+    TEST_ALMOST_EQUAL_ABS(projFrom.x, a.x, 1e-9, ("offY =", offY));
+    TEST_ALMOST_EQUAL_ABS(projFrom.y, a.y, 1e-9, ("offY =", offY));
+    TEST_ALMOST_EQUAL_ABS(projTo.y, b.y, 1e-9, ("offY =", offY));
+
+    // The summed tail length is |A - B|, i.e. the remaining-distance plateau of the subroute.
+    double const tailLenM = ms::DistanceOnEarth(starter->GetJunction(route[n - 2], false /* front */).GetLatLon(),
+                                                starter->GetJunction(route[n - 2], true /* front */).GetLatLon()) +
+                            ms::DistanceOnEarth(lastFrom.GetLatLon(), lastTo.GetLatLon());
+    TEST_ALMOST_EQUAL_ABS(tailLenM, mercator::DistanceOnEarth(a, b), 1e-6, ("offY =", offY));
+  }
+}
+
+// The derived connector (Dist(E-1) - Dist(E-3)) is exactly the remaining-distance plateau the
+// matcher saturates at when driving past an off-road stop.
+UNIT_TEST(PassCheckpoint_ConnectorEqualsPlateau)
+{
+  for (double c : {10.0, 15.0, 33.0, 50.0, 100.0, 200.0})
+  {
+    Fixture f(c, VehicleType::Car);
+    double plateauM = -1.0;
+    for (double x = 0.0035; x < 0.0075; x += 0.00005)
+      if (f.m_route.MoveIterator(GetGps(x, 0.0)) && MetersPastA({x, 0.0}) > 5.0)
+        plateauM = f.RemainingToStopM();
+
+    TEST_GREATER(plateauM, 0.0, ("No matched fix past A, c =", c));
+
+    auto const & segments = f.m_route.GetRouteSegments();
+    double const derivedM =
+        segments[f.m_stopIdx - 1].GetDistFromBeginningMeters() - segments[f.m_stopIdx - 3].GetDistFromBeginningMeters();
+    TEST_ALMOST_EQUAL_ABS(derivedM, plateauM, 1e-6, ("Derived connector must equal the plateau, c =", c));
+    TEST_ALMOST_EQUAL_ABS(derivedM, c, 0.01, ("Nominal degree-to-metre conversion tolerance, c =", c));
+  }
+}
+
+// Driving past an off-road stop passes it promptly after the closest point of approach A, for
+// every vehicle and every off-road distance.
+UNIT_TEST(PassCheckpoint_OffRoadPassBy)
+{
+  for (auto const vehicle : {VehicleType::Car, VehicleType::Bicycle, VehicleType::Pedestrian, VehicleType::Transit})
+  {
+    // 10.5 is the first value clearly above the kOnEndToleranceM boundary; 9 m and below are
+    // covered by PassCheckpoint_OnRoadRegression, which pins the old rule for them.
+    for (double c : {10.5, 15.0, 33.0, 50.0, 100.0, 200.0})
+    {
+      Fixture f(c, vehicle);
+      double fireAtM = -1.0;
+      for (double x = 0.0035; x < 0.0075 && fireAtM < 0.0; x += 0.00005)
+        if (MoveAndCheckPassed(f.m_route, GetGps(x, 0.0)))
+          fireAtM = MetersPastA({x, 0.0});
+
+      TEST_GREATER_OR_EQUAL(fireAtM, 14.9, ("Must not fire before departing A", vehicle, c));
+      TEST_LESS_OR_EQUAL(fireAtM, 25.0, ("Must fire promptly after A", vehicle, c));
+    }
+  }
+}
+
+// Pedestrian is the tightest case: the gate fires ~15 m past A while matching dies at 20 m.
+// At a realistic 1 Hz walking cadence there must be matched fixes to spare.
+UNIT_TEST(PassCheckpoint_PedestrianFixSpacing)
+{
+  for (double c : {15.0, 33.0, 100.0})
+  {
+    Fixture f(c, VehicleType::Pedestrian);
+    size_t matchedFromFire = 0;
+    for (double x = 0.0045; x < 0.0055; x += 1.4 / kDegToM)
+      if (MoveAndCheckPassed(f.m_route, GetGps(x, 0.0, 5.0 /* accuracy */, 1.4 /* speed */)))
+        ++matchedFromFire;
+
+    TEST_GREATER_OR_EQUAL(matchedFromFire, 3, ("Pedestrian needs the firing fix and >= 2 more, c =", c));
+  }
+}
+
+// On-road stops (connector < kOnEndToleranceM) keep today's rule bit-for-bit.
+UNIT_TEST(PassCheckpoint_OnRoadRegression)
+{
+  for (double c : {0.0, 2.0, 5.0, 8.0, 9.0})
+  {
+    Fixture f(c, VehicleType::Car);
+    int fireOld = -1, fireNew = -1, sample = 0;
+    for (double x = 0.0035; x < 0.0075; x += 0.00005, ++sample)
+    {
+      auto const info = GetGps(x, 0.0);
+      if (!f.m_route.MoveIterator(info))
+        continue;
+      if (fireOld < 0 && f.RemainingToStopM() < 10.0)
+        fireOld = sample;
+      if (fireNew < 0 && IsPassed(f.m_route, info))
+        fireNew = sample;
+    }
+    TEST_GREATER_OR_EQUAL(fireNew, 0, ("The stop must be passed, c =", c));
+    TEST_EQUAL(fireOld, fireNew, ("On-road stop behaviour must be identical, c =", c));
+  }
+}
+
+// A user who actually visits the stop keeps it through approach, drive-in, dwell and moving around
+// behind the stop; it is passed only after departing along the road.
+UNIT_TEST(PassCheckpoint_VisitorKeepsStop)
+{
+  // Returns the track phase in which the stop was passed and how far past A that happened.
+  auto const runVisit = [](double c, bool wrongAttrsFinish)
+  {
+    Fixture f(c, VehicleType::Car);
+    if (wrongAttrsFinish)
+      f.SetSubroutes(f.m_path.back());
+
+    vector<pair<string, m2::PointD>> track;
+    for (double x = 0.0045; x < kAx; x += 0.00005)
+      track.emplace_back("approach-road", m2::PointD(x, 0.0));
+    for (double t = 0.0; t <= 1.0; t += 0.1)
+      track.emplace_back("drive-in", m2::PointD(kAx, c / kDegToM * t));
+    for (int i = 0; i < 5; ++i)
+      track.emplace_back("dwell-at-B", f.m_b);
+    // Moving around behind the stop (parking, another entrance) leaves the projection at B, so the
+    // depart gate opens and only the "at/heading into the stop" check keeps the checkpoint.
+    for (int i = 0; i < 2; ++i)
+      track.emplace_back("behind-B", m2::PointD(f.m_b.x, f.m_b.y + 20.0 / kDegToM));
+    for (double t = 1.0; t >= 0.0; t -= 0.1)
+      track.emplace_back("drive-out", m2::PointD(kAx, c / kDegToM * t));
+    for (double x = kAx + 0.00005; x < 0.0062; x += 0.00005)
+      track.emplace_back("depart-east", m2::PointD(x, 0.0));
+
+    pair<string, double> fire{"never", -1.0};
+    for (auto const & [phase, pos] : track)
+    {
+      // Dwell fixes report zero speed: the geometry conditions, not the speed gate, must be what
+      // protects the visitor.
+      double const speed = phase == "dwell-at-B" ? 0.0 : 20.0;
+      auto const info = GetGps(pos.x, pos.y, 5.0 /* accuracy */, speed);
+      if (!f.m_route.MoveIterator(info) || fire.first != "never")
+        continue;
+      if (IsPassed(f.m_route, info))
+        fire = {phase, MetersPastA(pos)};
+    }
+    return fire;
+  };
+
+  for (double c : {33.0, 100.0})
+  {
+    auto const [phase, fireAtM] = runVisit(c, false /* wrongAttrsFinish */);
+    TEST_EQUAL(phase, "depart-east", ("Visitor must keep the stop until departing, c =", c));
+    TEST_LESS_OR_EQUAL(fireAtM, 25.0, ("c =", c));
+
+    // The checkpoint must be read from the route geometry, not from SubrouteAttrs: for a leg
+    // rebuilt by IndexRouter::AdjustRoute() the latter holds the route's final destination.
+    TEST_EQUAL(runVisit(c, true /* wrongAttrsFinish */).first, "depart-east",
+               ("Wrong SubrouteAttrs finish must not drop the stop, c =", c));
+  }
+}
+
+// Overshooting A by less than kCheckpointDepartM and turning back keeps the stop; a clear
+// overshoot passes it (the documented boundary of the U-turn grace window).
+UNIT_TEST(PassCheckpoint_UTurnGrace)
+{
+  auto const runOvershoot = [](double c, double overshootM)
+  {
+    Fixture f(c, VehicleType::Car);
+    bool fired = false;
+    auto const step = [&f, &fired](double x, double y)
+    {
+      if (MoveAndCheckPassed(f.m_route, GetGps(x, y)))
+        fired = true;
+    };
+
+    for (double x = 0.0045; x <= kAx + overshootM / kDegToM + 1e-9; x += 0.00005)
+      step(x, 0.0);
+    // Turn back to A and drive into the stop.
+    for (double x = kAx + overshootM / kDegToM; x >= kAx; x -= 0.00005)
+      step(x, 0.0);
+    for (double t = 0.0; t <= 1.0; t += 0.1)
+      step(kAx, c / kDegToM * t);
+    return fired;
+  };
+
+  for (double c : {33.0, 100.0})
+  {
+    TEST(!runOvershoot(c, 11.0), ("Overshoot below kCheckpointDepartM must keep the stop, c =", c));
+    TEST(runOvershoot(c, 25.0), ("Overshoot beyond the depart distance passes the stop, c =", c));
+  }
+}
+
+// A constant lateral GPS error must not fake a departure while still approaching A, however large
+// it is: it never moves the projection, which stays short of A until the user really gets there.
+UNIT_TEST(PassCheckpoint_ApproachLateralError)
+{
+  for (double c : {12.0, 33.0, 100.0})
+  {
+    for (double errorM : {10.0, 15.0, 20.0, 30.0})
+    {
+      for (double side : {1.0, -1.0})
+      {
+        // A fix on the side of the stop that lands at or past the stop itself is indistinguishable
+        // from one taken there, so only errors staying clearly short of it are asserted.
+        if (side > 0.0 && errorM + 5.0 >= c)
+          continue;
+
+        Fixture f(c, VehicleType::Car);
+        for (double x = 0.0035; x < kAx - 1e-9; x += 0.00005)
+        {
+          auto const info = GetGps(x, side * errorM / kDegToM);
+          if (!f.m_route.MoveIterator(info))
+            continue;
+          TEST(!IsPassed(f.m_route, info), ("Lateral error must not fake a pass, c =", c, "error =", errorM,
+                                            "side =", side, "at", MetersPastA({x, 0.0}), "m past A"));
+        }
+      }
+    }
+  }
+}
+
+// Standstill GPS wander satisfies every distance condition; only the car speed gate rejects it.
+// A fix without speed data must not be blocked forever.
+UNIT_TEST(PassCheckpoint_StandstillSpeedGate)
+{
+  double constexpr c = 33.0;
+  m2::PointD const wander(kAx + 16.0 / kDegToM, -16.0 / kDegToM);
+  {
+    Fixture f(c, VehicleType::Car);
+    TEST(f.m_route.MoveIterator(GetGps(0.0049, 0.0)), ());
+    auto const idle = GetGps(wander.x, wander.y, 5.0 /* accuracy */, 0.2 /* speed */);
+    for (int i = 0; i < 5; ++i)
+      if (f.m_route.MoveIterator(idle))
+        TEST(!IsPassed(f.m_route, idle), ("Standstill wander must not pass the stop"));
+
+    auto const moving = GetGps(wander.x, wander.y, 5.0 /* accuracy */, 20.0 /* speed */);
+    TEST(f.m_route.MoveIterator(moving), ());
+    TEST(IsPassed(f.m_route, moving), ("A moving fix past A must pass the stop"));
+  }
+  {
+    Fixture f(c, VehicleType::Car);
+    TEST(f.m_route.MoveIterator(GetGps(0.0049, 0.0)), ());
+    auto const speedless = GetGps(wander.x, wander.y, 5.0 /* accuracy */, -1.0 /* speed */);
+    TEST(f.m_route.MoveIterator(speedless), ());
+    TEST(IsPassed(f.m_route, speedless), ("Speedless fixes must not block passing forever"));
+  }
+}
+
+// Two consecutive off-road stops are passed in order, each shortly after its own projection root.
+UNIT_TEST(PassCheckpoint_TwoStopsInOrder)
+{
+  double constexpr c1 = 33.0, c2 = 15.0;
+  m2::PointD const a1(0.005, 0.0), b1(0.005, c1 / kDegToM);
+  m2::PointD const a2(0.007, 0.0), b2(0.007, c2 / kDegToM);
+
+  vector<m2::PointD> path = {{0.0, 0.0}, {0.0, 0.0}, {0.002, 0.0}, {0.004, 0.0}, a1, b1};
+  size_t const stop1Idx = path.size();
+  path.push_back(b1);
+  path.push_back(b1);
+  path.insert(path.end(), {a1, {0.006, 0.0}, a2, b2});
+  size_t const stop2Idx = path.size();
+  path.push_back(b2);
+  path.push_back(b2);
+  path.insert(path.end(), {a2, {0.008, 0.0}, {0.009, 0.0}, {0.009, 0.0}});
+
+  vector<Segment> segs;
+  for (uint32_t i = 0; i + 1 < path.size(); ++i)
+    segs.push_back(RealSeg(i));
+  for (size_t idx :
+       {stop1Idx - 2, stop1Idx - 1, stop1Idx, stop1Idx + 1, stop2Idx - 2, stop2Idx - 1, stop2Idx, stop2Idx + 1})
+    segs[idx] = FakeSeg(static_cast<uint32_t>(idx));
+
+  vector<RouteSegment> segments;
+  RouteSegmentsFrom(segs, path, {}, {}, segments);
+  FillSegmentInfo(vector<double>(path.size() - 1, 0.0), segments);
+
+  Route route;
+  route.SetRoutingSettings(GetRoutingSettings(VehicleType::Car));
+  route.SetRouteSegments(std::move(segments));
+  route.SetGeometry(path.begin(), path.end());
+
+  auto const wa = [](m2::PointD const & p) { return geometry::PointWithAltitude(p, geometry::kDefaultAltitudeMeters); };
+  route.SetSubroutes(
+      vector<Route::SubrouteAttrs>{Route::SubrouteAttrs(wa(path.front()), wa(b1), 0, stop1Idx),
+                                   Route::SubrouteAttrs(wa(b1), wa(b2), stop1Idx, stop2Idx),
+                                   Route::SubrouteAttrs(wa(b2), wa(path.back()), stop2Idx, path.size() - 1)});
+
+  double fire1M = -1.0, fire2M = -1.0;
+  size_t passedLegs = 0;
+  for (double x = 0.003; x < 0.0085; x += 0.00005)
+  {
+    auto const info = GetGps(x, 0.0);
+    if (!route.MoveIterator(info))
+      continue;
+    // Mirror RoutingSession::PassCheckpoints().
+    while (passedLegs < 2 && IsPassed(route, info, passedLegs))
+    {
+      route.PassNextSubroute();
+      ++passedLegs;
+      (passedLegs == 1 ? fire1M : fire2M) = (x - (passedLegs == 1 ? a1.x : a2.x)) * kDegToM;
+    }
+  }
+
+  TEST_EQUAL(passedLegs, 2, ("Both stops must be passed"));
+  TEST_GREATER_OR_EQUAL(fire1M, 14.9, ());
+  TEST_LESS_OR_EQUAL(fire1M, 25.0, ());
+  TEST_GREATER_OR_EQUAL(fire2M, 14.9, ());
+  TEST_LESS_OR_EQUAL(fire2M, 25.0, ());
+}
+
+// Ruler routes (see the layout table in ruler_router.cpp) have subroutes shorter than 3 segments,
+// so they keep today's rule bit-for-bit despite consisting of fake segments only.
+UNIT_TEST(PassCheckpoint_RulerLayoutUnchanged)
+{
+  vector<m2::PointD> const pts = {{0.0, 0.0}, {0.001, 0.0}, {0.002, 0.0}, {0.003, 0.0}};  // start, 1, 2, finish
+  vector<m2::PointD> geometry;
+  for (auto const & p : pts)
+  {
+    geometry.push_back(p);
+    geometry.push_back(p);
+  }
+
+  vector<RouteSegment> routeSegments;
+  vector<Segment> const segs(geometry.size() - 1, Segment(kFakeNumMwmId, 0, 0, false));
+  RouteSegmentsFrom(segs, geometry, {}, {}, routeSegments);
+  FillSegmentInfo(vector<double>(geometry.size() - 1, 0.0), routeSegments);
+
+  Route route;
+  route.SetRoutingSettings(GetRoutingSettings(VehicleType::Pedestrian));
+  route.SetRouteSegments(std::move(routeSegments));
+  route.SetGeometry(geometry.begin(), geometry.end());
+
+  auto const wa = [](m2::PointD const & p) { return geometry::PointWithAltitude(p, geometry::kDefaultAltitudeMeters); };
+  vector<Route::SubrouteAttrs> subroutes;
+  for (size_t i = 1; i < pts.size(); ++i)
+  {
+    subroutes.emplace_back(wa(pts[i - 1]), wa(pts[i]), i * 2 - 2, i * 2);
+    subroutes.emplace_back(wa(pts[i - 1]), wa(pts[i]), i * 2 - 1, i * 2);
+  }
+  route.SetSubroutes(std::move(subroutes));
+
+  auto const & segments = route.GetRouteSegments();
+  size_t const endSegmentIdx = route.GetSubrouteAttrs(0).GetEndSegmentIdx();
+  int fireOld = -1, fireNew = -1, sample = 0;
+  for (double x = 0.0; x < 0.0015; x += 0.00002, ++sample)
+  {
+    auto const info = GetGps(x, 0.0);
+    if (!route.MoveIterator(info))
+      continue;
+    double const remainingM =
+        segments[endSegmentIdx - 1].GetDistFromBeginningMeters() - route.GetCurrentDistanceFromBeginMeters();
+    if (fireOld < 0 && remainingM < 10.0)
+      fireOld = sample;
+    if (fireNew < 0 && IsPassed(route, info))
+      fireNew = sample;
+  }
+
+  TEST_GREATER_OR_EQUAL(fireNew, 0, ("The ruler leg must be passed"));
+  TEST_EQUAL(fireOld, fireNew, ("Ruler-shaped legs must keep today's rule"));
+}
+
+// Returns a prebuilt off-road-stop route, so that the session exercises the real build, promotion
+// and following pipeline.
+class StopRouter : public IRouter
+{
+public:
+  explicit StopRouter(Route const & route) : m_route(route) {}
+
+  string GetName() const override { return "stop-router"; }
+  void ClearState() override {}
+  void SetGuides(GuidesTracks &&) override {}
+
+  RouterResultCode CalculateRoute(Checkpoints const &, m2::PointD const &, bool, RouterDelegate const &,
+                                  RoutesResult & result) override
+  {
+    result.MakeFrom(GetName(), Route(m_route));
+    return RouterResultCode::NoError;
+  }
+
+  bool FindClosestProjectionToRoad(m2::PointD const &, m2::PointD const &, double, EdgeProj &) override
+  {
+    return false;
+  }
+
+private:
+  Route m_route;
+};
+
+// End to end: driving past an off-road stop passes the checkpoint and never asks for a rebuild.
+UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, PassOffRoadCheckpointNoRebuild)
+{
+  Fixture f(33.0, VehicleType::Car);
+
+  TimedSignal buildSignal;
+  GetPlatform().RunTask(Platform::Thread::Gui, [&buildSignal, &f, this]()
+  {
+    InitRoutingSession();
+    m_session->SetRoutingSettings(GetRoutingSettings(VehicleType::Car));
+    m_session->SetRouter(make_unique<StopRouter>(f.m_route), nullptr);
+    m_session->SetRoutingCallbacks([&buildSignal](RoutesResult const &, RouterResultCode) { buildSignal.Signal(); },
+                                   nullptr, nullptr, nullptr);
+    // BuildRoute() is what gives the session real three-point checkpoints.
+    m_session->BuildRoute(Checkpoints(CheckpointsGeometry{f.m_path.front(), f.m_b, f.m_path.back()}),
+                          RouterDelegate::kNoTimeout);
+  });
+  TEST(buildSignal.WaitUntil(chrono::steady_clock::now() + chrono::seconds(30)), ("Route was not built."));
+
+  TimedSignal driveSignal;
+  bool sawRebuild = false;
+  size_t passedIdx = 0;
+  GetPlatform().RunTask(Platform::Thread::Gui, [&, this]()
+  {
+    m_session->SetCheckpointCallback([&passedIdx](size_t idx) { passedIdx = idx; });
+    for (double x = 0.0035; x < 0.0075; x += 0.00005)
+      sawRebuild = sawRebuild || m_session->OnLocationPositionChanged(GetGps(x, 0.0)) == SessionState::RouteNeedRebuild;
+    driveSignal.Signal();
+  });
+  TEST(driveSignal.WaitUntil(chrono::steady_clock::now() + chrono::seconds(30)), ("Drive timeout."));
+
+  TEST(!sawRebuild, ("Passing an off-road stop must never request a rebuild"));
+  TEST_EQUAL(passedIdx, 1, ("The intermediate checkpoint must be passed"));
+}
+}  // namespace checkpoint_pass_tests

--- a/libs/routing/routing_tests/route_tests.cpp
+++ b/libs/routing/routing_tests/route_tests.cpp
@@ -86,22 +86,22 @@ UNIT_TEST(FinshRouteOnSomeDistanceToTheFinishPointTest)
       // The route should be finished at some distance to the finish point.
       double const distToFinish = settings.m_finishToleranceM;
 
-      route.MoveIterator(GetGps(kTestGeometry.back().x, kTestGeometry.back().y - 0.1));
-      TEST(!route.IsSubroutePassed(0), ());
+      auto const move = [&route](double y)
+      {
+        auto const info = GetGps(kTestGeometry.back().x, y);
+        route.MoveIterator(info);
+        return route.IsSubroutePassed(0, mercator::FromLatLon(info.m_latitude, info.m_longitude), info.m_speed);
+      };
+
+      TEST(!move(kTestGeometry.back().y - 0.1), ());
       TEST_GREATER(route.GetCurrentDistanceToEndMeters(), distToFinish, ());
 
-      route.MoveIterator(GetGps(kTestGeometry.back().x, kTestGeometry.back().y - 0.02));
-      TEST(!route.IsSubroutePassed(0), ());
+      TEST(!move(kTestGeometry.back().y - 0.02), ());
       TEST_GREATER(route.GetCurrentDistanceToEndMeters(), distToFinish, ());
 
       // Finish tolerance value for cars is greater then for other vehicle types.
       // The iterator for other types should be moved closer to the finish point.
-      if (vehicleType == VehicleType::Car)
-        route.MoveIterator(GetGps(kTestGeometry.back().x, kTestGeometry.back().y - 0.00014));
-      else
-        route.MoveIterator(GetGps(kTestGeometry.back().x, kTestGeometry.back().y - 0.00011));
-
-      TEST(route.IsSubroutePassed(0), ());
+      TEST(move(kTestGeometry.back().y - (vehicleType == VehicleType::Car ? 0.00014 : 0.00011)), ());
       TEST_LESS(route.GetCurrentDistanceToEndMeters(), distToFinish, ());
     }
   }

--- a/libs/routing/routing_tests/routing_session_test.cpp
+++ b/libs/routing/routing_tests/routing_session_test.cpp
@@ -115,30 +115,6 @@ private:
   size_t m_returnCodesIdx = 0;
 };
 
-class TimedSignal
-{
-public:
-  TimedSignal() : m_flag(false) {}
-  void Signal()
-  {
-    lock_guard<mutex> guard(m_waitingMutex);
-    m_flag = true;
-    m_cv.notify_one();
-  }
-
-  bool WaitUntil(steady_clock::time_point const & time)
-  {
-    unique_lock<mutex> lock(m_waitingMutex);
-    m_cv.wait_until(lock, time, [this, &time] { return m_flag || steady_clock::now() > time; });
-    return m_flag;
-  }
-
-private:
-  mutex m_waitingMutex;
-  condition_variable m_cv;
-  bool m_flag;
-};
-
 /// \brief This class is developed to test callback on RoutingSession::m_state changing.
 /// An new instance of the class should be constructed for every new test.
 class SessionStateTest

--- a/libs/routing/routing_tests/tools.hpp
+++ b/libs/routing/routing_tests/tools.hpp
@@ -4,10 +4,37 @@
 
 #include "routing/routing_session.hpp"
 
+#include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 
 namespace routing
 {
+/// \brief One-shot signal a test thread waits on until it fires or the deadline passes.
+class TimedSignal
+{
+public:
+  void Signal()
+  {
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_flag = true;
+    m_cv.notify_one();
+  }
+
+  bool WaitUntil(std::chrono::steady_clock::time_point const & time)
+  {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    m_cv.wait_until(lock, time, [this, &time] { return m_flag || std::chrono::steady_clock::now() > time; });
+    return m_flag;
+  }
+
+private:
+  std::mutex m_mutex;
+  std::condition_variable m_cv;
+  bool m_flag = false;
+};
+
 class AsyncGuiThreadTest
 {
   platform::tests_support::AsyncGuiThread m_asyncGuiThread;


### PR DESCRIPTION
## What

Intermediate stops (via points) placed even slightly off the road were never detected as passed: the app kept navigating the user **back** to a stop they had already driven by.

The router joins a tapped stop `B` to the road network with a straight, non-drivable connector from its projection `A` on the road. `Route::IsSubroutePassed()` measures the remaining *along-route* distance to `B`, but the follow-time projection can never climb that connector — it saturates at `A`, so the remaining distance plateaus at the connector length. Against the 10 m tolerance this means:

> **a stop more than 10 m from the road can never be passed, at any speed, however the user drives.**

Measured sweep: 2 / 5 / 8 / 9 m pass; 10 / 11 / 15 / 25 / 50 m never do. Matching then fails a matching-threshold past `A`, `m_moveAwayCounter` overflows and the session rebuilds *to the still-pending stop* (measured: 111 m past a 33 m off-road stop).

This PR derives the connector length from the subroute's two trailing fake segments and passes such a stop at the plateau — i.e. at `A`, the closest drivable point — but only once the raw position has left `A` behind and is not at, or heading into, the stop.

Behaviour:

* driving or walking past an off-road stop removes it **~15-17 m past the closest point of approach** (≈1 s at 50 km/h, ≈3 s cycling, ≈11 s walking) and never triggers a reroute;
* someone who actually turns in and visits the stop keeps it through approach, arrival, dwell and even parking behind it, and loses it shortly after rejoining the road;
* stops on the road, and arrival at the final destination, are unchanged.

Core only — no UI, no strings, no new dependencies; 72 insertions in `libs/routing/route.{hpp,cpp}`.

Fixes #4363. Also addresses the arrival-radius half of #12798 (the manual "skip stop" ask there, and #9528, still need UI). Does **not** cover #7095 (no position updates near the stop at all — backgrounded app or tunnel); that needs a look-ahead rejoin and is left for a follow-up.

## How it was tested

New `libs/routing/routing_tests/checkpoint_pass_tests.cpp`, 12 tests:

* the route shape the index router really produces around a checkpoint, asserted against a live `IndexGraphStarter` on a synthetic graph, so a future change to the ending geometry is caught;
* the derived connector equals the measured plateau for 10-200 m;
* off-road pass-by for car / bicycle / pedestrian / transit × 6 connector lengths, fire position bounded;
* pedestrian at realistic 1.4 m fix spacing (the tightest margin);
* must-not-pass cases: approaching with a 10 m lateral error, visiting the stop (approach → drive in → dwell → behind the stop → drive out), an 11 m overshoot and U-turn, standing still;
* on-road stops and ruler routes fire at the *identical* sample as before (`TEST_EQUAL`, not a bound);
* end-to-end through `RoutingSession`: a 33 m off-road stop is passed and `RouteNeedRebuild` is never entered.

`routing_tests` 283/283 green, repo-wide `ctest -L omim-test` 36/36, `desktop` builds, clang-format clean. Each gate was verified load-bearing by neutering it and checking which tests fail.