### PR TITLE
[android] Fix Hide all / Show all for child bookmark lists

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCollectionAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCollectionAdapter.java
@@ -197,10 +197,20 @@ public class BookmarkCollectionAdapter extends RecyclerView.Adapter<RecyclerView
   {
     Holders.HeaderViewHolder headerViewHolder = (Holders.HeaderViewHolder) holder;
     headerViewHolder.getText().setText(holder.itemView.getResources().getString(R.string.bookmarks));
-    final boolean visibility = !BookmarkManager.INSTANCE.areAllCategoriesVisible();
-    headerViewHolder.setAction(mMassOperationAction, visibility);
+    headerViewHolder.setAction(mMassOperationAction, areAllChildCategoriesInvisible());
     headerViewHolder.setSkipDivider(true);
     updateVisibility(headerViewHolder.itemView);
+  }
+
+  /**
+   * Mirrors {@link BookmarkCategoriesAdapter}: "Show all" is offered only when nothing is left to hide.
+   */
+  private boolean areAllChildCategoriesInvisible()
+  {
+    for (BookmarkCategory category : mItemsCategory)
+      if (category.isVisible())
+        return false;
+    return true;
   }
 
   private void updateVisibility(@NonNull View itemView)
@@ -229,15 +239,21 @@ public class BookmarkCollectionAdapter extends RecyclerView.Adapter<RecyclerView
     return itemCount;
   }
 
-  private void updateAllItems()
-  {
-    setCategories(BookmarkManager.INSTANCE.getChildrenCategories(mCategoryId));
-  }
-
   void show(boolean visible)
   {
     mVisible = visible;
     notifyDataSetChanged();
+  }
+
+  /**
+   * The rows and the header read visibility from the core when they bind, so a mass operation only has to redraw
+   * them. Re-reading the child lists would rebuild every BookmarkCategory for fields the operation cannot change,
+   * and notifyDataSetChanged() on a member of a ConcatAdapter invalidates the bookmark list next to this card too.
+   */
+  private void setChildCategoriesVisibility(boolean visible)
+  {
+    BookmarkManager.INSTANCE.setChildCategoriesVisibility(mCategoryId, visible);
+    notifyItemRangeChanged(0, getItemCount());
   }
 
   class MassOperationAction implements Holders.HeaderViewHolder.HeaderActionChildCategories
@@ -245,17 +261,13 @@ public class BookmarkCollectionAdapter extends RecyclerView.Adapter<RecyclerView
     @Override
     public void onHideAll()
     {
-      // TODO: Missing implementation
-      // BookmarkManager.INSTANCE.setChildCategoriesVisibility(mCategoryId, false);
-      updateAllItems();
+      setChildCategoriesVisibility(false);
     }
 
     @Override
     public void onShowAll()
     {
-      // TODO: Missing implementation
-      // BookmarkManager.INSTANCE.setChildCategoriesVisibility(mCategoryId, true);
-      updateAllItems();
+      setChildCategoriesVisibility(true);
     }
   }
 }

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCollectionAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCollectionAdapter.java
@@ -26,6 +26,8 @@ public class BookmarkCollectionAdapter extends RecyclerView.Adapter<RecyclerView
   private final static int TYPE_CATEGORY_ITEM = BookmarkManager.CATEGORY;
   private final static int TYPE_HEADER_ITEM = 3;
 
+  private static final int HEADER_POSITION = 0;
+
   private final long mCategoryId;
 
   @NonNull
@@ -40,24 +42,6 @@ public class BookmarkCollectionAdapter extends RecyclerView.Adapter<RecyclerView
   private OnItemClickListener<BookmarkCategory> mClickListener;
   @NonNull
   private final MassOperationAction mMassOperationAction = new MassOperationAction();
