### PR TITLE
[routing] Rejoin the route after a gap instead of routing back to a passed stop

### DIFF
--- a/libs/routing/base/followed_polyline.hpp
+++ b/libs/routing/base/followed_polyline.hpp
@@ -2,6 +2,8 @@
 
 #include "geometry/polyline2d.hpp"
 
+#include "base/assert.hpp"
+
 #include <limits>
 #include <vector>
 
@@ -66,6 +68,17 @@ public:
   };
 
   Iter GetCurrentIter() const { return m_current; }
+
+  /// \brief Moves the current position to |iter|, skipping the polyline in between. Used to
+  /// re-attach to a part of the route the user reached without matching it (Route::RejoinPastCheckpoints).
+  void SetCurrentIter(Iter const & iter)
+  {
+    ASSERT(iter.IsValid(), ());
+    ASSERT_LESS(iter.m_ind, m_segProj.size(), ());
+    // The position never moves backwards; the passed-distance bookkeeping assumes it.
+    ASSERT_LESS_OR_EQUAL(m_current.m_ind, iter.m_ind, ());
+    m_current = iter;
+  }
 
   double GetDistanceM(Iter const & it1, Iter const & it2) const;
 

--- a/libs/routing/route.cpp
+++ b/libs/routing/route.cpp
@@ -598,12 +598,15 @@ void Route::GetCurrentDirectionPoint(m2::PointD & pt) const
   m_poly.GetCurrentDirectionPoint(pt, kOnEndToleranceM);
 }
 
+m2::RectD Route::GetMatchingRect(location::GpsInfo const & info) const
+{
+  return mercator::MetersToXY(info.m_longitude, info.m_latitude,
+                              std::max(m_routingSettings.m_matchingThresholdM, info.m_horizontalAccuracy));
+}
+
 bool Route::MoveIterator(location::GpsInfo const & info)
 {
-  m2::RectD const rect = mercator::MetersToXY(
-      info.m_longitude, info.m_latitude, std::max(m_routingSettings.m_matchingThresholdM, info.m_horizontalAccuracy));
-
-  return m_poly.UpdateMatchingProjection(rect);
+  return m_poly.UpdateMatchingProjection(GetMatchingRect(info));
 }
 
 double Route::GetPolySegAngle(size_t ind) const
