### PR TITLE
[ci] Run live OSM tests once per HTTP backend

### DIFF
--- a/.github/workflows/build-cmake-mac.yaml
+++ b/.github/workflows/build-cmake-mac.yaml
@@ -92,6 +92,7 @@ jobs:
       #   routing_integration_tests - https://github.com/organicmaps/organicmaps/issues/221
       #   world_feed_integration_tests - https://github.com/organicmaps/organicmaps/issues/215
       #   routing_benchmarks, routing_quality_tests, search_quality_tests - benchmarks, not pass/fail tests
+      #   osm_auth_tests - runs in the regular CMake workflow's GCC 14 and macOS Debug legs
       #   storage_integration_tests - downloads real maps from planet.organicmaps.app (~28 min, ~690 MB);
       #     the offline part of that coverage lives in storage_tests
       - name: Run tests

--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -55,6 +55,7 @@ jobs:
           - os: ubuntu-24.04
             cc: gcc-14
             cxx: g++-14
+            run-osm-tests: true
 
           - os: ubuntu-24.04
             cc: gcc-13
@@ -64,6 +65,7 @@ jobs:
             cc: clang
             cxx: clang++
             developer-dir: /Applications/Xcode_26.5.app/Contents/Developer
+            run-osm-tests: true
         exclude:
           - environment: { no-unity: true }
             cmake-build-type: Release
@@ -172,11 +174,17 @@ jobs:
       #   routing_integration_tests - https://github.com/organicmaps/organicmaps/issues/221
       #   world_feed_integration_tests - https://github.com/organicmaps/organicmaps/issues/215
       #   routing_benchmarks, routing_quality_tests, search_quality_tests - benchmarks, not pass/fail tests
+      #   osm_auth_tests - uses the shared OSM development server; the next step runs it
+      #     once per HTTP backend (Qt on Linux, Apple on macOS), in the Debug legs only
       #   storage_integration_tests - downloads real maps from planet.organicmaps.app (~28 min, ~690 MB);
       #     the offline part of that coverage lives in storage_tests
       - name: Run tests
         if: ${{ matrix.environment.no-tests != true }}
         run: ctest --preset ci -j$(nproc --all)
+
+      - name: Run OSM live tests
+        if: ${{ matrix.environment.run-osm-tests == true && matrix.cmake-build-type == 'Debug' }}
+        run: ctest --preset ci-osm
 
       # Run drape tests separately. They require offscreen rendering support.
       # The "ci-drape" test preset sets QT_QPA_PLATFORM=offscreen; setting it

--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -45,8 +45,8 @@ jobs:
           - os: ubuntu-24.04
             cc: clang-19
             cxx: clang++-19
-            unity: OFF
-            run-tests: OFF
+            no-unity: true
+            no-tests: true
 
           - os: ubuntu-24.04
             cc: clang-19
@@ -65,10 +65,10 @@ jobs:
             cxx: clang++
             developer-dir: /Applications/Xcode_26.5.app/Contents/Developer
         exclude:
-          - environment: { unity: OFF }
+          - environment: { no-unity: true }
             cmake-build-type: Release
 
-    name: "${{ matrix.environment.os }} ${{ matrix.environment.cc }} ${{ matrix.cmake-build-type }}${{ matrix.environment.unity == 'OFF' && ' No Unity' || '' }}"
+    name: "${{ matrix.environment.os }} ${{ matrix.environment.cc }} ${{ matrix.cmake-build-type }}${{ matrix.environment.no-unity && ' No Unity' || '' }}"
 
     runs-on: ${{ matrix.environment.os }}
 
@@ -116,10 +116,10 @@ jobs:
       - name: Configure ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ github.workflow }}-${{ matrix.environment.os }}-${{ matrix.environment.cc }}-${{ matrix.environment.unity }}-${{ matrix.cmake-build-type }}
