### PR TITLE
[map] Create new POI under the Add-Place crosshair

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryActivity.java
+++ b/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryActivity.java
@@ -32,9 +32,20 @@ public class FeatureCategoryActivity
   public void onFeatureCategorySelected(FeatureCategory category)
   {
     final Intent in = getIntent();
-    final double lat = in.getDoubleExtra(EXTRA_POSITION_LAT, 0);
-    final double lon = in.getDoubleExtra(EXTRA_POSITION_LON, 0);
-    Editor.createMapObject(category, lat, lon);
+    final double lat = in.getDoubleExtra(EXTRA_POSITION_LAT, Double.NaN);
+    final double lon = in.getDoubleExtra(EXTRA_POSITION_LON, Double.NaN);
+    if (Double.isNaN(lat) || Double.isNaN(lon))
+      throw new IllegalStateException("FeatureCategoryActivity missing position extras");
+
+    if (!Editor.createMapObject(category, lat, lon))
+    {
+      // The position was checked when the user confirmed it, but the map under it can be updated or
+      // deleted while the category is being picked. No other category can succeed at the same
+      // point, so return to the map.
+      InvalidFeaturePositionDialogFragment.show(getSupportFragmentManager());
+      return;
+    }
+
     final Intent intent = new Intent(this, EditorActivity.class);
     intent.putExtra(EXTRA_FEATURE_CATEGORY, category);
     intent.putExtra(EditorActivity.EXTRA_NEW_OBJECT, true);

--- a/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryFragment.java
@@ -129,7 +129,6 @@ public class FeatureCategoryFragment
 
   public void selectCategory(FeatureCategory category)
   {
-    Editor.nativeAddToRecentCategories(category.getType());
     if (requireActivity() instanceof FeatureCategoryListener)
       ((FeatureCategoryListener) requireActivity()).onFeatureCategorySelected(category);
     else if (getParentFragment() instanceof FeatureCategoryListener)
@@ -160,8 +159,8 @@ public class FeatureCategoryFragment
     final Bundle args = requireArguments();
     final double lat = args.getDouble(FeatureCategoryActivity.EXTRA_POSITION_LAT, Double.NaN);
     final double lon = args.getDouble(FeatureCategoryActivity.EXTRA_POSITION_LON, Double.NaN);
-    // No native CHECK on the note path (unlike CreateMapObject), so an invariant
-    // break would silently post the note to (0, 0). Crash explicitly instead.
+    // nativeCreateStandaloneNote() takes raw lat/lon, so an invariant break would silently post
+    // the note to (0, 0). Crash explicitly instead.
     if (Double.isNaN(lat) || Double.isNaN(lon))
       throw new IllegalStateException("FeatureCategoryFragment missing position extras");
 

--- a/android/app/src/main/java/app/organicmaps/editor/InvalidFeaturePositionDialogFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/InvalidFeaturePositionDialogFragment.java
@@ -1,0 +1,41 @@
+package app.organicmaps.editor;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentManager;
+import app.organicmaps.R;
+import app.organicmaps.base.BaseMwmDialogFragment;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+public final class InvalidFeaturePositionDialogFragment extends BaseMwmDialogFragment
+{
+  private static final String TAG = InvalidFeaturePositionDialogFragment.class.getSimpleName();
+
+  public static void show(@NonNull FragmentManager manager)
+  {
+    if (manager.findFragmentByTag(TAG) == null)
+      new InvalidFeaturePositionDialogFragment().show(manager, TAG);
+  }
+
+  @NonNull
+  @Override
+  public Dialog onCreateDialog(Bundle savedInstanceState)
+  {
+    return new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
+        .setTitle(R.string.message_invalid_feature_position)
+        .setPositiveButton(R.string.ok, null)
+        .create();
+  }
+
+  @Override
+  public void onDismiss(@NonNull DialogInterface dialog)
+  {
+    super.onDismiss(dialog);
+    final Activity activity = getActivity();
+    if (activity != null)
+      activity.finish();
+  }
+}

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -521,11 +521,6 @@ void Framework::Touch(int action, Finger const & f1, Finger const & f2, uint8_t 
   m_work.TouchEvent(event);
 }
 
-m2::PointD Framework::GetViewportCenter() const
-{
-  return m_work.GetViewportCenter();
-}
-
 void Framework::AddString(std::string const & name, std::string const & value)
 {
   m_work.AddString(name, value);

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.hpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.hpp
@@ -129,8 +129,6 @@ public:
   void RemoveLocalMaps();
   void ReloadWorldMaps();
 
-  m2::PointD GetViewportCenter() const;
-
   void AddString(std::string const & name, std::string const & value);
 
   void Scale(::Framework::EScaleMode mode);

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/editor/Editor.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/editor/Editor.cpp
@@ -347,13 +347,12 @@ JNIEXPORT void Java_app_organicmaps_sdk_editor_Editor_nativeStartEdit(JNIEnv *, 
   CHECK(fr->GetEditableMapObject(info.GetID(), g_editableMapObject), ("Invalid feature in the place page."));
 }
 
-JNIEXPORT void Java_app_organicmaps_sdk_editor_Editor_nativeCreateMapObject(JNIEnv * env, jclass, jstring featureType,
-                                                                            jdouble lat, jdouble lon)
+JNIEXPORT jboolean Java_app_organicmaps_sdk_editor_Editor_nativeCreateMapObject(JNIEnv * env, jclass,
+                                                                                jstring featureType, jdouble lat,
+                                                                                jdouble lon)
 {
-  ::Framework * fr = frm();
   auto const type = classif().GetTypeByReadableObjectName(jni::ToNativeString(env, featureType));
-  CHECK(fr->CreateMapObject(mercator::FromLatLon(lat, lon), type, g_editableMapObject),
-        ("Couldn't create mapobject, wrong coordinates of missing mwm"));
+  return frm()->CreateMapObject(mercator::FromLatLon(lat, lon), type, g_editableMapObject);
 }
 
 // static void nativeCreateNote(String text);

--- a/android/sdk/src/main/java/app/organicmaps/sdk/editor/Editor.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/editor/Editor.java
@@ -164,12 +164,17 @@ public final class Editor
    * can drift between the position check and creation.
    * {@link Framework#nativeIsDownloadedMapAtScreenCenter()} should be called before
    * to check whether new feature can be created on the map.
+   *
+   * @return false if a new feature cannot be created at the given point.
    */
-  public static void createMapObject(FeatureCategory category, double lat, double lon)
+  public static boolean createMapObject(FeatureCategory category, double lat, double lon)
   {
-    nativeCreateMapObject(category.getType(), lat, lon);
+    if (!nativeCreateMapObject(category.getType(), lat, lon))
+      return false;
+    nativeAddToRecentCategories(category.getType());
+    return true;
   }
-  public static native void nativeCreateMapObject(@NonNull String type, double lat, double lon);
+  public static native boolean nativeCreateMapObject(@NonNull String type, double lat, double lon);
   public static native void nativeCreateNote(String text);
   public static native void nativePlaceDoesNotExist(@NonNull String comment);
   public static native void nativeRollbackMapObject();

--- a/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.mm
+++ b/iphone/Maps/UI/Editor/MWMObjectsCategorySelectorController.mm
@@ -1,4 +1,5 @@
 #import "MWMObjectsCategorySelectorController.h"
+#import "MWMAlertViewController.h"
 #import "MWMAuthorizationCommon.h"
 #import "MWMEditorViewController.h"
 #import "MWMKeyboard.h"
@@ -21,6 +22,7 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
                                                     MWMKeyboardObserver>
 {
   m2::PointD m_createdPosition;
+  EditableMapObject m_createdObject;
 }
 
 @property(nonatomic) UISearchController * searchViewController;
@@ -155,13 +157,6 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
   ]];
 }
 
-- (void)onDone
-{
-  if (!self.selectedType)
-    return;
-  [self performSegueWithIdentifier:kToEditorSegue sender:nil];
-}
-
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
 {
   if (![segue.identifier isEqualToString:kToEditorSegue])
@@ -171,8 +166,7 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
   }
   MWMEditorViewController * dest = static_cast<MWMEditorViewController *>(segue.destinationViewController);
   dest.isCreating = YES;
-  auto const object = self.createdObject;
-  [dest setEditableMapObject:object];
+  [dest setEditableMapObject:m_createdObject];
 }
 
 #pragma mark - MWMKeyboard
