### PR TITLE
[core] Remove unused APIs

### DIFF
--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/platform/AndroidPlatform.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/platform/AndroidPlatform.cpp
@@ -16,26 +16,6 @@
 #include <memory>
 #include <utility>
 
-std::string Platform::GetMemoryInfo() const
-{
-  JNIEnv * env = jni::GetEnv();
-  if (env == nullptr)
-    return std::string();
-
-  static std::shared_ptr<jobject> classLogsManager =
-      jni::make_global_ref(env->FindClass("app/organicmaps/sdk/util/log/LogsManager"));
-  ASSERT(classLogsManager, ());
-
-  jobject context = android::Platform::Instance().GetContext();
-  static jmethodID const getMemoryInfoId = jni::GetStaticMethodID(
-      env, static_cast<jclass>(*classLogsManager), "getMemoryInfo", "(Landroid/content/Context;)Ljava/lang/String;");
-  jstring const memInfoString = static_cast<jstring>(
-      env->CallStaticObjectMethod(static_cast<jclass>(*classLogsManager), getMemoryInfoId, context));
-  ASSERT(memInfoString, ());
-
-  return jni::ToNativeString(env, memInfoString);
-}
-
 std::string Platform::DeviceName() const
 {
   JNIEnv * env = jni::GetEnv();

--- a/android/sdk/src/main/java/app/organicmaps/sdk/util/log/LogsManager.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/util/log/LogsManager.java
@@ -2,7 +2,6 @@ package app.organicmaps.sdk.util.log;
 
 import android.Manifest;
 import android.annotation.TargetApi;
-import android.app.ActivityManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -11,9 +10,7 @@ import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.os.Build;
-import android.os.Debug;
 import android.util.Log;
-import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -290,43 +287,6 @@ public final class LogsManager
     sb.append("\n\n");
 
     return sb.toString();
-  }
-
-  // Called from JNI.
-  @SuppressWarnings("unused")
-  @NonNull
-  @Keep
-  public static String getMemoryInfo(@NonNull Context context)
-  {
-    final Debug.MemoryInfo debugMI = new Debug.MemoryInfo();
-    Debug.getMemoryInfo(debugMI);
-    final ActivityManager.MemoryInfo mi = new ActivityManager.MemoryInfo();
-    final ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
-    activityManager.getMemoryInfo(mi);
-
-    final StringBuilder log = new StringBuilder(256);
-    log.append("Memory info: ")
-        .append(" Debug.getNativeHeapSize() = ")
-        .append(Debug.getNativeHeapSize() / 1024)
-        .append("KB; Debug.getNativeHeapAllocatedSize() = ")
-        .append(Debug.getNativeHeapAllocatedSize() / 1024)
-        .append("KB; Debug.getNativeHeapFreeSize() = ")
-        .append(Debug.getNativeHeapFreeSize() / 1024)
-        .append("KB; debugMI.getTotalPrivateDirty() = ")
-        .append(debugMI.getTotalPrivateDirty())
-        .append("KB; debugMI.getTotalPss() = ")
-        .append(debugMI.getTotalPss())
-        .append("KB; mi.availMem = ")
-        .append(mi.availMem / 1024)
-        .append("KB; mi.threshold = ")
-        .append(mi.threshold / 1024)
-        .append("KB; mi.lowMemory = ")
-        .append(mi.lowMemory)
-        .append("; mi.totalMem = ")
-        .append(mi.totalMem / 1024)
-        .append("KB;");
-
-    return log.toString();
   }
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/generator/osm_o5m_source.hpp
+++ b/generator/osm_o5m_source.hpp
@@ -55,13 +55,6 @@ public:
     return *(m_position++);
   }
 
-  inline TBuffer::value_type Peek()
-  {
-    if (m_position == m_buffer.end())
-      Refill();
-    return *m_position;
-  }
-
   void Skip(size_t size = 1)
   {
     size_t const bytesLeft = std::distance(m_position, m_buffer.cend());

--- a/iphone/CoreApi/CoreApi/Common/MWMCommon.h
+++ b/iphone/CoreApi/CoreApi/Common/MWMCommon.h
@@ -32,20 +32,4 @@ static inline NSString * formattedSize(uint64_t size)
   return [NSByteCountFormatter stringFromByteCount:size countStyle:NSByteCountFormatterCountStyleFile];
 }
 
-// Use only for screen dimensions CGFloat comparison
-static inline BOOL equalScreenDimensions(CGFloat left, CGFloat right)
-{
-  return fabs(left - right) < 0.5;
-}
-
-static inline void performOnce(MWMVoidBlock block, NSString * key)
-{
-  BOOL performed = [[NSUserDefaults standardUserDefaults] boolForKey:key];
-  if (!performed)
-  {
-    block();
-    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:key];
-  }
-}
-
 NS_ASSUME_NONNULL_END

--- a/iphone/Maps/Core/Location/MWMLocationHelpers.h
+++ b/iphone/Maps/Core/Location/MWMLocationHelpers.h
@@ -1,21 +1,11 @@
 #import "MWMMyPositionMode.h"
 
