### PR TITLE
[ios] Separate deep link highlight state

### DIFF
--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
@@ -274,7 +274,7 @@ using namespace osm_auth_ios;
   }
   else if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb] && userActivity.webpageURL != nil)
   {
-    LOG(LINFO, ("application:continueUserActivity:restorationHandler: %@", userActivity.webpageURL));
+    LOG(LINFO, ("handleUserActivity", userActivity.webpageURL.absoluteString.UTF8String));
     return [DeepLinkHandler.shared applicationDidReceiveUniversalLink:userActivity.webpageURL];
   }
 

--- a/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
+++ b/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
@@ -1,18 +1,17 @@
 @objc @objcMembers class DeepLinkHandler: NSObject {
   static let shared = DeepLinkHandler()
 
-  private(set) var isLaunchedByDeepLink = false
   private(set) var hasPendingColdLaunchDeepLink = false
   private(set) var url: URL?
+  private var pendingFeatureHighlightData: DeepLinkInAppFeatureHighlightData?
 
   override private init() {
     super.init()
   }
 
-  /// Keeps the last link received during a cold launch. It is handled by handleDeepLinkAndReset()
+  /// Keeps the last link received during a cold launch. It is handled by handlePendingDeepLink()
   /// once the map is ready, because the place page and viewport animations need an initialized map.
   func prepareForColdLaunch(url: URL) {
-    isLaunchedByDeepLink = true
     hasPendingColdLaunchDeepLink = true
     self.url = url
   }
@@ -30,8 +29,6 @@
     }
 
     self.url = url
-    // Set before handling: handleDeepLink() opens the screen that reads getInAppFeatureHighlightData().
-    isLaunchedByDeepLink = true
 
     // A link arriving before the map is ready supersedes the previous pending link.
     guard !hasPendingColdLaunchDeepLink else { return true }
@@ -46,9 +43,9 @@
   }
 
   func reset() {
-    isLaunchedByDeepLink = false
     hasPendingColdLaunchDeepLink = false
     url = nil
+    pendingFeatureHighlightData = nil
   }
 
   func getBackUrl() -> String? {
@@ -58,21 +55,18 @@
   }
 
   func getInAppFeatureHighlightData() -> DeepLinkInAppFeatureHighlightData? {
-    guard isLaunchedByDeepLink, let url else { return nil }
-    // Highlight the feature once, but keep the URL: goBack() still reads getBackUrl() from it.
-    isLaunchedByDeepLink = false
-    return DeepLinkInAppFeatureHighlightData(DeepLinkParser.parseAndSetApiURL(url))
+    defer { pendingFeatureHighlightData = nil }
+    return pendingFeatureHighlightData
   }
 
