### PR TITLE
[android] Fallback U-turn lanes for Automotive.

### DIFF
--- a/android/app/src/main/java/app/organicmaps/car/AndroidAutoService.java
+++ b/android/app/src/main/java/app/organicmaps/car/AndroidAutoService.java
@@ -18,6 +18,8 @@ import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
 import app.organicmaps.api.Const;
 import app.organicmaps.sdk.OrganicMaps;
+import app.organicmaps.sdk.car.CarType;
+import app.organicmaps.sdk.car.CarTypeHelper;
 import app.organicmaps.sdk.util.Config;
 import app.organicmaps.sdk.util.log.Logger;
 import java.io.IOException;
@@ -52,6 +54,7 @@ public final class AndroidAutoService extends CarAppServiceBase
   {
     super.onCreate();
     createNotificationChannel();
+    CarTypeHelper.setCarType(CarType.AndroidAuto);
 
     final MwmApplication app = MwmApplication.from(getApplicationContext());
     mOrganicMapsContext = app.getOrganicMaps();

--- a/android/sdk/car/src/main/java/app/organicmaps/sdk/car/CarType.java
+++ b/android/sdk/car/src/main/java/app/organicmaps/sdk/car/CarType.java
@@ -1,0 +1,7 @@
+package app.organicmaps.sdk.car;
+
+public enum CarType
+{
+  AndroidAuto,
+  Automotive
+}

--- a/android/sdk/car/src/main/java/app/organicmaps/sdk/car/CarTypeHelper.java
+++ b/android/sdk/car/src/main/java/app/organicmaps/sdk/car/CarTypeHelper.java
@@ -1,0 +1,30 @@
+package app.organicmaps.sdk.car;
+
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public final class CarTypeHelper
+{
+  @Nullable
+  static CarType sCarType;
+
+  @NonNull
+  public static CarType getCarType()
+  {
+    return Objects.requireNonNull(sCarType, "Car type is not initialized");
+  }
+
+  public static void setCarType(@Nullable CarType carType)
+  {
+    if (sCarType != null && sCarType != carType)
+      throw new IllegalStateException("Car type is already initialized to " + sCarType + ", cannot change to "
+                                      + carType);
+    sCarType = carType;
+  }
+
+  private CarTypeHelper()
+  {
+    throw new RuntimeException();
+  }
+}

--- a/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingHelpers.java
+++ b/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingHelpers.java
@@ -31,13 +31,12 @@ public final class RoutingHelpers
   @NonNull
   public static LaneDirection createLaneDirection(@NonNull LaneWay laneWay, boolean isRecommended)
   {
-    return createLaneDirection(laneWay, isRecommended, false);
-  }
+    // TODO: Android Automotive does not support U-turns.
+    //       Use closest shapes - SHARP_LEFT and SHARP_RIGHT instead of U-turns.
+    //       Remove this fallback when Android Automotive supports U-turns.
+    //       Bug: https://issuetracker.google.com/issues/549899072
+    final boolean useUTurnLaneShapeFallback = CarTypeHelper.getCarType() == CarType.Automotive;
 
-  @NonNull
-  static LaneDirection createLaneDirection(@NonNull LaneWay laneWay, boolean isRecommended,
-                                           boolean useUTurnLaneShapeFallback)
-  {
     @LaneDirection.Shape
     final int shape = switch (laneWay)
     {

--- a/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingHelpers.java
+++ b/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingHelpers.java
@@ -31,10 +31,17 @@ public final class RoutingHelpers
   @NonNull
   public static LaneDirection createLaneDirection(@NonNull LaneWay laneWay, boolean isRecommended)
   {
+    return createLaneDirection(laneWay, isRecommended, false);
+  }
+
+  @NonNull
+  static LaneDirection createLaneDirection(@NonNull LaneWay laneWay, boolean isRecommended,
+                                           boolean useUTurnLaneShapeFallback)
+  {
     @LaneDirection.Shape
     final int shape = switch (laneWay)
     {
-      case ReverseLeft -> LaneDirection.SHAPE_U_TURN_LEFT;
+      case ReverseLeft -> useUTurnLaneShapeFallback ? LaneDirection.SHAPE_SHARP_LEFT : LaneDirection.SHAPE_U_TURN_LEFT;
       case SharpLeft -> LaneDirection.SHAPE_SHARP_LEFT;
       case Left -> LaneDirection.SHAPE_NORMAL_LEFT;
       case MergeToLeft, SlightLeft -> LaneDirection.SHAPE_SLIGHT_LEFT;
@@ -42,7 +49,8 @@ public final class RoutingHelpers
       case SlightRight, MergeToRight -> LaneDirection.SHAPE_SLIGHT_RIGHT;
       case Right -> LaneDirection.SHAPE_NORMAL_RIGHT;
       case SharpRight -> LaneDirection.SHAPE_SHARP_RIGHT;
-      case ReverseRight -> LaneDirection.SHAPE_U_TURN_RIGHT;
+      case ReverseRight ->
+        useUTurnLaneShapeFallback ? LaneDirection.SHAPE_SHARP_RIGHT : LaneDirection.SHAPE_U_TURN_RIGHT;
       default -> LaneDirection.SHAPE_UNKNOWN;
     };
 

--- a/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingUtils.java
+++ b/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingUtils.java
@@ -1,6 +1,5 @@
 package app.organicmaps.sdk.car;
 
-import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.text.TextUtils;
 import android.text.style.CharacterStyle;
@@ -77,16 +76,12 @@ public final class RoutingUtils
     builder.setManeuver(RoutingHelpers.createManeuver(context, info.carDirection, info.exitNum));
     if (info.lanes != null)
     {
-      // Some AAOS template hosts crash on structured U-turn lane shapes. The separate lanes image
-      // retains the exact U-turn shape in the navigation template.
-      final boolean useUTurnLaneShapeFallback =
-          context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE);
       for (final LaneInfo laneInfo : info.lanes)
       {
         final Lane.Builder laneBuilder = new Lane.Builder();
         for (final LaneWay laneWay : laneInfo.mLaneWays)
-          laneBuilder.addDirection(RoutingHelpers.createLaneDirection(
-              laneWay, /* isRecommended */ laneWay == laneInfo.mActiveLaneWay, useUTurnLaneShapeFallback));
+          laneBuilder.addDirection(
+              RoutingHelpers.createLaneDirection(laneWay, /* isRecommended */ laneWay == laneInfo.mActiveLaneWay));
         builder.addLane(laneBuilder.build());
       }
       final LanesDrawable lanesDrawable = new LanesDrawable(context, info.lanes);

--- a/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingUtils.java
+++ b/android/sdk/car/src/main/java/app/organicmaps/sdk/car/RoutingUtils.java
@@ -1,5 +1,6 @@
 package app.organicmaps.sdk.car;
 
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.text.TextUtils;
 import android.text.style.CharacterStyle;
@@ -76,12 +77,16 @@ public final class RoutingUtils
     builder.setManeuver(RoutingHelpers.createManeuver(context, info.carDirection, info.exitNum));
     if (info.lanes != null)
     {
+      // Some AAOS template hosts crash on structured U-turn lane shapes. The separate lanes image
+      // retains the exact U-turn shape in the navigation template.
+      final boolean useUTurnLaneShapeFallback =
+          context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE);
       for (final LaneInfo laneInfo : info.lanes)
       {
         final Lane.Builder laneBuilder = new Lane.Builder();
         for (final LaneWay laneWay : laneInfo.mLaneWays)
-          laneBuilder.addDirection(
-              RoutingHelpers.createLaneDirection(laneWay, /* isRecommended */ laneWay == laneInfo.mActiveLaneWay));
+          laneBuilder.addDirection(RoutingHelpers.createLaneDirection(
+              laneWay, /* isRecommended */ laneWay == laneInfo.mActiveLaneWay, useUTurnLaneShapeFallback));
         builder.addLane(laneBuilder.build());
       }
       final LanesDrawable lanesDrawable = new LanesDrawable(context, info.lanes);

--- a/android/sdk/src/main/java/app/organicmaps/sdk/routing/LaneInfo.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/routing/LaneInfo.java
@@ -1,5 +1,6 @@
 package app.organicmaps.sdk.routing;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 
 public final class LaneInfo
@@ -7,6 +8,9 @@ public final class LaneInfo
   public final LaneWay[] mLaneWays;
   public final LaneWay mActiveLaneWay;
 
+  // Called from JNI.
+  @Keep
+  @SuppressWarnings("unused")
   public LaneInfo(@NonNull LaneWay[] laneWays, LaneWay activeLane)
   {
     mLaneWays = laneWays;


### PR DESCRIPTION
Test here: https://www.openstreetmap.org/way/1441807038

Automotive service hang stack:
```
08-19 03:00:27.069  1291  1507 W ServiceManagerCppClient: Waited one second for android.hardware.bluetooth.audio.IBluetoothAudioProviderFactory/default (is service started? Number of threads started in the threadpool: 16. Are binder threads started and available?)
08-19 03:00:27.070   161  4117 W libc    : Unable to set property "ctl.interface_start" to "aidl/android.hardware.bluetooth.audio.IBluetoothAudioProviderFactory/default": PROP_ERROR_HANDLE_CONTROL_MESSAGE (0x20)
08-19 03:00:27.071   441  1333 D AudioFlinger: Client defaulted notificationFrames to 2048 for frameCount 4096
08-19 03:00:27.072  3959  4073 E AndroidRuntime: FATAL EXCEPTION: DefaultDispatcher-worker-1
08-19 03:00:27.072  3959  4073 E AndroidRuntime: Process: com.google.android.apps.automotive.templates.host:renderer_service, PID: 3959
08-19 03:00:27.072  3959  4073 E AndroidRuntime: java.lang.IllegalArgumentException: Can't get the number of an unknown enum value.
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at com.google.protobuf.Internal.throwCannotGetNumberOfUnrecognized(Internal.java:79)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at android.car.cluster.navigation.NavigationState$Lane$LaneDirection$Shape.getNumber(NavigationState.java:4639)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at android.car.cluster.navigation.NavigationState$Lane$LaneDirection.setShape(NavigationState.java:4768)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at android.car.cluster.navigation.NavigationState$Lane$LaneDirection.-$$Nest$msetShape(Unknown Source:0)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at android.car.cluster.navigation.NavigationState$Lane$LaneDirection$Builder.setShape(NavigationState.java:4982)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at android.car.cluster.navigation.LaneKt$LaneDirectionKt$Dsl.setShape(LaneKt.kt:139)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at com.android.car.libraries.templates.host.navigation.NavigationStateConverterImpl.toNavStateLane(NavigationStateConverterImpl.kt:111)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at com.android.car.libraries.templates.host.navigation.NavigationStateConverterImpl.getNavigationStateSteps(NavigationStateConverterImpl.kt:101)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at com.android.car.libraries.templates.host.navigation.NavigationStateConverterImpl.access$getNavigationStateSteps(NavigationStateConverterImpl.kt:65)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at com.android.car.libraries.templates.host.navigation.NavigationStateConverterImpl$tripToNavigationState$2.invokeSuspend(NavigationStateConverterImpl.kt:76)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at com.android.car.libraries.templates.host.navigation.NavigationStateConverterImpl$tripToNavigationState$2.invoke(Unknown Source:8)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at com.android.car.libraries.templates.host.navigation.NavigationStateConverterImpl$tripToNavigationState$2.invoke(Unknown Source:4)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndspatched(Undispatched.kt:66)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:43)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:286)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at com.android.car.libraries.templates.host.navigation.NavigationStateConverterImpl.tripToNavigationState(NavigationStateConverterImpl.kt:72)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at com.android.car.libraries.templates.host.navigation.NavigationStateCallbackImpl$onUpdateTrip$2$navigationState$1.invokeSuspend(NavigationStateCallbackImpl.kt:68)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at com.android.car.libraries.templates.host.navigation.NavigationStateCallbackImpl$onUpdateTrip$2$navigationState$1.invoke(Unknown Source:8)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at com.android.car.libraries.templates.host.navigation.NavigationStateCallbackImpl$onUpdateTrip$2$navigationState$1.invoke(Unknown Source:4)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndspatched(Undispatched.kt:66)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturnIgnoreTimeout(Undispatched.kt:50)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlinx.coroutines.TimeoutKt.setupTimeout(Timeout.kt:149)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlinx.coroutines.TimeoutKt.withTimeout(Timeout.kt:44)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at com.android.car.libraries.templates.host.navigation.NavigationStateCallbackImpl$onUpdateTrip$2.invokeSuspend(NavigationStateCallbackImpl.kt:68)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:829)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
08-19 03:00:27.072  3959  4073 E AndroidRuntime: 	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@da7b9a3, Dispatchers.Default]
08-19 03:00:27.073   161   161 I servicemanager: Caller(pid=1291,uid=1001002,sid=u:r:bluetooth:s0) Since 'android.hardware.bluetooth.audio.IBluetoothAudioProviderFactory/default' could not be found trying to start it as a lazy AIDL service. (if it's not configured to be a lazy service, it may be stuck starting or still starting).
08-19 03:00:27.073     1     1 E init    : Control message: Could not find 'aidl/android.hardware.bluetooth.audio.IBluetoothAudioProviderFactory/default' for ctl.interface_start from pid: 161 (/system/bin/servicemanager)
08-19 03:00:27.073  4117  4117 I servicemanager: Caller(pid=1291,uid=1001002,sid=u:r:bluetooth:s0) Tried to start aidl service android.hardware.bluetooth.audio.IBluetoothAudioProviderFactory/default as a lazy service, but was unable to. Usually this happens when a service is not installed, but if the service is intended to be used as a lazy service, then it may be configured incorrectly.
08-19 03:00:27.076  3959  3959 I CarApp.H: Note: In Debug mode, ignoring HostMaxApiLevel, using App sent Latest Car API level directly, App: [app.organicmaps/.automotive.AndroidAutomotiveService], API level set as 9 [CONTEXT ratelimit_period="10 SECONDS" ]
08-19 03:00:27.086  3959  3968 V ClearcutMetricXmitter: Transmission is done.
```

Sharp-left shows the exact U-turn icon:
<img width="1506" height="838" alt="image" src="https://github.com/user-attachments/assets/59bef572-edbb-4392-b778-6914ca1ad992" />