-#include "platform/distance.hpp"
-#include "platform/localization.hpp"
 #include "platform/location.hpp"
 
 #include "geometry/mercator.hpp"
 
 namespace location_helpers
 {
-
-static inline NSString * formattedDistance(double const & meters)
-{
-  if (meters < 0.)
-    return nil;
-
-  return @(platform::Distance::CreateFormatted(meters).ToString().c_str());
-}
 
 static inline ms::LatLon ToLatLon(m2::PointD const & p)
 {

--- a/iphone/Maps/Extensions/UIKitCategories.h
+++ b/iphone/Maps/Extensions/UIKitCategories.h
@@ -1,25 +1,5 @@
 #import <CoreApi/MWMTypes.h>
 
-static inline CGPoint SubtractCGPoint(CGPoint p1, CGPoint p2)
-{
-  return CGPointMake(p1.x - p2.x, p1.y - p2.y);
-}
-
-static inline CGPoint AddCGPoint(CGPoint p1, CGPoint p2)
-{
-  return CGPointMake(p1.x + p2.x, p1.y + p2.y);
-}
-
-static inline CGPoint MultiplyCGPoint(CGPoint point, CGFloat multiplier)
-{
-  return CGPointMake(point.x * multiplier, point.y * multiplier);
-}
-
-static inline CGFloat LengthCGPoint(CGPoint point)
-{
-  return (CGFloat)sqrt(point.x * point.x + point.y * point.y);
-}
-
 @interface NSObject (Optimized)
 
 + (NSString *)className;

--- a/libs/base/bits.hpp
+++ b/libs/base/bits.hpp
@@ -91,12 +91,6 @@ inline uint8_t GetBit(void const * p, uint32_t offset)
   return (pData[offset >> 3] >> (offset & 7)) & 1;
 }
 
-inline void SetBitTo0(void * p, uint32_t offset)
-{
-  uint8_t * pData = static_cast<uint8_t *>(p);
-  pData[offset >> 3] &= ~(1 << (offset & 7));
-}
-
 inline void SetBitTo1(void * p, uint32_t offset)
 {
   uint8_t * pData = static_cast<uint8_t *>(p);

--- a/libs/coding/hex.hpp
+++ b/libs/coding/hex.hpp
@@ -97,16 +97,3 @@ inline std::string ByteToQuat(uint8_t n)
   }
   return result;
 }
-
-template <typename IntT>
-inline std::string NumToQuat(IntT n)
-{
-  std::string result;
-  for (size_t i = 0; i < sizeof(n); ++i)
-  {
-    uint8_t ub = n >> (sizeof(n) * 8 - 8);
-    result += ByteToQuat(ub);
-    n <<= 8;
-  }
-  return result;
-}

--- a/libs/coding/serdes_json.hpp
+++ b/libs/coding/serdes_json.hpp
@@ -89,11 +89,6 @@ inline JsonValue MakeJSONArray()
   return value;
 }
 
-inline void ThrowJsonError(std::string const & message)
-{
-  MYTHROW(JsonException, (message));
-}
-
 inline JsonValue const * GetOptionalField(JsonValue const * root, char const * field)
 {
   if (root == nullptr || !root->is_object())

--- a/libs/drape/gl_functions.cpp
+++ b/libs/drape/gl_functions.cpp
@@ -938,14 +938,6 @@ void GLFunctions::glUniformValuef(int location, float v1, float v2, float v3, fl
   GLCHECK(glUniform4fFn(location, v1, v2, v3, v4));
 }
 
-void GLFunctions::glUniformValuefv(int location, float const * v, uint32_t size)
-{
-  ASSERT_EQUAL(CurrentApiVersion, dp::ApiVersion::OpenGLES3, ());
-  ASSERT(glUniform1fvFn != nullptr, ());
-  ASSERT(location != -1, ());
-  GLCHECK(glUniform1fvFn(location, size, v));
-}
-
 void GLFunctions::glUniformValue4fv(int location, float const * v, uint32_t size)
 {
   ASSERT_EQUAL(CurrentApiVersion, dp::ApiVersion::OpenGLES3, ());

--- a/libs/drape/gl_functions.hpp
+++ b/libs/drape/gl_functions.hpp
@@ -125,7 +125,6 @@ public:
   static void glUniformValuef(int location, float v1, float v2);
   static void glUniformValuef(int location, float v1, float v2, float v3);
   static void glUniformValuef(int location, float v1, float v2, float v3, float v4);
-  static void glUniformValuefv(int location, float const * v, uint32_t size);
   static void glUniformValue4fv(int location, float const * v, uint32_t size);
 
   static void glUniformMatrix4x4Value(int location, float const * values);

--- a/libs/geometry/mercator.hpp
+++ b/libs/geometry/mercator.hpp
@@ -93,11 +93,6 @@ inline double MetersToMercator(double meters)
 {
   return meters * Bounds::kDegreesInMeter;
 }
-inline double MercatorToMeters(double mercator)
-{
-  return mercator * Bounds::kMetersInDegree;
-}
-
 /// @name Get rect for center point (lon, lat) and dimensions in meters.
 /// @return mercator rect.
 m2::RectD MetersToXY(double lon, double lat, double lonMetersR, double latMetersR);

--- a/libs/geometry/screenbase.cpp
+++ b/libs/geometry/screenbase.cpp
@@ -159,12 +159,6 @@ void ScreenBase::SetFromParams(m2::PointD const & org, double angle, double scal
   UpdateDependentParameters();
 }
 
-void ScreenBase::MatchGandP(m2::PointD const & g, m2::PointD const & p)
-{
-  m2::PointD g_current = PtoG(p);
-  SetOrg(m_Org - g_current + g);
-}
-
 void ScreenBase::MatchGandP3d(m2::PointD const & g, m2::PointD const & p3d)
 {
   m2::PointD g_current = PtoG(P3dtoP(p3d));
@@ -283,22 +277,6 @@ m2::AnyRectD ScreenBase::GetTouchRect(m2::PointD const & pixPoint, double const 
   double const width = pxWidth * m_Scale;
   double const height = pxHeight * m_Scale;
   return m2::AnyRectD(PtoG(pixPoint), m_Angle, m2::RectD(-width, -height, width, height));
-}
-
-bool IsPanningAndRotate(ScreenBase const & s1, ScreenBase const & s2)
-{
-  m2::RectD const & r1 = s1.GlobalRect().GetLocalRect();
-  m2::RectD const & r2 = s2.GlobalRect().GetLocalRect();
-
-  m2::PointD c1 = r1.Center();
-  m2::PointD c2 = r2.Center();
-
-  m2::PointD globPt(c1.x - r1.minX(), c1.y - r1.minY());
-
-  m2::PointD p1 = s1.GtoP(s1.GlobalRect().ConvertFrom(c1)) - s1.GtoP(s1.GlobalRect().ConvertFrom(c1 + globPt));
-  m2::PointD p2 = s2.GtoP(s2.GlobalRect().ConvertFrom(c2)) - s2.GtoP(s2.GlobalRect().ConvertFrom(c2 + globPt));
-
-  return p1.EqualDxDy(p2, 0.00001);
 }
 
 void ScreenBase::ExtractGtoPParams(MatrixT const & m, double & a, double & s, double & dx, double & dy)

--- a/libs/geometry/screenbase.hpp
+++ b/libs/geometry/screenbase.hpp
@@ -56,7 +56,6 @@ public:
   void GtoP(m2::RectD const & gr, m2::RectD & sr) const;
   void PtoG(m2::RectD const & pr, m2::RectD & gr) const;
 
-  void MatchGandP(m2::PointD const & g, m2::PointD const & p);
   void MatchGandP3d(m2::PointD const & g, m2::PointD const & p3d);
 
   m2::AnyRectD GetTouchRect(m2::PointD const & pixPoint, double const pxWidth, double const pxHeight) const;
@@ -167,6 +166,3 @@ private:
   bool m_isPerspective;
   bool m_isAutoPerspective;
 };
-
-/// checking whether the s1 transforms into s2 without scaling, only with shift and rotation
-bool IsPanningAndRotate(ScreenBase const & s1, ScreenBase const & s2);

--- a/libs/indexer/data_source.cpp
+++ b/libs/indexer/data_source.cpp
@@ -137,13 +137,6 @@ bool FeaturesLoaderGuard::IsWorld() const
   return m_handle.GetValue()->GetHeader().GetType() == feature::DataHeader::MapType::World;
 }
 
-std::unique_ptr<FeatureType> FeaturesLoaderGuard::GetOriginalOrEditedFeatureByIndex(uint32_t index) const
-{
-  ASSERT(m_handle.IsAlive(), ());
-  ASSERT_NOT_EQUAL(m_source->GetFeatureStatus(index), FeatureStatus::Created, ());
-  return GetFeatureByIndex(index);
-}
-
 std::unique_ptr<FeatureType> FeaturesLoaderGuard::GetFeatureByIndex(uint32_t index) const
 {
   ASSERT(m_handle.IsAlive(), ());

--- a/libs/indexer/data_source.hpp
+++ b/libs/indexer/data_source.hpp
@@ -106,7 +106,6 @@ public:
 
   /// Editor core only method, to get 'untouched', original version of feature.
   std::unique_ptr<FeatureType> GetOriginalFeatureByIndex(uint32_t index) const;
-  std::unique_ptr<FeatureType> GetOriginalOrEditedFeatureByIndex(uint32_t index) const;
 
   /// Everyone, except Editor core, should use this method.
   std::unique_ptr<FeatureType> GetFeatureByIndex(uint32_t index) const;

--- a/libs/map/bookmark.cpp
+++ b/libs/map/bookmark.cpp
@@ -56,7 +56,6 @@ std::string GetBookmarkIconType(kml::BookmarkIcon const & icon)
 }
 
 std::string const kCustomImageProperty = "CustomImage";
-std::string const kHasElevationProfileProperty = "has_elevation_profile";
 }  // namespace
 
 Bookmark::Bookmark(m2::PointD const & ptOrg) : Base(ptOrg, UserMark::BOOKMARK), m_groupId(kml::kInvalidMarkGroupId)