@@ -193,13 +187,20 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
 
 #pragma mark - Create object
 
-- (EditableMapObject)createdObject
+- (BOOL)createObject
 {
-  EditableMapObject emo;
-  auto & f = GetFramework();
   auto const type = classif().GetTypeByReadableObjectName(self.selectedType.UTF8String);
-  CHECK(f.CreateMapObject(m_createdPosition, type, emo), ());
-  return emo;
+  if (GetFramework().CreateMapObject(m_createdPosition, type, m_createdObject))
+    return YES;
+
+  // The position was checked when the user confirmed it, but the map under it can be updated or
+  // deleted while the category is being picked. No other category can succeed at the same point,
+  // so return to the map instead of leaving the user on a dead-end list.
+  __weak auto weakSelf = self;
+  [self.alertController presentIncorrectFeaturePositionAlertWithOkBlock:^{
+    [weakSelf.navigationController popToRootViewControllerAnimated:YES];
+  }];
+  return NO;
 }
 
 #pragma mark - UITableView
@@ -230,13 +231,16 @@ NSString * const kToEditorSegue = @"CategorySelectorToEditorSegue";
     self.selectedType = [self.dataSource getRecentCategoriesType:indexPath.row];
   else
     self.selectedType = [self.dataSource getType:indexPath.row];