@@ -685,6 +688,12 @@ bool Route::IsSubroutePassed(size_t subrouteIdx, m2::PointD const & fixPoint, do
   if (endSegmentIdx == 0)
     return true;
 
+  // The followed position is already at or past the end of the subroute, so it is passed whatever
+  // the raw fix looks like. Only RejoinPastCheckpoints() can put it there: while following, the
+  // position is clamped to the current subroute (FollowedPolyline::GetBestMatchingProjection()).
+  if (m_poly.GetCurrentIter().m_ind >= endSegmentIdx)
+    return true;
+
   size_t const segmentIdx = endSegmentIdx - 1;
   CHECK_LESS(segmentIdx, m_routeSegments.size(), ());
   double const lengthMeters = m_routeSegments[segmentIdx].GetDistFromBeginningMeters();
@@ -721,6 +730,53 @@ bool Route::IsSubroutePassed(size_t subrouteIdx, m2::PointD const & fixPoint, do
   // movement where the vehicle defines a minimum speed (car only). A fix without speed data
   // (negative, as location::GpsInfo::HasSpeed()) must not block passing forever.
   return fixSpeedMpS < 0.0 || fixSpeedMpS >= m_routingSettings.m_minSpeedForRouteRebuildMpS;
+}
+
+bool Route::RejoinPastCheckpoints(location::GpsInfo const & info)
+{
+  // Nothing to skip unless an intermediate checkpoint is still pending. This also keeps the scan
+  // below away from every route without intermediate points.
+  if (m_currentSubrouteIdx + 1 >= m_subrouteAttrs.size())
+    return false;
+
+  // The very rect MoveIterator() has just failed to match, so a poor fix widens the scan below and
+  // the matching alike: it can only push the accept farther away, never closer.
+  auto const rect = GetMatchingRect(info);
+
+  // The closest projection over the whole route and not only over what lies ahead: on geometry the
+  // route travels twice (a checkpoint on a dead end, an out-and-back leg) the earliest segment wins
+  // the tie, so a fix that is still approaching the checkpoint resolves to the part already behind
+  // us and is rejected below, and a self-crossing route passes as few checkpoints as possible.
+  auto const iter = m_poly.GetClosestMatchingProjectionInInterval(rect, 0, m_subrouteAttrs.back().GetEndSegmentIdx());
+  if (!iter.IsValid())
+    return false;
+
+  // The scan is bounded by the last subroute's end, so the loop always stops on a valid subroute.
+  size_t subrouteIdx = m_currentSubrouteIdx + 1;
+  while (subrouteIdx < m_subrouteAttrs.size() && iter.m_ind >= GetSubrouteAttrs(subrouteIdx).GetEndSegmentIdx())
+    ++subrouteIdx;
+  ASSERT_LESS(subrouteIdx, m_subrouteAttrs.size(), ());
+
+  // The projection matches the current subroute or something behind it: the user has not passed
+  // the pending checkpoint.
+  if (iter.m_ind < GetSubrouteAttrs(subrouteIdx).GetBeginSegmentIdx())
+    return false;
+
+  // Both subroutes project their shared checkpoint onto the same road point A, so this one starts
+  // with the connector the previous one ends with: a fix short of the checkpoint projects onto it
+  // exactly at the connector length. Accept only a full matching threshold past that point.
+  double const startConnectorMeters = GetSubrouteEndConnectorMeters(GetSubrouteAttrs(subrouteIdx - 1));
+  size_t const beginSegmentIdx = GetSubrouteAttrs(subrouteIdx).GetBeginSegmentIdx();
+  double const alongSubrouteMeters = m_poly.GetDistanceM(m_poly.GetIterToIndex(beginSegmentIdx), iter);
+  if (alongSubrouteMeters < startConnectorMeters + m_routingSettings.m_matchingThresholdM)
+    return false;
+
+  // The position is now on |subrouteIdx|, so let the matcher work on it right away. The caller is
+  // expected to run RoutingSession::PassCheckpoints(), which sets the very same index again, but
+  // until it does the position must not sit beyond the checkpoint the polyline matches up to.
+  m_poly.SetCurrentIter(iter);
+  m_poly.SetNextCheckpointIndex(GetSubrouteAttrs(subrouteIdx).GetEndSegmentIdx());
+  return true;
 }
 
 std::string Route::DebugPrintTurns() const

--- a/libs/routing/route.hpp
+++ b/libs/routing/route.hpp
@@ -526,6 +526,14 @@ public:
   /// driving past an off-road intermediate checkpoint from arriving at it.
   bool IsSubroutePassed(size_t subrouteIdx, m2::PointD const & fixPoint, double fixSpeedMpS) const;
 
+  /// \brief Tries to re-attach the current position to a subroute lying past one or more pending
+  /// checkpoints. A gap in the fixes across a checkpoint (a tunnel, a backgrounded app) never
+  /// matches the route near it, so the checkpoint stays pending forever and the session ends up
+  /// rebuilding a route back to it.
+  /// \returns true if the position was moved, so that IsSubroutePassed() reports every skipped
+  /// subroute as passed.
+  bool RejoinPastCheckpoints(location::GpsInfo const & info);
+
   std::string DebugPrintTurns() const;
 
 private:
@@ -533,6 +541,11 @@ private:
 
   double GetPolySegAngle(size_t ind) const;
   void GetClosestTurnAfterIdx(size_t segIdx, turns::TurnItem & turn) const;
+
+  /// \returns Area to look for the route around |info|: the matching threshold, widened to the
+  /// fix's own accuracy so that a poor fix still matches. MoveIterator() and RejoinPastCheckpoints()
+  /// share it -- the rejoin only ever runs on a fix this very rect has failed to match.
+  m2::RectD GetMatchingRect(location::GpsInfo const & info) const;
 
   /// \returns Length of the trailing pure-fake connector (projection edge A->B + standalone B->B)
   /// of the subroute, i.e. how far its checkpoint sits off the road, or 0 when the subroute does

--- a/libs/routing/routing_session.cpp
+++ b/libs/routing/routing_session.cpp
@@ -265,36 +265,9 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
 
   m_turnNotificationsMgr.SetSpeedMetersPerSecond(info.m_speed);
 
-  auto const formerIter = m_route->GetCurrentIteratorTurn();
+  auto const formerTurn = m_route->GetCurrentIteratorTurn();
   if (m_route->MoveIterator(info))
-  {
-    m_moveAwayCounter = 0;
-    m_lastDistance = 0.0;
-
-    PassCheckpoints(info);
-
-    if (m_checkpoints.IsFinished())
-    {
-      m_passedDistanceOnRouteMeters += m_route->GetTotalDistanceMeters();
-      SetState(SessionState::RouteFinished);
-    }
-    else
-    {
-      SetState(SessionState::OnRoute);
-      m_speedCameraManager.OnLocationPositionChanged(info);
-    }
-
-    if (m_userCurrentPositionValid)
-      m_lastGoodPosition = m_userCurrentPosition;
-
-    auto const curIter = m_route->GetCurrentIteratorTurn();
-    // If we are moving to the next segment after passing the turn
-    // it means the turn is changed. So the |m_onNewTurn| should be called.
-    if (IsNormalTurn(formerIter) && formerIter.m_index < curIter.m_index && m_onNewTurn)
-      m_onNewTurn();
-
-    return m_state;
-  }
+    return OnRoutePosition(info, formerTurn);
 
   if (m_state != SessionState::RouteNeedRebuild && m_state != SessionState::RouteRebuilding)
   {
@@ -315,10 +288,48 @@ SessionState RoutingSession::OnLocationPositionChanged(GpsInfo const & info)
 
     if (m_moveAwayCounter > kOnRouteMissedCount)
     {
+      // Rebuilding now would route the user back to a checkpoint they may have already passed
+      // without a single fix ever matching near it (a tunnel, a backgrounded app). Re-attach to a
+      // later subroute if the position is clearly on one, and keep following the route.
+      if (m_route->RejoinPastCheckpoints(info))
+        return OnRoutePosition(info, formerTurn);
+
       m_passedDistanceOnRouteMeters += m_route->GetCurrentDistanceFromBeginMeters();
       SetState(SessionState::RouteNeedRebuild);
     }
   }
+
+  return m_state;
+}
+
+SessionState RoutingSession::OnRoutePosition(GpsInfo const & info, turns::TurnItem const & formerTurn)
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+
+  m_moveAwayCounter = 0;
+  m_lastDistance = 0.0;
+
+  PassCheckpoints(info);
+
+  if (m_checkpoints.IsFinished())
+  {
+    m_passedDistanceOnRouteMeters += m_route->GetTotalDistanceMeters();
+    SetState(SessionState::RouteFinished);
+  }
+  else
+  {
+    SetState(SessionState::OnRoute);
+    m_speedCameraManager.OnLocationPositionChanged(info);
+  }
+
+  if (m_userCurrentPositionValid)
+    m_lastGoodPosition = m_userCurrentPosition;
+
+  auto const curTurn = m_route->GetCurrentIteratorTurn();
+  // If we are moving to the next segment after passing the turn
+  // it means the turn is changed. So the |m_onNewTurn| should be called.
+  if (IsNormalTurn(formerTurn) && formerTurn.m_index < curTurn.m_index && m_onNewTurn)
+    m_onNewTurn();
 
   return m_state;
 }

