### PR TITLE
[routing] Fix the finish point of the subroute rebuilt by AdjustRoute

### DIFF
--- a/libs/routing/index_router.cpp
+++ b/libs/routing/index_router.cpp
@@ -1190,7 +1190,7 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints, m2::P
 
   auto const & lastSubroutes = m_lastRoute->GetSubroutes();
   CHECK(!lastSubroutes.empty(), ());
-  auto const & lastSubroute = m_lastRoute->GetSubroute(checkpoints.GetPassedIdx());
+  auto const & rebuiltSubroute = m_lastRoute->GetSubroute(checkpoints.GetPassedIdx());
 
   auto const & steps = m_lastRoute->GetSteps();
   CHECK(!steps.empty(), ());
@@ -1202,8 +1202,8 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints, m2::P
   starter.Append(*m_lastFakeEdges);
 
   std::vector<SegmentEdge> prevEdges;
-  CHECK_LESS_OR_EQUAL(lastSubroute.GetEndSegmentIdx(), steps.size(), ());
-  for (size_t i = lastSubroute.GetBeginSegmentIdx(); i < lastSubroute.GetEndSegmentIdx(); ++i)
+  CHECK_LESS_OR_EQUAL(rebuiltSubroute.GetEndSegmentIdx(), steps.size(), ());
+  for (size_t i = rebuiltSubroute.GetBeginSegmentIdx(); i < rebuiltSubroute.GetEndSegmentIdx(); ++i)
   {
     auto const & step = steps[i];
     prevEdges.emplace_back(step.GetSegment(),
@@ -1235,8 +1235,10 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints, m2::P
   PushPassedSubroutes(checkpoints, subroutes);
 
   size_t subrouteOffset = result.m_path.size();
-  subroutes.emplace_back(starter.GetStartJunction().ToPointWithAltitude(),
-                         starter.GetFinishJunction().ToPointWithAltitude(), 0 /* beginSegmentIdx */, subrouteOffset);
+  // Append() above copied starter's finish ending from m_lastFakeEdges: it is the whole route's final
+  // destination, which differs from this leg's finish while an intermediate checkpoint is pending.
+  subroutes.emplace_back(starter.GetStartJunction().ToPointWithAltitude(), rebuiltSubroute.GetFinish(),
+                         0 /* beginSegmentIdx */, subrouteOffset);
 
   for (size_t i = checkpoints.GetPassedIdx() + 1; i < lastSubroutes.size(); ++i)
   {


### PR DESCRIPTION
## What

`IndexRouter::AdjustRoute()` builds its starter with an empty finish ending and then `Append()`s the previous route's fake edges:

```cpp
FakeEnding dummy{};
IndexGraphStarter starter(MakeFakeEnding(startSegments, pointFrom, *graph), dummy, ...);
starter.Append(*m_lastFakeEdges);
```

`IndexGraphStarter::Append()` does `m_finish = container.m_finish`, and `m_lastFakeEdges` was captured from the previous build's *concatenated* starter — whose finish is the route's **last** checkpoint. So `starter.GetFinishJunction()` is the final destination, not the end of the leg being rebuilt, and filling the rebuilt `SubrouteAttrs` with it makes `SubrouteAttrs::GetFinish()` report the final destination for every leg of an adjusted multi-point route.

Take the finish from the subroute being rebuilt (`lastSubroute`, already in scope) instead.

Only the metadata was wrong — the rebuilt geometry is correct, since `AdjustRoute` joins the previous leg via `prevEdges` and ends where that leg ended.

## Why bother

`SubrouteAttrs::GetFinish()` has no readers today, so this changes no behaviour. It is still worth fixing because the data is silently wrong for the next caller: while working on #13351 an intermediate-checkpoint check was written against `attrs.GetFinish()` and behaved correctly on freshly built routes but not on adjusted ones — the failure is invisible until a route is rebuilt mid-navigation with more than one checkpoint pending.

## How it was tested

`routing_tests` green (271/271), `desktop` builds, clang-format clean. No test is added: with no readers there is nothing observable to assert, and asserting on the field alone would only restate the implementation.