+
+  if (![self createObject])
+    return;
+
   [self.dataSource addToRecentCategories:self.selectedType];
 
   id<MWMObjectsCategorySelectorDelegate> delegate = self.delegate;
   if (delegate)
   {
-    auto const object = self.createdObject;
-    [delegate reloadObject:object];
+    [delegate reloadObject:m_createdObject];
     [self goBack];
   }
   else

--- a/iphone/Maps/UI/Map/MapViewControls/MWMMapViewControlsManager.mm
+++ b/iphone/Maps/UI/Map/MapViewControls/MWMMapViewControlsManager.mm
@@ -161,7 +161,7 @@ NSString * const kMapToCategorySelectorSegue = @"MapToCategorySelectorSegue";
           [ownerController performSegueWithIdentifier:kMapToCategorySelectorSegue sender:sender];
         }
         else
-          [ownerController.alertController presentIncorrectFeauturePositionAlert];
+          [ownerController.alertController presentIncorrectFeaturePositionAlertWithOkBlock:nil];
 
         [self didFinishAddingPlace];
       }

--- a/iphone/Maps/UI/ReusableComponents/CustomAlerts/AlertController/MWMAlertViewController.h
+++ b/iphone/Maps/UI/ReusableComponents/CustomAlerts/AlertController/MWMAlertViewController.h
@@ -19,7 +19,7 @@
 - (void)presentDeleteMapProhibitedAlert;
 - (void)presentUnsavedEditsAlertWithOkBlock:(nonnull MWMVoidBlock)okBlock;
 - (void)presentNoWiFiAlertWithOkBlock:(nullable MWMVoidBlock)okBlock andCancelBlock:(nullable MWMVoidBlock)cancelBlock;
