### PR TITLE
[bookmarks][android] Make child lists deletable and let bookmarks lea…

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
@@ -68,12 +68,6 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
   @NonNull
   private DataChangedListener mCategoriesAdapterObserver;
 
-  private final ActivityResultLauncher<Intent> startBookmarkListForResult =
-      registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), activityResult -> {
-        if (activityResult.getResultCode() == Activity.RESULT_OK)
-          onDeleteActionSelected(getSelectedCategory());
-      });
-
   private final ActivityResultLauncher<Intent> startImportDirectoryForResult =
       registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), activityResult -> {
         if (activityResult.getResultCode() == Activity.RESULT_OK)
@@ -275,8 +269,8 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
   @Override
   public void onItemClick(@NonNull View v, @NonNull BookmarkCategory category)
   {
-    mSelectedCategory = category;
-    BookmarkListActivity.startForResult(this, startBookmarkListForResult, category);
+    // A list screen deletes its own list, and this one redraws from onCategoriesChanged(), so no result is expected.
+    BookmarkListActivity.start(this, category);
   }
 
   @Override
@@ -359,14 +353,6 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
       mCategoryEditor.commit(text);
 
     getAdapter().notifyDataSetChanged();
-  }
-
-  @NonNull
-  protected BookmarkCategory getSelectedCategory()
-  {
-    if (mSelectedCategory == null)
-      throw new AssertionError("Invalid attempt to use null selected category.");
-    return mSelectedCategory;
   }
 
   interface CategoryEditor

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListActivity.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListActivity.java
@@ -60,12 +60,22 @@ public class BookmarkListActivity extends BaseToolbarActivity
     return R.layout.bookmark_list_activity;
   }
 
+  static void start(@NonNull Fragment fragment, @NonNull BookmarkCategory category)
+  {
+    fragment.startActivity(makeIntent(fragment, category));
+  }
+
+  /// For a caller that has to refresh itself from the core once the list screen is done with it.
   static void startForResult(@NonNull Fragment fragment, ActivityResultLauncher<Intent> startBookmarkListForResult,
                              @NonNull BookmarkCategory category)
   {
-    Bundle args = new Bundle();
-    Intent intent = new Intent(fragment.requireActivity(), BookmarkListActivity.class);
-    intent.putExtra(BookmarksListFragment.EXTRA_CATEGORY, category);
-    startBookmarkListForResult.launch(intent);
+    startBookmarkListForResult.launch(makeIntent(fragment, category));
+  }
+
+  @NonNull
+  private static Intent makeIntent(@NonNull Fragment fragment, @NonNull BookmarkCategory category)
+  {
+    return new Intent(fragment.requireActivity(), BookmarkListActivity.class)
+        .putExtra(BookmarksListFragment.EXTRA_CATEGORY, category);
   }
 }

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
@@ -622,6 +622,32 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
     dropEmptySortedResults();
   }
 
+  /**
+   * Drops from the snapshots every id the core no longer has at all. Unlike {@link #removeDeletedItems(Set, Set)},
+   * the caller does not know what went away: an item deleted on another screen — a child list of this category has
+   * one of its own — is pruned from that screen's snapshot, never from this one. Binding an id that outlived the
+   * core aborts there or dereferences null, so nothing may be drawn in between. Items that merely left this
+   * category are still dropped by the re-sort.
+   */
+  void removeMissingItems()
+  {
+    if (mSearchResults != null)
+      mSearchResults.removeIf(id -> !BookmarkManager.INSTANCE.hasBookmark(id));
+
+    if (mSortedResults == null)
+      return;
+
+    for (int i = mSortedResults.size() - 1; i >= 0; --i)
+    {
+      final SortedBlock block = mSortedResults.get(i);
+      block.getBookmarkIds().removeIf(id -> !BookmarkManager.INSTANCE.hasBookmark(id));
+      block.getTrackIds().removeIf(id -> !BookmarkManager.INSTANCE.hasTrack(id));
+      if (block.getBookmarkIds().isEmpty() && block.getTrackIds().isEmpty())
+        mSortedResults.remove(i);
+    }
+    dropEmptySortedResults();
+  }
+
   boolean isSearchResults()
   {
     return mSearchResults != null;

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
@@ -835,6 +835,17 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
     return getBookmarkListAdapter().isSearchResults() && getBookmarkListAdapter().getItemCount() == 0;
   }
 
+  private boolean isChildList()
+  {
+    // The core keeps child lists apart from the top-level ones getCategories() returns, and BookmarkCategory
+    // compares by id, so not being in that list is what makes a category a child of another.
+    return !BookmarkManager.INSTANCE.getCategories().contains(mCategoryDataSource.getData());
+  }
+
+  /**
+   * Counts top-level lists only, so it is meaningless for a child list: one is never the last list left, and
+   * deleting it leaves its parent in place. Ask {@link #isChildList()} first.
+   */
   private boolean isLastOwnedCategory()
   {
     return BookmarkManager.INSTANCE.getCategoriesCount() == 1;
@@ -1126,7 +1137,9 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
 
   private void onDeleteOptionSelected()
   {
-    requireActivity().setResult(Activity.RESULT_OK);
+    // The screen that opened this one refreshes from the core when it comes back, so it needs no result: a parent
+    // list drops the child card in refreshFromCore(), the categories screen through its data changed listener.
+    BookmarkManager.INSTANCE.deleteCategory(mCategoryDataSource.getData().getId());
     requireActivity().finish();
   }
 
@@ -1325,7 +1338,10 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
     final long[] bookmarkIds = toLongArray(mViewModel.getBookmarkIds());
     final long[] trackIds = toLongArray(mViewModel.getTrackIds());
     forgetSelectedItems();
-    BookmarkManager.INSTANCE.moveBookmarksAndTracks(bookmarkIds, trackIds, newCategory.getId());
+    // The core is given the list the items are shown in, not just the destination: on a child list screen the
+    // chooser only ever offers top-level lists, and leaving the child list is part of the same move.
+    BookmarkManager.INSTANCE.moveBookmarksAndTracks(bookmarkIds, trackIds, mCategoryDataSource.getData().getId(),
+                                                    newCategory.getId());
     finishMembershipChange();
   }
 
