### PR TITLE
[ios] Use navigation state for vehicle map style

### DIFF
--- a/iphone/Maps/Core/Theme/Core/ThemeManager.swift
+++ b/iphone/Maps/Core/Theme/Core/ThemeManager.swift
@@ -25,21 +25,12 @@ final class ThemeManager: NSObject {
 
     updateSystemUserInterfaceStyle(effectivePreference)
 
-    let actualTheme: MWMTheme = { theme in
-      let isVehicleRouting = MWMRouter.isRoutingActive() && (MWMRouter.type() == .vehicle)
-      switch theme {
-      case .day: fallthrough
-      case .vehicleDay: return isVehicleRouting ? .vehicleDay : .day
-      case .night: fallthrough
-      case .vehicleNight: return isVehicleRouting ? .vehicleNight : .night
-      case .auto:
-        let isDarkModeEnabled = UIScreen.main.traitCollection.userInterfaceStyle == .dark
-        guard isVehicleRouting else { return isDarkModeEnabled ? .night : .day }
-        return isDarkModeEnabled ? .vehicleNight : .vehicleDay
-      @unknown default:
-        fatalError()
-      }
-    }(effectivePreference)
+    let isVehicleNavigation = MWMRouter.isOnRoute() && MWMRouter.type() == .vehicle
+    let actualTheme = Self.resolveMapTheme(
+      effectivePreference,
+      isVehicleNavigation: isVehicleNavigation,
+      systemStyle: UIScreen.main.traitCollection.userInterfaceStyle
+    )
 
     let newNightMode = actualTheme == .night || actualTheme == .vehicleNight
 
@@ -52,6 +43,23 @@ final class ThemeManager: NSObject {
       // Re-apply styles for non-dynamic properties (CGColor, themed images).
       isNightMode = newNightMode
       StyleManager.shared.update()
+    }
+  }
+
+  static func resolveMapTheme(_ preference: MWMTheme,
+                              isVehicleNavigation: Bool,
+                              systemStyle: UIUserInterfaceStyle) -> MWMTheme {
+    switch preference {
+    case .day: fallthrough
+    case .vehicleDay: return isVehicleNavigation ? .vehicleDay : .day
+    case .night: fallthrough
+    case .vehicleNight: return isVehicleNavigation ? .vehicleNight : .night
+    case .auto:
+      let isDarkModeEnabled = systemStyle == .dark
+      guard isVehicleNavigation else { return isDarkModeEnabled ? .night : .day }
+      return isDarkModeEnabled ? .vehicleNight : .vehicleDay
+    @unknown default:
+      fatalError()
     }
   }
 

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -615,6 +615,7 @@
 		ED91432C300168020081DF0B /* MainSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED91432B300168020081DF0B /* MainSceneDelegate.swift */; };
 		ED914330300168200081DF0B /* MainSceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED91432F300168200081DF0B /* MainSceneDelegateTests.swift */; };
 		ED91433B3001A0000081DF0B /* DeepLinkHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED91433A3001A0000081DF0B /* DeepLinkHandlerTests.swift */; };
+		AB7E00000000000000000002 /* ThemeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7E00000000000000000001 /* ThemeManagerTests.swift */; };
 		ED914332300168CF0081DF0B /* CarPlaySceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED914331300168CF0081DF0B /* CarPlaySceneDelegateTests.swift */; };
 		ED9BEED62FFEB5C8008DB423 /* ColorGridViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9BEED52FFEB5C8008DB423 /* ColorGridViewController.swift */; };
 		ED9DDF9D2D6F6F7900645BC8 /* TrackRecordingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9DDF9B2D6F6DA300645BC8 /* TrackRecordingManagerTests.swift */; };