@@ -261,11 +260,6 @@ void Bookmark::SetName(std::string const & name, int8_t langCode)
   m_data.m_name[langCode] = name;
 }
 
-std::string Bookmark::GetCustomName() const
-{
-  return GetPreferredBookmarkStr(m_data.m_customName);
-}
-
 void Bookmark::SetCustomName(std::string const & customName)
 {
   SetDirty();
@@ -407,12 +401,6 @@ void BookmarkCategory::SetCustomProperty(std::string const & key, std::string co
 std::string BookmarkCategory::GetName() const
 {
   return GetPreferredBookmarkStr(m_data.m_name);
-}
-
-bool BookmarkCategory::HasElevationProfile() const
-{
-  auto const it = m_data.m_properties.find(kHasElevationProfileProperty);
-  return (it != m_data.m_properties.end()) && (it->second != "0");
 }
 
 void BookmarkCategory::SetAuthor(std::string const & name, std::string const & id)

--- a/libs/map/bookmark.hpp
+++ b/libs/map/bookmark.hpp
@@ -39,7 +39,6 @@ public:
   void SetName(kml::LocalizableString const & name);
   void SetName(std::string const & name, int8_t langCode);
 
-  std::string GetCustomName() const;
   void SetCustomName(std::string const & customName);
 
   // Returns the preset color, or None for a custom-colored bookmark. A bookmark is a preset only for
@@ -121,8 +120,6 @@ public:
 
   void SetServerId(std::string const & serverId);
   std::string const & GetServerId() const { return m_serverId; }
-
-  bool HasElevationProfile() const;
 
   void SetAuthor(std::string const & name, std::string const & id);
   void SetAccessRules(kml::AccessRules accessRules);

--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -610,9 +610,6 @@ void BookmarkManager::NotifyChanges(bool saveChangesOnDisk)
   if (m_changesTracker.HasBookmarksChanges())
     NotifyBookmarksChanged();
 
-  if (m_changesTracker.HasCategoriesChanges())
-    NotifyCategoriesChanged();
-
   m_bookmarksChangesTracker.AddChanges(m_changesTracker);
   m_drapeChangesTracker.AddChanges(m_changesTracker);
   m_changesTracker.ResetChanges();
@@ -1736,14 +1733,6 @@ void BookmarkManager::SetCategoryCustomProperty(kml::MarkGroupId categoryId, std
   GetBmCategory(categoryId)->SetCustomProperty(key, value);
 }
 
-std::string BookmarkManager::GetCategoryCustomProperty(kml::MarkGroupId categoryId, std::string const & key) const
-{
-  CHECK_THREAD_CHECKER(m_threadChecker, ());
-  auto const & properties = GetCategoryData(categoryId).m_properties;
-  auto const it = properties.find(key);
-  return (it != properties.end()) ? it->second : std::string();
-}
-
 std::string BookmarkManager::GetCategoryFileName(kml::MarkGroupId categoryId) const
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
@@ -1930,11 +1919,6 @@ void BookmarkManager::UpdateViewport(ScreenBase const & screen)
 void BookmarkManager::SetBookmarksChangedCallback(BookmarksChangedCallback && callback)
 {
   m_bookmarksChangedCallback = std::move(callback);
-}
-
-void BookmarkManager::SetCategoriesChangedCallback(CategoriesChangedCallback && callback)
-{
-  m_categoriesChangedCallback = std::move(callback);
 }
 
 void BookmarkManager::SetAsyncLoadingCallbacks(AsyncLoadingCallbacks && callbacks)
@@ -2561,12 +2545,6 @@ void BookmarkManager::NotifyBookmarksChanged()
     m_bookmarksChangedCallback();
 }
 
-void BookmarkManager::NotifyCategoriesChanged()
-{
-  if (m_categoriesChangedCallback != nullptr)
-    m_categoriesChangedCallback();
-}
-
 bool BookmarkManager::HasBmCategory(kml::MarkGroupId groupId) const
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
@@ -2649,7 +2627,6 @@ kml::MarkGroupId BookmarkManager::CreateBookmarkCategory(std::string const & nam
   UpdateBmGroupIdList();
   m_changesTracker.OnAddGroup(groupId);
   NotifyBookmarksChanged();
-  NotifyCategoriesChanged();
   return groupId;
 }
 
@@ -3221,31 +3198,6 @@ void BookmarkManager::SetAllCategoriesVisibility(bool visible)
   auto session = GetEditSession();
   for (auto const & category : m_categories)
     category.second->SetIsVisible(visible);
-}
-
-void BookmarkManager::SetChildCategoriesVisibility(kml::MarkGroupId categoryId, kml::CompilationType compilationType,
-                                                   bool visible)
-{
-  CHECK_THREAD_CHECKER(m_threadChecker, ());
-  auto session = GetEditSession();
-  auto const categoryIt = m_categories.find(categoryId);
-  CHECK(categoryIt != m_categories.end(), ());
-  auto & category = *categoryIt->second;
-  for (kml::MarkGroupId const compilationId : category.GetCategoryData().m_compilationIds)
-  {
-    auto const compilationIt = m_compilations.find(compilationId);
-    CHECK(compilationIt != m_compilations.cend(), ());
-    auto & compilation = *compilationIt->second;
-    if (compilation.GetCategoryData().m_type != compilationType)
-      continue;
-    if (visible != compilation.IsVisible())
-    {
-      compilation.SetIsVisible(visible);
-      category.SetDirty(false /* updateModificationTime */);
-      if (visible)
-        category.SetIsVisible(true);
-    }
-  }
 }
 
 void BookmarkManager::SetNotificationsEnabled(bool enabled)