-
-  private class ToggleVisibilityClickListener implements View.OnClickListener
-  {
-    @NonNull
-    private final Holders.CollectionViewHolder mHolder;
-
-    ToggleVisibilityClickListener(@NonNull Holders.CollectionViewHolder holder)
-    {
-      mHolder = holder;
-    }
-
-    @Override
-    public void onClick(View v)
-    {
-      mHolder.getEntity().toggleVisibility();
-      notifyItemChanged(0);
-    }
-  }
 
   BookmarkCollectionAdapter(@NonNull BookmarkCategory bookmarkCategory, @NonNull List<BookmarkCategory> itemsCategories)
   {
@@ -186,8 +170,14 @@ public class BookmarkCollectionAdapter extends RecyclerView.Adapter<RecyclerView
     collectionViewHolder.setSize();
     collectionViewHolder.setVisibilityState(category.isVisible());
     collectionViewHolder.setOnClickListener(mClickListener);
-    ToggleVisibilityClickListener listener = new ToggleVisibilityClickListener(collectionViewHolder);
-    collectionViewHolder.setVisibilityListener(listener);
+    // The eye is repainted on the holder that was tapped: unlike the CheckBox it replaced, an ImageView does not
+    // redraw itself, and a notify would have to survive the adapter having no position for the row yet.
+    collectionViewHolder.setVisibilityListener(v -> {
+      category.toggleVisibility();
+      collectionViewHolder.setVisibilityState(category.isVisible());
+      // The header's label depends on the child lists' visibility.
+      notifyItemChanged(HEADER_POSITION);
+    });
     final int itemsCount = getItemsCount(position.getSectionIndex());
     collectionViewHolder.bindCardPosition(position.getItemIndex() == 0, position.getItemIndex() == itemsCount - 1);
     updateVisibility(collectionViewHolder.itemView);

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
@@ -1470,7 +1470,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
     // A load rebuilds every category from its file, so the one this screen was opened with can be gone. Nothing
     // below may run then, adapter creation included: every lookup, down to the ids the list is laid out from,
     // goes to the core by category id and aborts there for a group it no longer has.
-    if (!hasCategory(mCategoryDataSource.getData().getId()))
+    if (!BookmarkManager.INSTANCE.hasCategory(mCategoryDataSource.getData().getId()))
     {
       requireActivity().finish();
       return;
@@ -1525,7 +1525,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
   private boolean refreshFromCore()
   {
     final long categoryId = mCategoryDataSource.getData().getId();
-    if (!hasCategory(categoryId))
+    if (!BookmarkManager.INSTANCE.hasCategory(categoryId))
     {
       requireActivity().finish();
       return false;
@@ -1551,15 +1551,6 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
     // Drop the snapshot rather than keep one that no longer matches the category.
     if (mLastSortTimestamp == 0)
       getBookmarkListAdapter().setSortedResults(null);
-  }
-
-  private static boolean hasCategory(long categoryId)
-  {
-    // Reads the cached list rather than asking the core by id, which would abort on a category that is gone.
-    for (BookmarkCategory category : BookmarkManager.INSTANCE.getCategories())
-      if (category.getId() == categoryId)
-        return true;
-    return false;
   }
 
   private void updateToolbarTitle()

--- a/android/app/src/main/java/app/organicmaps/bookmarks/Holders.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/Holders.java
@@ -318,14 +318,14 @@ public class Holders
     @NonNull
     private final TextView mName;
     @NonNull
-    private final CheckBox mVisibilityMarker;
+    private final ImageView mEyeIcon;
 
     CollectionViewHolder(@NonNull View root)
     {
       super(root);
       mView = root;
       mName = root.findViewById(R.id.name);
-      mVisibilityMarker = root.findViewById(R.id.checkbox);
+      mEyeIcon = root.findViewById(R.id.eye);
     }
 
     void setOnClickListener(@Nullable OnItemClickListener<BookmarkCategory> listener)
@@ -338,12 +338,13 @@ public class Holders
 
     void setVisibilityState(boolean visible)
     {
-      mVisibilityMarker.setChecked(visible);
+      mEyeIcon.setImageResource(visible ? R.drawable.ic_show : R.drawable.ic_hide);
+      mEyeIcon.setContentDescription(mEyeIcon.getContext().getString(visible ? R.string.hide : R.string.show));
     }
 
     void setVisibilityListener(@Nullable View.OnClickListener listener)
     {
-      mVisibilityMarker.setOnClickListener(listener);
+      mEyeIcon.setOnClickListener(listener);
     }
 
     void setName(@NonNull String name)

--- a/android/app/src/main/res/layout/item_bookmark_collection.xml
+++ b/android/app/src/main/res/layout/item_bookmark_collection.xml
@@ -1,44 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
-  android:layout_width="match_parent"
-  android:layout_height="wrap_content"
+  style="@style/BookmarkListRow"
   android:background="@drawable/bg_card_item_middle"
-  android:gravity="center_vertical"
-  android:orientation="horizontal">
-  <CheckBox
-    android:id="@+id/checkbox"
-    android:layout_width="wrap_content"
-    android:layout_height="match_parent"
+  android:paddingEnd="@dimen/margin_base">
+
+  <!-- The visibility toggle leads the row, like the checkbox on the bookmark lists screen.
+       The padding brings the 40dp icon slot back to the icon's own 24dp. -->
+  <ImageView
+    android:id="@+id/eye"
+    style="@style/BookmarkListRow.Icon"
     android:padding="@dimen/margin_half"
-    android:layout_marginStart="@dimen/margin_half_plus"
-    android:layout_marginEnd="@dimen/margin_base_plus" />
-  <LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:contentDescription="@string/hide"
+    app:srcCompat="@drawable/ic_show"
+    app:tint="?secondary" />
+
+  <LinearLayout style="@style/BookmarkListRow.Text">
     <TextView
       android:id="@+id/name"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="@dimen/margin_base"
-      android:layout_marginEnd="@dimen/bookmark_collection_item_end_margin"
-      android:ellipsize="middle"
-      android:singleLine="true"
-      android:textAppearance="?fontBody1"
+      style="@style/BookmarkListRow.Title"
       tools:text="Bookmark name looooooooooooooooooongasdasdasd" />
+
     <TextView
       android:id="@+id/size"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_gravity="center_vertical"
-      android:layout_marginEnd="@dimen/bookmark_collection_item_end_margin"
-      android:layout_marginBottom="@dimen/margin_half_plus"
-      android:ellipsize="end"
-      android:singleLine="true"
-      android:textColor="?android:textColorSecondary"
-      style="?fontBody2"
+      style="@style/BookmarkListRow.Subtitle"
       tools:text="42000000" />
   </LinearLayout>
 </LinearLayout>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -205,8 +205,6 @@
   <dimen name="dp_0">0dp</dimen>
   <dimen name="toggle_map_layer_frame_height">98dp</dimen>
   <dimen name="toggle_map_layer_icon_size">54dp</dimen>
-  <dimen name="bookmark_collection_item_end_margin">56dp</dimen>
-  <dimen name="bookmark_category_checkbox_width">36dp</dimen>
 
   <!-- Purchases-->
   <dimen name="sharing_options_img_size">18dp</dimen>

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/BookmarkManager.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/BookmarkManager.cpp
@@ -286,6 +286,12 @@ JNIEXPORT jboolean Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativ
   return static_cast<jboolean>(frm()->GetBookmarkManager().HasTrack(static_cast<kml::TrackId>(trackId)));
 }
 
+JNIEXPORT jboolean Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeHasCategory(JNIEnv *, jclass,
+                                                                                             jlong catId)
+{
+  return static_cast<jboolean>(frm()->GetBookmarkManager().HasBmCategory(static_cast<kml::MarkGroupId>(catId)));
+}
+
 // The batch operations themselves live in the core, where any platform can reach them: see
 // BookmarkManager::EditSession and Framework::DeleteBookmarksAndTracks.
 JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeDeleteBookmarksAndTracks(

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/BookmarkManager.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/BookmarkManager.cpp
@@ -452,16 +452,18 @@ Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeAreAllCategoriesIn
   return static_cast<jboolean>(frm()->GetBookmarkManager().AreAllCategoriesInvisible());
 }
 
-JNIEXPORT jboolean JNICALL
-Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeAreAllCategoriesVisible(JNIEnv *, jclass)
-{
-  return static_cast<jboolean>(frm()->GetBookmarkManager().AreAllCategoriesVisible());
-}
-
 JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeSetAllCategoriesVisibility(
     JNIEnv *, jclass, jboolean visible)
 {
   frm()->GetBookmarkManager().SetAllCategoriesVisibility(static_cast<bool>(visible));
+}
+
+JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeSetChildCategoriesVisibility(
+    JNIEnv *, jclass, jlong catId, jboolean visible)
+{
+  // Category is the type nativeGetChildrenCategories() filters by, so the affected lists are the displayed ones.
+  frm()->GetBookmarkManager().SetChildCategoriesVisibility(static_cast<kml::MarkGroupId>(catId),
+                                                           kml::CompilationType::Category, static_cast<bool>(visible));
 }
 
 JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeSetTrackVisibility(JNIEnv *, jclass,

--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/BookmarkManager.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/BookmarkManager.java
@@ -285,6 +285,15 @@ public enum BookmarkManager {
   }
 
   /**
+   * Unlike a scan of {@link #getCategories()}, this also sees child lists: the core keeps them in a separate map.
+   * Unlike {@link #getCategoryById(long)}, it does not abort on a category that is gone.
+   */
+  public boolean hasCategory(long catId)
+  {
+    return nativeHasCategory(catId);
+  }
+
+  /**
    * Deletes several bookmarks and tracks at once. Ids that no longer exist are skipped.
    */
   public void deleteBookmarksAndTracks(@NonNull long[] bookmarkIds, @NonNull long[] trackIds)
@@ -641,6 +650,8 @@ public enum BookmarkManager {
   private native void nativeDeleteBookmark(long bmkId);
 
   private static native boolean nativeHasTrack(long trackId);
+
+  private static native boolean nativeHasCategory(long catId);
 
   private static native void nativeDeleteBookmarksAndTracks(@NonNull long[] bookmarkIds, @NonNull long[] trackIds);
 

--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/BookmarkManager.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/BookmarkManager.java
@@ -565,11 +565,6 @@ public enum BookmarkManager {
     nativePrepareForSearch(catId);
   }
 
-  public boolean areAllCategoriesVisible()
-  {
-    return nativeAreAllCategoriesVisible();
-  }
-
   public boolean areAllCategoriesInvisible()
   {
     return nativeAreAllCategoriesInvisible();
@@ -578,6 +573,13 @@ public enum BookmarkManager {
   public void setAllCategoriesVisibility(boolean visible)
   {
     nativeSetAllCategoriesVisibility(visible);
+  }
+
+  /// Shows or hides all child lists of a category at once.
+  /// Uses EditSession internally, so the map is redrawn once instead of once per child list.
+  public void setChildCategoriesVisibility(long catId, boolean visible)
+  {
+    nativeSetChildCategoriesVisibility(catId, visible);
   }
 
   /// Sets individual track visibility. Uses EditSession internally for thread safety.
@@ -684,11 +686,11 @@ public enum BookmarkManager {
 
   private static native void nativePrepareForSearch(long catId);
 
-  private static native boolean nativeAreAllCategoriesVisible();
-
   private static native boolean nativeAreAllCategoriesInvisible();
 
   private static native void nativeSetAllCategoriesVisibility(boolean visible);
+
+  private static native void nativeSetChildCategoriesVisibility(long catId, boolean visible);
 
   private static native void nativeSetTrackVisibility(long trackId, boolean visible);
 

--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/CategoryDataSource.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/CategoryDataSource.java
@@ -3,7 +3,6 @@ package app.organicmaps.sdk.bookmarks.data;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import app.organicmaps.sdk.content.DataSource;
-import java.util.List;
 
 public class CategoryDataSource extends RecyclerView.AdapterDataObserver implements DataSource<BookmarkCategory>
 {
@@ -26,10 +25,11 @@ public class CategoryDataSource extends RecyclerView.AdapterDataObserver impleme
   public void onChanged()
   {
     super.onChanged();
-    List<BookmarkCategory> categories = BookmarkManager.INSTANCE.getCategories();
-    int index = categories.indexOf(mCategory);
-    if (index >= 0)
-      mCategory = categories.get(index);
+    // Looked up by id rather than scanned out of getCategories(), which holds top-level lists only: a child list
+    // would never be found there and the screen would keep the snapshot it was opened with.
+    final long id = mCategory.getId();
+    if (BookmarkManager.INSTANCE.hasCategory(id))
+      mCategory = BookmarkManager.INSTANCE.getCategoryById(id);
   }
 
   @Override

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -3195,11 +3195,6 @@ bool BookmarkManager::IsUsedCategoryName(std::string const & name) const
   return false;
 }
 
-bool BookmarkManager::AreAllCategoriesVisible() const
-{
-  return CheckVisibility(true /* isVisible */);
-}
-
 bool BookmarkManager::AreAllCategoriesInvisible() const
 {
   return CheckVisibility(false /* isVisible */);

--- a/libs/map/bookmark_manager.hpp
+++ b/libs/map/bookmark_manager.hpp
@@ -370,7 +370,6 @@ public:
   bool IsCategoryEmpty(kml::MarkGroupId categoryId) const;
 
   bool IsUsedCategoryName(std::string const & name) const;
-  bool AreAllCategoriesVisible() const;
   bool AreAllCategoriesInvisible() const;
   void SetAllCategoriesVisibility(bool visible);
   void SetChildCategoriesVisibility(kml::MarkGroupId categoryId, kml::CompilationType compilationType, bool visible);


### PR DESCRIPTION
Three commits, all on the child-lists card of a bookmark list screen.
The core is unchanged — `SetChildCategoriesVisibility()` and `HasBmCategory()` already exist, only the Android side was missing.

**1. A child list would not open.** `refreshFromCore()` resolved the category by
scanning `getCategories()`, which lists top-level categories only, so the lookup always failed and the activity finished itself before its first frame. Regression from 9af83e63a2, not released. `CategoryDataSource` made the same
top-level-only assumption, which left a child list screen with a stale name and stale item counts after a rename. Both now ask the core by id through a new `BookmarkManager.hasCategory()`, which also sees compilations and reports a missing category instead of aborting.

**2. Hide all / Show all did nothing.** The call was left commented out and the SDK had no binding for it. The button's label came from the global `areAllCategoriesVisible()`, which counts top-level lists rather than the child lists on screen, so it could disagree with what the user saw; that was its last caller, so the Android binding for it goes too. A mass operation now only
redraws the rows instead of re-reading every child list, which also stops it from invalidating the bookmark list next to the card.

**3. The row used a bare CheckBox** while every other row on the screen uses the eye icon, and it was the last row left out of the shared `BookmarkListRow` styles. It now leads with `ic_show`/`ic_hide`.

Stale counts also made the list bind a row the category no longer has, which crashed on a null `BookmarkInfo` after deleting or moving a bookmark inside a child list.

Fixes #13324
Fixes #13323

<img width="280" src="https://github.com/user-attachments/assets/6a2a2391-dc9e-42fa-a5e3-e4b75197da81" />
<img width="280" src="https://github.com/user-attachments/assets/888ae6e2-0059-4746-961f-991e71a3d28d" />
