### PR TITLE
[ios] Deduplicate the CarPlay pan handlers

### DIFF
--- a/iphone/Maps/Core/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayService.swift
@@ -18,6 +18,10 @@ private struct CarPlaySpeedState {
 final class CarPlayService: NSObject {
   private enum Constants {
     static let openCarPlayURL = URL(string: "om://carplay")
+    /// Fraction of the viewport the map is moved by, repeated while a pan button is held.
+    static let panStep: CGFloat = 0.1
+    /// Fraction of the viewport the map is moved by once, when a pan button is released.
+    static let panEndedStep: CGFloat = 0.25
   }
 
   @objc static let shared = CarPlayService()
@@ -994,39 +998,11 @@ extension CarPlayService: CPMapTemplateDelegate {
   }
 
   func mapTemplate(_: CPMapTemplate, panEndedWith direction: CPMapTemplate.PanDirection) {
-    var offset = UIOffset(horizontal: 0.0, vertical: 0.0)
-    let offsetStep: CGFloat = 0.25
-    if direction.contains(.up) {
-      offset.vertical -= offsetStep
-    }
-    if direction.contains(.down) {
-      offset.vertical += offsetStep
-    }
-    if direction.contains(.left) {
-      offset.horizontal += offsetStep
-    }
-    if direction.contains(.right) {
-      offset.horizontal -= offsetStep
-    }
-    FrameworkHelper.moveMap(offset)
+    FrameworkHelper.moveMap(direction.offset(step: Constants.panEndedStep))
   }
 
   func mapTemplate(_: CPMapTemplate, panWith direction: CPMapTemplate.PanDirection) {
-    var offset = UIOffset(horizontal: 0.0, vertical: 0.0)
-    let offsetStep: CGFloat = 0.1
-    if direction.contains(.up) {
-      offset.vertical -= offsetStep
-    }
-    if direction.contains(.down) {
-      offset.vertical += offsetStep
-    }
-    if direction.contains(.left) {
-      offset.horizontal += offsetStep
-    }
-    if direction.contains(.right) {
-      offset.horizontal -= offsetStep
-    }
-    FrameworkHelper.moveMap(offset)
+    FrameworkHelper.moveMap(direction.offset(step: Constants.panStep))
   }
 
   func mapTemplate(_ mapTemplate: CPMapTemplate, didUpdatePanGestureWithTranslation translation: CGPoint, velocity _: CGPoint) {
@@ -1178,10 +1154,8 @@ extension CarPlayService: CarPlayRouterListener {
   }
 
   func routeDidFinish(_ trip: CPTrip) {
-    if router?.currentTrip == nil {
-      return
-    }
-    router?.finishTrip()
+    guard let router, router.currentTrip != nil else { return }
+    router.finishTrip()
     hideSpeedState()
     updateMapTemplateUIToTripFinished(trip)
   }
@@ -1408,5 +1382,17 @@ extension CarPlayService {
     let alert = CPAlertTemplate(titleVariants: [title], actions: [noAction, yesAction])
     alert.userInfo = [CPConstants.TemplateKey.alert: CPConstants.TemplateType.restoreRoute]
     presentAlert(alert, animated: true)
+  }
+}
+
+// MARK: - Pan direction offset
+
+extension CPMapTemplate.PanDirection {
+  /// A pan button moves the viewport, so the map moves the opposite way.
+  /// FrameworkHelper.moveMap shifts the map by a fraction of the viewport, with the vertical
+  /// axis pointing up, unlike UIKit's.
+  func offset(step: CGFloat) -> UIOffset {
+    UIOffset(horizontal: (contains(.left) ? step : 0) - (contains(.right) ? step : 0),
+             vertical: (contains(.down) ? step : 0) - (contains(.up) ? step : 0))
   }
 }

--- a/iphone/Maps/Core/CarPlay/Template Builders/ListTemplateBuilder.swift
+++ b/iphone/Maps/Core/CarPlay/Template Builders/ListTemplateBuilder.swift
@@ -81,9 +81,7 @@ final class ListTemplateBuilder {
     let bookmarkManager = BookmarksManager.shared()
     let categories = bookmarkManager.sortedUserCategories()
     let items: [CPListItem] = categories.compactMap { category in
-      if category.bookmarksCount == 0 {
-        return nil
-      }
+      guard category.bookmarksCount > 0 else { return nil }
       let placesString = category.placesCountTitle()
       let item = CPListItem(text: category.title, detailText: placesString)
       item.userInfo = ListItemInfo(type: CPConstants.ListItemType.bookmarkLists,

--- a/iphone/Maps/Tests/Classes/CarPlay/CarPlayServiceTests.swift
+++ b/iphone/Maps/Tests/Classes/CarPlay/CarPlayServiceTests.swift
@@ -1,3 +1,4 @@
+import CarPlay
 @testable import Organic_Maps__Debug_
 import XCTest
 
@@ -35,5 +36,36 @@ final class CarPlayServiceTests: XCTestCase {
 
     XCTAssertEqual(estimates.distanceRemaining, Measurement<UnitLength>(value: 25.2, unit: .kilometers))
     XCTAssertEqual(estimates.timeRemaining, 100)
+  }
+
+  /// A pan button moves the viewport, so the map moves the opposite way.
+  /// FrameworkHelper.moveMap uses an upward-positive vertical axis, unlike UIKit.
+  func testPanDirectionOffset() {
+    let step: CGFloat = 0.25
+    // Direction, and the expected offset in `step` units.
+    let expected: [(CPMapTemplate.PanDirection, CGFloat, CGFloat)] = [
+      ([], 0, 0),
+      ([.left], 1, 0),
+      ([.right], -1, 0),
+      ([.up], 0, -1),
+      ([.down], 0, 1),
+      ([.left, .right], 0, 0),
+      ([.up, .down], 0, 0),
+      ([.left, .up], 1, -1),
+      ([.left, .down], 1, 1),
+      ([.right, .up], -1, -1),
+      ([.right, .down], -1, 1),
+      ([.left, .right, .up], 0, -1),
+      ([.left, .right, .down], 0, 1),
+      ([.left, .up, .down], 1, 0),
+      ([.right, .up, .down], -1, 0),
+      ([.left, .right, .up, .down], 0, 0),
+    ]
+
+    for (direction, horizontal, vertical) in expected {
+      XCTAssertEqual(direction.offset(step: step),
+                     UIOffset(horizontal: horizontal * step, vertical: vertical * step),
+                     "direction \(direction.rawValue)")
+    }
   }
 }


### PR DESCRIPTION
### What

`panEndedWith` and `panWith` in `CarPlayService` were 15 identical lines each, differing only in the offset step. Both now call one `CPMapTemplate.PanDirection.offset(step:)` helper, keeping the previous signs; the two steps are named in `Constants`.

`FrameworkHelper.moveMap` uses mixed axes -- a positive horizontal moves the camera left, a positive vertical moves it down -- so the helper is documented and a test pins the resulting offset for all 16 direction combinations.

Two nearby early exits (`routeDidFinish`, and the `compactMap` in `ListTemplateBuilder`) read better as a `guard`, which also keeps them on one line: swiftformat's `wrapIfStatementBodies` spreads a one-line `if` body over three lines, `guard` bodies it leaves alone.

The optional-unwrap cleanup this PR used to carry is gone: the CarPlay dashboard work on master collapsed the same `if let carplayVC = carplayVC` call sites, and replaced two of them with `renderSpeedState()`.

Split out of #13361, where the reformat made the duplication visible but the files are no longer part of that diff.

### How it was tested

- `CarPlayServiceTests.testPanDirectionOffset` checks all 16 combinations of `.up`/`.down`/`.left`/`.right` against the offsets the old code produced, opposite directions still cancelling to 0.
- iOS Simulator Debug build and `OMapsTests/CarPlayServiceTests` pass locally; `swiftformat --lint` clean.