--- a/libs/routing/routing_session.hpp
+++ b/libs/routing/routing_session.hpp
@@ -180,6 +180,8 @@ private:
   void RebuildRouteOnTrafficUpdate();
 
   void PassCheckpoints(location::GpsInfo const & info);
+  /// \brief Common bookkeeping for a position that belongs to the route, matched or rejoined.
+  SessionState OnRoutePosition(location::GpsInfo const & info, turns::TurnItem const & formerTurn);
 
 private:
   std::unique_ptr<AsyncRouter> m_router;

--- a/libs/routing/routing_tests/checkpoint_pass_tests.cpp
+++ b/libs/routing/routing_tests/checkpoint_pass_tests.cpp
@@ -23,6 +23,7 @@
 #include "geometry/point2d.hpp"
 #include "geometry/point_with_altitude.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -73,16 +74,22 @@ Segment FakeSeg(uint32_t idx)
 // stop B sits |connectorM| north of A. Polyline (per IndexGraphStarter::AddEnding + RedressRoute):
 //   start, start, road..., A, B, B, | B, A, road..., finish, finish
 // Leg 0 tail = pure fakes (A->B, B->B); leg 1 head = pure fakes (B->B, B->A).
+// |reversed| turns leg 1 back west instead, so that it retraces the road of leg 0.
 struct Fixture
 {
-  explicit Fixture(double connectorM, VehicleType vehicle = VehicleType::Car) : m_b(kAx, connectorM / kDegToM)
+  explicit Fixture(double connectorM, VehicleType vehicle = VehicleType::Car, bool reversed = false)
+    : m_b(kAx, connectorM / kDegToM)
   {
     m2::PointD const a(kAx, 0.0);
     m_path = {{0.0, 0.0}, {0.0, 0.0}, {0.001, 0.0}, {0.002, 0.0}, {0.003, 0.0}, {0.004, 0.0}, a, m_b};
     m_stopIdx = m_path.size();  // polyline index of leg-0 end vertex (the standalone B).
     m_path.push_back(m_b);      // leg 0 standalone B->B end vertex.
     m_path.push_back(m_b);      // leg 1 standalone B->B vertex.
-    m_path.insert(m_path.end(), {a, {0.006, 0.0}, {0.007, 0.0}, {0.008, 0.0}, {0.009, 0.0}, {0.01, 0.0}, {0.01, 0.0}});
+    if (reversed)
+      m_path.insert(m_path.end(), {a, {0.004, 0.0}, {0.003, 0.0}, {0.002, 0.0}, {0.001, 0.0}, {0.0, 0.0}, {0.0, 0.0}});
+    else
+      m_path.insert(m_path.end(),
+                    {a, {0.006, 0.0}, {0.007, 0.0}, {0.008, 0.0}, {0.009, 0.0}, {0.01, 0.0}, {0.01, 0.0}});
 
     vector<Segment> segs;
     for (uint32_t i = 0; i + 1 < m_path.size(); ++i)
@@ -420,44 +427,68 @@ UNIT_TEST(PassCheckpoint_StandstillSpeedGate)
   }
 }
 