@@ -1407,7 +1423,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
       items.addAll(ExportMenuItems.create(this::onShareOptionSelected));
     }
     items.add(new MenuBottomSheetItem(R.string.edit, R.drawable.ic_settings, this::onSettingsOptionSelected));
-    if (!isLastOwnedCategory())
+    if (isChildList() || !isLastOwnedCategory())
       items.add(new MenuBottomSheetItem(R.string.delete_list, R.drawable.ic_delete, this::onDeleteOptionSelected));
     return items;
   }
@@ -1531,6 +1547,9 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
       return false;
     }
 
+    // Before refreshDataSource(), which rebuilds the sections from the sorted or search snapshot when there is one
+    // and would carry an item the core has since dropped straight into the next bind.
+    getBookmarkListAdapter().removeMissingItems();
     getBookmarkListAdapter().refreshDataSource();
     getBookmarkCollectionAdapter().setCategories(BookmarkManager.INSTANCE.getChildrenCategories(categoryId));
     updateToolbarTitle();

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/BookmarkManager.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/bookmarks/data/BookmarkManager.cpp
@@ -280,6 +280,12 @@ JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeDel
   frm()->DeleteTrack(static_cast<kml::TrackId>(trkId));
 }
 
+JNIEXPORT jboolean Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeHasBookmark(JNIEnv *, jclass,
+                                                                                             jlong bmkId)
+{
+  return static_cast<jboolean>(frm()->GetBookmarkManager().HasBookmark(static_cast<kml::MarkId>(bmkId)));
+}
+
 JNIEXPORT jboolean Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeHasTrack(JNIEnv *, jclass,
                                                                                           jlong trackId)
 {
@@ -302,11 +308,12 @@ JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeDel
 }
 
 JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeMoveBookmarksAndTracks(
-    JNIEnv * env, jclass, jlongArray jBookmarkIds, jlongArray jTrackIds, jlong newCatId)
+    JNIEnv * env, jclass, jlongArray jBookmarkIds, jlongArray jTrackIds, jlong curCatId, jlong newCatId)
 {
   frm()->GetBookmarkManager().GetEditSession().MoveBookmarksAndTracks(
       jni::ToNativeLongVector<kml::MarkIdCollection>(env, jBookmarkIds),
-      jni::ToNativeLongVector<kml::TrackIdCollection>(env, jTrackIds), static_cast<kml::MarkGroupId>(newCatId));
+      jni::ToNativeLongVector<kml::TrackIdCollection>(env, jTrackIds), static_cast<kml::MarkGroupId>(curCatId),
+      static_cast<kml::MarkGroupId>(newCatId));
 }
 
 JNIEXPORT void Java_app_organicmaps_sdk_bookmarks_data_BookmarkManager_nativeChangeBookmarksAndTracksColor(

--- a/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/BookmarkManager.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/bookmarks/data/BookmarkManager.java
@@ -277,6 +277,14 @@ public enum BookmarkManager {
   }
 
   /**
+   * Unlike {@link #getBookmarkInfo(long)}, it says so instead of returning null on an already deleted bookmark.
+   */
+  public boolean hasBookmark(long bmkId)
+  {
+    return nativeHasBookmark(bmkId);
+  }
+
+  /**
    * Unlike {@link #getTrack(long)}, it does not assert on an already deleted track.
    */
   public boolean hasTrack(long trackId)
@@ -302,12 +310,17 @@ public enum BookmarkManager {
   }
 
   /**
-   * Moves several bookmarks and tracks into {@code newCategoryId} at once. Ids that no longer exist and items that
-   * already belong to the destination category are skipped.
+   * Moves several bookmarks and tracks into {@code newCategoryId} at once. Ids that no longer exist are skipped, and
+   * so is the move itself for an item already in the destination category.
+   *
+   * @param curCategoryId the category they are shown in, which is a child list when the caller is one of its
+   *     screens: the bookmarks are then taken out of it, whether or not the move that follows has anything left
+   *     to do.
    */
-  public void moveBookmarksAndTracks(@NonNull long[] bookmarkIds, @NonNull long[] trackIds, long newCategoryId)
+  public void moveBookmarksAndTracks(@NonNull long[] bookmarkIds, @NonNull long[] trackIds, long curCategoryId,
+                                     long newCategoryId)
   {
-    nativeMoveBookmarksAndTracks(bookmarkIds, trackIds, newCategoryId);
+    nativeMoveBookmarksAndTracks(bookmarkIds, trackIds, curCategoryId, newCategoryId);
   }
 
   /**
@@ -651,6 +664,8 @@ public enum BookmarkManager {
 
   private native void nativeDeleteBookmark(long bmkId);
 
+  private static native boolean nativeHasBookmark(long bmkId);
+
   private static native boolean nativeHasTrack(long trackId);
 
   private static native boolean nativeHasCategory(long catId);
@@ -658,7 +673,7 @@ public enum BookmarkManager {
   private static native void nativeDeleteBookmarksAndTracks(@NonNull long[] bookmarkIds, @NonNull long[] trackIds);
 
   private static native void nativeMoveBookmarksAndTracks(@NonNull long[] bookmarkIds, @NonNull long[] trackIds,
-                                                          long newCatId);
+                                                          long curCatId, long newCatId);
 
   private static native void nativeChangeBookmarksAndTracksColor(@NonNull long[] bookmarkIds, @NonNull long[] trackIds,
                                                                  @ColorInt int color);

--- a/libs/map/bookmark.cpp
+++ b/libs/map/bookmark.cpp
@@ -336,6 +336,18 @@ void Bookmark::AttachCompilation(kml::MarkGroupId groupId)
   m_compilationIds.push_back(groupId);
 }
 
+void Bookmark::DetachCompilation(kml::MarkGroupId groupId, kml::CompilationId compilationId)
+{
+  std::erase(m_compilationIds, groupId);
+  std::erase(m_data.m_compilations, compilationId);
+}
+
+void Bookmark::ClearCompilations()
+{
+  m_compilationIds.clear();
+  m_data.m_compilations.clear();
+}
+
 void Bookmark::Detach()
 {
   m_groupId = kml::kInvalidMarkGroupId;

--- a/libs/map/bookmark.hpp
+++ b/libs/map/bookmark.hpp
@@ -81,6 +81,11 @@ public:
 
   void Attach(kml::MarkGroupId groupId);
   void AttachCompilation(kml::MarkGroupId groupId);
+  /// @param compilationId the child list's id within its file, which is what m_data carries and serializes.
+  void DetachCompilation(kml::MarkGroupId groupId, kml::CompilationId compilationId);
+  /// Leaves every child list, the serialized ids included. Only for a bookmark leaving the list that owns them:
+  /// CompilationId is numbered per file, so kept across a move it would name a child list of the destination.
+  void ClearCompilations();
   void Detach();
 
   kml::GroupIdCollection const & GetCompilations() const { return m_compilationIds; }

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -409,7 +409,12 @@ void BookmarkManager::AttachBookmark(kml::MarkId bmId, kml::MarkGroupId catId)
 void BookmarkManager::DetachBookmark(kml::MarkId bmId, kml::MarkGroupId catId)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
-  GetBookmarkForEdit(bmId)->Detach();
+  auto * bookmark = GetBookmarkForEdit(bmId);
+  // The only path that takes a bookmark out of the list it belongs to, and so the only one where the child lists
+  // of that list stop applying. Restoring a deleted bookmark also goes through Bookmark::Detach(), but puts it
+  // back where it was.
+  bookmark->ClearCompilations();
+  bookmark->Detach();
   DetachUserMark(bmId, catId);
 }
 
@@ -2704,7 +2709,11 @@ bool BookmarkManager::DeleteBmCategory(kml::MarkGroupId groupId, bool permanentl
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   auto it = m_categories.find(groupId);
   if (it == m_categories.end())
-    return false;
+  {
+    // A child list is stored inside its parent's file, so there is nothing to trash: `permanently` has no meaning
+    // for it and the deletion is always irreversible.
+    return DeleteBmCompilation(groupId);
+  }
 
   ClearGroup(groupId);
   m_changesTracker.OnDeleteGroup(groupId);
@@ -2728,6 +2737,57 @@ bool BookmarkManager::DeleteBmCategory(kml::MarkGroupId groupId, bool permanentl
   m_categories.erase(it);
   UpdateBmGroupIdList();
   return true;
+}
+
+bool BookmarkManager::DeleteBmCompilation(kml::MarkGroupId compilationId)
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+  auto const it = m_compilations.find(compilationId);
+  if (it == m_compilations.end())
+    return false;
+
+  auto * parent = GetBmCategory(it->second->GetParentID());
+
+  // Only the grouping goes. The bookmarks belong to the list that owns this one and are shown there either way,
+  // so deleting a child list is not a way to lose them -- ClearGroup(), which would, is not an option here.
+  auto const & markIds = it->second->GetUserMarks();
+  DetachBookmarksFromCompilation({markIds.begin(), markIds.end()}, compilationId);
+
+  m_changesTracker.OnDeleteGroup(compilationId);
+  m_compilations.erase(it);
+
+  // A child list has no file of its own: it is written out with its parent, from the live m_compilationIds -- see
+  // CollectBmGroupKMLData(). Only re-saving the parent drops it from disk.
+  std::erase(parent->m_data.m_compilationIds, compilationId);
+  parent->SetDirty(true /* updateModificationDate */);
+  return true;
+}
+
+void BookmarkManager::DetachBookmarksFromCompilation(kml::MarkIdCollection const & bookmarkIds,
+                                                     kml::MarkGroupId compilationId)
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+  auto const it = m_compilations.find(compilationId);
+  if (it == m_compilations.end())
+    return;
+
+  auto * compilation = it->second.get();
+  auto const kmlCompilationId = compilation->GetCategoryData().m_compilationId;
+
+  bool detached = false;
+  for (auto const markId : bookmarkIds)
+  {
+    if (compilation->GetUserMarks().count(markId) == 0)
+      continue;
+    compilation->DetachUserMark(markId);
+    GetBookmarkForEdit(markId)->DetachCompilation(compilationId, kmlCompilationId);
+    detached = true;
+  }
+
+  // The bookmarks stay where they were, so only the owning list's file changes. Its dirty flag also gets the
+  // visibility of a bookmark that now belongs to no child list re-inferred.
+  if (detached)
+    GetBmCategory(compilation->GetParentID())->SetDirty(true /* updateModificationDate */);
 }
 
 namespace