--- a/libs/map/bookmark_manager.hpp
+++ b/libs/map/bookmark_manager.hpp
@@ -49,7 +49,6 @@ public:
   using KMLDataCollectionPtr = std::shared_ptr<KMLDataCollection>;
 
   using BookmarksChangedCallback = std::function<void()>;
-  using CategoriesChangedCallback = std::function<void()>;
   using ElevationActivePointChangedCallback = std::function<void(kml::TrackId, double)>;
   using ElevationMyPositionChangedCallback = std::function<void(kml::TrackId, double)>;
 
@@ -191,7 +190,6 @@ public:
   void InitRegionAddressGetter(DataSource const & dataSource, storage::CountryInfoGetter const & infoGetter);
 
   void SetBookmarksChangedCallback(BookmarksChangedCallback && callback);
-  void SetCategoriesChangedCallback(CategoriesChangedCallback && callback);
   void SetAsyncLoadingCallbacks(AsyncLoadingCallbacks && callbacks);
   bool IsAsyncLoadingInProgress() const { return m_asyncLoadingInProgress; }
 
@@ -288,7 +286,6 @@ public:
   kml::MarkGroupId GetCategoryByFileName(std::string const & fileName) const;
   m2::RectD GetCategoryRect(kml::MarkGroupId categoryId, bool addIconsSize) const;
   kml::CategoryData const & GetCategoryData(kml::MarkGroupId categoryId) const;
-  std::string GetCategoryCustomProperty(kml::MarkGroupId categoryId, std::string const & key) const;
 
   kml::MarkGroupId GetCategoryId(std::string const & name) const;
 
@@ -373,7 +370,6 @@ public:
   bool AreAllCategoriesVisible() const;
   bool AreAllCategoriesInvisible() const;
   void SetAllCategoriesVisibility(bool visible);
-  void SetChildCategoriesVisibility(kml::MarkGroupId categoryId, kml::CompilationType compilationType, bool visible);
 
   void SetNotificationsEnabled(bool enabled);
   bool AreNotificationsEnabled() const;
@@ -654,7 +650,6 @@ private:
   void UpdateBmGroupIdList();
 
   void NotifyBookmarksChanged();
-  void NotifyCategoriesChanged();
 
   void SendBookmarksChanges(MarksChangesTracker const & changesTracker);
   void GetBookmarksInfo(kml::MarkIdSet const & marks, std::vector<BookmarkInfo> & bookmarks) const;
@@ -754,7 +749,6 @@ private:
   std::mutex m_regionAddressMutex;
 
   BookmarksChangedCallback m_bookmarksChangedCallback;
-  CategoriesChangedCallback m_categoriesChangedCallback;
   ElevationActivePointChangedCallback m_elevationActivePointChanged;
   ElevationMyPositionChangedCallback m_elevationMyPositionChanged;
   m2::PointD m_lastElevationMyPosition = m2::PointD::Zero();

--- a/libs/map/elevation_info.cpp
+++ b/libs/map/elevation_info.cpp
@@ -109,12 +109,6 @@ size_t ElevationInfo::GetSize() const
   return size;
 }
 