+// Production-faithful three-leg route: stops 33 m off the road at x = 0.005 and 15 m off it at
+// x = 0.007, same tail/head shape as Fixture.
+struct TwoStopFixture
+{
+  TwoStopFixture() : m_a1(0.005, 0.0), m_b1(0.005, 33.0 / kDegToM), m_a2(0.007, 0.0), m_b2(0.007, 15.0 / kDegToM)
+  {
+    m_path = {{0.0, 0.0}, {0.0, 0.0}, {0.002, 0.0}, {0.004, 0.0}, m_a1, m_b1};
+    m_stop1Idx = m_path.size();
+    m_path.push_back(m_b1);
+    m_path.push_back(m_b1);
+    m_path.insert(m_path.end(), {m_a1, {0.006, 0.0}, m_a2, m_b2});
+    m_stop2Idx = m_path.size();
+    m_path.push_back(m_b2);
+    m_path.push_back(m_b2);
+    m_path.insert(m_path.end(), {m_a2, {0.008, 0.0}, {0.009, 0.0}, {0.009, 0.0}});
+
+    vector<Segment> segs;
+    for (uint32_t i = 0; i + 1 < m_path.size(); ++i)
+      segs.push_back(RealSeg(i));
+    for (size_t idx : {m_stop1Idx - 2, m_stop1Idx - 1, m_stop1Idx, m_stop1Idx + 1, m_stop2Idx - 2, m_stop2Idx - 1,
+                       m_stop2Idx, m_stop2Idx + 1})
+      segs[idx] = FakeSeg(static_cast<uint32_t>(idx));
+
+    vector<RouteSegment> segments;
+    RouteSegmentsFrom(segs, m_path, {}, {}, segments);
+    FillSegmentInfo(vector<double>(m_path.size() - 1, 0.0), segments);
+
+    m_route.SetRoutingSettings(GetRoutingSettings(VehicleType::Car));
+    m_route.SetRouteSegments(std::move(segments));
+    m_route.SetGeometry(m_path.begin(), m_path.end());
+
+    auto const wa = [](m2::PointD const & p)
+    { return geometry::PointWithAltitude(p, geometry::kDefaultAltitudeMeters); };
+    m_route.SetSubroutes(
+        vector<Route::SubrouteAttrs>{Route::SubrouteAttrs(wa(m_path.front()), wa(m_b1), 0, m_stop1Idx),
+                                     Route::SubrouteAttrs(wa(m_b1), wa(m_b2), m_stop1Idx, m_stop2Idx),
+                                     Route::SubrouteAttrs(wa(m_b2), wa(m_path.back()), m_stop2Idx, m_path.size() - 1)});
+  }
+
+  m2::PointD m_a1, m_b1, m_a2, m_b2;
+  vector<m2::PointD> m_path;
+  size_t m_stop1Idx = 0, m_stop2Idx = 0;
+  Route m_route;
+};
+
+// Mirrors RoutingSession::PassCheckpoints() for a route with |subrouteCount| subroutes.
+size_t PassIntermediateStops(Route & route, location::GpsInfo const & info, size_t subrouteCount)
+{
+  size_t passed = 0;
+  while (passed + 1 < subrouteCount && IsPassed(route, info, passed))
+  {
+    route.PassNextSubroute();
+    ++passed;
+  }
+  return passed;
+}
+
 // Two consecutive off-road stops are passed in order, each shortly after its own projection root.
 UNIT_TEST(PassCheckpoint_TwoStopsInOrder)
 {
-  double constexpr c1 = 33.0, c2 = 15.0;
-  m2::PointD const a1(0.005, 0.0), b1(0.005, c1 / kDegToM);
-  m2::PointD const a2(0.007, 0.0), b2(0.007, c2 / kDegToM);
-
-  vector<m2::PointD> path = {{0.0, 0.0}, {0.0, 0.0}, {0.002, 0.0}, {0.004, 0.0}, a1, b1};
-  size_t const stop1Idx = path.size();
-  path.push_back(b1);
-  path.push_back(b1);
-  path.insert(path.end(), {a1, {0.006, 0.0}, a2, b2});
-  size_t const stop2Idx = path.size();
-  path.push_back(b2);
-  path.push_back(b2);
-  path.insert(path.end(), {a2, {0.008, 0.0}, {0.009, 0.0}, {0.009, 0.0}});
-
-  vector<Segment> segs;
-  for (uint32_t i = 0; i + 1 < path.size(); ++i)
-    segs.push_back(RealSeg(i));
-  for (size_t idx :
-       {stop1Idx - 2, stop1Idx - 1, stop1Idx, stop1Idx + 1, stop2Idx - 2, stop2Idx - 1, stop2Idx, stop2Idx + 1})
-    segs[idx] = FakeSeg(static_cast<uint32_t>(idx));
-
-  vector<RouteSegment> segments;
-  RouteSegmentsFrom(segs, path, {}, {}, segments);
-  FillSegmentInfo(vector<double>(path.size() - 1, 0.0), segments);
-
-  Route route;
-  route.SetRoutingSettings(GetRoutingSettings(VehicleType::Car));
-  route.SetRouteSegments(std::move(segments));
-  route.SetGeometry(path.begin(), path.end());
-
-  auto const wa = [](m2::PointD const & p) { return geometry::PointWithAltitude(p, geometry::kDefaultAltitudeMeters); };
-  route.SetSubroutes(
-      vector<Route::SubrouteAttrs>{Route::SubrouteAttrs(wa(path.front()), wa(b1), 0, stop1Idx),
-                                   Route::SubrouteAttrs(wa(b1), wa(b2), stop1Idx, stop2Idx),
-                                   Route::SubrouteAttrs(wa(b2), wa(path.back()), stop2Idx, path.size() - 1)});
+  TwoStopFixture f;
+  auto & route = f.m_route;
 
   double fire1M = -1.0, fire2M = -1.0;
   size_t passedLegs = 0;
@@ -471,7 +502,7 @@ UNIT_TEST(PassCheckpoint_TwoStopsInOrder)
     {
       route.PassNextSubroute();
       ++passedLegs;
-      (passedLegs == 1 ? fire1M : fire2M) = (x - (passedLegs == 1 ? a1.x : a2.x)) * kDegToM;
+      (passedLegs == 1 ? fire1M : fire2M) = (x - (passedLegs == 1 ? f.m_a1.x : f.m_a2.x)) * kDegToM;
     }
   }
 