@@ -2896,18 +2956,26 @@ void BookmarkManager::CreateCategories(KMLDataCollection && dataCollection, bool
 
     for (auto & bmData : fileData.m_bookmarksData)
     {
-      auto const compilationIds = bmData.m_compilations;
+      // A file can name a child list it does not declare: hand-written, produced by another tool, or written by a
+      // version of us that left the ids of the previous list on a moved bookmark. Such an id is dropped from the
+      // bookmark's own data too, so the next save writes the file out repaired instead of carrying it forever.
+      // It must not be LERROR either, which aborts a Debug build before the app has finished starting.
+      std::erase_if(bmData.m_compilations, [&](auto const c)
+      {
+        if (compilations.count(c) != 0)
+          return false;
+        LOG(LWARNING, ("Incorrect compilation id", c, "into", fileName));
+        return true;
+      });
+
       auto * bm = CreateBookmark(std::move(bmData));
       bm->Attach(groupId);
       group->m_userMarks.insert(bm->GetId());
-      for (auto const c : compilationIds)
+      // The ids the bookmark kept are the ones the filter above let through; attaching does not touch them.
+      for (auto const c : bm->GetData().m_compilations)
       {
         auto const it = compilations.find(c);
-        if (it == compilations.end())
-        {
-          LOG(LERROR, ("Incorrect compilation id", c, "into", fileName));
-          continue;
-        }
+        ASSERT(it != compilations.end(), (c, fileName));
         bm->AttachCompilation(it->second->GetID());
         it->second->AttachUserMark(bm->GetId());
       }
@@ -3722,12 +3790,18 @@ void BookmarkManager::EditSession::DeleteBookmarksAndTracks(kml::MarkIdCollectio
 
 void BookmarkManager::EditSession::MoveBookmarksAndTracks(kml::MarkIdCollection const & bookmarkIds,
                                                           kml::TrackIdCollection const & trackIds,
-                                                          kml::MarkGroupId newGroupId)
+                                                          kml::MarkGroupId curGroupId, kml::MarkGroupId newGroupId)
 {
   // The destination comes from a category list the UI snapshotted, so it can already be deleted; attaching to it
-  // would fail a CHECK deeper down.
+  // would fail a CHECK deeper down. Nothing may leave its group before this, or a stale destination would strand
+  // the bookmarks outside the child list they were taken from without moving them anywhere.
   if (!m_bmManager.HasBmCategory(newGroupId))
     return;
+
+  // Bookmarks shown in a child list belong to the list that owns it, so the move below sees them as already in
+  // the destination whenever that destination is the owner. Leaving the child list is a step of its own.
+  if (m_bmManager.IsCompilation(curGroupId))
+    m_bmManager.DetachBookmarksFromCompilation(bookmarkIds, curGroupId);
 
   for (auto const markId : bookmarkIds)
   {

--- a/libs/map/bookmark_manager.hpp
+++ b/libs/map/bookmark_manager.hpp
@@ -140,8 +140,10 @@ public:
     /// notified, once instead of once per item.
     /// @note Prefer Framework::DeleteBookmarksAndTracks(), which also closes a Place Page showing a deleted item.
     void DeleteBookmarksAndTracks(kml::MarkIdCollection const & bookmarkIds, kml::TrackIdCollection const & trackIds);
+    /// @param curGroupId the group the items are shown in, which is a child list when the caller is one of its
+    /// screens. Bookmarks are then taken out of it as part of the move, in this same session.
     void MoveBookmarksAndTracks(kml::MarkIdCollection const & bookmarkIds, kml::TrackIdCollection const & trackIds,
-                                kml::MarkGroupId newGroupId);
+                                kml::MarkGroupId curGroupId, kml::MarkGroupId newGroupId);
     void SetBookmarksAndTracksColor(kml::MarkIdCollection const & bookmarkIds, kml::TrackIdCollection const & trackIds,
                                     dp::Color color);
 
@@ -176,7 +178,7 @@ public:
 
     /// Removes the category from the list of categories and deletes the related file.
     /// @param permanently If true, the file will be removed from the disk. If false, the file will be marked as deleted
-    /// and moved into a trash.
+    /// and moved into a trash. Ignored for a child list, which has no file of its own -- see DeleteBmCompilation().
     bool DeleteBmCategory(kml::MarkGroupId groupId, bool permanently);
     void NotifyChanges();
 
@@ -608,6 +610,9 @@ private:
   void SetCategoryAccessRules(kml::MarkGroupId categoryId, kml::AccessRules accessRules);
   void SetCategoryCustomProperty(kml::MarkGroupId categoryId, std::string const & key, std::string const & value);
   bool DeleteBmCategory(kml::MarkGroupId groupId, bool permanently);
+  /// Removes a child list, leaving its bookmarks in the list that owns it, where they are shown either way.
+  bool DeleteBmCompilation(kml::MarkGroupId compilationId);
+  void DetachBookmarksFromCompilation(kml::MarkIdCollection const & bookmarkIds, kml::MarkGroupId compilationId);
 
   void MoveBookmark(kml::MarkId bmID, kml::MarkGroupId curGroupID, kml::MarkGroupId newGroupID);
   void UpdateBookmark(kml::MarkId bmId, kml::BookmarkData const & bm);

--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -19,6 +19,7 @@
 
 #include "base/file_name_utils.hpp"
 #include "base/scope_guard.hpp"
+#include "base/stl_helpers.hpp"
 #include "base/timer.hpp"
 
 #include "std/target_os.hpp"
@@ -636,7 +637,7 @@ UNIT_CLASS_TEST(VisualParamsFixture, Bookmarks_BatchMove)
   auto const staleBm = AddBookmark(bmManager, cat1, 30);
   bmManager.GetEditSession().DeleteBookmark(staleBm);
 
-  bmManager.GetEditSession().MoveBookmarksAndTracks({bm1, staleBm}, {trk}, cat2);
+  bmManager.GetEditSession().MoveBookmarksAndTracks({bm1, staleBm}, {trk}, cat1, cat2);
   TEST_EQUAL(bmManager.GetUserMarkIds(cat1).size(), 1, ("bm2 stays behind"));
   TEST_EQUAL(bmManager.GetUserMarkIds(cat2).size(), 1, ());
   TEST_EQUAL(bmManager.GetTrackIds(cat1).size(), 0, ());
@@ -647,13 +648,13 @@ UNIT_CLASS_TEST(VisualParamsFixture, Bookmarks_BatchMove)
 
   // Moving into the category the items already belong to is the no-op the chooser hands back when the current
   // list is picked; it must not detach anything.
-  bmManager.GetEditSession().MoveBookmarksAndTracks({bm1}, {trk}, cat2);
+  bmManager.GetEditSession().MoveBookmarksAndTracks({bm1}, {trk}, cat2, cat2);
   TEST_EQUAL(bmManager.GetUserMarkIds(cat2).size(), 1, ());
   TEST_EQUAL(bmManager.GetTrackIds(cat2).size(), 1, ());
 
   // A destination that disappeared between snapshot and tap leaves everything where it was.
   bmManager.GetEditSession().DeleteBmCategory(cat2, true /* permanently */);
-  bmManager.GetEditSession().MoveBookmarksAndTracks({bm2}, {} /* trackIds */, cat2);
+  bmManager.GetEditSession().MoveBookmarksAndTracks({bm2}, {} /* trackIds */, cat1, cat2);
   TEST_EQUAL(bmManager.GetUserMarkIds(cat1).size(), 1, ());
   TEST_EQUAL(bmManager.GetBookmark(bm2)->GetGroupId(), cat1, ());
 }
@@ -2349,6 +2350,250 @@ UNIT_CLASS_TEST(Runner, Bookmarks_RecentlyDeleted)
 
   TEST(!Platform::IsFileExistsByFullPath(filePath), ());
   TEST(!Platform::IsFileExistsByFullPath(deletedFilePath), ());
+}
+
+// A parent list with two child lists: "Child A" holds OnlyA and Shared, "Child B" holds OnlyB and Shared, and
+// Loose belongs to no child list. Child lists are declared inside the parent's file and referenced from a
+// bookmark by the file-local kml::CompilationId, not by the runtime group id.
+kml::FileData MakeParentWithTwoChildLists()
+{
+  kml::FileData data;
+  kml::SetDefaultStr(data.m_categoryData.m_name, "Parent");
+
+  double x = 0.0;
+  auto const addBookmark = [&data, &x](string const & name, vector<kml::CompilationId> compilations)
+  {
+    kml::BookmarkData bm;
+    kml::SetDefaultStr(bm.m_name, name);
+    bm.m_point = m2::PointD(x, x);
+    x += 0.001;
+    bm.m_compilations = std::move(compilations);
+    data.m_bookmarksData.push_back(std::move(bm));
+  };
+  addBookmark("OnlyA", {1});
+  addBookmark("OnlyB", {2});
+  addBookmark("Shared", {1, 2});
+  addBookmark("Loose", {});
+
+  auto const addChildList = [&data](kml::CompilationId id, string const & name)
+  {
+    kml::CategoryData child;
+    child.m_compilationId = id;
+    child.m_type = kml::CompilationType::Category;
+    kml::SetDefaultStr(child.m_name, name);
+    data.m_compilationsData.push_back(std::move(child));
+  };
+  addChildList(1, "Child A");
+  addChildList(2, "Child B");
+
+  return data;
+}
+
+void LoadParentWithTwoChildLists(BookmarkManager & bmManager, string const & filePath)
+{
+  BookmarkManager::KMLDataCollection kmlDataCollection;
+  kmlDataCollection.emplace_back(filePath, make_unique<kml::FileData>(MakeParentWithTwoChildLists()));
+  bmManager.CreateCategories(std::move(kmlDataCollection));
+}
+
+set<string> GetMarkNames(BookmarkManager const & bmManager, kml::MarkGroupId groupId)
+{
+  set<string> names;
+  for (auto const markId : bmManager.GetUserMarkIds(groupId))
+    names.insert(kml::GetDefaultStr(bmManager.GetBookmark(markId)->GetName()));
+  return names;
+}
+
+UNIT_CLASS_TEST(Runner, Bookmarks_DeleteChildList)
+{
+  BookmarkManager bmManager(BM_CALLBACKS);
+  bmManager.EnableTestMode(true);
+
+  string const filePath = base::JoinPath(GetBookmarksDirectory(), "compilations" + string{kKmlExtension});
+  LoadParentWithTwoChildLists(bmManager, filePath);
+
+  auto const parentId = bmManager.GetUnsortedBmGroupsIdList().front();
+  auto const children = bmManager.GetChildrenCategories(parentId);
+  TEST_EQUAL(children.size(), 2, ());
+
+  auto const childA = children.front();
+  auto const childB = children.back();
+  TEST(bmManager.IsCompilation(childA), ());
+  TEST(bmManager.HasBmCategory(childA), ());
+  TEST_EQUAL(GetMarkNames(bmManager, childA), set<string>({"OnlyA", "Shared"}), ());
+  TEST_EQUAL(GetMarkNames(bmManager, childB), set<string>({"OnlyB", "Shared"}), ());
+
+  TEST(bmManager.GetEditSession().DeleteBmCategory(childA, true /* permanently */), ());
+
+  TEST(!bmManager.HasBmCategory(childA), ());
+  TEST(!bmManager.IsCompilation(childA), ());
+  TEST_EQUAL(bmManager.GetChildrenCategories(parentId), kml::GroupIdCollection({childB}), ());
+  TEST_EQUAL(bmManager.GetCategoryData(parentId).m_compilationIds, kml::GroupIdCollection({childB}), ());
+
+  // Only the grouping goes: every bookmark stays in the list that owned the child list, and the sibling list is
+  // untouched, Shared included.
+  TEST_EQUAL(GetMarkNames(bmManager, parentId), set<string>({"OnlyA", "OnlyB", "Shared", "Loose"}), ());
+  TEST_EQUAL(GetMarkNames(bmManager, childB), set<string>({"OnlyB", "Shared"}), ());
+
+  // No bookmark was deleted, so the Place Page undo of an unrelated deletion must be left alone.
+  TEST(!bmManager.HasRecentlyDeletedBookmark(), ());
+
+  // The membership is gone on both sides, so nothing points at the deleted list any more.
+  for (auto const markId : bmManager.GetUserMarkIds(parentId))
+  {
+    auto const * bm = bmManager.GetBookmark(markId);
+    TEST(!base::IsExist(bm->GetCompilations(), childA), (kml::GetDefaultStr(bm->GetName())));
+    TEST(!base::IsExist(bm->GetData().m_compilations, kml::CompilationId(1)), (kml::GetDefaultStr(bm->GetName())));
+  }
+
+  TEST(!bmManager.GetEditSession().DeleteBmCategory(childA, true /* permanently */), ("Already deleted"));
+
+  // The parent outlives its last child list, unlike a top-level list, which cannot be the last one.
+  TEST(bmManager.GetEditSession().DeleteBmCategory(childB, true /* permanently */), ());
+  TEST(bmManager.GetChildrenCategories(parentId).empty(), ());
+  TEST(bmManager.HasBmCategory(parentId), ());
+  TEST_EQUAL(GetMarkNames(bmManager, parentId), set<string>({"OnlyA", "OnlyB", "Shared", "Loose"}), ());
+}
+
+// Files naming a child list they do not declare are out there: hand-written, made by another tool, or written by a
+// version of us that left the ids of the previous list on a moved bookmark. Loading one has to drop the membership
+// and carry on -- it used to log at a level that aborts a Debug build before the app finished starting.
+UNIT_CLASS_TEST(Runner, Bookmarks_ChildListIdWithoutDeclaration)
+{
+  BookmarkManager bmManager(BM_CALLBACKS);
+  bmManager.EnableTestMode(true);
+
+  auto data = MakeParentWithTwoChildLists();
+  data.m_compilationsData.pop_back();  // "Child B" stays referenced by two bookmarks but is no longer declared.
+
+  string const filePath = base::JoinPath(GetBookmarksDirectory(), "dangling" + string{kKmlExtension});
+  BookmarkManager::KMLDataCollection kmlDataCollection;
+  kmlDataCollection.emplace_back(filePath, make_unique<kml::FileData>(std::move(data)));
+  bmManager.CreateCategories(std::move(kmlDataCollection));
+
+  auto const parentId = bmManager.GetUnsortedBmGroupsIdList().front();
+  auto const children = bmManager.GetChildrenCategories(parentId);
+  TEST_EQUAL(children.size(), 1, ());
+
+  // Every bookmark is kept; only the membership in the undeclared child list is gone.
+  TEST_EQUAL(GetMarkNames(bmManager, parentId), set<string>({"OnlyA", "OnlyB", "Shared", "Loose"}), ());
+  TEST_EQUAL(GetMarkNames(bmManager, children.front()), set<string>({"OnlyA", "Shared"}), ());
+
+  // The id is dropped from the bookmarks too, so the file is written out repaired rather than carrying it forever.
+  TEST(bmManager.SaveBookmarkCategory(parentId), ());
+  auto const reloaded = LoadKmlFile(filePath, FileType::Kml);
+  TEST(reloaded != nullptr, ());
+  for (auto const & bm : reloaded->m_bookmarksData)
+    TEST(!base::IsExist(bm.m_compilations, kml::CompilationId(2)),
+         ("An undeclared child list must not survive a save", kml::GetDefaultStr(bm.m_name)));
+}
+
+UNIT_CLASS_TEST(Runner, Bookmarks_MoveBookmarkOutOfChildList)
+{
+  BookmarkManager bmManager(BM_CALLBACKS);
+  bmManager.EnableTestMode(true);
+
+  string const filePath = base::JoinPath(GetBookmarksDirectory(), "compilations" + string{kKmlExtension});
+  LoadParentWithTwoChildLists(bmManager, filePath);
+
+  auto const parentId = bmManager.GetUnsortedBmGroupsIdList().front();
+  auto const children = bmManager.GetChildrenCategories(parentId);
+  auto const childA = children.front();
+  auto const childB = children.back();
+
+  kml::MarkIdCollection sharedId;
+  for (auto const markId : bmManager.GetUserMarkIds(childA))
+    if (kml::GetDefaultStr(bmManager.GetBookmark(markId)->GetName()) == "Shared")
+      sharedId.push_back(markId);
+  TEST_EQUAL(sharedId.size(), 1, ());
+
+  // Moving into the list that owns the child list is what the chooser offers on a child list screen: the bookmark
+  // is already there, so all the move does is take it out of the child list.
+  bmManager.GetEditSession().MoveBookmarksAndTracks(sharedId, {} /* trackIds */, childA, parentId);
+
+  // Only the membership goes away: the bookmark stays in the list that owns the child list, and in its sibling.
+  TEST_EQUAL(GetMarkNames(bmManager, childA), set<string>({"OnlyA"}), ());
+  TEST_EQUAL(GetMarkNames(bmManager, childB), set<string>({"OnlyB", "Shared"}), ());
+  TEST_EQUAL(GetMarkNames(bmManager, parentId), set<string>({"OnlyA", "OnlyB", "Shared", "Loose"}), ());
+
+  // Both halves of the membership go: the runtime group ids and the ids that get written back out.
+  auto const * shared = bmManager.GetBookmark(sharedId.front());
+  TEST_EQUAL(shared->GetCompilations(), kml::GroupIdCollection({childB}), ());
+  TEST_EQUAL(shared->GetData().m_compilations, vector<kml::CompilationId>({2}), ("Child B is 2 in the file"));
+
+  // Repeating it changes nothing: the bookmark is no longer in the child list and has nowhere to move.
+  bmManager.GetEditSession().MoveBookmarksAndTracks(sharedId, {} /* trackIds */, childA, parentId);
+  TEST_EQUAL(GetMarkNames(bmManager, childA), set<string>({"OnlyA"}), ());
+  TEST_EQUAL(GetMarkNames(bmManager, parentId), set<string>({"OnlyA", "OnlyB", "Shared", "Loose"}), ());
+
+  // A destination deleted while the chooser was open must leave the child list alone: taking the bookmarks out of
+  // it before that is known would strand them outside it without moving them anywhere.
+  auto const goneId = bmManager.CreateBookmarkCategory("Gone", false /* autoSave */);
+  bmManager.GetEditSession().DeleteBmCategory(goneId, true /* permanently */);
+
+  kml::MarkIdCollection onlyBId;
+  for (auto const markId : bmManager.GetUserMarkIds(childB))
+    onlyBId.push_back(markId);
+  bmManager.GetEditSession().MoveBookmarksAndTracks(onlyBId, {} /* trackIds */, childB, goneId);
+  TEST_EQUAL(GetMarkNames(bmManager, childB), set<string>({"OnlyB", "Shared"}), ());
+}
+
+// A bookmark carries the ids of its child lists in the data that gets serialized, and CompilationId is numbered
+// per file: left behind on a move, they would name whatever child lists the destination file happens to have.
+UNIT_CLASS_TEST(Runner, Bookmarks_MovedBookmarkLeavesItsChildLists)
+{
+  BookmarkManager bmManager(BM_CALLBACKS);
+  bmManager.EnableTestMode(true);
+
+  string const filePath = base::JoinPath(GetBookmarksDirectory(), "compilations" + string{kKmlExtension});
+  LoadParentWithTwoChildLists(bmManager, filePath);
+
+  auto const parentId = bmManager.GetUnsortedBmGroupsIdList().front();
+  auto const otherId = bmManager.CreateBookmarkCategory("Other", false /* autoSave */);
+
+  kml::MarkIdCollection sharedId;
+  for (auto const markId : bmManager.GetUserMarkIds(parentId))
+    if (kml::GetDefaultStr(bmManager.GetBookmark(markId)->GetName()) == "Shared")
+      sharedId.push_back(markId);
+  TEST_EQUAL(sharedId.size(), 1, ());
+
+  bmManager.GetEditSession().MoveBookmarksAndTracks(sharedId, {} /* trackIds */, parentId, otherId);
+
+  TEST_EQUAL(GetMarkNames(bmManager, otherId), set<string>({"Shared"}), ());
+  auto const * moved = bmManager.GetBookmark(sharedId.front());
+  TEST(moved->GetCompilations().empty(), ());
+  TEST(moved->GetData().m_compilations.empty(), ());
+
+  for (auto const childId : bmManager.GetChildrenCategories(parentId))
+    TEST(bmManager.GetUserMarkIds(childId).count(sharedId.front()) == 0, ());
+}
+
+UNIT_CLASS_TEST(Runner, Bookmarks_DeletedChildListIsNotSaved)
+{
+  BookmarkManager bmManager(BM_CALLBACKS);
+  bmManager.EnableTestMode(true);
+
+  string const filePath = base::JoinPath(GetBookmarksDirectory(), "compilations" + string{kKmlExtension});
+  LoadParentWithTwoChildLists(bmManager, filePath);
+
+  auto const parentId = bmManager.GetUnsortedBmGroupsIdList().front();
+  auto const childA = bmManager.GetChildrenCategories(parentId).front();
+  TEST(bmManager.GetEditSession().DeleteBmCategory(childA, true /* permanently */), ());
+
+  // A child list has no file of its own: it is only gone from disk once the parent is written out again.
+  TEST(bmManager.SaveBookmarkCategory(parentId), ());
+  auto const reloaded = LoadKmlFile(filePath, FileType::Kml);
+  TEST(reloaded != nullptr, ());
+
+  TEST_EQUAL(reloaded->m_compilationsData.size(), 1, ());
+  TEST_EQUAL(kml::GetDefaultStr(reloaded->m_compilationsData.front().m_name), "Child B", ());
+
+  // Every bookmark is still written out, only without the membership the deleted list stood for.
+  kml::CompilationId const deletedId = 1;
+  TEST_EQUAL(reloaded->m_bookmarksData.size(), 4, ());
+  for (auto const & bm : reloaded->m_bookmarksData)
+    TEST(!base::IsExist(bm.m_compilations, deletedId),
+         ("A deleted child list must leave no reference behind", kml::GetDefaultStr(bm.m_name)));
 }
 
 UNIT_CLASS_TEST(Runner, Bookmarks_TestSaveRoute)


### PR DESCRIPTION
Child lists (KML `<mwm:compilation>`) are second-class in the bookmark manager: they live in a map of their own, apart from the top-level categories, and the operations around them either did nothing or left dangling data behind.

**1. Delete list did nothing on a child list.** The screen closed and the list stayed. The core refused any id that was not a top-level category (`DeleteBmCategory()` looks it up in `m_categories`), and the Android screen only signalled `RESULT_OK` to a launcher that ignored it — only `BookmarkCategoriesFragment`'s launcher turned that into a delete, and it never opens child lists.

A child list is now removed on the spot, and **only the grouping goes**: its bookmarks stay in the list that owns it, where they are shown either way. A child list has no file of its own, so there is nothing to trash — it disappears from disk when its owner is written out again.

**2. Moving a bookmark out of a child list into that same owning list did nothing at all.** The chooser offers top-level lists only, and the core reads the source group off the bookmark — which *is* the owning list — so the move was skipped as a no-op. Leaving the child list is now part of the move: `MoveBookmarksAndTracks()` takes the group the items are shown in, and does the detach in the same edit session, after the destination is known to still exist. Doing it in two steps would strand the bookmarks outside the child list when the destination was deleted while the chooser was open.

**3. A moved bookmark kept the ids of its old child lists** in the data that gets serialized. `CompilationId` is numbered per file, so after a restart the bookmark could silently join an unrelated child list of the destination file.

**4. Loading a file that names a child list it does not declare aborted Debug builds** before the app had finished starting — `GetDefaultLogAbortLevel()` is `LERROR` there. Such files exist: hand-written, produced by another tool, or written by a version of us that hit 3. The id is now dropped from the bookmark as well, so the file is written back repaired instead of carrying it forever.

**5. The bookmark list kept drawing rows from a sorted snapshot** that an item deleted on another screen had already left, which crashed on a null `BookmarkInfo`. This one is a pre-existing bug rather than a consequence of the above, but a child list screen is the easy way to reach it: it prunes its own snapshot on a delete, never its parent's.

### Platforms

Only `libs/map/` and `android/` are touched. iOS gets 1 and 2 through the core — its subgroup screen already calls `deleteCategory` and pops itself when the group is gone. Its own gaps are out of scope here and worth a separate `[ios]` issue: `canDeleteGroup()` counts top-level lists, and a child list can never reach Recently Deleted. Qt never lists child lists at all.

Fixes #13358

Based on #13357 — review that one first.

### Tested

- `map_tests` and `kml_tests` pass. Five new cases in `bookmarks_test.cpp` are the first compilation coverage in `map_tests`: deleting a child list, the save/reload round-trip, moving a bookmark out of one, a move that finds its destination gone, and a file naming an undeclared child list.
- `assembleGoogleDebug`, `lintAllModules`, `app:testGoogleDebug`, `sdk:testDebug`.
- On device: import a KML with two child lists, delete one, move bookmarks out of the other into the owning list and into an unrelated one, restart.
