### PR TITLE
Don't show gift box

### DIFF
--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarInteractor.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarInteractor.swift
@@ -28,7 +28,8 @@ class BottomTabBarInteractor {
 extension BottomTabBarInteractor: BottomTabBarInteractorProtocol {
   @objc
   func configureTabBar() {
-    viewController?.updateAboutButtonIcon(isCrowdfunding: Settings.canShowCrowdfundingPromo())
+    let isCrowdfunding = Settings.canShowCrowdfundingPromo() && Settings.donateUrl() != nil
+    viewController?.updateAboutButtonIcon(isCrowdfunding: isCrowdfunding)
   }
 
   func openSearch() {

--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.swift
@@ -35,9 +35,9 @@ class BottomTabBarViewController: UIViewController {
   func updateAboutButtonIcon(isCrowdfunding: Bool) {
     if isCrowdfunding {
       helpButton.setImage(UIImage(resource: .icCrowdfunding), for: .normal)
-      return
+    } else {
+      helpButton.setImage(UIImage(resource: Settings.isNY() ? .icChristmasTree : .logo), for: .normal)
     }
-    helpButton.setImage(UIImage(resource: Settings.isNY() ? .icChristmasTree : .logo), for: .normal)
     updateBadge()
   }
 

--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.swift
@@ -33,11 +33,8 @@ class BottomTabBarViewController: UIViewController {
   }
 
   func updateAboutButtonIcon(isCrowdfunding: Bool) {
-    if isCrowdfunding {
-      helpButton.setImage(UIImage(resource: .icCrowdfunding), for: .normal)
-    } else {
-      helpButton.setImage(UIImage(resource: Settings.isNY() ? .icChristmasTree : .logo), for: .normal)
-    }
+    let icon: ImageResource = isCrowdfunding ? .icCrowdfunding : (Settings.isNY() ? .icChristmasTree : .logo)
+    helpButton.setImage(UIImage(resource: icon), for: .normal)
     updateBadge()
   }
 

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -4045,7 +4045,7 @@ bool Framework::CanShowCrowdfundingPromo() const
   uint64_t lastDonationTapTime = 0;
   bool const donationWasTapped = settings::Get(kDonationTapTimeKey, lastDonationTapTime) && lastDonationTapTime > 0;
   bool const crowdfundingHasEnded = base::SecondsSinceEpoch() > kCrowdfundingEndTime;
-  if (donationWasTapped && crowdfundingHasEnded)
+  if (donationWasTapped || crowdfundingHasEnded)
     return false;
 
   return true;

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -124,6 +124,8 @@ std::string_view constexpr kLastAskedForRateUsTimeKey = "LastAskedForRateUsTime"
 std::string_view constexpr kDonationTapTimeKey = "DonationTapTime";
 std::string_view constexpr kDonationTapCountKey = "DonationTapCount";
 
+// The gift box is shown during this campaign only, update both dates to run the next one.
+auto const kCrowdfundingStartTime = base::YYMMDDToSecondsSinceEpoch(251220);
 auto const kCrowdfundingEndTime = base::YYMMDDToSecondsSinceEpoch(260120);
 
 auto constexpr kLargeFontsScaleFactor = 1.6;
@@ -4039,16 +4041,15 @@ std::string Framework::GetDonateUrl() const
 
 bool Framework::CanShowCrowdfundingPromo() const
 {
-  if (GetDonateUrl().empty())
+  auto const now = base::SecondsSinceEpoch();
+  if (now < kCrowdfundingStartTime || now > kCrowdfundingEndTime)
     return false;
 
+  // Don't nag users who have already opened the donation page during this campaign.
   uint64_t lastDonationTapTime = 0;
-  bool const donationWasTapped = settings::Get(kDonationTapTimeKey, lastDonationTapTime) && lastDonationTapTime > 0;
-  bool const crowdfundingHasEnded = base::SecondsSinceEpoch() > kCrowdfundingEndTime;
-  if (donationWasTapped || crowdfundingHasEnded)
-    return false;
-
-  return true;
+  bool const donatedDuringCampaign =
+      settings::Get(kDonationTapTimeKey, lastDonationTapTime) && lastDonationTapTime >= kCrowdfundingStartTime;
+  return !donatedDuringCampaign;
 }
 
 void Framework::DidShowDonationPage() const

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -124,7 +124,8 @@ std::string_view constexpr kLastAskedForRateUsTimeKey = "LastAskedForRateUsTime"
 std::string_view constexpr kDonationTapTimeKey = "DonationTapTime";
 std::string_view constexpr kDonationTapCountKey = "DonationTapCount";
 
-// The gift box is shown during this campaign only, update both dates to run the next one.
+// The gift box is shown from 00:00 UTC of the start date until 00:00 UTC of the end date,
+// i.e. the end date is the first day without it. Update both dates to run the next campaign.
 auto const kCrowdfundingStartTime = base::YYMMDDToSecondsSinceEpoch(251220);
 auto const kCrowdfundingEndTime = base::YYMMDDToSecondsSinceEpoch(260120);
 
@@ -3931,8 +3932,12 @@ std::optional<products::ProductsConfig> Framework::GetProductsConfiguration() co
 
 void Framework::DidCloseProductsPopup(ProductsPopupCloseReason reason) const
 {
-  settings::Set(kPlacePageProductsPopupCloseTime, base::SecondsSinceEpoch());
+  auto const now = base::SecondsSinceEpoch();
+  settings::Set(kPlacePageProductsPopupCloseTime, now);
   settings::Set(kPlacePageProductsPopupCloseReason, ToString(reason));
+  // Users who say they have already donated shouldn't see the crowdfunding promo either.
+  if (reason == ProductsPopupCloseReason::AlreadyDonated)
+    settings::Set(kDonationTapTimeKey, now);
 }
 
 void Framework::DidSelectProduct(products::ProductsConfig::Product const & product) const
@@ -4047,9 +4052,8 @@ bool Framework::CanShowCrowdfundingPromo() const
 
   // Don't nag users who have already opened the donation page during this campaign.
   uint64_t lastDonationTapTime = 0;
-  bool const donatedDuringCampaign =
-      settings::Get(kDonationTapTimeKey, lastDonationTapTime) && lastDonationTapTime >= kCrowdfundingStartTime;
-  return !donatedDuringCampaign;
+  settings::TryGet(kDonationTapTimeKey, lastDonationTapTime);
+  return lastDonationTapTime < kCrowdfundingStartTime;
 }
 
 void Framework::DidShowDonationPage() const

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -843,9 +843,9 @@ public:
   void DidShowRateUsRequest() const;
 
   std::string GetDonateUrl() const;
+  /// @note Check that a donate URL is available too: platforms may have their own fallback.
   bool CanShowCrowdfundingPromo() const;
   void DidShowDonationPage() const;
-  void DidPossiblyReturnFromDonationPage() const;
   // Only for testing purposes.
   void ResetDonations();
 

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -843,7 +843,6 @@ public:
   void DidShowRateUsRequest() const;
 
   std::string GetDonateUrl() const;
-  /// @note Check that a donate URL is available too: platforms may have their own fallback.
   bool CanShowCrowdfundingPromo() const;
   void DidShowDonationPage() const;
   // Only for testing purposes.


### PR DESCRIPTION
The gift box was hidden only for users who had *both* tapped Donate *and* passed the campaign end
date, so everyone else kept seeing it after the campaign had ended.

The second commit fixes the checks around it, so that the promo is correct when it is enabled again:
the next campaign should only need both dates updated. The rest of the plumbing (icons, JNI,
`MWMSettings`) is intentionally kept.

### What changed

- The promo is scoped to an explicit campaign window. Checking the start date also hides the box
  before a campaign begins, so the next dates can be shipped in advance.
- `DonationTapTime` is compared with the campaign start instead of `0`. It is a permanent "ever
  tapped Donate" flag, also set from the place page products popup and the About screen, so
  otherwise every user who once opened the donation page would be excluded from all future
  campaigns.
- The donate URL is checked where the promo is shown instead of in the core. `GetDonateUrl()` is
  empty when the server meta config carries no `DonateUrl`, while `Utils.getDonateUrl()` falls back
  to the localized donate page for non-google/huawei flavors, so the gift box was unreachable on
  those Android builds, even though their donate entry points work. iOS behavior is unchanged, and
  the URL is no longer built on every help button refresh.
- [ios] `updateAboutButtonIcon()` no longer returns before `updateBadge()`, so the downloads badge
  is refreshed while the gift box is shown.
- Removed `Framework::DidPossiblyReturnFromDonationPage()`: it has neither a definition nor callers.

### Testing

- Desktop: `desktop` target builds, `map_tests` pass.
- iOS Simulator (`OMaps` scheme) and Android (`:app:assembleGoogleDebug -Parm64`) build.
- Both campaign dates are in the past, so `CanShowCrowdfundingPromo()` is `false` and the help
  button shows the regular logo. Checked in the code, not on a device.

Related: #13287