-ElevationInfo::Altitude ElevationInfo::GetFirstAltitude() const
-{
-  ASSERT(!IsEmpty() && !m_lines.front().empty(), ());
-  return m_lines.front().front().m_altitude;
-}
-
 void ElevationInfo::Assign(std::vector<double> const & segDistances, geometry::Altitudes const & altitudes)
 {
   ASSERT_EQUAL(segDistances.size() + 1, altitudes.size(), ());

--- a/libs/map/elevation_info.hpp
+++ b/libs/map/elevation_info.hpp
@@ -59,9 +59,6 @@ public:
   static Altitude constexpr kDefThresholdMWM = 5;
   static Altitude constexpr kDefThresholdGPS = 10;
 
-  /// First altitude in the first line. Asserts non-empty.
-  Altitude GetFirstAltitude() const;
-
   struct AltitudesInfo
   {
     uint32_t m_totalAscentRaw = 0;

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1701,7 +1701,6 @@ void Framework::FillSearchResultsMarks(SearchResultsIterT beg, SearchResultsIter
       mark->SetFoundFeature(fID);
       mark->SetFromType(r.GetFeatureType());
       mark->SetVisited(m_searchMarks.IsVisited(fID));
-      mark->SetSelected(m_searchMarks.IsSelected(fID));
     }
   }
 }
@@ -2243,8 +2242,6 @@ void Framework::ActivateMapSelection()
 
   auto const & featureId = m_currentPlacePageInfo->GetID();
 
-  m_searchMarks.SetSelected(featureId);
-
   auto const selObj = m_currentPlacePageInfo->GetSelectedObject();
   CHECK_NOT_EQUAL(selObj, df::SelectionShape::OBJECT_EMPTY, ("Empty selections are impossible."));
   if (m_drapeEngine)
@@ -2330,7 +2327,6 @@ void Framework::DeactivateHotelSearchMark()
   if (!m_currentPlacePageInfo)
     return;
 
-  m_searchMarks.SetSelected({});
   if (m_currentPlacePageInfo->IsHotel())
   {
     auto const & featureId = m_currentPlacePageInfo->GetID();
@@ -3828,7 +3824,6 @@ void Framework::ShowViewportSearchResults(SearchResultsIterT begin, SearchResult
 
 void Framework::ClearViewportSearchResults()
 {
-  m_searchMarks.ClearTrackedProperties();
   GetBookmarkManager().GetEditSession().ClearGroup(UserMark::Type::SEARCH);
 }
 

--- a/libs/map/isolines_manager.cpp
+++ b/libs/map/isolines_manager.cpp
@@ -146,18 +146,6 @@ void IsolinesManager::Invalidate()
     UpdateViewport(*m_currentModelView);
 }
 
-isolines::Quality IsolinesManager::GetDataQuality(MwmSet::MwmId const & id) const
-{
-  if (!id.IsAlive())
-    return isolines::Quality::None;
-
-  auto const it = m_mwmCache.find(id);
-  if (it == m_mwmCache.cend())
-    return LoadIsolinesInfo(id).m_quality;
-
-  return it->second.m_quality;
-}
-
 void IsolinesManager::OnMwmDeregistered(platform::LocalCountryFile const & countryFile)
 {
   for (auto it = m_mwmCache.begin(); it != m_mwmCache.end(); ++it)

--- a/libs/map/isolines_manager.hpp
+++ b/libs/map/isolines_manager.hpp
@@ -45,8 +45,6 @@ public:
   void UpdateViewport(ScreenBase const & screen);
   void Invalidate();
 
-  isolines::Quality GetDataQuality(MwmSet::MwmId const & id) const;
-
   void OnMwmDeregistered(platform::LocalCountryFile const & countryFile);
   void Clear();
 

--- a/libs/map/place_page_info.cpp
+++ b/libs/map/place_page_info.cpp
@@ -624,22 +624,4 @@ void Info::SetRoadType(FeatureType & ft, RoadWarningMarkType type, std::string c
   }
 }
 
-std::string Info::FormatRouteRefs() const
-{
-  std::string res;
-  std::string_view last;
-  for (auto const & r : m_routes)
-  {
-    // routes are sorted by ref
-    if (r.m_ref != last)
-    {
-      if (!res.empty())
-        res += feature::kFieldsSeparator;
-      res += r.m_ref;
-      last = r.m_ref;
-    }
-  }
-  return res;
-}
-
 }  // namespace place_page

--- a/libs/map/place_page_info.hpp
+++ b/libs/map/place_page_info.hpp
@@ -267,8 +267,6 @@ public:
   void SetSelectedObject(df::SelectionShape::ESelectedObject selectedObject) { m_selectedObject = selectedObject; }
   df::SelectionShape::ESelectedObject GetSelectedObject() const { return m_selectedObject; }
 