+          key: ${{ github.workflow }}-${{ matrix.environment.os }}-${{ matrix.environment.cc }}-${{ matrix.environment.no-unity && 'no-unity' || '' }}-${{ matrix.cmake-build-type }}
           # No Unity compiles every TU separately, so its cache needs more room
           # than the 500M default (max-size is a ceiling, not a reservation).
-          max-size: ${{ matrix.environment.unity == 'OFF' && '2G' || '1G' }}
+          max-size: ${{ matrix.environment.no-unity && '2G' || '1G' }}
           # Restore-only on PRs: master populates the shared cache, PRs read it.
           # Avoids overflowing the 10GB repo limit, which evicts master's caches.
           save: ${{ github.ref == 'refs/heads/master' }}
@@ -130,7 +130,7 @@ jobs:
           CXX: ${{ matrix.environment.cxx }}
           CMAKE_C_COMPILER_LAUNCHER: ccache
           CMAKE_CXX_COMPILER_LAUNCHER: ccache
-          UNITY_BUILD: ${{ matrix.environment.unity || 'ON' }}
+          UNITY_BUILD: ${{ matrix.environment.no-unity && 'OFF' || 'ON' }}
         run: |
           cmake --preset ci \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} \
@@ -175,12 +175,12 @@ jobs:
       #   storage_integration_tests - downloads real maps from planet.organicmaps.app (~28 min, ~690 MB);
       #     the offline part of that coverage lives in storage_tests
       - name: Run tests
-        if: ${{ matrix.environment.run-tests != 'OFF' }}
+        if: ${{ matrix.environment.no-tests != true }}
         run: ctest --preset ci -j$(nproc --all)
 
       # Run drape tests separately. They require offscreen rendering support.
       # The "ci-drape" test preset sets QT_QPA_PLATFORM=offscreen; setting it
       # globally breaks network tests on macOS.
       - name: Run drape tests
