### PR TITLE
[search][android][iOS] Adjust viewport when the keyboard's search button is pressed.

### DIFF
--- a/android/app/src/main/java/app/organicmaps/search/SearchFragment.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchFragment.java
@@ -777,6 +777,8 @@ public class SearchFragment extends Fragment implements SearchListener, Categori
   interface SearchFragmentListener
   {
     void onSearchClicked();
+    // The "search" action on the keyboard: the sheet is minimized to show the results on the map.
+    void onQuerySubmitted();
     void closeSearch();
   }
 
@@ -907,7 +909,11 @@ public class SearchFragment extends Fragment implements SearchListener, Categori
         mSearchViewModel.notifyHistoryChanged();
       }
       deactivate();
-      mSearchFragmentListener.onSearchClicked();
+      mSearchFragmentListener.onQuerySubmitted();
+      // During navigation the map follows the current position, so the viewport is not overridden;
+      // the results are still drawn as marks on the map.
+      if (!RoutingController.get().isNavigating())
+        SearchEngine.INSTANCE.updateViewportWithLastResults();
       return true;
     }
 

--- a/android/app/src/main/java/app/organicmaps/search/SearchFragmentController.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchFragmentController.java
@@ -369,6 +369,12 @@ public class SearchFragmentController extends Fragment implements SearchFragment
   }
 
   @Override
+  public void onQuerySubmitted()
+  {
+    showSearchSheet(BottomSheetBehavior.STATE_COLLAPSED);
+  }
+
+  @Override
   public void closeSearch()
   {
     hideSearchSheet();

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/search/SearchEngine.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/search/SearchEngine.cpp
@@ -27,8 +27,8 @@
 
 namespace
 {
-// This cache is needed only for showing a specific result on the map after click on the list item.
-// Don't use it with another intentions!
+// This cache is needed only for showing the results on the map (a specific result after click on the list item
+// or the viewport update on the search button). Don't use it with another intentions!
 search::Results g_results;
 
 // Timestamp of last search query. Results with older stamps are ignored.
@@ -355,6 +355,12 @@ JNIEXPORT void Java_app_organicmaps_sdk_search_SearchEngine_nativeSelectResult(J
   if (mode == location::Follow || mode == location::FollowAndRotate)
     g_framework->NativeFramework()->StopLocationFollow();
   g_framework->NativeFramework()->SelectSearchResult(g_results[index], true /* animation */);
+}
+
+JNIEXPORT void Java_app_organicmaps_sdk_search_SearchEngine_nativeUpdateViewportWithLastResults(JNIEnv * env,
+                                                                                                jclass clazz)
+{
+  g_framework->NativeFramework()->UpdateViewport(g_results);
 }
 
 JNIEXPORT void Java_app_organicmaps_sdk_search_SearchEngine_nativeCancelInteractiveSearch(JNIEnv * env, jclass clazz)

--- a/android/sdk/src/main/java/app/organicmaps/sdk/search/SearchEngine.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/search/SearchEngine.java
@@ -218,7 +218,7 @@ public enum SearchEngine implements SearchListener, MapSearchListener,
   }
 
   /**
-   * Moves the map viewport to make the nearest of the last results visible.
+   * Applies the search results viewport policy to the last results, see Framework::UpdateViewport().
    */
   @MainThread
   public void updateViewportWithLastResults()

--- a/android/sdk/src/main/java/app/organicmaps/sdk/search/SearchEngine.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/search/SearchEngine.java
@@ -217,6 +217,15 @@ public enum SearchEngine implements SearchListener, MapSearchListener,
     nativeSelectResult(index);
   }
 