@@ -531,6 +562,200 @@ UNIT_TEST(PassCheckpoint_RulerLayoutUnchanged)
 
   TEST_GREATER_OR_EQUAL(fireNew, 0, ("The ruler leg must be passed"));
   TEST_EQUAL(fireOld, fireNew, ("Ruler-shaped legs must keep today's rule"));
+}
+
+// A gap in the fixes across a stop (a tunnel, a backgrounded app) leaves every position unmatched,
+// so nothing is ever evaluated near the stop. Re-attaching to the next subroute passes it.
+UNIT_TEST(PassCheckpoint_RejoinAfterGap)
+{
+  for (auto const vehicle : {VehicleType::Car, VehicleType::Bicycle, VehicleType::Pedestrian, VehicleType::Transit})
+  {
+    // Both on-road (0, 5 m) and off-road stops are missed when no fix lands near them.
+    for (double c : {0.0, 5.0, 33.0, 200.0})
+    {
+      Fixture f(c, vehicle);
+      for (double x = 0.0035; x < kAx - 100.0 / kDegToM; x += 0.00005)
+        TEST(f.m_route.MoveIterator(GetGps(x, 0.0)), ("Must follow the route before the gap", vehicle, c));
+
+      auto const afterGap = GetGps(kAx + 200.0 / kDegToM, 0.0);
+      TEST(!f.m_route.MoveIterator(afterGap), ("The fix after the gap must not match", vehicle, c));
+      TEST(!IsPassed(f.m_route, afterGap), ("Without a rejoin the stop stays pending", vehicle, c));
+
+      TEST(f.m_route.RejoinPastCheckpoints(afterGap), ("Must rejoin the next subroute", vehicle, c));
+      TEST_GREATER_OR_EQUAL(f.m_route.GetCurrentIter().m_ind, f.m_stopIdx, ("Position must move onto leg 1", vehicle));
+      TEST(IsPassed(f.m_route, afterGap), ("The stop must be passed after the rejoin", vehicle, c));
+      // Following continues on the new subroute even before the session passes the checkpoints.
+      TEST(f.m_route.MoveIterator(GetGps(kAx + 250.0 / kDegToM, 0.0)), ("Must match after the rejoin", vehicle, c));
+    }
+  }
+}
+
+// Everything that must not count as a rejoin.
+UNIT_TEST(PassCheckpoint_RejoinRejects)
+{
+  double constexpr kOffRoadM = 33.0;
+  // Follow the route up to 100 m before A, so that the positions below are all unmatched.
+  auto const followToGap = [](Fixture & f)
+  {
+    for (double x = 0.0035; x < kAx - 100.0 / kDegToM; x += 0.00005)
+      f.m_route.MoveIterator(GetGps(x, 0.0));
+  };
+
+  // A stop farther off the road than the matching threshold is the interesting case: the next
+  // subroute retraces the connector, so its first |c| metres are not progress along the route.
+  for (double c : {33.0, 200.0})
+  {
+    Fixture f(c);
+    followToGap(f);
+    // Still short of the stop: such a fix projects onto the next subroute exactly at the connector
+    // root, because both subroutes join the checkpoint to the road at the same point.
+    for (double d : {-30.0, -60.0, -150.0})
+      TEST(!f.m_route.RejoinPastCheckpoints(GetGps(kAx + d / kDegToM, 0.0)), ("Approaching the stop", c, d));
+
+    // Past the stop but not far enough to rule out a fix taken while approaching it.
+    for (double d : {5.0, 20.0, 45.0})
+      TEST(!f.m_route.RejoinPastCheckpoints(GetGps(kAx + d / kDegToM, 0.0)), ("Too close to the stop", c, d));
+
+    // Wandering off the road near the stop (a parking lot, a park path).
+    TEST(!f.m_route.RejoinPastCheckpoints(GetGps(kAx - 30.0 / kDegToM, 60.0 / kDegToM)), ("Off the road", c));
+    TEST(!f.m_route.RejoinPastCheckpoints(GetGps(kAx + 100.0 / kDegToM, 200.0 / kDegToM)), ("Far off the road", c));
+  }
+  {
+    // The route turns back after the stop: driving on gives no rejoin (the user really left the
+    // route), and -- the reason the whole route is scanned -- a fix still approaching the stop
+    // must not be read as progress along the leg that retraces the very same road.
+    Fixture f(kOffRoadM, VehicleType::Car, true /* reversed */);
+    followToGap(f);
+    TEST(!f.m_route.RejoinPastCheckpoints(GetGps(kAx + 200.0 / kDegToM, 0.0)), ("Driving on past a reversed leg"));
+    for (double d : {-30.0, -60.0, -150.0})
+      TEST(!f.m_route.RejoinPastCheckpoints(GetGps(kAx + d / kDegToM, 0.0)), ("Approaching, reversed leg, d =", d));
+  }
+  {
+    // A route without intermediate checkpoints has nothing to skip.
+    Fixture f(kOffRoadM);
+    auto const wa = [](m2::PointD const & p)
+    { return geometry::PointWithAltitude(p, geometry::kDefaultAltitudeMeters); };
+    f.m_route.SetSubroutes(vector<Route::SubrouteAttrs>{
+        Route::SubrouteAttrs(wa(f.m_path.front()), wa(f.m_path.back()), 0, f.m_path.size() - 1)});
+    followToGap(f);
+    TEST(!f.m_route.RejoinPastCheckpoints(GetGps(0.009, 0.0)), ("No intermediate checkpoint to pass"));
+  }
+}
+
+// The rejoin needs a full matching threshold of progress past the point where the route touches the
+// stop, whatever the connector length -- closer than that a fix is still explainable as approaching.
+UNIT_TEST(PassCheckpoint_RejoinAcceptDistance)
+{
+  for (auto const vehicle : {VehicleType::Car, VehicleType::Bicycle, VehicleType::Pedestrian, VehicleType::Transit})
+  {
+    double const thresholdM = GetRoutingSettings(vehicle).m_matchingThresholdM;
+    for (double c : {0.0, 33.0, 200.0})
+    {
+      Fixture f(c, vehicle);
+      double firstAcceptM = -1.0;
+      // 0.00001 deg ~ 1.1 m sampling; the fixture is untouched until the first accepted position.
+      for (double x = kAx; x < 0.0095 && firstAcceptM < 0.0; x += 0.00001)
+        if (f.m_route.RejoinPastCheckpoints(GetGps(x, 0.0)))
+          firstAcceptM = MetersPastA({x, 0.0});
+
+      TEST_ALMOST_EQUAL_ABS(firstAcceptM, thresholdM, 1.2, ("Accept distance from A", vehicle, c));
+    }
+  }
+}
+
+// A poor fix widens the search rect of the matching and of the rejoin alike, so it can only push
+// the accept farther away: the rejoin is reached at all only after MoveIterator() has failed with
+// that same rect, which already puts the fix |m_horizontalAccuracy| away from the stop's road point.
+UNIT_TEST(PassCheckpoint_RejoinPoorAccuracy)
+{
+  double const thresholdM = GetRoutingSettings(VehicleType::Car).m_matchingThresholdM;
+  for (double c : {0.0, 33.0, 200.0})
+  {
+    for (double accuracyM : {5.0, 100.0, 200.0})
+    {
+      Fixture f(c);
+      // Follow the route up to 100 m before A, then drive on with no fix landing near the stop.
+      for (double x = 0.0035; x < kAx - 100.0 / kDegToM; x += 0.00005)
+        f.m_route.MoveIterator(GetGps(x, 0.0));
+
+      double firstAcceptM = -1.0;
+      for (double x = kAx; x < 0.013 && firstAcceptM < 0.0; x += 0.00001)
+      {
+        auto const info = GetGps(x, 0.0, accuracyM);
+        // Mirror RoutingSession: a matched fix never reaches the rejoin.
+        if (f.m_route.MoveIterator(info))
+          continue;
+        if (f.m_route.RejoinPastCheckpoints(info))
+          firstAcceptM = MetersPastA({x, 0.0});
+      }
+
+      TEST_ALMOST_EQUAL_ABS(firstAcceptM, std::max(thresholdM, accuracyM), 1.2,
+                            ("A poor fix rejoins later, never earlier", c, accuracyM));
+    }
+  }
+}
+
+// A gap spanning two stops passes both of them at once.
+UNIT_TEST(PassCheckpoint_RejoinSkipsTwoStops)
+{
+  TwoStopFixture f;
+  for (double x = 0.003; x < 0.0045; x += 0.00005)
+    TEST(f.m_route.MoveIterator(GetGps(x, 0.0)), ());
+
+  auto const afterGap = GetGps(0.0085, 0.0);  // 167 m past the second stop.
+  TEST(!f.m_route.MoveIterator(afterGap), ("The fix after the gap must not match"));
+  TEST(f.m_route.RejoinPastCheckpoints(afterGap), ("Must rejoin the last subroute"));
+  TEST_EQUAL(PassIntermediateStops(f.m_route, afterGap, 3), 2, ("Both stops must be passed"));
+}
+
+// A route that runs over the same road twice must pass as few checkpoints as it can explain.
+UNIT_TEST(PassCheckpoint_RejoinEarliestSubrouteWins)
+{
+  double constexpr c = 33.0;
+  m2::PointD const a1(0.005, 0.0), b1(0.005, c / kDegToM);
+  m2::PointD const a2(0.005, 0.0), b2(0.005, -c / kDegToM);
+
+  // Leg 0: start -> A1 -> B1. Leg 1: B1 -> A1 -> east 0.009 -> back to A2 -> B2 (an out-and-back).
+  // Leg 2: B2 -> A2 -> east 0.009 -> 0.013, i.e. it retraces leg 1's eastward half.
+  vector<m2::PointD> path = {{0.0, 0.0}, {0.0, 0.0}, {0.002, 0.0}, {0.004, 0.0}, a1, b1};
+  size_t const stop1Idx = path.size();
+  path.push_back(b1);
+  path.push_back(b1);
+  path.insert(path.end(), {a1, {0.007, 0.0}, {0.009, 0.0}, {0.007, 0.0}, a2, b2});
+  size_t const stop2Idx = path.size();
+  path.push_back(b2);
+  path.push_back(b2);
+  path.insert(path.end(), {a2, {0.007, 0.0}, {0.009, 0.0}, {0.011, 0.0}, {0.013, 0.0}, {0.013, 0.0}});
+
+  vector<Segment> segs;
+  for (uint32_t i = 0; i + 1 < path.size(); ++i)
+    segs.push_back(RealSeg(i));
+  for (size_t idx :
+       {stop1Idx - 2, stop1Idx - 1, stop1Idx, stop1Idx + 1, stop2Idx - 2, stop2Idx - 1, stop2Idx, stop2Idx + 1})
+    segs[idx] = FakeSeg(static_cast<uint32_t>(idx));
+
+  vector<RouteSegment> segments;
+  RouteSegmentsFrom(segs, path, {}, {}, segments);
+  FillSegmentInfo(vector<double>(path.size() - 1, 0.0), segments);
+
+  Route route;
+  route.SetRoutingSettings(GetRoutingSettings(VehicleType::Car));
+  route.SetRouteSegments(std::move(segments));
+  route.SetGeometry(path.begin(), path.end());
+
+  auto const wa = [](m2::PointD const & p) { return geometry::PointWithAltitude(p, geometry::kDefaultAltitudeMeters); };
+  route.SetSubroutes(
+      vector<Route::SubrouteAttrs>{Route::SubrouteAttrs(wa(path.front()), wa(b1), 0, stop1Idx),
+                                   Route::SubrouteAttrs(wa(b1), wa(b2), stop1Idx, stop2Idx),
+                                   Route::SubrouteAttrs(wa(b2), wa(path.back()), stop2Idx, path.size() - 1)});
+
+  for (double x = 0.003; x < 0.0045; x += 0.00005)
+    TEST(route.MoveIterator(GetGps(x, 0.0)), ());
+
+  auto const afterGap = GetGps(0.008, 0.0);  // On the road both legs 1 and 2 run over.
+  TEST(!route.MoveIterator(afterGap), ());
+  TEST(route.RejoinPastCheckpoints(afterGap), ());
+  TEST_EQUAL(PassIntermediateStops(route, afterGap, 3), 1, ("Only the first stop can be explained as passed"));
 }
 
 // Returns a prebuilt off-road-stop route, so that the session exercises the real build, promotion