-  func handleDeepLinkAndReset() -> Bool {
-    guard let url else {
-      LOG(.error, "handleDeepLink is called with nil URL")
+  func handlePendingDeepLink() -> Bool {
+    guard hasPendingColdLaunchDeepLink, let url else {
+      LOG(.error, "handlePendingDeepLink is called without a pending URL")
       return false
     }
 
-    let handled = handleDeepLink(url: url)
-    reset()
-    return handled
+    hasPendingColdLaunchDeepLink = false
+    return handleDeepLink(url: url)
   }
 
   private func handleFileImport(url: URL, openInPlace: Bool) -> Bool {
@@ -127,6 +121,7 @@
 
   private func handleDeepLink(url: URL) -> Bool {
     LOG(.info, "handleDeepLink: \(url)")
+    pendingFeatureHighlightData = nil
 
     var url = url
     if #available(iOS 18.4, *), let omURL = GeoNavigationToOMURLConverter.convert(url) {
@@ -171,9 +166,11 @@
       }
       return true
     case .menu:
+      pendingFeatureHighlightData = DeepLinkInAppFeatureHighlightData(urlType)
       MapsAppDelegate.theApp().mapViewController.openMenu()
       return true
     case .settings:
+      pendingFeatureHighlightData = DeepLinkInAppFeatureHighlightData(urlType)
       MapsAppDelegate.theApp().mapViewController.openSettings()
       return true
     case .crosshair:

--- a/iphone/Maps/Tests/Core/DeepLink/DeepLinkHandlerTests.swift
+++ b/iphone/Maps/Tests/Core/DeepLink/DeepLinkHandlerTests.swift
@@ -19,8 +19,8 @@ final class DeepLinkHandlerTests: XCTestCase {
     handler.prepareForColdLaunch(url: url)
 
     XCTAssertTrue(handler.hasPendingColdLaunchDeepLink)
-    XCTAssertTrue(handler.isLaunchedByDeepLink)
     XCTAssertEqual(handler.url, url)
+    XCTAssertNil(handler.getInAppFeatureHighlightData())
   }
 
   func testColdUniversalLinkIsConvertedAndQueued() throws {
@@ -29,8 +29,8 @@ final class DeepLinkHandlerTests: XCTestCase {
     )
 
     XCTAssertTrue(handler.hasPendingColdLaunchDeepLink)
-    XCTAssertTrue(handler.isLaunchedByDeepLink)
     XCTAssertEqual(handler.url?.absoluteString, "om://AbCd/Test")
+    XCTAssertNil(handler.getInAppFeatureHighlightData())
   }
 
   func testLastLinkReceivedBeforeMapIsReadyWins() throws {
@@ -40,7 +40,7 @@ final class DeepLinkHandlerTests: XCTestCase {
 
     XCTAssertTrue(handler.applicationDidOpenUrl(laterURL))
     XCTAssertEqual(handler.url, laterURL)
-    XCTAssertTrue(handler.isLaunchedByDeepLink)
+    XCTAssertNil(handler.getInAppFeatureHighlightData())
   }
 
   func testUniversalLinkReceivedBeforeMapIsReadyIsNotHandledTwice() throws {
@@ -49,8 +49,18 @@ final class DeepLinkHandlerTests: XCTestCase {
     let universalLink = try XCTUnwrap(URL(string: "https://omaps.app/AbCd/Test"))
     XCTAssertTrue(handler.applicationDidReceiveUniversalLink(universalLink))
     XCTAssertTrue(handler.hasPendingColdLaunchDeepLink)
-    XCTAssertTrue(handler.isLaunchedByDeepLink)
     XCTAssertEqual(handler.url?.absoluteString, "om://AbCd/Test")
+    XCTAssertNil(handler.getInAppFeatureHighlightData())
+  }
+
+  func testHandlingPendingLinkRetainsBackURL() throws {
+    let url = try XCTUnwrap(URL(string: "om://invalid?backurl=testapp%3A%2F%2F"))
+    handler.prepareForColdLaunch(url: url)
+
+    XCTAssertFalse(handler.handlePendingDeepLink())
+    XCTAssertFalse(handler.hasPendingColdLaunchDeepLink)
+    XCTAssertEqual(handler.getBackUrl(), "testapp://")
+    XCTAssertEqual(handler.url, url)
   }
 
   func testResetClearsColdLaunchState() throws {
@@ -58,7 +68,7 @@ final class DeepLinkHandlerTests: XCTestCase {
     handler.reset()
 
     XCTAssertFalse(handler.hasPendingColdLaunchDeepLink)
-    XCTAssertFalse(handler.isLaunchedByDeepLink)
     XCTAssertNil(handler.url)
+    XCTAssertNil(handler.getInAppFeatureHighlightData())
   }
 }

--- a/iphone/Maps/UI/Map/MapViewController.mm
+++ b/iphone/Maps/UI/Map/MapViewController.mm
@@ -528,7 +528,7 @@ NSString * const kCategorySelectorSegue = @"MapToCategorySelectorSegue";
 
   /// @todo: Uncomment update dialog when will be ready to handle big traffic bursts.
   /*
-  if (!DeepLinkHandler.shared.isLaunchedByDeepLink)
+  if (!DeepLinkHandler.shared.hasPendingColdLaunchDeepLink)
   {
     auto const todo = GetFramework().ToDoAfterUpdate();
     switch (todo) {
@@ -550,7 +550,7 @@ NSString * const kCategorySelectorSegue = @"MapToCategorySelectorSegue";
   // Cold start deep links should be handled when the map is initialized.
   // Otherwise PP container view is nil, or there is no animation/selection of the point.
   if (DeepLinkHandler.shared.hasPendingColdLaunchDeepLink)
-    (void)[DeepLinkHandler.shared handleDeepLinkAndReset];
+    (void)[DeepLinkHandler.shared handlePendingDeepLink];
 }
 
 - (void)viewDidLayoutSubviews


### PR DESCRIPTION
Follow-up to #12612.

Separates cold-launch deferral, feature highlighting, and the retained back URL in `DeepLinkHandler`. Feature-highlight data is now created only for parsed menu/settings links, so map, route, search, and invalid links cannot reach the highlight-only C++ accessor. Handling a cold link clears only the deferred state and keeps its back URL. The stale pre-scene user-activity log message is also corrected.

This prevents a Debug assertion when the menu is opened after a non-feature deep link and avoids reparsing unrelated links when the menu or settings UI is created.

Tested:
- `OMapsTests` on an arm64 iOS 26.5 simulator: 102 tests passed
- `swiftformat --lint` on changed Swift files
- `clang-format --dry-run --Werror` on changed Objective-C++ files
- `git diff --check`

AI tools were used for implementation and review.