-- (void)presentIncorrectFeauturePositionAlert;
+- (void)presentIncorrectFeaturePositionAlertWithOkBlock:(nullable MWMVoidBlock)okBlock;
 - (void)presentNotEnoughSpaceAlert;
 - (void)presentInvalidUserNameOrPasswordAlert;
 - (void)presentDownloaderNoConnectionAlertWithOkBlock:(nonnull MWMVoidBlock)okBlock

--- a/iphone/Maps/UI/ReusableComponents/CustomAlerts/AlertController/MWMAlertViewController.mm
+++ b/iphone/Maps/UI/ReusableComponents/CustomAlerts/AlertController/MWMAlertViewController.mm
@@ -79,9 +79,9 @@ static NSString * const kAlertControllerNibIdentifier = @"MWMAlertViewController
   [self displayAlert:[MWMAlert noWiFiAlertWithOkBlock:okBlock andCancelBlock:cancelBlock]];
 }
 
-- (void)presentIncorrectFeauturePositionAlert
+- (void)presentIncorrectFeaturePositionAlertWithOkBlock:(nullable MWMVoidBlock)okBlock
 {
-  [self displayAlert:[MWMAlert incorrectFeaturePositionAlert]];
+  [self displayAlert:[MWMAlert incorrectFeaturePositionAlertWithOkBlock:okBlock]];
 }
 
 - (void)presentNotEnoughSpaceAlert

--- a/iphone/Maps/UI/ReusableComponents/CustomAlerts/BaseAlert/MWMAlert.h
+++ b/iphone/Maps/UI/ReusableComponents/CustomAlerts/BaseAlert/MWMAlert.h
@@ -12,7 +12,7 @@
 + (MWMAlert *)deleteMapProhibitedAlert;
 + (MWMAlert *)unsavedEditsAlertWithOkBlock:(MWMVoidBlock)okBlock;
 + (MWMAlert *)locationServiceNotSupportedAlert;
-+ (MWMAlert *)incorrectFeaturePositionAlert;
++ (MWMAlert *)incorrectFeaturePositionAlertWithOkBlock:(MWMVoidBlock)okBlock;
 + (MWMAlert *)notEnoughSpaceAlert;
 + (MWMAlert *)invalidUserNameOrPasswordAlert;
 + (MWMAlert *)point2PointAlertWithOkBlock:(MWMVoidBlock)okBlock needToRebuild:(BOOL)needToRebuild;

--- a/iphone/Maps/UI/ReusableComponents/CustomAlerts/BaseAlert/MWMAlert.mm
+++ b/iphone/Maps/UI/ReusableComponents/CustomAlerts/BaseAlert/MWMAlert.mm
@@ -99,9 +99,9 @@
   }
 }
 
-+ (MWMAlert *)incorrectFeaturePositionAlert
++ (MWMAlert *)incorrectFeaturePositionAlertWithOkBlock:(MWMVoidBlock)okBlock
 {
-  return [MWMDefaultAlert incorrectFeaturePositionAlert];
+  return [MWMDefaultAlert incorrectFeaturePositionAlertWithOkBlock:okBlock];
 }
 
 + (MWMAlert *)notEnoughSpaceAlert

--- a/iphone/Maps/UI/ReusableComponents/CustomAlerts/DefaultAlert/MWMDefaultAlert.h
+++ b/iphone/Maps/UI/ReusableComponents/CustomAlerts/DefaultAlert/MWMDefaultAlert.h
@@ -10,7 +10,7 @@
 + (instancetype)startPointNotFoundAlert;
 + (instancetype)intermediatePointNotFoundAlert;
 + (instancetype)internalRoutingErrorAlert;
-+ (instancetype)incorrectFeaturePositionAlert;
++ (instancetype)incorrectFeaturePositionAlertWithOkBlock:(MWMVoidBlock)okBlock;
 + (instancetype)notEnoughSpaceAlert;
 + (instancetype)invalidUserNameOrPasswordAlert;
 + (instancetype)noCurrentPositionAlert;