@@ -593,5 +818,85 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, PassOffRoadCheckpointNoReb
 
   TEST(!sawRebuild, ("Passing an off-road stop must never request a rebuild"));
   TEST_EQUAL(passedIdx, 1, ("The intermediate checkpoint must be passed"));
+}
+
+// End to end: a gap in the fixes across the stop must not send the user back to it.
+UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, RejoinPastCheckpointAfterGap)
+{
+  Fixture f(33.0, VehicleType::Car);
+
+  TimedSignal buildSignal;
+  GetPlatform().RunTask(Platform::Thread::Gui, [&buildSignal, &f, this]()
+  {
+    InitRoutingSession();
+    m_session->SetRoutingSettings(GetRoutingSettings(VehicleType::Car));
+    m_session->SetRouter(make_unique<StopRouter>(f.m_route), nullptr);
+    m_session->SetRoutingCallbacks([&buildSignal](RoutesResult const &, RouterResultCode) { buildSignal.Signal(); },
+                                   nullptr, nullptr, nullptr);
+    m_session->BuildRoute(Checkpoints(CheckpointsGeometry{f.m_path.front(), f.m_b, f.m_path.back()}),
+                          RouterDelegate::kNoTimeout);
+  });
+  TEST(buildSignal.WaitUntil(chrono::steady_clock::now() + chrono::seconds(30)), ("Route was not built."));
+
+  TimedSignal driveSignal;
+  bool sawRebuild = false;
+  size_t passedIdx = 0;
+  SessionState state = SessionState::NoValidRoute;
+  GetPlatform().RunTask(Platform::Thread::Gui, [&, this]()
+  {
+    m_session->SetCheckpointCallback([&passedIdx](size_t idx) { passedIdx = idx; });
+    // Fixes stop 100 m before the stop and resume 100 m past it.
+    for (double x = 0.0035; x < kAx - 100.0 / kDegToM; x += 0.00005)
+      m_session->OnLocationPositionChanged(GetGps(x, 0.0));
+    for (double x = kAx + 100.0 / kDegToM; x < 0.0075; x += 0.00005)
+    {
+      state = m_session->OnLocationPositionChanged(GetGps(x, 0.0));
+      sawRebuild = sawRebuild || state == SessionState::RouteNeedRebuild;
+    }
+    driveSignal.Signal();
+  });
+  TEST(driveSignal.WaitUntil(chrono::steady_clock::now() + chrono::seconds(30)), ("Drive timeout."));
+
+  TEST(!sawRebuild, ("A stop passed during a gap must not trigger a rebuild back to it"));
+  TEST_EQUAL(passedIdx, 1, ("The intermediate checkpoint must be passed"));
+  TEST_EQUAL(state, SessionState::OnRoute, ("Following must continue"));
+}
+
+// A user who really leaves the route still gets a rebuild.
+UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, RejoinFailureStillRebuilds)
+{
+  Fixture f(33.0, VehicleType::Car);
+
+  TimedSignal buildSignal;
+  GetPlatform().RunTask(Platform::Thread::Gui, [&buildSignal, &f, this]()
+  {
+    InitRoutingSession();
+    m_session->SetRoutingSettings(GetRoutingSettings(VehicleType::Car));
+    m_session->SetRouter(make_unique<StopRouter>(f.m_route), nullptr);
+    m_session->SetRoutingCallbacks([&buildSignal](RoutesResult const &, RouterResultCode) { buildSignal.Signal(); },
+                                   nullptr, nullptr, nullptr);
+    m_session->BuildRoute(Checkpoints(CheckpointsGeometry{f.m_path.front(), f.m_b, f.m_path.back()}),
+                          RouterDelegate::kNoTimeout);
+  });
+  TEST(buildSignal.WaitUntil(chrono::steady_clock::now() + chrono::seconds(30)), ("Route was not built."));
+
+  TimedSignal driveSignal;
+  bool sawRebuild = false;
+  size_t passedIdx = 0;
+  GetPlatform().RunTask(Platform::Thread::Gui, [&, this]()
+  {
+    m_session->SetCheckpointCallback([&passedIdx](size_t idx) { passedIdx = idx; });
+    for (double x = 0.0035; x < kAx - 100.0 / kDegToM; x += 0.00005)
+      m_session->OnLocationPositionChanged(GetGps(x, 0.0));
+    // Turn off the route and drive away from it.
+    for (double y = 100.0; y < 1000.0; y += 50.0)
+      sawRebuild = sawRebuild || m_session->OnLocationPositionChanged(GetGps(kAx - 100.0 / kDegToM, y / kDegToM)) ==
+                                     SessionState::RouteNeedRebuild;
+    driveSignal.Signal();
+  });
+  TEST(driveSignal.WaitUntil(chrono::steady_clock::now() + chrono::seconds(30)), ("Drive timeout."));
+
+  TEST(sawRebuild, ("Leaving the route must still request a rebuild"));
+  TEST_EQUAL(passedIdx, 0, ("No checkpoint may be passed"));
 }
 }  // namespace checkpoint_pass_tests