-  std::string FormatRouteRefs() const;
-
   struct RouteRef
   {
     std::string m_ref, m_from, m_to;

--- a/libs/map/routing_mark.cpp
+++ b/libs/map/routing_mark.cpp
@@ -117,12 +117,6 @@ bool RouteMarkPoint::IsEqualFullType(RouteMarkType type, size_t intermediateInde
   return m_markData.m_pointType == type;
 }
 
-void RouteMarkPoint::SetIsMyPosition(bool isMyPosition)
-{
-  SetDirty();
-  m_markData.m_isMyPosition = isMyPosition;
-}
-
 void RouteMarkPoint::SetPassed(bool isPassed)
 {
   SetDirty();

--- a/libs/map/routing_mark.hpp
+++ b/libs/map/routing_mark.hpp
@@ -53,7 +53,6 @@ public:
   void SetRoutePointFullType(RouteMarkType type, size_t intermediateIndex);
   bool IsEqualFullType(RouteMarkType type, size_t intermediateIndex) const;
 
-  void SetIsMyPosition(bool isMyPosition);
   bool IsMyPosition() const { return m_markData.m_isMyPosition; }
 
   void SetPassed(bool isPassed);

--- a/libs/map/search_api.cpp
+++ b/libs/map/search_api.cpp
@@ -319,11 +319,6 @@ void SearchAPI::EnableIndexingOfBookmarkGroup(kml::MarkGroupId const & groupId, 
   m_engine.EnableIndexingOfBookmarkGroup(KmlGroupIdToSearchGroupId(groupId), enable);
 }
 
-std::unordered_set<kml::MarkGroupId> const & SearchAPI::GetIndexableGroups() const
-{
-  return m_indexableGroups;
-}
-
 void SearchAPI::ResetBookmarksEngine()
 {
   m_indexableGroups.clear();

--- a/libs/map/search_api.hpp
+++ b/libs/map/search_api.hpp
@@ -116,7 +116,6 @@ public:
   // This method must be used to enable or disable indexing all current and future
   // bookmarks belonging to |groupId|.
   void EnableIndexingOfBookmarkGroup(kml::MarkGroupId const & groupId, bool enable);
-  std::unordered_set<kml::MarkGroupId> const & GetIndexableGroups() const;
 
   // Returns the bookmarks search to its default, pre-launch state.
   // This includes dropping all bookmark data for created bookmarks (efficiently

--- a/libs/map/search_mark.cpp
+++ b/libs/map/search_mark.cpp
@@ -91,7 +91,6 @@ namespace
 df::ColorConstant const kColorConstant = "SearchmarkDefault";
 
 float const kVisitedSymbolOpacity = 0.7f;
-float const kOutOfFiltersSymbolOpacity = 0.4f;
 
 std::array<std::string, SearchMarkType::Count> const kSymbols = {
     "search-result",                          // Default.
@@ -360,11 +359,7 @@ SearchMarkType GetSearchMarkType(uint32_t type)
 SearchMarkPoint::SearchMarkPoint(m2::PointD const & ptOrg)
   : UserMark(ptOrg, UserMark::Type::SEARCH)
   , m_type(SearchMarkType::Default)
-  , m_isPreparing(false)
-  , m_hasSale(false)
-  , m_isSelected(false)
   , m_isVisited(false)
-  , m_isAvailable(true)
 {}
 
 m2::PointD SearchMarkPoint::GetPixelOffset() const
@@ -396,8 +391,6 @@ bool SearchMarkPoint::IsMarkAboveText() const
 
 float SearchMarkPoint::GetSymbolOpacity() const
 {
-  if (!m_isAvailable)
-    return kOutOfFiltersSymbolOpacity;
   return m_isVisited ? kVisitedSymbolOpacity : 1.0f;
 }
 
@@ -436,63 +429,12 @@ void SearchMarkPoint::SetNotFoundType()
   SetAttributeValue(m_type, SearchMarkType::NotFound);
 }
 
-#define SET_BOOL_ATTRIBUTE(dest, src) \
-  if (dest != src)                    \
-  {                                   \
-    dest = src;                       \
-    SetDirty();                       \
-  }
-
-void SearchMarkPoint::SetPreparing(bool isPreparing)
-{
-  SET_BOOL_ATTRIBUTE(m_isPreparing, isPreparing);
-}
-
-void SearchMarkPoint::SetSale(bool hasSale)
-{
-  SET_BOOL_ATTRIBUTE(m_hasSale, hasSale);
-}
-
-void SearchMarkPoint::SetSelected(bool isSelected)
-{
-  SET_BOOL_ATTRIBUTE(m_isSelected, isSelected);
-}
-
 void SearchMarkPoint::SetVisited(bool isVisited)
 {
-  SET_BOOL_ATTRIBUTE(m_isVisited, isVisited);
-}
-
-void SearchMarkPoint::SetAvailable(bool isAvailable)
-{
-  SET_BOOL_ATTRIBUTE(m_isAvailable, isAvailable);
-}
-
-#undef SET_BOOL_ATTRIBUTE
-
-void SearchMarkPoint::SetReason(std::string const & reason)
-{
-  SetAttributeValue(m_reason, reason);
-}
-
-bool SearchMarkPoint::IsSelected() const
-{
-  return m_isSelected;
-}
-
-bool SearchMarkPoint::IsAvailable() const
-{
-  return m_isAvailable;
-}
-
-std::string const & SearchMarkPoint::GetReason() const
-{
-  return m_reason;
-}
-
-bool SearchMarkPoint::HasReason() const
-{
-  return !m_reason.empty();
+  if (m_isVisited == isVisited)
+    return;
+  m_isVisited = isVisited;
+  SetDirty();
 }
 
 std::string const * SearchMarkPoint::GetSymbolName() const
@@ -568,34 +510,6 @@ std::optional<m2::PointD> SearchMarks::GetSize(std::string const & symbolName)
   return m2::PointD(it->second);
 }
 
-void SearchMarks::SetPreparingState(std::vector<FeatureID> const & features, bool isPreparing)
-{
-  if (features.empty())
-    return;
-
-  ProcessMarks([&features, isPreparing](SearchMarkPoint * mark) -> base::ControlFlow
-  {
-    ASSERT(std::is_sorted(features.cbegin(), features.cend()), ());
-    if (std::binary_search(features.cbegin(), features.cend(), mark->GetFeatureID()))
-      mark->SetPreparing(isPreparing);
-    return base::ControlFlow::Continue;
-  });
-}
-
-void SearchMarks::SetSales(std::vector<FeatureID> const & features, bool hasSale)
-{
-  if (features.empty())
-    return;
-
-  ProcessMarks([&features, hasSale](SearchMarkPoint * mark) -> base::ControlFlow
-  {
-    ASSERT(std::is_sorted(features.cbegin(), features.cend()), ());
-    if (std::binary_search(features.cbegin(), features.cend(), mark->GetFeatureID()))
-      mark->SetSale(hasSale);
-    return base::ControlFlow::Continue;
-  });
-}
-
 bool SearchMarks::IsThereSearchMarkForFeature(FeatureID const & featureId) const
 {
   for (auto const markId : m_bmManager->GetUserMarkIds(UserMark::Type::SEARCH))
@@ -604,66 +518,17 @@ bool SearchMarks::IsThereSearchMarkForFeature(FeatureID const & featureId) const
   return false;
 }
 
-void SearchMarks::OnActivate(FeatureID const & featureId)
-{
-  m_selectedFeature = featureId;
-  m_visitedSearchMarks.erase(featureId);
-  ProcessMarks([&featureId](SearchMarkPoint * mark) -> base::ControlFlow
-  {
-    if (featureId != mark->GetFeatureID())
-      return base::ControlFlow::Continue;
-    mark->SetVisited(false);
-    mark->SetSelected(true);
-    return base::ControlFlow::Break;
-  });
-}
-
 void SearchMarks::OnDeactivate(FeatureID const & featureId)
 {
-  m_selectedFeature = {};
   m_visitedSearchMarks.insert(featureId);
   ProcessMarks([&featureId](SearchMarkPoint * mark) -> base::ControlFlow
   {
     if (featureId != mark->GetFeatureID())
       return base::ControlFlow::Continue;
     mark->SetVisited(true);
-    mark->SetSelected(false);
     return base::ControlFlow::Break;
   });
 }
-
-/*
-void SearchMarks::SetUnavailable(SearchMarkPoint & mark, std::string const & reasonKey)
-{
-  {
-    std::scoped_lock<std::mutex> lock(m_lock);
-    m_unavailable.insert_or_assign(mark.GetFeatureID(), reasonKey);
-  }
-  mark.SetAvailable(false);
-  mark.SetReason(platform::GetLocalizedString(reasonKey));
-}
-
-void SearchMarks::SetUnavailable(std::vector<FeatureID> const & features,
-                                 std::string const & reasonKey)
-{
-  if (features.empty())
-    return;
-
-  ProcessMarks([this, &features, &reasonKey](SearchMarkPoint * mark) -> base::ControlFlow
-  {
-    ASSERT(std::is_sorted(features.cbegin(), features.cend()), ());
-    if (std::binary_search(features.cbegin(), features.cend(), mark->GetFeatureID()))
-      SetUnavailable(*mark, reasonKey);
-    return base::ControlFlow::Continue;
-  });
-}
-
-bool SearchMarks::IsUnavailable(FeatureID const & id) const
-{
-  std::scoped_lock<std::mutex> lock(m_lock);
-  return m_unavailable.find(id) != m_unavailable.cend();
-}
-*/
 
 void SearchMarks::SetVisited(FeatureID const & id)
 {
@@ -673,25 +538,6 @@ void SearchMarks::SetVisited(FeatureID const & id)
 bool SearchMarks::IsVisited(FeatureID const & id) const
 {
   return m_visitedSearchMarks.find(id) != m_visitedSearchMarks.cend();
-}
-
-void SearchMarks::SetSelected(FeatureID const & id)
-{
-  m_selectedFeature = id;
-}
-
-bool SearchMarks::IsSelected(FeatureID const & id) const
-{
-  return id == m_selectedFeature;
-}
-
-void SearchMarks::ClearTrackedProperties()
-{
-  //  {
-  //    std::scoped_lock<std::mutex> lock(m_lock);
-  //    m_unavailable.clear();
-  //  }
-  m_selectedFeature = {};
 }
 
 void SearchMarks::ProcessMarks(std::function<base::ControlFlow(SearchMarkPoint *)> && processor) const

--- a/libs/map/search_mark.hpp
+++ b/libs/map/search_mark.hpp
@@ -47,16 +47,7 @@ public:
   void SetFromType(uint32_t type);
   void SetNotFoundType();
 
-  void SetPreparing(bool isPreparing);
-  void SetSale(bool hasSale);
-  void SetSelected(bool isSelected);
   void SetVisited(bool isVisited);
-  void SetAvailable(bool isAvailable);
-  void SetReason(std::string const & reason);
-
-  bool IsSelected() const;
-  bool IsAvailable() const;
-  std::string const & GetReason() const;
 
 protected:
   template <typename T, typename U>
@@ -69,22 +60,15 @@ protected:
     dst = std::forward<U>(src);
   }
 
-  bool HasReason() const;
-
   std::string const * GetSymbolName() const;
 
   // Used to pass exact search result matched string into a place page.
   std::string m_matchedName;
-  std::string m_reason;
 
   FeatureID m_featureID;
   SearchMarkType m_type;
 
-  bool m_isPreparing : 1;
-  bool m_hasSale : 1;
-  bool m_isSelected : 1;
   bool m_isVisited : 1;
-  bool m_isAvailable : 1;
 };
 
 class SearchMarks
@@ -97,27 +81,11 @@ public:
 
   m2::PointD GetMaxDimension(ScreenBase const & modelView) const;
 
-  // NOTE: Vector of features must be sorted.
-  void SetPreparingState(std::vector<FeatureID> const & features, bool isPreparing);
-
-  // NOTE: Vector of features must be sorted.
-  void SetSales(std::vector<FeatureID> const & features, bool hasSale);
-
   bool IsThereSearchMarkForFeature(FeatureID const & featureId) const;
-  void OnActivate(FeatureID const & featureId);
   void OnDeactivate(FeatureID const & featureId);
-
-  //  void SetUnavailable(SearchMarkPoint & mark, std::string const & reasonKey);
-  //  void SetUnavailable(std::vector<FeatureID> const & features, std::string const & reasonKey);
-  //  bool IsUnavailable(FeatureID const & id) const;
 
   void SetVisited(FeatureID const & id);
   bool IsVisited(FeatureID const & id) const;
-
-  void SetSelected(FeatureID const & id);
-  bool IsSelected(FeatureID const & id) const;
-
-  void ClearTrackedProperties();
 
   static bool HaveSizes() { return !s_markSizes.empty(); }
   static std::optional<m2::PointD> GetSize(std::string const & symbolName);
@@ -134,8 +102,4 @@ private:
   m2::PointD m_maxDimension{0, 0};
 
   std::set<FeatureID> m_visitedSearchMarks;
-  FeatureID m_selectedFeature;
-
-  //  mutable std::mutex m_lock;
-  //  std::map<FeatureID, std::string /* SearchMarkPoint::m_reason */> m_unavailable;
 };