--- a/iphone/Maps/UI/ReusableComponents/CustomAlerts/DefaultAlert/MWMDefaultAlert.mm
+++ b/iphone/Maps/UI/ReusableComponents/CustomAlerts/DefaultAlert/MWMDefaultAlert.mm
@@ -166,14 +166,14 @@ static NSString * const kDefaultAlertNibName = @"MWMDefaultAlert";
                                  log:@"Internal Routing Error Alert"];
 }
 
-+ (instancetype)incorrectFeaturePositionAlert
++ (instancetype)incorrectFeaturePositionAlertWithOkBlock:(MWMVoidBlock)okBlock
 {
   return [self defaultAlertWithTitle:L(@"dialog_incorrect_feature_position")
                              message:L(@"message_invalid_feature_position")
                     rightButtonTitle:L(@"ok")
                      leftButtonTitle:nil
-                   rightButtonAction:nil
-                                 log:@"Incorrect Feature Possition Alert"];
+                   rightButtonAction:okBlock
+                                 log:@"Incorrect Feature Position Alert"];
 }
 
 + (instancetype)notEnoughSpaceAlert

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -3545,6 +3545,10 @@ bool Framework::CanEditMapForPosition(m2::PointD const & position) const
 bool Framework::CreateMapObject(m2::PointD const & mercator, uint32_t const featureType,
                                 osm::EditableMapObject & emo) const
 {
+  // GetRegionCountryId() below wraps internally, but Editor::CreatePoint() tests the MWM's bounding
+  // box as is, so an unwrapped point would silently fail there instead of here.
+  ASSERT(mercator::ValidX(mercator.x), (mercator));
+
   emo = {};
   auto const & dataSource = m_featuresFetcher.GetDataSource();
   MwmSet::MwmId const mwmId =

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1160,9 +1160,10 @@ m2::PointD Framework::GetVisiblePixelCenter() const
   return m_visibleViewport.Center();
 }
 