@@ -1694,6 +1695,7 @@
 		ED91432B300168020081DF0B /* MainSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSceneDelegate.swift; sourceTree = "<group>"; };
 		ED91432F300168200081DF0B /* MainSceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSceneDelegateTests.swift; sourceTree = "<group>"; };
 		ED91433A3001A0000081DF0B /* DeepLinkHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkHandlerTests.swift; sourceTree = "<group>"; };
+		AB7E00000000000000000001 /* ThemeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManagerTests.swift; sourceTree = "<group>"; };
 		ED914331300168CF0081DF0B /* CarPlaySceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegateTests.swift; sourceTree = "<group>"; };
 		ED9BEED52FFEB5C8008DB423 /* ColorGridViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorGridViewController.swift; sourceTree = "<group>"; };
 		ED9DDF9B2D6F6DA300645BC8 /* TrackRecordingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackRecordingManagerTests.swift; sourceTree = "<group>"; };
@@ -1965,6 +1967,7 @@
 		4B4153B62BF9709100EE4B02 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				AB7E00000000000000000001 /* ThemeManagerTests.swift */,
 				ED91433C3001A0000081DF0B /* DeepLink */,
 				EDBAB6F12E980415007962B5 /* GeoNavigationToOMURLConverterTests */,
 				ED9DDF982D6F6D8000645BC8 /* TrackRecorder */,
@@ -4982,6 +4985,7 @@
 				EDF838BF2C00B9D0007E4E67 /* SynchronizationStateManagerTests.swift in Sources */,
 				ED914330300168200081DF0B /* MainSceneDelegateTests.swift in Sources */,
 				ED91433B3001A0000081DF0B /* DeepLinkHandlerTests.swift in Sources */,
+				AB7E00000000000000000002 /* ThemeManagerTests.swift in Sources */,
 				ED810EC52D566E9B00ECDE2C /* SearchOnMapTests.swift in Sources */,
 				4B83AE4B2C2E642100B0C3BC /* TTSTesterTest.m in Sources */,
 				EDF838C22C00B9D6007E4E67 /* MetadataItemStubs.swift in Sources */,

--- a/iphone/Maps/Tests/Core/ThemeManagerTests.swift
+++ b/iphone/Maps/Tests/Core/ThemeManagerTests.swift
@@ -1,0 +1,32 @@
+@testable import Organic_Maps__Debug_
+import UIKit
+import XCTest
+
+final class ThemeManagerTests: XCTestCase {
+  func testResolveMapTheme() {
+    let testCases: [(String, MWMTheme, Bool, UIUserInterfaceStyle, MWMTheme)] = [
+      ("day", .day, false, .light, .day),
+      ("vehicle day", .day, true, .light, .vehicleDay),
+      ("night", .night, false, .light, .night),
+      ("vehicle night", .night, true, .light, .vehicleNight),
+      ("auto light", .auto, false, .light, .day),
+      ("auto vehicle light", .auto, true, .light, .vehicleDay),
+      ("auto dark", .auto, false, .dark, .night),
+      ("auto vehicle dark", .auto, true, .dark, .vehicleNight),
+      ("stale vehicle day", .vehicleDay, false, .light, .day),
+      ("stale vehicle night", .vehicleNight, false, .dark, .night),
+    ]
+
+    for (name, preference, isVehicleNavigation, systemStyle, expected) in testCases {
+      XCTAssertEqual(
+        ThemeManager.resolveMapTheme(
+          preference,
+          isVehicleNavigation: isVehicleNavigation,
+          systemStyle: systemStyle
+        ),
+        expected,
+        name
+      )
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #12612.

Selects the Vehicle map style only while a vehicle route is actually being followed. Previously iOS keyed the style off routing being active, which is already true during route building and preview; any unrelated theme invalidation could therefore switch a preview to Vehicle before navigation started.

The existing start/stop invalidations remain the transition points. The theme decision is extracted into a pure resolver and covered across day, night, auto, vehicle-navigation, and stale Vehicle-theme inputs.

User impact: vehicle route previews keep the base map style, navigation switches to Vehicle immediately, and stopping restores the base style.

Tested:
- `OMapsTests` on an arm64 iOS 26.5 simulator: 102 tests passed
- `ThemeManagerTests` resolver matrix
- `swiftformat --lint` on changed Swift files
- Xcode project plist validation
- `git diff --check`

AI tools were used for implementation and review.