### PR TITLE
[android][wear] Gate the Data Layer publisher to debug and beta builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -203,6 +203,16 @@ android {
   }
 }
 
+// Wear publisher only in Google debug/beta until the watch app ships (#12030); other variants keep
+// the WearBridge no-op. Deferred because AGP creates flavor+buildType configurations after the
+// script is evaluated.
+afterEvaluate {
+  dependencies {
+    googleDebugImplementation project(':sdk:wear:gms')
+    googleBetaImplementation project(':sdk:wear:gms')
+  }
+}
+
 dependencies {
   implementation project(':libs:api')
   implementation project(':libs:branding')
@@ -225,11 +235,9 @@ dependencies {
   huaweiImplementation project(':sdk:location:gms:google')
   fdroidImplementation project(':sdk:location:gms:foss')
 
-  // Wear OS phone-side bridge: the all-flavors seam (interface + registry + no-op) plus the Google
-  // Wear Data Layer publisher, which self-registers and ships in Google builds only. wear-protocol
-  // arrives transitively via :sdk:wear:core (api).
+  // Wear OS phone-side seam (interface + registry + no-op); wear-protocol arrives transitively.
+  // The Google publisher that plugs into it is declared in the afterEvaluate block above.
   implementation project(':sdk:wear:core')
-  googleImplementation project(':sdk:wear:gms')
 
   coreLibraryDesugaring libs.android.tools.desugaring
 

--- a/android/sdk/wear/core/src/main/java/app/organicmaps/sdk/wear/WearBridge.java
+++ b/android/sdk/wear/core/src/main/java/app/organicmaps/sdk/wear/WearBridge.java
@@ -6,9 +6,10 @@ import app.organicmaps.wear.protocol.WearNavigationState;
 /**
  * Routes navigation state to a paired Wear OS device.
  *
- * <p>The Google variant bundles {@code :sdk:wear:gms}, whose manifest-merged {@code ContentProvider}
- * registers the real publisher at startup. On F-Droid/Huawei/Web nothing registers and the bridge
- * falls back to a no-op, so callers in common code never reference Play services types.
+ * <p>Google debug and beta bundle {@code :sdk:wear:gms}, whose manifest-merged
+ * {@code ContentProvider} registers the real publisher at startup. Everywhere else -- Google
+ * release and profileable, F-Droid, Huawei, Web -- nothing registers and the bridge falls back to a
+ * no-op, so callers in common code never reference Play services types.
  */
 public final class WearBridge
 {

--- a/android/sdk/wear/core/src/main/java/app/organicmaps/sdk/wear/WearNavigationPublisher.java
+++ b/android/sdk/wear/core/src/main/java/app/organicmaps/sdk/wear/WearNavigationPublisher.java
@@ -7,9 +7,9 @@ import app.organicmaps.wear.protocol.WearNavigationState;
  * Phone-side port for pushing navigation state to a paired Wear OS device.
  *
  * <p>The real implementation ({@code :sdk:wear:gms}) talks to the Google Wear Data Layer and ships
- * only in flavors that bundle Google Play services. It registers itself at startup through
- * {@link WearBridge}; every other flavor keeps the no-op default, so callers in common, all-flavors
- * code never reference Play services types.
+ * in Google debug and beta only. It registers itself at startup through {@link WearBridge}; every
+ * other variant keeps the no-op default, so callers in common, all-variants code never reference
+ * Play services types.
  */
 public interface WearNavigationPublisher
 {

--- a/android/sdk/wear/gms/src/main/AndroidManifest.xml
+++ b/android/sdk/wear/gms/src/main/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <!--
-    Registers the Google Wear Data Layer publisher at process startup. This module is consumed via
-    googleImplementation, so the merger adds this provider to the app manifest ONLY for Google
-    builds; other flavors never see it and fall back to the no-op in WearBridge. The provider is a
-    manifest component, so R8 keeps WearBridgeInitProvider automatically — no @Keep required.
+    Registers the Google Wear Data Layer publisher at process startup. This module is consumed by
+    Google debug and beta only, so the merger adds this provider to those two variants; every other
+    variant never sees it and falls back to the no-op in WearBridge. The provider is a manifest
+    component, so R8 keeps WearBridgeInitProvider automatically — no @Keep required.
     ${applicationId} keeps the authority unique per install (debug/beta/release coexistence).
   -->
   <application>

--- a/android/sdk/wear/gms/src/main/java/app/organicmaps/sdk/wear/gms/GmsWearNavigationPublisher.java
+++ b/android/sdk/wear/gms/src/main/java/app/organicmaps/sdk/wear/gms/GmsWearNavigationPublisher.java
@@ -7,6 +7,8 @@ import app.organicmaps.sdk.wear.WearNavigationPublisher;
 import app.organicmaps.wear.protocol.WearNavigationData;
 import app.organicmaps.wear.protocol.WearNavigationState;
 import app.organicmaps.wear.protocol.WearNavigationStateCodec;
+import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.wearable.PutDataRequest;
 import com.google.android.gms.wearable.Wearable;
 
@@ -34,7 +36,19 @@ final class GmsWearNavigationPublisher implements WearNavigationPublisher
     final PutDataRequest request = PutDataRequest.create(WearNavigationData.PATH_NAVIGATION_STATE);
     request.setData(WearNavigationStateCodec.encode(state));
     request.setUrgent();
-    Wearable.getDataClient(mContext).putDataItem(request).addOnFailureListener(
-        e -> Log.w(TAG, "Failed to publish Wear navigation state", e));
+    Wearable.getDataClient(mContext)
+        .putDataItem(request)
+        .addOnSuccessListener(item -> Log.d(TAG, "Published Wear navigation state: " + state.getMode()))
+        .addOnFailureListener(GmsWearNavigationPublisher::logFailure);
+  }
+
+  // API_NOT_CONNECTED reports that the Wearable API is unavailable, not that delivery failed, so it
+  // is expected whenever no watch is around and does not deserve a warning.
+  private static void logFailure(@NonNull Exception e)
+  {
+    if (e instanceof ApiException apiError && apiError.getStatusCode() == CommonStatusCodes.API_NOT_CONNECTED)
+      Log.d(TAG, "Wear Data Layer unavailable, navigation state not published");
+    else
+      Log.w(TAG, "Failed to publish Wear navigation state", e);
   }
 }

--- a/android/sdk/wear/gms/src/main/java/app/organicmaps/sdk/wear/gms/WearBridgeInitProvider.java
+++ b/android/sdk/wear/gms/src/main/java/app/organicmaps/sdk/wear/gms/WearBridgeInitProvider.java
@@ -12,9 +12,9 @@ import app.organicmaps.sdk.wear.WearBridge;
 /**
  * Registers the Google Wear Data Layer publisher at process startup.
  *
- * <p>Declared in this module's manifest, which is merged into the app only for flavors that pull in
- * {@code :sdk:wear:gms} via {@code googleImplementation} -- so the publisher is installed on Google
- * builds and absent elsewhere. Runs before {@code Application.onCreate()}, so the publisher is
+ * <p>Declared in this module's manifest, which is merged into the app only for the variants that
+ * pull in {@code :sdk:wear:gms} -- Google debug and beta -- so the publisher is absent everywhere
+ * else, including Google release. Runs before {@code Application.onCreate()}, so the publisher is
  * registered before that method's initial publish and before any later navigation-state change --
  * no startup-ordering race.
  */


### PR DESCRIPTION
The Wear OS watch app is not released yet, but the phone-side Data Layer publisher shipped in every Google build, including release. That means production users run code that talks to the Wearable API for a feature
they cannot use.

This limits `:sdk:wear:gms` to Google debug and beta. Release and profileable keep the `WearBridge` no-op and never touch the Wearable API; F-Droid, Web and Huawei are unaffected, as before.

The declaration sits in an `afterEvaluate` block rather than in `dependencies {}` because AGP creates flavor+buildType configurations (`googleBetaImplementation`) only after the build script is evaluated — declaring them inline fails with "Could not find method".

Refs: #12030

### Testing

Dependency matrix, checked via `:app:dependencies --configuration <variant>CompileClasspath`:

| Variant | `:sdk:wear:gms` | `:sdk:wear:core` |
|---|---|---|
| googleDebug | yes | yes |
| googleBeta | yes | yes |
| googleRelease | no | yes |
| googleProfileable | no | yes |
| fdroidDebug / fdroidRelease | no | yes |
| webBeta | no | yes |
| huaweiRelease | no | yes |