### PR TITLE
[ios] Enable AirDrop for place sharing

### DIFF
--- a/iphone/Maps/UI/ReusableComponents/Share/MWMActivityViewController.mm
+++ b/iphone/Maps/UI/ReusableComponents/Share/MWMActivityViewController.mm
@@ -83,17 +83,13 @@
 + (instancetype)shareControllerForMyPosition:(CLLocationCoordinate2D)location
 {
   MWMShareActivityItem * item = [[MWMShareActivityItem alloc] initForMyPositionAtLocation:location];
-  MWMActivityViewController * shareVC = [[self alloc] initWithActivityItems:@[item]];
-  shareVC.excludedActivityTypes = [shareVC.excludedActivityTypes arrayByAddingObject:UIActivityTypeAirDrop];
-  return shareVC;
+  return [[self alloc] initWithActivityItems:item.activityItems];
 }
 
 + (instancetype)shareControllerForCurrentPlacePage
 {
   MWMShareActivityItem * item = [[MWMShareActivityItem alloc] initForCurrentPlacePage];
-  MWMActivityViewController * shareVC = [[self alloc] initWithActivityItems:@[item]];
-  shareVC.excludedActivityTypes = [shareVC.excludedActivityTypes arrayByAddingObject:UIActivityTypeAirDrop];
-  return shareVC;
+  return [[self alloc] initWithActivityItems:item.activityItems];
 }
 
 + (instancetype)shareControllerForURL:(NSURL *)url

--- a/iphone/Maps/UI/ReusableComponents/Share/MWMShareActivityItem.h
+++ b/iphone/Maps/UI/ReusableComponents/Share/MWMShareActivityItem.h
@@ -1,4 +1,6 @@
-@interface MWMShareActivityItem : NSObject <UIActivityItemSource>
+@interface MWMShareActivityItem : NSObject
+
+@property(nonatomic, readonly) NSArray<id<UIActivityItemSource>> * activityItems;
 
 - (instancetype)initForMyPositionAtLocation:(CLLocationCoordinate2D const &)location;
 // The place page is open, so the core has the info (with metadata) to build the shared text.

--- a/iphone/Maps/UI/ReusableComponents/Share/MWMShareActivityItem.mm
+++ b/iphone/Maps/UI/ReusableComponents/Share/MWMShareActivityItem.mm
@@ -1,13 +1,47 @@
 #import "MWMShareActivityItem.h"
 
+#include "base/assert.hpp"
+
 #include <CoreApi/Framework.h>
 
 #import <LinkPresentation/LPLinkMetadata.h>
 
-@interface MWMShareActivityItem ()
+@interface MWMAirDropActivityItem : NSObject <UIActivityItemSource>
+
+- (instancetype)initWithURL:(NSURL *)url;
+
+@end
+
+@implementation MWMAirDropActivityItem
+{
+  NSURL * _url;
+}
+
+- (instancetype)initWithURL:(NSURL *)url
+{
+  self = [super init];
+  if (self)
+    _url = url;
+  return self;
+}
+
+- (id)activityViewControllerPlaceholderItem:(UIActivityViewController *)activityViewController
+{
+  return _url;
+}
+
+- (id)activityViewController:(UIActivityViewController *)activityViewController
+         itemForActivityType:(UIActivityType)activityType
+{
+  return [activityType isEqualToString:UIActivityTypeAirDrop] ? _url : nil;
+}
+
+@end
+
+@interface MWMShareActivityItem () <UIActivityItemSource>
 
 @property(nonatomic) BOOL isMyPosition;
-@property(nonatomic, copy) NSString * shareUrl;
+@property(nonatomic) NSURL * shareUrl;
 @property(nonatomic, copy) NSString * shareText;
 @property(nonatomic, copy) NSString * shareHtml;
 @property(nonatomic, copy) NSString * subjectBasis;
@@ -38,10 +72,25 @@
 - (void)fillFrom:(share::Result const &)result
 {
   _isMyPosition = result.m_isMyPosition;
-  _shareUrl = @(result.m_url.c_str());
+  // ge0 %-escapes unsafe ASCII but leaves non-ASCII place name bytes raw, which NSURL rejects before iOS 17.
+  // Encoding only non-ASCII preserves existing ge0 escapes. Backslash is the only unsafe ASCII byte ge0 leaves raw,
+  // so it is encoded here as well.
+  NSMutableCharacterSet * allowed = [[NSCharacterSet characterSetWithRange:NSMakeRange(0, 128)] mutableCopy];
+  [allowed removeCharactersInString:@"\\"];
+  NSString * url = [@(result.m_url.c_str()) stringByAddingPercentEncodingWithAllowedCharacters:allowed];
+  _shareUrl = [NSURL URLWithString:url];
+  ASSERT(_shareUrl != nil, ("Failed to build a share URL from", result.m_url));
   _shareText = @(result.m_text.c_str());
   _shareHtml = @(result.m_html.c_str());
   _subjectBasis = @(result.m_subjectBasis.c_str());
+}
+
+- (NSArray<id<UIActivityItemSource>> *)activityItems
+{
+  // AirDrop types its payload from the source's placeholder, and this source's placeholder is plain text.
+  // A separate NSURL-placeholder source provides an openable link only to AirDrop; dataTypeIdentifierForActivityType:
+  // applies to NSData only. A bare NSURL item would go to every target and duplicate the link in shareText.
+  return @[self, [[MWMAirDropActivityItem alloc] initWithURL:self.shareUrl]];
 }
 
 // Email subject: place name/address, "I am here" for the current position, or a generic fallback.
@@ -78,6 +127,9 @@
 - (id)activityViewController:(UIActivityViewController *)activityViewController
          itemForActivityType:(UIActivityType)activityType
 {
+  // The URL-typed source in -activityItems serves AirDrop; returning text here would add a second payload.
+  if ([activityType isEqualToString:UIActivityTypeAirDrop])
+    return nil;
   if ([activityType isEqualToString:UIActivityTypeMail])
     return [self attributedBody] ?: [[NSAttributedString alloc] initWithString:self.shareText];
   return self.shareText;
@@ -92,7 +144,7 @@
 - (LPLinkMetadata *)activityViewControllerLinkMetadata:(UIActivityViewController *)activityViewController
 {
   LPLinkMetadata * metadata = [[LPLinkMetadata alloc] init];
-  metadata.originalURL = [NSURL URLWithString:self.shareUrl];
+  metadata.originalURL = self.shareUrl;
   metadata.title = [self subject];
   metadata.iconProvider = [[NSItemProvider alloc] initWithObject:[UIImage imageNamed:@"imgLogo"]];
   return metadata;


### PR DESCRIPTION
When sharing a place or current position on iOS, AirDrop was disabled, so receivers could not get an openable Organic Maps link. This covers POI/bookmarks/pins and current position (https://github.com/organicmaps/organicmaps/issues/13188).

This PR is stacked on https://github.com/organicmaps/organicmaps/pull/13100 and keeps its core-built https share payload. iOS uses UIActivityItemSource only for place sharing so AirDrop receives a typed public https://omaps.app/... URL that the receiver can open automatically in Organic Maps, while other share targets keep the existing text payload. The URL used for AirDrop/link metadata encodes only non-ASCII bytes to remain valid on iOS 15/16 without double-encoding ge0 escapes.

Testing: git diff --check organicmaps/ab/fix-long-share-message..HEAD. xcodebuild was started but stopped before completion at maintainer request.

Closes https://github.com/organicmaps/organicmaps/issues/13188