-m2::PointD const & Framework::GetViewportCenter() const
+m2::PointD Framework::GetViewportCenter() const
 {
-  return m_currentModelView.GetOrg();
+  ASSERT(m_visibleViewport.IsValid(), ("Set by OnSize() from CreateDrapeEngine()"));
+  return P3dtoG(GetVisiblePixelCenter());
 }
 
 void Framework::SetViewportCenter(m2::PointD const & pt, int zoomLevel /* = -1 */, bool isAnim /* = true */,

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -534,7 +534,7 @@ public:
   bool GetDistanceAndAzimut(m2::PointD const & point, double lat, double lon, double north,
                             platform::Distance & distance, double & azimut);
 
-  /// @name For Desktop only.
+  /// @name Screen pixel to geo point conversions.
   /// @{
   m2::PointD PtoG(m2::PointD const & p) const;
   m2::PointD P3dtoG(m2::PointD const & p) const;
@@ -545,7 +545,9 @@ public:
 
   m2::PointD GetVisiblePixelCenter() const;
 
-  m2::PointD const & GetViewportCenter() const;
+  /// @returns Geo point under the visible viewport center: the pixel where the Add-Place crosshair
+  /// is drawn and the anchor that SetViewportCenter() matches its argument to.
+  m2::PointD GetViewportCenter() const;
   void SetViewportCenter(m2::PointD const & pt, int zoomLevel = -1, bool isAnim = true,
                          bool trackVisibleViewport = false);
 

--- a/libs/map/map_tests/CMakeLists.txt
+++ b/libs/map/map_tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SRC
   editor_notes_tests.cpp
   extrapolator_tests.cpp
   feature_getters_tests.cpp
+  framework_viewport_tests.cpp
   gps_track_collection_test.cpp
   gps_track_storage_test.cpp
   gps_track_test.cpp

--- a/libs/map/map_tests/framework_viewport_tests.cpp
+++ b/libs/map/map_tests/framework_viewport_tests.cpp
@@ -1,0 +1,49 @@
+#include "testing/testing.hpp"
+
+#include "map/framework.hpp"
+
+#include "geometry/any_rect2d.hpp"
+#include "geometry/mercator.hpp"
+
+#include "base/math.hpp"
+
+namespace framework_viewport_tests
+{
+namespace
+{
+class TestFramework final : public Framework
+{
+public:
+  TestFramework() : Framework({}, false /* loadMaps */) {}
+
+  void SetViewport(ScreenBase const & screen, m2::RectD const & visibleViewport)
+  {
+    m_currentModelView = screen;
+    m_visibleViewport = visibleViewport;
+  }
+};
+}  // namespace
+
+UNIT_TEST(Framework_GetViewportCenter)
+{
+  m2::RectD const pixelRect(0.0, 0.0, 1000.0, 1000.0);
+  m2::RectD const visibleViewport(0.0, 0.0, 1000.0, 700.0);
+  m2::PointD const target(185.0, 5.0);
+  double constexpr kEps = 1e-7;
+
+  TestFramework framework;
+  for (bool const perspective : {false, true})
+  {
+    ScreenBase screen;
+    screen.SetFromRects(m2::AnyRectD(m2::RectD(170.0, -10.0, 190.0, 10.0)), pixelRect);
+    if (perspective)
+      screen.ApplyPerspective(math::pi4, math::pi4, math::pi / 3.0);
+    screen.MatchGandP3d(target, visibleViewport.Center());
+
+    framework.SetViewport(screen, visibleViewport);
+    auto const actual = framework.GetViewportCenter();
+    TEST_ALMOST_EQUAL_ABS(actual.x, mercator::WrapX(target.x), kEps, (perspective));
+    TEST_ALMOST_EQUAL_ABS(actual.y, target.y, kEps, (perspective));
+  }
+}
+}  // namespace framework_viewport_tests


### PR DESCRIPTION
Two bugs share one root cause: `Framework::GetViewportCenter()` returned the model view origin — the geo point under the center of the **full** pixel rect — while the Add-Place crosshair is drawn at the **visible viewport** center and `SetViewportCenter()` anchors its argument there.

### 1. The POI is created next to the crosshair (#13367)

The two points differ whenever a bottom sheet has shrunk the visible viewport. Android shrinks it routinely, so the created POI could land below the crosshair.

`GetViewportCenter()` now returns `P3dtoG(GetVisiblePixelCenter())`, the inverse of the `MatchGandP3d()` call that centers the map. `GetViewportCenter()` and `SetViewportCenter()` therefore use the same anchor again.

### 2. Adding a POI past the antimeridian crashes the app

Panning across the antimeridian can leave the model view origin outside the canonical Mercator range. `GetRegionCountryId()` wraps internally, but `Editor::CreatePoint()` checks the MWM bounding box with the original point, so creation failed and platform `CHECK`s aborted the app.

`P3dtoG()` wraps longitude. Failed creation is also handled as a normal runtime outcome because the map can be updated or removed while the user chooses a category. Both platforms show the existing invalid-position message and return to the map; Android preserves the dialog across activity recreation, and unsuccessful attempts are not added to recent categories.

### Notes

- The shared `libs/map` fix also corrects iOS and Qt callers that query the editable map or region at the visible viewport center.
- `Framework_GetViewportCenter` covers asymmetric viewports, perspective projection, and antimeridian wrapping. `SetCenter_AlignsToVisibleViewportCenter` covers the corresponding drape alignment.

### Testing

- Desktop: `map_tests`, `drape_frontend_tests`, and `geometry_tests` pass.
- Android arm64: `assembleGoogleDebug`, `app:testGoogleDebug`, `sdk:testDebug`, and `lintAllModules` pass.
- iOS: arm64 simulator build passes.
- On-device verification of the crosshair and antimeridian flow is still pending.

Fixes #13367