--- a/libs/opening_hours/oh/parser.hpp
+++ b/libs/opening_hours/oh/parser.hpp
@@ -77,11 +77,6 @@ constexpr Weekday weekday_from_index(int i)
   return static_cast<Weekday>(((i % kNumWeekdays) + kNumWeekdays) % kNumWeekdays);
 }
 
-constexpr Weekday next_weekday(Weekday d)
-{
-  return weekday_from_index(static_cast<int>(d) + 1);
-}
-
 constexpr char const * weekday_short(Weekday d)
 {
   constexpr char const * tbl[] = {"Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"};
@@ -107,11 +102,6 @@ enum class Month : uint8_t
 constexpr Month next_month(Month m)
 {
   return static_cast<Month>((static_cast<int>(m) % 12) + 1);
-}
-
-constexpr Month prev_month(Month m)
-{
-  return static_cast<Month>(((static_cast<int>(m) + 10) % 12) + 1);
 }
 
 constexpr char const * month_short(Month m)

--- a/libs/platform/platform.cpp
+++ b/libs/platform/platform.cpp
@@ -363,18 +363,6 @@ void Platform::SetGuiThread(std::unique_ptr<base::TaskLoop> guiThread)
   m_guiThread = std::move(guiThread);
 }
 
-void Platform::CancelTask(Thread thread, base::TaskLoop::TaskId id)
-{
-  ASSERT(m_networkThread && m_fileThread && m_backgroundThread, ());
-  switch (thread)
-  {
-  case Thread::File: m_fileThread->Cancel(id); return;
-  case Thread::Network: m_networkThread->Cancel(id); return;
-  case Thread::Gui: CHECK(false, ("Task cancelling for gui thread is not supported yet")); return;
-  case Thread::Background: m_backgroundThread->Cancel(id); return;
-  }
-}
-
 std::string DebugPrint(Platform::EError err)
 {
   switch (err)

--- a/libs/platform/platform.hpp
+++ b/libs/platform/platform.hpp
@@ -266,11 +266,6 @@ public:
 
   bool IsTablet() const { return m_isTablet; }
 
-  /// @return information about kinds of memory which are relevant for a platform.
-  /// This method is implemented for iOS and Android only.
-  /// @TODO remove as its not used anywhere?
-  std::string GetMemoryInfo() const;
-
   static EConnectionType ConnectionStatus();
   static bool IsConnected() { return ConnectionStatus() != EConnectionType::CONNECTION_NONE; }
 
@@ -316,8 +311,6 @@ public:
     }
     UNREACHABLE();
   }