-        if: ${{ matrix.environment.run-tests != 'OFF' }}
+        if: ${{ matrix.environment.no-tests != true }}
         run: ctest --preset ci-drape --verbose

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -190,7 +190,25 @@
     {
       "name": "ci",
       "inherits": "omim-tests",
-      "configurePreset": "ci"
+      "configurePreset": "ci",
+      "filter": {
+        "exclude": {
+          "label": "omim-live-test"
+        }
+      }
+    },
+    {
+      "name": "ci-osm",
+      "description": "Live integration tests against the OpenStreetMap development server.",
+      "configurePreset": "ci",
+      "output": {
+        "outputOnFailure": true
+      },
+      "filter": {
+        "include": {
+          "label": "omim-live-test"
+        }
+      }
     },
     {
       "name": "ci-drape",
@@ -200,7 +218,12 @@
     {
       "name": "ci-xcode",
       "inherits": "omim-tests",
-      "configurePreset": "ci-xcode"
+      "configurePreset": "ci-xcode",
+      "filter": {
+        "exclude": {
+          "label": "omim-live-test"
+        }
+      }
     },
     {
       "name": "ci-drape-xcode",

--- a/libs/editor/editor_tests/CMakeLists.txt
+++ b/libs/editor/editor_tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SRC
   match_by_geometry_test.cpp
   new_feature_categories_test.cpp
   opening_hours_ui_test.cpp
+  osm_auth_test.cpp
   osm_editor_test.cpp
   osm_editor_test.hpp
   ui2oh_test.cpp

--- a/libs/editor/editor_tests/osm_auth_test.cpp
+++ b/libs/editor/editor_tests/osm_auth_test.cpp
@@ -1,0 +1,84 @@
+#include "testing/testing.hpp"
+
+#include "editor/osm_auth.hpp"
+
+#include <string>
+
+namespace osm_auth_test
+{
+UNIT_TEST(OAuth_Token_parse)
+{
+  auto token = osm::FindAuthenticityToken(
+      "/oauth2/authorize",
+      R"(<div class="col-auto mx-1"><form action="/oauth2/authorize" accept-charset="UTF-8" method="post">
+    <input type="hidden" name="authenticity_token" value="J5senhh" />
+    <input value="om://oauth2/osm/callback" type="hidden" name="redirect_uri" />
+    <input type="submit" name="commit" value="Authorize" class="btn btn-primary" />
+  </form></div>)");
+
+  TEST_EQUAL(token, "J5senhh", ("Invalid token"));
+
+  // Two tokens. One for "Allow" other for "Deny". Always pick the first one.
+  token = osm::FindAuthenticityToken(
+      "/oauth2/authorize",
+      R"(<div class="col-auto mx-1"><form action="/oauth2/authorize" accept-charset="UTF-8" method="post">
+    <input type="hidden" name="authenticity_token" value="lRFbEQN0d2r7XeFq" />
+    <input value="om://oauth2/osm/callback" type="hidden" name="redirect_uri" />
+    <input type="submit" name="commit" value="Authorize" class="btn btn-primary" />
+  </form></div>
+  <div class="col-auto mx-1"><form action="/oauth2/authorize" accept-charset="UTF-8" method="post">
+    <input type="hidden" name="_method" value="delete" />
+    <input type="hidden" name="authenticity_token" value="J5senhh" />
+    <input value="om://oauth2/osm/callback" type="hidden" name="redirect_uri" />
+    <input type="submit" name="commit" value="Deny" class="btn btn-secondary" />
+  </form></div>)");
+
+  TEST_EQUAL(token, "lRFbEQN0d2r7XeFq", ("Invalid token"));
+
+  // Three forms: one for language, two for OAuth
+  token = osm::FindAuthenticityToken(
+      "/oauth2/authorize",
+      R"(<div class="modal-body px-1"><form action="/preferences/basic" accept-charset="UTF-8" method="post">
+    <input type="hidden" name="_method" value="put" />
+    <input type="hidden" name="authenticity_token" value="8h-snCINM3O" />
+  </form></div>\n"   "<div class="col-auto mx-1"><form action="/oauth2/authorize" accept-charset="UTF-8" method="post">
+    <input type="hidden" name="authenticity_token" value="8DDeqYcFHUIjw" />
+    <input value="om://oauth2/osm/callback" type="hidden" name="redirect_uri" />
+    <input type="submit" name="commit" value="Authorize" class="btn btn-primary" />
+  </form></div>
+  <div class="col-auto mx-1"><form action="/oauth2/authorize" accept-charset="UTF-8" method="post">
+    <input type="hidden" name="_method" value="delete" />
+    <input type="hidden" name="authenticity_token" value="4RbveLjuvOXlok9Q" />
+    <input value="om://oauth2/osm/callback" type="hidden" name="redirect_uri" />
+    <input type="submit" name="commit" value="Deny" class="btn btn-secondary" />
+  </form></div>)");
+
+  TEST_EQUAL(token, "8DDeqYcFHUIjw", ("Invalid token"));
+}
+
+UNIT_TEST(OAuth_FindOauthCode)
+{
+  auto code = osm::FindOauthCode("om://oauth2/osm/callback?redirect=true&code=befd_095315f197f4");
+  TEST_EQUAL(code, "befd_095315f197f4", ("Invalid code"));
+
+  code = osm::FindOauthCode("om://oauth2/osm/callback?code=45c023d6");
+  TEST_EQUAL(code, "45c023d6", ("Invalid code"));
+
+  code = osm::FindOauthCode("om://oauth2/osm/callback?the_code=cant_find");
+  TEST_EQUAL(code, std::string{}, ("Code should not be found"));
+}
+
+UNIT_TEST(OAuth_FindAccessToken)
+{
+  auto token =
+      osm::FindAccessToken(R"({"access_token":"vAK5XMBJeUDsF3xxFHt0", "token_type":"Bearer", "scope":"read_prefs"})");
+  TEST_EQUAL(token, "vAK5XMBJeUDsF3xxFHt0", ("Invalid access_token"));
+
+  token =
+      osm::FindAccessToken(R"({"token_type":"Bearer", "scope":"read_prefs", "access_token":"W1xgY0CtTDz0klQGa4Yp"})");
+  TEST_EQUAL(token, "W1xgY0CtTDz0klQGa4Yp", ("Invalid access_token"));
+
+  token = osm::FindAccessToken(R"({"token_type":"Bearer", "scope":"read_prefs", "some_other_token":"9cMyxvsOrM"})");
+  TEST_EQUAL(token, std::string{}, ("access_token should not be found"));
+}
+}  // namespace osm_auth_test

--- a/libs/editor/osm_auth_tests/CMakeLists.txt
+++ b/libs/editor/osm_auth_tests/CMakeLists.txt
@@ -8,5 +8,7 @@ set(SRC
 # On Linux, OsmOAuth goes through the Qt-backed platform HttpClient implementation,
 # so these tests need the Qt unit-test event loop/QCoreApplication bootstrap.
 omim_add_test(${PROJECT_NAME} ${SRC} REQUIRE_QT)
+# Extends the "omim-test" label set by omim_add_test.
+set_property(TEST ${PROJECT_NAME} APPEND PROPERTY LABELS "omim-live-test")
 
 target_link_libraries(${PROJECT_NAME} PRIVATE editor)

--- a/libs/editor/osm_auth_tests/osm_auth_tests.cpp
+++ b/libs/editor/osm_auth_tests/osm_auth_tests.cpp
@@ -1,3 +1,5 @@
+// Live tests against the OpenStreetMap development server.
+// Offline parsing helpers are covered by editor_tests/osm_auth_test.cpp.
 #include "testing/testing.hpp"
 
 #include "editor/osm_auth.hpp"
@@ -46,81 +48,5 @@ UNIT_TEST(OSM_Auth_ForgotPassword)
   TEST_EQUAL(result, false, ("Incorrect email"));
 }
 */
-
-UNIT_TEST(OAuth_Token_parse)
-{
-  auto token = osm::FindAuthenticityToken(
-      "/oauth2/authorize",
-      R"(<div class="col-auto mx-1"><form action="/oauth2/authorize" accept-charset="UTF-8" method="post">
-    <input type="hidden" name="authenticity_token" value="J5senhh" />
-    <input value="om://oauth2/osm/callback" type="hidden" name="redirect_uri" />
-    <input type="submit" name="commit" value="Authorize" class="btn btn-primary" />
-  </form></div>)");
-
-  TEST_EQUAL(token, "J5senhh", ("Invalid token"));
-
-  // Two tokens. One for "Allow" other for "Deny". Always pick the first one.
-  token = osm::FindAuthenticityToken(
-      "/oauth2/authorize",
-      R"(<div class="col-auto mx-1"><form action="/oauth2/authorize" accept-charset="UTF-8" method="post">
-    <input type="hidden" name="authenticity_token" value="lRFbEQN0d2r7XeFq" />
-    <input value="om://oauth2/osm/callback" type="hidden" name="redirect_uri" />
-    <input type="submit" name="commit" value="Authorize" class="btn btn-primary" />
-  </form></div>
-  <div class="col-auto mx-1"><form action="/oauth2/authorize" accept-charset="UTF-8" method="post">
-    <input type="hidden" name="_method" value="delete" />
-    <input type="hidden" name="authenticity_token" value="J5senhh" />
-    <input value="om://oauth2/osm/callback" type="hidden" name="redirect_uri" />
-    <input type="submit" name="commit" value="Deny" class="btn btn-secondary" />
-  </form></div>)");
-
-  TEST_EQUAL(token, "lRFbEQN0d2r7XeFq", ("Invalid token"));
-
-  // Three forms: one for language, two for OAuth
-  token = osm::FindAuthenticityToken(
-      "/oauth2/authorize",
-      R"(<div class="modal-body px-1"><form action="/preferences/basic" accept-charset="UTF-8" method="post">
-    <input type="hidden" name="_method" value="put" />
-    <input type="hidden" name="authenticity_token" value="8h-snCINM3O" />
-  </form></div>\n"   "<div class="col-auto mx-1"><form action="/oauth2/authorize" accept-charset="UTF-8" method="post">
-    <input type="hidden" name="authenticity_token" value="8DDeqYcFHUIjw" />
-    <input value="om://oauth2/osm/callback" type="hidden" name="redirect_uri" />
-    <input type="submit" name="commit" value="Authorize" class="btn btn-primary" />
-  </form></div>
-  <div class="col-auto mx-1"><form action="/oauth2/authorize" accept-charset="UTF-8" method="post">
-    <input type="hidden" name="_method" value="delete" />
-    <input type="hidden" name="authenticity_token" value="4RbveLjuvOXlok9Q" />
-    <input value="om://oauth2/osm/callback" type="hidden" name="redirect_uri" />
-    <input type="submit" name="commit" value="Deny" class="btn btn-secondary" />
-  </form></div>)");
-
-  TEST_EQUAL(token, "8DDeqYcFHUIjw", ("Invalid token"));
-}
-
-UNIT_TEST(OAuth_FindOauthCode)
-{
-  auto code = osm::FindOauthCode("om://oauth2/osm/callback?redirect=true&code=befd_095315f197f4");
-  TEST_EQUAL(code, "befd_095315f197f4", ("Invalid code"));
-
-  code = osm::FindOauthCode("om://oauth2/osm/callback?code=45c023d6");
-  TEST_EQUAL(code, "45c023d6", ("Invalid code"));
-
-  code = osm::FindOauthCode("om://oauth2/osm/callback?the_code=cant_find");
-  TEST_EQUAL(code, std::string{}, ("Code should not be found"));
-}
-
-UNIT_TEST(OAuth_FindAccessToken)
-{
-  auto token =
-      osm::FindAccessToken(R"({"access_token":"vAK5XMBJeUDsF3xxFHt0", "token_type":"Bearer", "scope":"read_prefs"})");
-  TEST_EQUAL(token, "vAK5XMBJeUDsF3xxFHt0", ("Invalid access_token"));
-
-  token =
-      osm::FindAccessToken(R"({"token_type":"Bearer", "scope":"read_prefs", "access_token":"W1xgY0CtTDz0klQGa4Yp"})");
-  TEST_EQUAL(token, "W1xgY0CtTDz0klQGa4Yp", ("Invalid access_token"));
-
-  token = osm::FindAccessToken(R"({"token_type":"Bearer", "scope":"read_prefs", "some_other_token":"9cMyxvsOrM"})");
-  TEST_EQUAL(token, std::string{}, ("access_token should not be found"));
-}
 
 }  // namespace osm_auth


### PR DESCRIPTION
## Summary

- label `osm_auth_tests` as a live integration suite (`omim-live-test`) and drop it from the parallel CI test presets
- run it from a dedicated `ci-osm` preset in the Ubuntu GCC 14 and macOS Debug legs only, covering the Qt and Apple HTTP backends
- move the three offline OAuth parsing tests to `editor_tests`, so labelling the suite live does not cost every other leg its coverage of them
- switch the build matrix flags from `ON`/`OFF` to YAML booleans

Related failure: https://github.com/organicmaps/organicmaps/actions/runs/32381507167/job/96465579215 — the confusing *shape* of those failures turned out to be a separate client bug, fixed in #13394.

The matrix flags had to become opt-in (`no-unity` / `no-tests`) rather than `unity: false`: a missing key is `null`, and GitHub coerces both `null` and `false` to `0`, so `== false` would be true on every leg that omits the key.

## Testing

- `ctest --preset ci -N` selects 35 tests without `osm_auth_tests`; `ctest --preset ci-osm -N` selects exactly it, and prints both labels — confirming the label is appended, not replacing the one `omim_add_test` sets
- `editor_tests` passes in full, including the three moved tests
- the matrix expands to the same 9 jobs with unchanged names, gating, `UNITY_BUILD` and `max-size`; only the new OSM step differs

## AI assistance

OpenAI Codex was used to investigate the CI failure and prepare these changes.