### PR DESCRIPTION
Stacked on #13351 — it must be merged first (this PR targets its branch; rebase to `master` after).

### What

#13351 fixed intermediate stops that the user drives *past* while the position still matches the route. It does not help when **no fix ever lands near the stop**: passing a stop is only evaluated on a position that matched, so a gap in the fixes across it — a tunnel, or an app that receives no location updates while backgrounded — leaves the stop pending however far past it the user already is. Matching keeps failing, the move-away counter overflows and the session rebuilds a route **back to the stop**.

Right where that rebuild would fire (and nowhere else, so the worst case is exactly today's behaviour), the position is now projected onto the whole route. If it lands on a later subroute, a full matching threshold past the point where the route touches the pending stop, the followed position is moved there and the usual checkpoint bookkeeping passes every stop behind it. Otherwise the rebuild happens as before.

The closest projection wins and ties go to the earliest segment, which is what makes it safe: a position that is still approaching the stop — including one on a leg that doubles back over the same road, e.g. a stop on a dead end — resolves to the part of the route already behind us and is rejected, and a route that crosses itself passes as few stops as it can explain.

Measured (car, 50 m matching threshold, stop 33 m off the road; probe harness on the production fixtures):

| position when the rebuild would fire | rejoin |
|---|---|
| 56 / 111 / 223 / 445 m past the stop | accepted (this is the fix) |
| 5 / 20 / 45 m past the stop | rejected |
| 30 / 60 / 150 m short of the stop | rejected |
| 60 m off the road near the stop | rejected |
| next leg turns back, driving on | rejected (the user really left the route) |
| next leg turns back, 60 / 150 m short of the stop | rejected (whole-route scan; a per-leg scan accepts this) |
| shared geometry of two later legs | earliest leg wins, one stop passed |
| fix with 100 / 200 m accuracy | accepted only 100 / 200 m past the stop |

The accept distance is exactly one matching threshold past the point where the route touches the stop: 50 m car, 40 m transit, 30 m bicycle, 20 m pedestrian, independent of how far off the road the stop is. A fix whose own `m_horizontalAccuracy` exceeds that threshold widens the search rect of the matching and of the rejoin alike, so it can only be accepted *later* -- measured `max(threshold, accuracy)` past the stop, never earlier.

Session level, 33 m off-road stop, fixes stopping 100 m before it and resuming 100 m past it: before — `RouteNeedRebuild` 128 m past the stop, checkpoint still pending; after — the checkpoint is passed, the state stays `OnRoute`, no rebuild. A user who really leaves the route still gets the rebuild (covered by a test).

Relates to #4363 and #7095. It does not *fix* #7095 by itself: while a backgrounded iOS app receives no fixes at all, nothing in the core can act — but this is what recovers the route as soon as fixes resume, instead of guiding the user back to a stop they already walked past.

### How it was tested

`routing_tests` (full suite green, 291 tests) with 7 new unit tests and 2 session tests: gap rejoin for every vehicle and both on- and off-road stops, all the reject cases above, the accept distance per vehicle, the accept distance under a poor fix, two stops skipped at once, earliest-subroute-wins, no rebuild after a gap, rebuild preserved when leaving the route. Repo-wide `ctest` (36 suites) green, `desktop` builds, clang-format clean. Every branch of the new code was neutered in turn to confirm each is covered by a test.

Known, pre-existing and out of scope: `RulerRouter` emits two subroutes per checkpoint pair, so a ruler route with an intermediate point already ends navigation at that point (measured on master's behaviour). With this change, a ruler route with a fix gap reports `RouteFinished` where it previously asked for a rebuild — both come from that same pre-existing defect.