-
-  void CancelTask(Thread thread, base::TaskLoop::TaskId id);
 
   // Use this method for testing purposes only.
   void SetGuiThread(std::unique_ptr<base::TaskLoop> guiThread);

--- a/libs/platform/platform_ios.mm
+++ b/libs/platform/platform_ios.mm
@@ -14,8 +14,6 @@
 #include <fcntl.h>
 #include <ifaddrs.h>
 
-#include <mach/mach.h>
-
 #include <net/if.h>
 #include <net/if_dl.h>
 
@@ -28,7 +26,6 @@
 #import <UIKit/UIKit.h>
 
 #include <memory>
-#include <sstream>
 #include <string>
 #include <utility>
 
@@ -116,25 +113,6 @@ std::unique_ptr<ModelReader> Platform::GetReader(std::string const & file, std::
 {
   return std::make_unique<FileReader>(ReadPathForFile(file, std::move(searchScope)), READER_CHUNK_LOG_SIZE,
                                       READER_CHUNK_LOG_COUNT);
-}
-
-std::string Platform::GetMemoryInfo() const
-{
-  struct task_basic_info info;
-  mach_msg_type_number_t size = sizeof(info);
-  kern_return_t const kerr = task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&info, &size);
-  std::stringstream ss;
-  if (kerr == KERN_SUCCESS)
-  {
-    ss << "Memory info: Resident_size = " << info.resident_size / 1024
-       << "KB; virtual_size = " << info.resident_size / 1024 << "KB; suspend_count = " << info.suspend_count
-       << " policy = " << info.policy;
-  }
-  else
-  {
-    ss << "Error with task_info(): " << mach_error_string(kerr);
-  }
-  return ss.str();
 }
 
 std::string Platform::DeviceName() const

--- a/libs/routing/turns_generator.hpp
+++ b/libs/routing/turns_generator.hpp
@@ -53,11 +53,6 @@ struct TurnInfo;
 bool GetNextRoutePointIndex(IRoutingResult const & result, RoutePointIndex const & index, NumMwmIds const & numMwmIds,
                             bool const forward, RoutePointIndex & nextIndex);
 
-inline size_t GetFirstSegmentPointIndex(std::pair<size_t, size_t> const & p)
-{
-  return p.first;
-}
-
 bool GetTurnInfo(IRoutingResult const & result, size_t const outgoingSegmentIndex,
                  RoutingSettings const & vehicleSettings, TurnInfo & turnInfo);
 

--- a/libs/search/processor.hpp
+++ b/libs/search/processor.hpp
@@ -61,8 +61,6 @@ public:
   void SetInputLocale(std::string const & locale);
   void SetQuery(std::string const & query, bool categorialRequest = false);
 
-  inline bool IsEmptyQuery() const { return m_query.IsEmpty(); }
-
   void Search(SearchParams params);
 
   /// Tries to parse a custom debugging command from |m_query|.

--- a/libs/search/search_tests_support/test_results_matching.hpp
+++ b/libs/search/search_tests_support/test_results_matching.hpp
@@ -66,11 +66,6 @@ std::shared_ptr<MatchingRule> ExactMatch(Args &&... args)
   return std::make_shared<ExactMatchingRule>(std::forward<Args>(args)...);
 }
 
-inline std::shared_ptr<MatchingRule> AlternativesMatch(std::vector<std::shared_ptr<MatchingRule>> && rules)
-{
-  return std::make_shared<AlternativesMatchingRule>(std::move(rules));
-}
-
 bool MatchResults(DataSource const & dataSource, std::vector<std::shared_ptr<MatchingRule>> rules,
                   std::vector<search::Result> const & actual);
 bool MatchResults(DataSource const & dataSource, std::vector<std::shared_ptr<MatchingRule>> rules,


### PR DESCRIPTION
Removes APIs with no repository callers and their newly unreachable implementation state.

This includes core map/search/bookmark/platform helpers, header-only utilities, iOS helpers, and the unreleased Android SDK memory-info JNI bridge.

Issue: cleanup only; no linked issue.

Tested:
- Qt desktop app and generator build with CMake Debug
- coding, drape, geometry, indexer, map, opening-hours, routing, and search tests
- `android/gradlew -p android assembleGoogleDebug -Parm64`
- arm64-only iOS Simulator archive with `EXCLUDED_ARCHS=x86_64`

Codex was used to audit and implement this cleanup.