+  /**
+   * Moves the map viewport to make the nearest of the last results visible.
+   */
+  @MainThread
+  public void updateViewportWithLastResults()
+  {
+    nativeUpdateViewportWithLastResults();
+  }
+
   @Nullable
   public SearchResult[] getCachedResults()
   {
@@ -259,6 +268,8 @@ public enum SearchEngine implements SearchListener, MapSearchListener,
   private static native void nativeShowResult(int index);
 
   private static native void nativeSelectResult(int index);
+
+  private static native void nativeUpdateViewportWithLastResults();
 
   private static native void nativeCancelInteractiveSearch();
 

--- a/iphone/Maps/Core/Search/MWMSearch.h
+++ b/iphone/Maps/Core/Search/MWMSearch.h
@@ -25,6 +25,8 @@ typedef NS_ENUM(NSUInteger, SearchMode) { SearchModeEverywhere, SearchModeViewpo
 + (void)searchQuery:(SearchQuery *)query;
 
 + (void)showResultAtIndex:(NSUInteger)index;
+// Moves the map viewport to make the nearest result visible.
++ (void)updateViewportWithResults;
 + (SearchMode)searchMode;
 + (void)setSearchMode:(SearchMode)mode;
 

--- a/iphone/Maps/Core/Search/MWMSearch.h
+++ b/iphone/Maps/Core/Search/MWMSearch.h
@@ -25,7 +25,7 @@ typedef NS_ENUM(NSUInteger, SearchMode) { SearchModeEverywhere, SearchModeViewpo
 + (void)searchQuery:(SearchQuery *)query;
 
 + (void)showResultAtIndex:(NSUInteger)index;
-// Moves the map viewport to make the nearest result visible.
+// Applies the search results viewport policy, see Framework::UpdateViewport().
 + (void)updateViewportWithResults;
 + (SearchMode)searchMode;
 + (void)setSearchMode:(SearchMode)mode;

--- a/iphone/Maps/Core/Search/MWMSearch.mm
+++ b/iphone/Maps/Core/Search/MWMSearch.mm
@@ -199,6 +199,11 @@ BOOL HandleIOSDebugCommand(NSString * query)
   GetFramework().SelectSearchResult(result, true);
 }
 
++ (void)updateViewportWithResults
+{
+  GetFramework().UpdateViewport([MWMSearch manager]->m_everywhereResults);
+}
+
 + (SearchResult *)resultWithContainerIndex:(NSUInteger)index
 {
   SearchResult * result = [[SearchResult alloc] initWithResult:[MWMSearch manager]->m_everywhereResults[index]

--- a/iphone/Maps/Tests/UI/SearchOnMapTests/SearchOnMapTests.swift
+++ b/iphone/Maps/Tests/UI/SearchOnMapTests/SearchOnMapTests.swift
@@ -24,6 +24,7 @@ final class SearchOnMapTests: XCTestCase {
     view = nil
     searchManager.results = .empty
     searchManager.setSearchMode(.everywhere)
+    searchManager.updateViewportCallsCount = 0
     searchManager = nil
     super.tearDown()
   }
@@ -97,24 +98,49 @@ final class SearchOnMapTests: XCTestCase {
     interactor.handle(.searchButtonDidTap(query))
 
     XCTAssertEqual(currentState, .searching)
-    XCTAssertEqual(view.viewModel.presentationStep, .halfScreen)
+    XCTAssertEqual(view.viewModel.presentationStep, .compact)
     XCTAssertEqual(view.viewModel.contentState, .results(results))
     XCTAssertEqual(view.viewModel.searchingText, nil)
     XCTAssertEqual(view.viewModel.isTyping, false)
   }
 
-  func test_GivenCompactSearch_WhenTapSearch_ThenShowMapInHalfScreen() {
+  func test_GivenHalfScreenSearch_WhenTapSearch_ThenShowMapInCompact() {
     interactor.handle(.openSearch)
-    interactor.handle(.didStartDraggingMap)
-    XCTAssertEqual(view.viewModel.presentationStep, .compact)
+    interactor.handle(.didUpdatePresentationStep(.halfScreen))
+    XCTAssertEqual(view.viewModel.presentationStep, .halfScreen)
 
     let query = SearchQuery("text", source: .typedText)
     interactor.handle(.searchButtonDidTap(query))
     interactor.handle(.didUpdatePresentationStep(view.viewModel.presentationStep))
 
-    XCTAssertEqual(view.viewModel.presentationStep, .halfScreen)
+    XCTAssertEqual(view.viewModel.presentationStep, .compact)
     XCTAssertEqual(view.viewModel.isTyping, false)
     XCTAssertEqual(searchManager.searchMode(), .everywhereAndViewport)
+  }
+
+  func test_GivenResults_WhenTapSearch_ThenUpdateViewport() {
+    interactor.handle(.openSearch)
+    let query = SearchQuery("text", source: .typedText)
+    interactor.handle(.didType(query))
+    searchManager.results = SearchResult.stubResults()
+
+    interactor.handle(.searchButtonDidTap(query))
+    XCTAssertEqual(searchManager.updateViewportCallsCount, 1)
+  }
+
+  func test_GivenRouting_WhenTapSearch_ThenHideSearchAndKeepViewport() {
+    presenter = SearchOnMapPresenter(isRouting: true,
+                                     didChangeState: { [weak self] in self?.currentState = $0 })
+    interactor = SearchOnMapInteractor(presenter: presenter, searchManager: searchManager)
+    presenter.view = view
+    interactor.handle(.openSearch)
+
+    let query = SearchQuery("text", source: .typedText)
+    interactor.handle(.didType(query))
+    interactor.handle(.searchButtonDidTap(query))
+
+    XCTAssertEqual(view.viewModel.presentationStep, .hidden)
+    XCTAssertEqual(searchManager.updateViewportCallsCount, 0)
   }
 
   func test_GivenSearchIsOpened_WhenMapIsDragged_ThenCollapseSearchScreen() {
@@ -295,6 +321,7 @@ private class SearchManagerMock: SearchManager {
   }
 
   private static var _searchMode: SearchMode = .everywhere
+  static var updateViewportCallsCount = 0
 
   static func add(_ observer: any MWMSearchObserver) {
     observers.addListener(observer)
@@ -307,6 +334,7 @@ private class SearchManagerMock: SearchManager {
   static func save(_: SearchQuery) {}
   static func searchQuery(_: SearchQuery) {}
   static func showResult(at _: UInt) {}
+  static func updateViewportWithResults() { updateViewportCallsCount += 1 }
   static func clear() {}
   static func getResults() -> [SearchResult] { results.results }
   static func searchMode() -> SearchMode { _searchMode }

--- a/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapInteractor.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapInteractor.swift
@@ -79,6 +79,11 @@ final class SearchOnMapInteractor: NSObject {
 
   private func processSearchButtonDidTap(_ query: SearchQuery) -> SearchOnMap.Response {
     searchManager.save(query)
+    // During navigation the map follows the current position, so the viewport is not overridden;
+    // the results are still drawn as marks on the map.
+    if !presenter.isRouting {
+      searchManager.updateViewportWithResults()
+    }
     return .showOnTheMap
   }
 

--- a/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapPresenter.swift
+++ b/iphone/Maps/UI/Search/SearchOnMap/SearchOnMapPresenter.swift
@@ -12,7 +12,7 @@ final class SearchOnMapPresenter {
   }
 
   private var viewModel: ViewModel = .initial
-  private var isRouting: Bool
+  let isRouting: Bool
   private var didChangeState: ((SearchOnMapState) -> Void)?
 
   init(isRouting: Bool, didChangeState: ((SearchOnMapState) -> Void)?) {
@@ -56,7 +56,7 @@ final class SearchOnMapPresenter {
     case .showOnTheMap:
       viewModel.isTyping = false
       viewModel.skipSuggestions = true
-      viewModel.presentationStep = isRouting ? .hidden : .halfScreen
+      viewModel.presentationStep = isRouting ? .hidden : .compact
       if case .results(var results) = viewModel.contentState, !results.isEmpty {
         results.skipSuggestions()
         viewModel.contentState = .results(results)

--- a/libs/drape_frontend/tile_key.cpp
+++ b/libs/drape_frontend/tile_key.cpp
@@ -107,10 +107,9 @@ m2::RectD TileKey::GetWrappedDataRect(bool clipByDataMaxZoom /* = true */) const
   // the feature index will find data in the intersection.
   if (rect.minX() < mercator::Bounds::kMaxX && rect.maxX() > mercator::Bounds::kMinX)
     return rect;
-  // For tiles completely outside the canonical range, wrap minX into [-180, 180)
-  // so the data query covers the equivalent geographic area.
-  double const startX = mercator::WrapX(rect.minX());
-  return m2::RectD(startX, rect.minY(), startX + rect.SizeX(), rect.maxY());
+  // Tiles completely outside the canonical range are wrapped so the data query covers
+  // the equivalent geographic area.
+  return mercator::WrapRectX(rect);
 }
 
 m2::PointI TileKey::GetTileCoords() const

--- a/libs/geometry/any_rect2d.hpp
+++ b/libs/geometry/any_rect2d.hpp
@@ -64,7 +64,7 @@ public:
 
   Point<T> LocalCenter() const { return m_rect.Center(); }
 
-  T GetMaxSize() const { return max(m_rect.SizeX(), m_rect.SizeY()); }
+  T GetMaxSize() const { return std::max(m_rect.SizeX(), m_rect.SizeY()); }
 
   bool EqualDxDy(AnyRect<T> const & r, T eps) const
   {

--- a/libs/geometry/geometry_tests/mercator_test.cpp
+++ b/libs/geometry/geometry_tests/mercator_test.cpp
@@ -93,6 +93,22 @@ UNIT_TEST(Mercator_WrapX)
   TEST_ALMOST_EQUAL_ABS(mercator::WrapX(-540.0), -180.0, 1e-10, ());
 }
 
+UNIT_TEST(Mercator_WrapRectX)
+{
+  auto const test = [](m2::RectD const & rect, m2::RectD const & expected)
+  { TEST(m2::IsEqual(mercator::WrapRectX(rect), expected, 1e-10, 1e-10), (rect, expected)); };
+
+  test({-1, -1, 1, 1}, {-1, -1, 1, 1});
+  test({359, -1, 361, 1}, {-1, -1, 1, 1});
+  test({-361, -1, -359, 1}, {-1, -1, 1, 1});
+  test({185, 10, 195, 20}, {-175, 10, -165, 20});
+  test({-195, 10, -185, 20}, {165, 10, 175, 20});
+  // Crossing rects are kept as is (or shifted to the equivalent copy).
+  test({170, -1, 190, 1}, {-190, -1, -170, 1});
+  test({-190, -1, -170, 1}, {-190, -1, -170, 1});
+  test({500, -1, 560, 1}, {140, -1, 200, 1});
+}
+
 UNIT_TEST(Mercator_NearestWrapX)
 {
   // No adjustment needed (within 180 of reference).

--- a/libs/geometry/mercator.hpp
+++ b/libs/geometry/mercator.hpp
@@ -61,8 +61,8 @@ inline double ClampY(double d)
 /// geographic position across the antimeridian: WrapX(185) = -175.
 inline double WrapX(double x)
 {
-  x = std::fmod(x - Bounds::kMinX, Bounds::kRangeX);
-  return (x < 0.0 ? x + Bounds::kRangeX : x) + Bounds::kMinX;
+  x = std::remainder(x, 360.0);  // [-180, 180]
+  return x == 180.0 ? -180.0 : x;
 }
 
 /// Returns the world copy of x (x shifted by whole multiples of 360) nearest to refX,
@@ -73,6 +73,15 @@ inline double NearestWrapX(double x, double refX)
   if (dx >= -180.0 && dx <= 180.0)
     return x;
   return refX + std::remainder(dx, 360.0);
+}
+
+/// Shifts the rect by whole world widths so that its center is within [-180, 180).
+/// The result may still cross the antimeridian.
+inline m2::RectD WrapRectX(m2::RectD rect)
+{
+  double const x = rect.Center().x;
+  rect.Offset(WrapX(x) - x, 0.0);
+  return rect;
 }
 
 void ClampPoint(m2::PointD & pt);

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1643,7 +1643,7 @@ void Framework::UpdateViewport(search::Results const & results)
   // Fit into the part of the screen that is not covered by UI (e.g. the search bottom sheet).
   auto viewport = m_currentModelView.GetTouchRect(m_visibleViewport.Center(), m_visibleViewport.SizeX() / 2,
                                                   m_visibleViewport.SizeY() / 2);
-  if (search::ExtendViewportToNearestResult(results, viewport))
+  if (search::AdjustViewportToSearchResults(results, viewport))
   {
     StopLocationFollow();
     ShowRect(viewport, true /* animation */, true /* useVisibleViewport */);

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1640,37 +1640,13 @@ void Framework::HideRouteTransitIfNeeded()
 
 void Framework::UpdateViewport(search::Results const & results)
 {
-  // Setup viewport according to results.
-  m2::AnyRectD viewport = m_currentModelView.GlobalRect();
-  m2::PointD const center = viewport.Center();
-
-  double minDistance = std::numeric_limits<double>::max();
-  search::Result const * res = nullptr;
-  for (auto const & r : results)
+  // Fit into the part of the screen that is not covered by UI (e.g. the search bottom sheet).
+  auto viewport = m_currentModelView.GetTouchRect(m_visibleViewport.Center(), m_visibleViewport.SizeX() / 2,
+                                                  m_visibleViewport.SizeY() / 2);
+  if (search::ExtendViewportToNearestResult(results, viewport))
   {
-    if (r.HasPoint())
-    {
-      double const dist = center.SquaredLength(r.GetFeatureCenter());
-      if (dist < minDistance)
-      {
-        minDistance = dist;
-        res = &r;
-      }
-    }
-  }
-
-  if (res)
-  {
-    m2::PointD const pt = res->GetFeatureCenter();
-    if (!viewport.IsPointInside(pt))
-    {
-      viewport.SetSizesToIncludePoint(pt);
-      double constexpr factor = 0.05;
-      viewport.Inflate(viewport.GetLocalRect().SizeX() * factor, viewport.GetLocalRect().SizeY() * factor);
-
-      StopLocationFollow();
-      ShowRect(viewport);
-    }
+    StopLocationFollow();
+    ShowRect(viewport, true /* animation */, true /* useVisibleViewport */);
   }
 }
 

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -519,6 +519,8 @@ public:
   // search result.
   void ShowSearchResult(search::Result const & res, bool animation = true);
 
+  // Moves the viewport to make the result nearest to the visible viewport's center visible,
+  // if it is not visible yet.
   void UpdateViewport(search::Results const & results);
 
   void FillSearchResultsMarks(bool clear, search::Results const & results);

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -519,8 +519,7 @@ public:
   // search result.
   void ShowSearchResult(search::Result const & res, bool animation = true);
 
-  // Moves the viewport to make the result nearest to the visible viewport's center visible,
-  // if it is not visible yet.
+  // Applies the search results viewport policy, see search::AdjustViewportToSearchResults().
   void UpdateViewport(search::Results const & results);
 
   void FillSearchResultsMarks(bool clear, search::Results const & results);

--- a/libs/map/map_tests/CMakeLists.txt
+++ b/libs/map/map_tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SRC
   road_warning_tests.cpp
   share_tests.cpp
   search_api_tests.cpp
+  search_viewport_tests.cpp
   transliteration_test.cpp
   relation_track_tests.cpp
   routing_manager_tests.cpp

--- a/libs/map/map_tests/search_api_tests.cpp
+++ b/libs/map/map_tests/search_api_tests.cpp
@@ -133,6 +133,42 @@ UNIT_CLASS_TEST(SearchAPITest, MultipleViewportsRequests)
   future1.wait();
 }
 
+UNIT_CLASS_TEST(SearchAPITest, ViewportPastAntimeridian)
+{
+  TestCafe cafe1(m2::PointD(0, 0), "cafe 1", "en");
+  TestCafe cafe2(m2::PointD(0.5, 0.5), "cafe 2", "en");
+  TestCafe cafe3(m2::PointD(10, 10), "cafe 3", "en");
+
+  auto const id = BuildCountry("Wonderland", [&](TestMwmBuilder & builder)
+  {
+    builder.Add(cafe1);
+    builder.Add(cafe2);
+    builder.Add(cafe3);
+  });
+
+  promise<void> promise;
+  auto future = promise.get_future();
+
+  ViewportSearchParams params;
+  params.m_query = "cafe ";
+  params.m_inputLocale = "en";
+  params.m_onCompleted = [&](Results const & results)
+  {
+    TEST(!results.IsEndedCancelled(), ());
+    if (!results.IsEndMarker())
+      return;
+
+    Rules const rules = {ExactMatch(id, cafe1), ExactMatch(id, cafe2)};
+    TEST(MatchResults(m_dataSource, rules, results), ());
+    promise.set_value();
+  };
+
+  // The map scrolled past the antimeridian reports the viewport shifted by the whole world.
+  m_api.OnViewportChanged(m2::RectD(359, -1, 361, 1));
+  m_api.SearchInViewport(params);
+  future.wait();
+}
+
 UNIT_CLASS_TEST(SearchAPITest, Cancellation)
 {
   TestCafe cafe(m2::PointD(0, 0), "cafe", "en");

--- a/libs/map/map_tests/search_viewport_tests.cpp
+++ b/libs/map/map_tests/search_viewport_tests.cpp
@@ -4,20 +4,38 @@
 
 #include "search/result.hpp"
 
+#include "indexer/classificator.hpp"
+#include "indexer/classificator_loader.hpp"
+#include "indexer/feature_decl.hpp"
+#include "indexer/mwm_set.hpp"
+#include "indexer/scales.hpp"
+
 #include "geometry/any_rect2d.hpp"
+#include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"
 #include "geometry/rect2d.hpp"
 
 #include <initializer_list>
+#include <memory>
 
 namespace search_viewport_tests
 {
 using namespace search;
 
-Result MakeResult(m2::PointD const & pt)
+double constexpr kEps = 1e-9;
+// Constants of the tested policy.
+double constexpr kFarDistanceMeters = 20000.0;
+int constexpr kLocalizedScale = 15;
+
+m2::PointD const kBuenosAires = mercator::FromLatLon(-34.6, -58.4);
+m2::PointD const kMinsk = mercator::FromLatLon(53.9, 27.6);
+m2::PointD const kTribuMins = mercator::FromLatLon(7.5, -5.5);  // Cote d'Ivoire, a misprinted match for "Minsk".
+
+Result MakeResult(m2::PointD const & pt, uint16_t errorsMade = 0)
 {
   Result res(pt, "name");
   res.SetType(Result::Type::LatLon);
+  res.SetErrorsMade(ErrorsMade(errorsMade));
   return res;
 }
 
@@ -29,66 +47,225 @@ Results MakeResults(std::initializer_list<m2::PointD> const & points)
   return results;
 }
 
-m2::AnyRectD MakeViewport(double angle = 0.0)
+// A viewport of the given size in meters, centered at |center| and rotated by |angle|.
+m2::AnyRectD MakeViewport(m2::PointD const & center, double widthMeters, double heightMeters, double angle = 0.0)
 {
-  return m2::AnyRectD(m2::PointD(0, 0), ang::AngleD(angle), m2::RectD(-10, -5, 10, 5));
+  double const w = mercator::MetersToMercator(widthMeters) / 2;
+  double const h = mercator::MetersToMercator(heightMeters) / 2;
+  return m2::AnyRectD(center, ang::AngleD(angle), m2::RectD(-w, -h, w, h));
 }
 
-UNIT_TEST(ExtendViewportToNearestResult_NoResults)
+// Named to avoid the ADL clash with m2::Shift().
+m2::PointD ShiftMeters(m2::PointD const & pt, double dxMeters, double dyMeters)
 {
-  auto viewport = MakeViewport();
-  auto const original = viewport;
+  return pt + m2::PointD(mercator::MetersToMercator(dxMeters), mercator::MetersToMercator(dyMeters));
+}
 
-  TEST(!ExtendViewportToNearestResult(Results(), viewport), ());
-  TEST_EQUAL(viewport.GetGlobalRect(), original.GetGlobalRect(), ());
+double SizeForScale(int scale)
+{
+  return mercator::Bounds::kRangeX / (1 << scale);
+}
+
+void TestUnchanged(Results const & results, m2::AnyRectD const & viewport)
+{
+  auto adjusted = viewport;
+  TEST(!AdjustViewportToSearchResults(results, adjusted), (adjusted));
+  TEST_EQUAL(adjusted.GetGlobalRect(), viewport.GetGlobalRect(), ());
+}
+
+UNIT_TEST(AdjustViewportToSearchResults_NoResults)
+{
+  auto const viewport = MakeViewport(kBuenosAires, 2000, 1000);
+  TestUnchanged(Results(), viewport);
 
   Results suggests;
   suggests.AddResultNoChecks(Result("ca", "cafe"));
-  TEST(!ExtendViewportToNearestResult(suggests, viewport), ());
-  TEST_EQUAL(viewport.GetGlobalRect(), original.GetGlobalRect(), ());
+  TestUnchanged(suggests, viewport);
 }
 
-UNIT_TEST(ExtendViewportToNearestResult_NearestInside)
+UNIT_TEST(AdjustViewportToSearchResults_NearestInside)
 {
-  auto viewport = MakeViewport();
-  auto const original = viewport;
-
-  // The nearest result is inside the viewport, so the far one must not affect it.
-  TEST(!ExtendViewportToNearestResult(MakeResults({{100, 100}, {1, 1}}), viewport), ());
-  TEST_EQUAL(viewport.GetGlobalRect(), original.GetGlobalRect(), ());
+  auto const viewport = MakeViewport(kBuenosAires, 2000, 1000);
+  // The nearest result is inside the viewport, so the others must not affect it.
+  TestUnchanged(MakeResults({kMinsk, ShiftMeters(kBuenosAires, 5000, 0), ShiftMeters(kBuenosAires, 100, 100)}),
+                viewport);
 }
 
-UNIT_TEST(ExtendViewportToNearestResult_NearestOutside)
+UNIT_TEST(AdjustViewportToSearchResults_NearZoomOut)
 {
-  auto viewport = MakeViewport();
-  auto const original = viewport;
+  for (double const angle : {0.0, math::pi / 4})
+  {
+    auto const original = MakeViewport(kBuenosAires, 2000, 1000, angle);
+    auto viewport = original;
 
-  m2::PointD const nearest(2, 20);
-  m2::PointD const far(0, 100);
-  TEST(ExtendViewportToNearestResult(MakeResults({far, nearest}), viewport), ());
+    m2::PointD const nearest = ShiftMeters(kBuenosAires, 200, 2000);
+    m2::PointD const far = ShiftMeters(kBuenosAires, 0, 10000);
+    TEST(AdjustViewportToSearchResults(MakeResults({far, nearest}), viewport), ());
 
-  // The viewport is zoomed out around its center to include the nearest result with a margin,
-  // and the original area stays inside.
-  TEST(viewport.IsPointInside(nearest), (viewport));
-  TEST(m2::AlmostEqualAbs(viewport.Center(), original.Center(), 1e-9), (viewport));
-  TEST_GREATER(viewport.GetLocalRect().maxY(), 20.0, (viewport));
-  TEST(viewport.IsRectInside(original), (viewport));
-  // The viewport is not extended to include all the results.
-  TEST(!viewport.IsPointInside(far), (viewport));
+    // The viewport is zoomed out around its center to include the nearest result with a margin,
+    // keeping the original area and the rotation.
+    TEST(viewport.IsPointInside(nearest), (viewport));
+    TEST(viewport.IsRectInside(original), (viewport));
+    TEST(m2::AlmostEqualAbs(viewport.Center(), original.Center(), kEps), (viewport));
+    TEST_ALMOST_EQUAL_ABS(viewport.Angle().val(), angle, kEps, ());
+    TEST_LESS(viewport.GetMaxSize(), mercator::MetersToMercator(3 * 2000), (viewport));
+    // The viewport is not extended to include all the results.
+    TEST(!viewport.IsPointInside(far), (viewport));
+  }
 }
 
-UNIT_TEST(ExtendViewportToNearestResult_KeepsRotation)
+UNIT_TEST(AdjustViewportToSearchResults_FarSingleResult)
+{
+  double const angle = math::pi / 6;
+  auto viewport = MakeViewport(kBuenosAires, 2000, 1000, angle);
+  TEST(AdjustViewportToSearchResults(MakeResults({kMinsk}), viewport), ());
+
+  // The viewport is moved to the result and shows it at the comfort scale instead of being zoomed out
+  // over the half of the world (which also fails to fit into the mercator bounds).
+  TEST(m2::AlmostEqualAbs(viewport.Center(), kMinsk, kEps), (viewport));
+  TEST(mercator::Bounds::FullRect().IsRectInside(viewport.GetGlobalRect()), (viewport));
+  TEST_ALMOST_EQUAL_ABS(viewport.Angle().val(), angle, kEps, ());
+  double const size = SizeForScale(scales::GetUpperComfortScale());
+  TEST_GREATER_OR_EQUAL(viewport.GetLocalRect().SizeX(), size, (viewport));
+  TEST_LESS(viewport.GetLocalRect().SizeX(), 2 * size, (viewport));
+  TEST_ALMOST_EQUAL_ABS(viewport.GetLocalRect().SizeX(), viewport.GetLocalRect().SizeY(), kEps, (viewport));
+}
+
+UNIT_TEST(AdjustViewportToSearchResults_FarSingleCity)
+{
+  classificator::Load();
+
+  auto viewport = MakeViewport(kBuenosAires, 2000, 1000);
+  Results results;
+  Result city(kMinsk, "Minsk");
+  // A feature id of any registered country mwm.
+  struct CountryMwmInfo : public MwmInfo
+  {
+    CountryMwmInfo()
+    {
+      m_minScale = 1;
+      m_maxScale = scales::GetUpperScale();
+      SetStatus(STATUS_REGISTERED);
+    }
+  };
+  auto const info = std::make_shared<CountryMwmInfo>();
+  city.FromFeature(FeatureID(MwmSet::MwmId(info), 0), classif().GetTypeByPath({"place", "city"}), 0 /* matchedType */,
+                   {});
+  results.AddResultNoChecks(std::move(city));
+  TEST(AdjustViewportToSearchResults(results, viewport), ());
+
+  // A city is shown farther than a POI.
+  TEST(m2::AlmostEqualAbs(viewport.Center(), kMinsk, kEps), (viewport));
+  double const size = SizeForScale(scales::GetUpperWorldScale());
+  TEST_GREATER_OR_EQUAL(viewport.GetLocalRect().SizeX(), size, (viewport));
+  TEST_LESS(viewport.GetLocalRect().SizeX(), 2 * size, (viewport));
+}
+
+UNIT_TEST(AdjustViewportToSearchResults_FarLocalized)
 {
   double const angle = math::pi / 4;
-  auto viewport = MakeViewport(angle);
-  auto const original = viewport;
+  auto viewport = MakeViewport(kBuenosAires, 2000, 1000, angle);
+  m2::PointD const p1 = ShiftMeters(kMinsk, -400, 0);
+  m2::PointD const p2 = ShiftMeters(kMinsk, 300, 500);
+  m2::PointD const p3 = ShiftMeters(kMinsk, 100, -200);
+  TEST(AdjustViewportToSearchResults(MakeResults({p1, p2, p3}), viewport), ());
 
-  m2::PointD const nearest(20, 20);
-  TEST(ExtendViewportToNearestResult(MakeResults({nearest}), viewport), ());
+  // All the localized results are shown at once, keeping the rotation.
+  for (auto const & pt : {p1, p2, p3})
+    TEST(viewport.IsPointInside(pt), (viewport, pt));
+  TEST_ALMOST_EQUAL_ABS(viewport.Angle().val(), angle, kEps, ());
+  TEST_LESS(viewport.GetMaxSize(), SizeForScale(kLocalizedScale), (viewport));
+  TEST_LESS(viewport.GetMaxSize(), mercator::MetersToMercator(2 * 1000), (viewport));
+}
 
-  TEST_ALMOST_EQUAL_ABS(viewport.Angle().val(), angle, 1e-9, ());
-  TEST(viewport.IsPointInside(nearest), (viewport));
-  TEST(m2::AlmostEqualAbs(viewport.Center(), original.Center(), 1e-9), (viewport));
+UNIT_TEST(AdjustViewportToSearchResults_FarSpread)
+{
+  double const angle = math::pi / 4;
+  auto viewport = MakeViewport(kBuenosAires, 2000, 1000, angle);
+  m2::PointD const nearest = ShiftMeters(kMinsk, -30000, -30000);
+  TEST(AdjustViewportToSearchResults(MakeResults({kMinsk, nearest, ShiftMeters(kMinsk, 30000, 0)}), viewport), ());
+
+  // The results are spread too much to be shown at once, so the top one is shown at its own scale
+  // (not the nearest one), keeping the rotation.
+  TEST(m2::AlmostEqualAbs(viewport.Center(), kMinsk, kEps), (viewport));
+  double const size = SizeForScale(scales::GetUpperComfortScale());
+  TEST_GREATER_OR_EQUAL(viewport.GetLocalRect().SizeX(), size, (viewport));
+  TEST_LESS(viewport.GetLocalRect().SizeX(), 2 * size, (viewport));
+  TEST_ALMOST_EQUAL_ABS(viewport.Angle().val(), angle, kEps, ());
+  TEST(!viewport.IsPointInside(nearest), (viewport));
+}
+
+UNIT_TEST(AdjustViewportToSearchResults_MisprintsAreIgnored)
+{
+  // The misprinted result is much closer to the viewport, but the exact one wins.
+  auto viewport = MakeViewport(kBuenosAires, 2000, 1000);
+  Results results;
+  results.AddResultNoChecks(MakeResult(kMinsk, 0 /* errorsMade */));
+  results.AddResultNoChecks(MakeResult(kTribuMins, 1 /* errorsMade */));
+  TEST(AdjustViewportToSearchResults(results, viewport), ());
+  TEST(m2::AlmostEqualAbs(viewport.Center(), kMinsk, kEps), (viewport));
+
+  // The same for the misprinted result inside the viewport: the exact one nearby is made visible.
+  auto const original = MakeViewport(kBuenosAires, 2000, 1000);
+  viewport = original;
+  m2::PointD const exact = ShiftMeters(kBuenosAires, 0, 3000);
+  results.Clear();
+  results.AddResultNoChecks(MakeResult(ShiftMeters(kBuenosAires, 100, 100), 1 /* errorsMade */));
+  results.AddResultNoChecks(MakeResult(exact, 0 /* errorsMade */));
+  TEST(AdjustViewportToSearchResults(results, viewport), ());
+  TEST(viewport.IsPointInside(exact), (viewport));
   TEST(viewport.IsRectInside(original), (viewport));
+
+  // The best available results are used when there are no exact ones.
+  viewport = original;
+  results.Clear();
+  results.AddResultNoChecks(MakeResult(kMinsk, 2 /* errorsMade */));
+  results.AddResultNoChecks(MakeResult(kTribuMins, 1 /* errorsMade */));
+  TEST(AdjustViewportToSearchResults(results, viewport), ());
+  TEST(m2::AlmostEqualAbs(viewport.Center(), kTribuMins, kEps), (viewport));
+
+  // Suggestions are query completions, not matches, and do not take part.
+  viewport = original;
+  results.Clear();
+  Result suggestion(MakeResult(ShiftMeters(kBuenosAires, 100, 100)), "Minsk");
+  results.AddResultNoChecks(std::move(suggestion));
+  results.AddResultNoChecks(MakeResult(kMinsk));
+  TEST(AdjustViewportToSearchResults(results, viewport), ());
+  TEST(m2::AlmostEqualAbs(viewport.Center(), kMinsk, kEps), (viewport));
+}
+
+UNIT_TEST(AdjustViewportToSearchResults_FarThreshold)
+{
+  // Mercator meters match the real ones at the equator only.
+  m2::PointD const equator = mercator::FromLatLon(0.0, 0.0);
+  auto const original = MakeViewport(equator, 2000, 1000);
+
+  // Just below the threshold: zoomed out around the center.
+  auto viewport = original;
+  m2::PointD const near = ShiftMeters(equator, 0, kFarDistanceMeters - 2000);
+  TEST(AdjustViewportToSearchResults(MakeResults({near}), viewport), ());
+  TEST(m2::AlmostEqualAbs(viewport.Center(), original.Center(), kEps), (viewport));
+  TEST(viewport.IsPointInside(near), (viewport));
+
+  // Just above the threshold: moved to the result.
+  viewport = original;
+  m2::PointD const far = ShiftMeters(equator, 0, kFarDistanceMeters + 2000);
+  TEST(AdjustViewportToSearchResults(MakeResults({far}), viewport), ());
+  TEST(m2::AlmostEqualAbs(viewport.Center(), far, kEps), (viewport));
+
+  // The threshold grows with the viewport (30x20 km, half diagonal ~18 km), so a result just outside
+  // of a big viewport is still shown by zooming out instead of a jump to the street level.
+  auto const big = MakeViewport(equator, 30000, 20000);
+  viewport = big;
+  m2::PointD const nearForBig = ShiftMeters(equator, 0, kFarDistanceMeters + 2000);
+  TEST(AdjustViewportToSearchResults(MakeResults({nearForBig}), viewport), ());
+  TEST(m2::AlmostEqualAbs(viewport.Center(), big.Center(), kEps), (viewport));
+  TEST(viewport.IsPointInside(nearForBig), (viewport));
+  TEST(viewport.IsRectInside(big), (viewport));
+
+  viewport = big;
+  m2::PointD const farForBig = ShiftMeters(equator, 0, 40000);
+  TEST(AdjustViewportToSearchResults(MakeResults({farForBig}), viewport), ());
+  TEST(m2::AlmostEqualAbs(viewport.Center(), farForBig, kEps), (viewport));
 }
 }  // namespace search_viewport_tests

--- a/libs/map/map_tests/search_viewport_tests.cpp
+++ b/libs/map/map_tests/search_viewport_tests.cpp
@@ -1,0 +1,94 @@
+#include "testing/testing.hpp"
+
+#include "map/search_api.hpp"
+
+#include "search/result.hpp"
+
+#include "geometry/any_rect2d.hpp"
+#include "geometry/point2d.hpp"
+#include "geometry/rect2d.hpp"
+
+#include <initializer_list>
+
+namespace search_viewport_tests
+{
+using namespace search;
+
+Result MakeResult(m2::PointD const & pt)
+{
+  Result res(pt, "name");
+  res.SetType(Result::Type::LatLon);
+  return res;
+}
+
+Results MakeResults(std::initializer_list<m2::PointD> const & points)
+{
+  Results results;
+  for (auto const & pt : points)
+    results.AddResultNoChecks(MakeResult(pt));
+  return results;
+}
+
+m2::AnyRectD MakeViewport(double angle = 0.0)
+{
+  return m2::AnyRectD(m2::PointD(0, 0), ang::AngleD(angle), m2::RectD(-10, -5, 10, 5));
+}
+
+UNIT_TEST(ExtendViewportToNearestResult_NoResults)
+{
+  auto viewport = MakeViewport();
+  auto const original = viewport;
+
+  TEST(!ExtendViewportToNearestResult(Results(), viewport), ());
+  TEST_EQUAL(viewport.GetGlobalRect(), original.GetGlobalRect(), ());
+
+  Results suggests;
+  suggests.AddResultNoChecks(Result("ca", "cafe"));
+  TEST(!ExtendViewportToNearestResult(suggests, viewport), ());
+  TEST_EQUAL(viewport.GetGlobalRect(), original.GetGlobalRect(), ());
+}
+
+UNIT_TEST(ExtendViewportToNearestResult_NearestInside)
+{
+  auto viewport = MakeViewport();
+  auto const original = viewport;
+
+  // The nearest result is inside the viewport, so the far one must not affect it.
+  TEST(!ExtendViewportToNearestResult(MakeResults({{100, 100}, {1, 1}}), viewport), ());
+  TEST_EQUAL(viewport.GetGlobalRect(), original.GetGlobalRect(), ());
+}
+
+UNIT_TEST(ExtendViewportToNearestResult_NearestOutside)
+{
+  auto viewport = MakeViewport();
+  auto const original = viewport;
+
+  m2::PointD const nearest(2, 20);
+  m2::PointD const far(0, 100);
+  TEST(ExtendViewportToNearestResult(MakeResults({far, nearest}), viewport), ());
+
+  // The viewport is zoomed out around its center to include the nearest result with a margin,
+  // and the original area stays inside.
+  TEST(viewport.IsPointInside(nearest), (viewport));
+  TEST(m2::AlmostEqualAbs(viewport.Center(), original.Center(), 1e-9), (viewport));
+  TEST_GREATER(viewport.GetLocalRect().maxY(), 20.0, (viewport));
+  TEST(viewport.IsRectInside(original), (viewport));
+  // The viewport is not extended to include all the results.
+  TEST(!viewport.IsPointInside(far), (viewport));
+}
+
+UNIT_TEST(ExtendViewportToNearestResult_KeepsRotation)
+{
+  double const angle = math::pi / 4;
+  auto viewport = MakeViewport(angle);
+  auto const original = viewport;
+
+  m2::PointD const nearest(20, 20);
+  TEST(ExtendViewportToNearestResult(MakeResults({nearest}), viewport), ());
+
+  TEST_ALMOST_EQUAL_ABS(viewport.Angle().val(), angle, 1e-9, ());
+  TEST(viewport.IsPointInside(nearest), (viewport));
+  TEST(m2::AlmostEqualAbs(viewport.Center(), original.Center(), 1e-9), (viewport));
+  TEST(viewport.IsRectInside(original), (viewport));
+}
+}  // namespace search_viewport_tests

--- a/libs/map/map_tests/search_viewport_tests.cpp
+++ b/libs/map/map_tests/search_viewport_tests.cpp
@@ -234,6 +234,39 @@ UNIT_TEST(AdjustViewportToSearchResults_MisprintsAreIgnored)
   TEST(m2::AlmostEqualAbs(viewport.Center(), kMinsk, kEps), (viewport));
 }
 
+UNIT_TEST(AdjustViewportToSearchResults_Antimeridian)
+{
+  // The viewport is next to the antimeridian, the results are on the other side of it.
+  m2::PointD const east = mercator::FromLatLon(0.0, 179.99);
+  m2::PointD const west = mercator::FromLatLon(0.0, -179.99);
+  auto const nearestCopy = [](m2::PointD pt, m2::PointD const & center)
+  {
+    pt.x = mercator::NearestWrapX(pt.x, center.x);
+    return pt;
+  };
+
+  // Inside: the result is ~2.2 km away across the antimeridian.
+  auto viewport = MakeViewport(east, 6000, 3000);
+  TEST(!AdjustViewportToSearchResults(MakeResults({west}), viewport), (viewport));
+
+  // Near: zoomed out around the center to the nearest world copy of the result.
+  auto const original = MakeViewport(east, 1000, 500);
+  viewport = original;
+  TEST(AdjustViewportToSearchResults(MakeResults({west}), viewport), ());
+  TEST(m2::AlmostEqualAbs(viewport.Center(), original.Center(), kEps), (viewport));
+  TEST(viewport.IsPointInside(nearestCopy(west, original.Center())), (viewport));
+  TEST_LESS(viewport.GetMaxSize(), mercator::MetersToMercator(10000), (viewport));
+
+  // The map itself may be scrolled past the antimeridian (unwrapped coordinates): a far result
+  // is shown in the world copy nearest to the viewport, not in the canonical one.
+  m2::PointD const unwrapped = mercator::FromLatLon(0.0, 190.0);
+  m2::PointD const far = mercator::FromLatLon(0.0, -160.0);  // 10 degrees to the east of the viewport.
+  viewport = MakeViewport(unwrapped, 2000, 1000);
+  TEST(AdjustViewportToSearchResults(MakeResults({far}), viewport), ());
+  TEST(m2::AlmostEqualAbs(viewport.Center(), nearestCopy(far, unwrapped), kEps), (viewport));
+  TEST_ALMOST_EQUAL_ABS(viewport.Center().x, 200.0, 1e-9, (viewport));
+}
+
 UNIT_TEST(AdjustViewportToSearchResults_FarThreshold)
 {
   // Mercator meters match the real ones at the equator only.

--- a/libs/map/search_api.cpp
+++ b/libs/map/search_api.cpp
@@ -8,6 +8,10 @@
 
 #include "storage/downloader_search_params.hpp"
 
+#include "indexer/feature_data.hpp"
+#include "indexer/feature_utils.hpp"
+#include "indexer/scales.hpp"
+
 #include "platform/preferred_languages.hpp"
 
 #include "geometry/mercator.hpp"
@@ -15,6 +19,7 @@
 #include "base/checked_cast.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <iterator>
 #include <limits>
 #include <string>
@@ -435,16 +440,69 @@ bool SearchAPI::QueryMayBeSkipped(SearchParams const & prevParams, SearchParams 
 
 namespace search
 {
-bool ExtendViewportToNearestResult(Results const & results, m2::AnyRectD & viewport)
+namespace
 {
+// Results farther than this from the viewport center (or than the viewport's half diagonal multiplied by the factor)
+// are shown by moving the viewport instead of zooming it out.
+double constexpr kFarDistanceMeters = 20000.0;
+double constexpr kFarViewportFactor = 2.0;
+// Results that fit into a rect of this scale are considered localized and are shown all at once.
+int constexpr kLocalizedScale = 15;
+double constexpr kMarginFactor = 0.05;
+
+// Mercator size of a square that is shown at |scale| (a tile of the world).
+double GetSizeForScale(int scale)
+{
+  return mercator::Bounds::kRangeX / (1 << scale);
+}
+
+// The scale to show a single result at: its feature's own comfort scale (e.g. a city is shown farther than a cafe).
+int GetScaleForResult(Result const & result)
+{
+  if (result.GetResultType() != Result::Type::Feature)
+    return scales::GetUpperComfortScale();
+
+  feature::TypesHolder types(feature::GeomType::Point);
+  types.Assign(result.GetFeatureType());
+  return feature::GetFeatureViewportScale(result.GetFeatureID(), types);
+}
+
+// Suggestions are query completions, not matches, although the ones made from features have a point.
+bool IsMatchedResult(Result const & result)
+{
+  return result.HasPoint() && !result.IsSuggest();
+}
+}  // namespace
+
+bool AdjustViewportToSearchResults(Results const & results, m2::AnyRectD & viewport)
+{
+  // Only the best matching results take part, e.g. a misprinted "Tribu Mins" should not outweigh "Minsk".
+  uint16_t minErrors = ErrorsMade::kInfiniteErrors;
+  for (auto const & r : results)
+    if (IsMatchedResult(r))
+      minErrors = std::min(minErrors, r.GetErrorsMade().m_errorsMade);
+
   m2::PointD const center = viewport.Center();
-  double minDistance = std::numeric_limits<double>::max();
+  Result const * top = nullptr;
   Result const * nearest = nullptr;
+  double minDistance = std::numeric_limits<double>::max();
+  size_t count = 0;
+  // Bounding rect of the results in the local coordinates of the viewport.
+  m2::RectD bounds;
   for (auto const & r : results)
   {
-    if (!r.HasPoint())
+    if (!IsMatchedResult(r) || r.GetErrorsMade().m_errorsMade != minErrors)
       continue;
-    double const dist = center.SquaredLength(r.GetFeatureCenter());
+
+    m2::PointD const pt = r.GetFeatureCenter();
+    if (viewport.IsPointInside(pt))
+      return false;
+
+    if (!top)
+      top = &r;
+    ++count;
+    bounds.Add(viewport.ConvertTo(pt));
+    double const dist = center.SquaredLength(pt);
     if (dist < minDistance)
     {
       minDistance = dist;
@@ -452,18 +510,36 @@ bool ExtendViewportToNearestResult(Results const & results, m2::AnyRectD & viewp
     }
   }
 
-  if (!nearest || viewport.IsPointInside(nearest->GetFeatureCenter()))
+  if (!top)
     return false;
 
-  // SetSizesToIncludePoint() sets the sizes symmetrically around the center from the point's offset,
-  // so restore the original size on the axis where the point is closer to the center than the border.
-  m2::RectD const original = viewport.GetLocalRect();
-  viewport.SetSizesToIncludePoint(nearest->GetFeatureCenter());
-  m2::RectD const & grown = viewport.GetLocalRect();
-  viewport.Inflate(std::max(0.0, (original.SizeX() - grown.SizeX()) / 2),
-                   std::max(0.0, (original.SizeY() - grown.SizeY()) / 2));
+  m2::RectD const local = viewport.GetLocalRect();
+  m2::PointD const nearestPt = nearest->GetFeatureCenter();
+  double const farDistance =
+      std::max(kFarDistanceMeters,
+               kFarViewportFactor * mercator::DistanceOnEarth(center, viewport.ConvertFrom(local.RightTop())));
+  if (mercator::DistanceOnEarth(center, nearestPt) <= farDistance)
+  {
+    // Zoom out symmetrically around the center, keeping the original extents.
+    m2::PointD const offset = viewport.ConvertTo(nearestPt) - local.Center();
+    viewport.Inflate(std::max(0.0, std::fabs(offset.x) - local.SizeX() / 2),
+                     std::max(0.0, std::fabs(offset.y) - local.SizeY() / 2));
+  }
+  else
+  {
+    double const localizedSize = GetSizeForScale(kLocalizedScale);
+    // Too far and spread to be shown at once: show the top result only, like a tap on it.
+    if (bounds.SizeX() > localizedSize || bounds.SizeY() > localizedSize)
+    {
+      count = 1;
+      bounds = m2::RectD(viewport.ConvertTo(top->GetFeatureCenter()), 0.0 /* dx */, 0.0 /* dy */);
+    }
+    // Show all the results, but not closer than the comfort scale (or the single result's own scale).
+    double const minSize = GetSizeForScale(count == 1 ? GetScaleForResult(*top) : scales::GetUpperComfortScale());
+    bounds.Inflate(std::max(0.0, (minSize - bounds.SizeX()) / 2), std::max(0.0, (minSize - bounds.SizeY()) / 2));
+    viewport = m2::AnyRectD(viewport.GlobalZero(), viewport.Angle(), bounds);
+  }
 
-  double constexpr kMarginFactor = 0.05;
   viewport.Inflate(viewport.GetLocalRect().SizeX() * kMarginFactor, viewport.GetLocalRect().SizeY() * kMarginFactor);
   return true;
 }

--- a/libs/map/search_api.cpp
+++ b/libs/map/search_api.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <limits>
 #include <string>
 #include <type_traits>
 
@@ -431,3 +432,39 @@ bool SearchAPI::QueryMayBeSkipped(SearchParams const & prevParams, SearchParams 
 
   return true;
 }
+
+namespace search
+{
+bool ExtendViewportToNearestResult(Results const & results, m2::AnyRectD & viewport)
+{
+  m2::PointD const center = viewport.Center();
+  double minDistance = std::numeric_limits<double>::max();
+  Result const * nearest = nullptr;
+  for (auto const & r : results)
+  {
+    if (!r.HasPoint())
+      continue;
+    double const dist = center.SquaredLength(r.GetFeatureCenter());
+    if (dist < minDistance)
+    {
+      minDistance = dist;
+      nearest = &r;
+    }
+  }
+
+  if (!nearest || viewport.IsPointInside(nearest->GetFeatureCenter()))
+    return false;
+
+  // SetSizesToIncludePoint() sets the sizes symmetrically around the center from the point's offset,
+  // so restore the original size on the axis where the point is closer to the center than the border.
+  m2::RectD const original = viewport.GetLocalRect();
+  viewport.SetSizesToIncludePoint(nearest->GetFeatureCenter());
+  m2::RectD const & grown = viewport.GetLocalRect();
+  viewport.Inflate(std::max(0.0, (original.SizeX() - grown.SizeX()) / 2),
+                   std::max(0.0, (original.SizeY() - grown.SizeY()) / 2));
+
+  double constexpr kMarginFactor = 0.05;
+  viewport.Inflate(viewport.GetLocalRect().SizeX() * kMarginFactor, viewport.GetLocalRect().SizeY() * kMarginFactor);
+  return true;
+}
+}  // namespace search

--- a/libs/map/search_api.cpp
+++ b/libs/map/search_api.cpp
@@ -150,7 +150,10 @@ SearchAPI::SearchAPI(DataSource & dataSource, storage::Storage const & storage,
 
 void SearchAPI::OnViewportChanged(m2::RectD const & viewport)
 {
-  m_viewport = viewport;
+  // The map may be scrolled past the antimeridian, while the search engine works with canonical coordinates only.
+  /// @todo A rect crossing the antimeridian is searched in its canonical part only: the engine (mwm selection,
+  /// features collection, pivot distances) doesn't support two-parts rects.
+  m_viewport = mercator::WrapRectX(viewport);
 
   auto const forceSearchInViewport = !m_isViewportInitialized;
   if (!m_isViewportInitialized)
@@ -483,8 +486,15 @@ bool AdjustViewportToSearchResults(Results const & results, m2::AnyRectD & viewp
       minErrors = std::min(minErrors, r.GetErrorsMade().m_errorsMade);
 
   m2::PointD const center = viewport.Center();
+  // The viewport may be scrolled past the antimeridian: take the results in the world copy nearest to it.
+  auto const nearestCopy = [&center](m2::PointD pt)
+  {
+    pt.x = mercator::NearestWrapX(pt.x, center.x);
+    return pt;
+  };
+
   Result const * top = nullptr;
-  Result const * nearest = nullptr;
+  m2::PointD topPt, nearestPt;
   double minDistance = std::numeric_limits<double>::max();
   size_t count = 0;
   // Bounding rect of the results in the local coordinates of the viewport.
@@ -494,19 +504,22 @@ bool AdjustViewportToSearchResults(Results const & results, m2::AnyRectD & viewp
     if (!IsMatchedResult(r) || r.GetErrorsMade().m_errorsMade != minErrors)
       continue;
 
-    m2::PointD const pt = r.GetFeatureCenter();
+    m2::PointD const pt = nearestCopy(r.GetFeatureCenter());
     if (viewport.IsPointInside(pt))
       return false;
 
     if (!top)
+    {
       top = &r;
+      topPt = pt;
+    }
     ++count;
     bounds.Add(viewport.ConvertTo(pt));
     double const dist = center.SquaredLength(pt);
     if (dist < minDistance)
     {
       minDistance = dist;
-      nearest = &r;
+      nearestPt = pt;
     }
   }
 
@@ -514,7 +527,6 @@ bool AdjustViewportToSearchResults(Results const & results, m2::AnyRectD & viewp
     return false;
 
   m2::RectD const local = viewport.GetLocalRect();
-  m2::PointD const nearestPt = nearest->GetFeatureCenter();
   double const farDistance =
       std::max(kFarDistanceMeters,
                kFarViewportFactor * mercator::DistanceOnEarth(center, viewport.ConvertFrom(local.RightTop())));
@@ -532,7 +544,7 @@ bool AdjustViewportToSearchResults(Results const & results, m2::AnyRectD & viewp
     if (bounds.SizeX() > localizedSize || bounds.SizeY() > localizedSize)
     {
       count = 1;
-      bounds = m2::RectD(viewport.ConvertTo(top->GetFeatureCenter()), 0.0 /* dx */, 0.0 /* dy */);
+      bounds = m2::RectD(viewport.ConvertTo(topPt), 0.0 /* dx */, 0.0 /* dy */);
     }
     // Show all the results, but not closer than the comfort scale (or the single result's own scale).
     double const minSize = GetSizeForScale(count == 1 ? GetScaleForResult(*top) : scales::GetUpperComfortScale());

--- a/libs/map/search_api.hpp
+++ b/libs/map/search_api.hpp
@@ -13,6 +13,7 @@
 #include "search/result.hpp"
 #include "search/search_params.hpp"
 
+#include "geometry/any_rect2d.hpp"
 #include "geometry/point2d.hpp"
 #include "geometry/rect2d.hpp"
 
@@ -171,3 +172,10 @@ private:
   // from |m_engine|.
   std::unordered_set<kml::MarkGroupId> m_indexableGroups;
 };
+
+namespace search
+{
+// Zooms |viewport| out around its center (keeping its extents) to include the result nearest to the center
+// with a small margin, unless that result is already inside. Returns true if |viewport| was changed.
+bool ExtendViewportToNearestResult(Results const & results, m2::AnyRectD & viewport);
+}  // namespace search

--- a/libs/map/search_api.hpp
+++ b/libs/map/search_api.hpp
@@ -175,7 +175,12 @@ private:
 
 namespace search
 {
-// Zooms |viewport| out around its center (keeping its extents) to include the result nearest to the center
-// with a small margin, unless that result is already inside. Returns true if |viewport| was changed.
-bool ExtendViewportToNearestResult(Results const & results, m2::AnyRectD & viewport);
+// Adjusts |viewport| to show the search results, keeping its rotation. Only the best matching results
+// (with the minimum number of misprints) are taken into account:
+// - one of them is already visible: nothing changes;
+// - the nearest one is not far away: zooms out around the center (keeping the extents) to include it;
+// - all of them are localized: shows all of them;
+// - otherwise shows the top ranked one at its own scale.
+// Returns true if |viewport| was changed.
+bool AdjustViewportToSearchResults(Results const & results, m2::AnyRectD & viewport);
 }  // namespace search

--- a/libs/search/ranker.cpp
+++ b/libs/search/ranker.cpp
@@ -773,6 +773,10 @@ Result Ranker::MakeResult(RankerResult const & rankerResult, bool needAddress, b
   case RankerResult::Type::Postcode: res.SetType(Result::Type::Postcode); break;
   }
 
+  // Coordinates and postcodes are parsed from the query as is.
+  bool const isFeature = res.GetResultType() == Result::Type::Feature;
+  res.SetErrorsMade(isFeature ? rankerResult.GetRankingInfo().m_errorsMade : ErrorsMade(0));
+
   if (needHighlighting)
     HighlightResult(m_params.m_query.m_tokens, m_params.m_query.m_prefix, res);
 

--- a/libs/search/ranking_info.cpp
+++ b/libs/search/ranking_info.cpp
@@ -240,7 +240,7 @@ std::string DebugPrint(StoredRankingInfo const & info)
   std::ostringstream os;
   os << "StoredRankingInfo "
      << "{ m_distanceToPivot: " << info.m_distanceToPivot << ", m_type: " << DebugPrint(info.m_type)
-     << ", m_classifType: ";
+     << ", m_errorsMade: " << DebugPrint(info.m_errorsMade) << ", m_classifType: ";
 
   if (Model::IsPoi(info.m_type))
     os << DebugPrint(info.m_classifType.poi);
@@ -261,12 +261,12 @@ std::string DebugPrint(RankingInfo const & info)
   os << ", " << DebugPrint(info.m_geoParts);
 
   os << ", m_rank: " << static_cast<int>(info.m_rank) << ", m_popularity: " << static_cast<int>(info.m_popularity)
-     << ", m_nameScore: " << DebugPrint(info.m_nameScore) << ", m_errorsMade: " << DebugPrint(info.m_errorsMade)
-     << ", m_isAltOrOldName: " << info.m_isAltOrOldName << ", m_numTokens: " << info.m_numTokens
-     << ", m_commonTokensFactor: " << info.m_commonTokensFactor << ", m_matchedFraction: " << info.m_matchedFraction
-     << ", m_pureCats: " << info.m_pureCats << ", m_falseCats: " << info.m_falseCats
-     << ", m_allTokensUsed: " << info.m_allTokensUsed << ", m_categorialRequest: " << info.m_categorialRequest
-     << ", m_hasName: " << info.m_hasName << ", m_nearbyMatch: " << info.m_nearbyMatch << " }";
+     << ", m_nameScore: " << DebugPrint(info.m_nameScore) << ", m_isAltOrOldName: " << info.m_isAltOrOldName
+     << ", m_numTokens: " << info.m_numTokens << ", m_commonTokensFactor: " << info.m_commonTokensFactor
+     << ", m_matchedFraction: " << info.m_matchedFraction << ", m_pureCats: " << info.m_pureCats
+     << ", m_falseCats: " << info.m_falseCats << ", m_allTokensUsed: " << info.m_allTokensUsed
+     << ", m_categorialRequest: " << info.m_categorialRequest << ", m_hasName: " << info.m_hasName
+     << ", m_nearbyMatch: " << info.m_nearbyMatch << " }";
 
   return os.str();
 }

--- a/libs/search/ranking_info.hpp
+++ b/libs/search/ranking_info.hpp
@@ -60,6 +60,9 @@ struct StoredRankingInfo
   // Search type for the feature.
   Model::Type m_type = Model::TYPE_COUNT;
 
+  // Number of misprints.
+  ErrorsMade m_errorsMade;
+
   // Used for non-categorial requests.
   union
   {
@@ -115,9 +118,6 @@ struct RankingInfo : public StoredRankingInfo
 
   // > 0 if matched only common tokens. Bigger is worse, depending on Feature's name tokens count.
   int16_t m_commonTokensFactor = 0;
-
-  // Number of misprints.
-  ErrorsMade m_errorsMade;
 
   // Rank of the feature. Store uint16_t because of possible 'normalization'.
   uint16_t m_rank = 0;

--- a/libs/search/result.hpp
+++ b/libs/search/result.hpp
@@ -117,6 +117,10 @@ public:
   int32_t GetPositionInResults() const { return m_positionInResults; }
   void SetPositionInResults(int32_t pos) { m_positionInResults = pos; }
 
+  // Number of misprints made to match the query: zero for exact matches, invalid if unknown.
+  ErrorsMade GetErrorsMade() const { return m_errorsMade; }
+  void SetErrorsMade(ErrorsMade errorsMade) { m_errorsMade = errorsMade; }
+
   /// @name Used for debug logs and tests only.
   /// @{
   RankingInfo const & GetRankingInfo() const
@@ -154,6 +158,7 @@ private:
   std::string m_suggestionStr;
   buffer_vector<std::pair<uint16_t, uint16_t>, 4> m_hightlightRanges;
   buffer_vector<std::pair<uint16_t, uint16_t>, 4> m_descHightlightRanges;
+  ErrorsMade m_errorsMade;
 
   std::shared_ptr<RankingInfo> m_dbgInfo;  // used in debug logs and tests, nullptr in production
 

--- a/libs/storage/country_info_getter.cpp
+++ b/libs/storage/country_info_getter.cpp
@@ -60,12 +60,9 @@ CountryInfoGetterBase::RegionId CountryInfoGetterBase::FindFirstCountry(m2::Poin
 // CountryInfoGetter -------------------------------------------------------------------------------
 std::vector<CountryId> CountryInfoGetter::GetRegionsCountryIdByRect(m2::RectD rect, bool rough) const
 {
-  // Wrap input rect into canonical range for further IsIntersectOrInside and IsIntersectedByRegion calls.
-  if (rect.minX() >= mercator::Bounds::kMaxX || rect.maxX() <= mercator::Bounds::kMinX)
-  {
-    double const startX = mercator::WrapX(rect.minX());
-    rect = m2::RectD(startX, rect.minY(), startX + rect.SizeX(), rect.maxY());
-  }
+  // Wrap input rect into canonical range for further IsIntersectOrInside and IsIntersectedByRegion calls
+  // (which handle rects crossing the antimeridian).
+  rect = mercator::WrapRectX(rect);
 
   std::vector<CountryId> result;
   for (size_t id = 0; id < m_countries.size(); ++id)

--- a/qt/search_panel.cpp
+++ b/qt/search_panel.cpp
@@ -34,6 +34,7 @@ SearchPanel::SearchPanel(DrawWidget * drawWidget, QWidget * parent)
 {
   m_pEditor = new QLineEdit(this);
   connect(m_pEditor, &QLineEdit::textChanged, this, &SearchPanel::OnSearchTextChanged);
+  connect(m_pEditor, &QLineEdit::returnPressed, this, &SearchPanel::OnReturnPressed);
 
   m_pTable = new QTableWidget(0, 4 /*columns*/, this);
   m_pTable->setFocusPolicy(Qt::NoFocus);
@@ -282,6 +283,12 @@ void SearchPanel::OnSearchTextChanged(QString const & str)
 
     GetFramework().GetSearchAPI().SearchInViewport(std::move(params));
   }
+}
+
+void SearchPanel::OnReturnPressed()
+{
+  // The same as the search button on mobile: apply the search results viewport policy.
+  GetFramework().UpdateViewport(m_results);
 }
 
 void SearchPanel::OnSearchModeChanged(int mode)

--- a/qt/search_panel.hpp
+++ b/qt/search_panel.hpp
@@ -61,6 +61,7 @@ private slots:
   void OnSearchModeChanged(int mode);
   void OnSearchPanelItemClicked(int row, int column);
   void OnSearchTextChanged(QString const & str);
+  void OnReturnPressed();
   void OnEverywhereSearchResults(uint64_t timestamp, search::Results results);
 
   void OnAnimationTimer();


### PR DESCRIPTION
Adjusts the map viewport when the keyboard Search action is submitted on Android, iOS, and desktop. The fit uses the visible map area, preserves rotation, ignores suggestions and lower-quality matches, and applies separate nearby, localized, and far-result policies.

Related: #10415, #7985, #5587, #4459
Fixes #13373

Tested:
- `build-codex/map_tests --filter=AdjustViewportToSearchResults_.*`
- `build-codex/search_tests`
- Android Google Debug APK with native code, car, and wear modules (`-Parm64`)
- iOS app build and `SearchOnMapTests` on an arm64 simulator
- Qt desktop build