### PR TITLE
[routing] Remove obsolete result codes

### DIFF
--- a/android/libs/routing/src/main/java/app/organicmaps/routing/ResultCodesHelper.java
+++ b/android/libs/routing/src/main/java/app/organicmaps/routing/ResultCodesHelper.java
@@ -36,11 +36,6 @@ public class ResultCodesHelper
         messages.add(resources.getString(R.string.dialog_routing_location_turn_wifi));
       }
       break;
-    case ResultCodes.INCONSISTENT_MWM_ROUTE:
-    case ResultCodes.ROUTING_FILE_NOT_EXIST:
-      titleRes = R.string.routing_download_maps_along;
-      messages.add(resources.getString(R.string.routing_requires_all_map));
-      break;
     case ResultCodes.START_POINT_NOT_FOUND:
       titleRes = R.string.dialog_routing_change_start;
       messages.add(resources.getString(R.string.dialog_routing_start_not_determined));
@@ -115,8 +110,7 @@ public class ResultCodesHelper
 
     return switch (resultCode)
     {
-      case ResultCodes.INCONSISTENT_MWM_ROUTE, ResultCodes.ROUTE_NOT_FOUND_REDRESS_ROUTE_ERROR,
-          ResultCodes.ROUTING_FILE_NOT_EXIST, ResultCodes.NEED_MORE_MAPS, ResultCodes.ROUTE_NOT_FOUND,
+      case ResultCodes.ROUTE_NOT_FOUND_REDRESS_ROUTE_ERROR, ResultCodes.NEED_MORE_MAPS, ResultCodes.ROUTE_NOT_FOUND,
           ResultCodes.FILE_TOO_OLD ->
         true;
       default -> false;

--- a/android/sdk/src/main/java/app/organicmaps/sdk/routing/ResultCodes.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/routing/ResultCodes.java
@@ -6,8 +6,6 @@ public interface ResultCodes
   int NO_ERROR = 0;
   int CANCELLED = 1;
   int NO_POSITION = 2;
-  int INCONSISTENT_MWM_ROUTE = 3;
-  int ROUTING_FILE_NOT_EXIST = 4;
   int START_POINT_NOT_FOUND = 5;
   int END_POINT_NOT_FOUND = 6;
   int DIFFERENT_MWM = 7;

--- a/iphone/Maps/Core/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayService.swift
@@ -1360,11 +1360,9 @@ extension CarPlayService {
     case .endPointNotFound:
       titleVariants = ["\(L("dialog_routing_change_end_carplay"))"]
     case .routeNotFoundRedressRouteError,
-         .routeNotFound,
-         .inconsistentMWMandRoute:
+         .routeNotFound:
       titleVariants = ["\(L("dialog_routing_unable_locate_route_carplay"))"]
-    case .routeFileNotExist,
-         .fileTooOld,
+    case .fileTooOld,
          .needMoreMaps,
          .pointsInDifferentMWM:
       titleVariants = ["\(L("dialog_routing_download_files_carplay"))"]

--- a/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRouterResultCode.h
+++ b/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRouterResultCode.h
@@ -2,8 +2,6 @@ typedef NS_CLOSED_ENUM(NSUInteger, MWMRouterResultCode) {
   MWMRouterResultCodeNoError = 0,
   MWMRouterResultCodeCancelled = 1,
   MWMRouterResultCodeNoCurrentPosition = 2,
-  MWMRouterResultCodeInconsistentMWMandRoute = 3,
-  MWMRouterResultCodeRouteFileNotExist = 4,
   MWMRouterResultCodeStartPointNotFound = 5,
   MWMRouterResultCodeEndPointNotFound = 6,
   MWMRouterResultCodePointsInDifferentMWM = 7,

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -560,8 +560,6 @@ using namespace routing;
     if (![MWMRouter IsRouteValid])
       [[MWMNavigationDashboardManager sharedManager] onRouteError:L(@"routing_planning_error")];
     break;
-  case routing::RouterResultCode::RouteFileNotExist:
-  case routing::RouterResultCode::InconsistentMWMandRoute:
   case routing::RouterResultCode::FileTooOld:
   case routing::RouterResultCode::RouteNotFound:
     self.routingOptions = [MWMRoutingOptions new];

--- a/iphone/Maps/UI/ReusableComponents/CustomAlerts/BaseAlert/MWMAlert.mm
+++ b/iphone/Maps/UI/ReusableComponents/CustomAlerts/BaseAlert/MWMAlert.mm
@@ -89,7 +89,7 @@
     return [MWMDefaultAlert routeNotFoundTooLongPedestrianAlert];
   case routing::RouterResultCode::RouteNotFoundRedressRouteError:
   case routing::RouterResultCode::RouteNotFound: return [MWMDefaultAlert routeNotFoundAlert];
-  case routing::RouterResultCode::FileTooOld: return [MWMDefaultAlert routeFileNotExistAlert];
+  case routing::RouterResultCode::FileTooOld: return [MWMDefaultAlert routeFileTooOldAlert];
   case routing::RouterResultCode::InternalError: return [MWMDefaultAlert internalRoutingErrorAlert];
   case routing::RouterResultCode::Cancelled:
   case routing::RouterResultCode::NoError:

--- a/iphone/Maps/UI/ReusableComponents/CustomAlerts/BaseAlert/MWMAlert.mm
+++ b/iphone/Maps/UI/ReusableComponents/CustomAlerts/BaseAlert/MWMAlert.mm
@@ -88,9 +88,7 @@
   case routing::RouterResultCode::TransitRouteNotFoundTooLongPedestrian:
     return [MWMDefaultAlert routeNotFoundTooLongPedestrianAlert];
   case routing::RouterResultCode::RouteNotFoundRedressRouteError:
-  case routing::RouterResultCode::RouteNotFound:
-  case routing::RouterResultCode::InconsistentMWMandRoute: return [MWMDefaultAlert routeNotFoundAlert];
-  case routing::RouterResultCode::RouteFileNotExist:
+  case routing::RouterResultCode::RouteNotFound: return [MWMDefaultAlert routeNotFoundAlert];
   case routing::RouterResultCode::FileTooOld: return [MWMDefaultAlert routeFileNotExistAlert];
   case routing::RouterResultCode::InternalError: return [MWMDefaultAlert internalRoutingErrorAlert];
   case routing::RouterResultCode::Cancelled:

--- a/iphone/Maps/UI/ReusableComponents/CustomAlerts/DefaultAlert/MWMDefaultAlert.h
+++ b/iphone/Maps/UI/ReusableComponents/CustomAlerts/DefaultAlert/MWMDefaultAlert.h
@@ -5,7 +5,7 @@
 + (instancetype)routeNotFoundAlert;
 + (instancetype)routeNotFoundNoPublicTransportAlert;
 + (instancetype)routeNotFoundTooLongPedestrianAlert;
-+ (instancetype)routeFileNotExistAlert;
++ (instancetype)routeFileTooOldAlert;
 + (instancetype)endPointNotFoundAlert;
 + (instancetype)startPointNotFoundAlert;
 + (instancetype)intermediatePointNotFoundAlert;

--- a/iphone/Maps/UI/ReusableComponents/CustomAlerts/DefaultAlert/MWMDefaultAlert.mm
+++ b/iphone/Maps/UI/ReusableComponents/CustomAlerts/DefaultAlert/MWMDefaultAlert.mm
@@ -23,14 +23,14 @@ static NSString * const kDefaultAlertNibName = @"MWMDefaultAlert";
 
 @implementation MWMDefaultAlert
 
-+ (instancetype)routeFileNotExistAlert
++ (instancetype)routeFileTooOldAlert
 {
   return [self defaultAlertWithTitle:L(@"dialog_routing_download_files")
                              message:L(@"dialog_routing_download_and_update_all")
                     rightButtonTitle:L(@"ok")
                      leftButtonTitle:nil
                    rightButtonAction:nil
-                                 log:@"Route File Not Exist Alert"];
+                                 log:@"Route File Too Old Alert"];
 }
 
 + (instancetype)routeNotFoundAlert
@@ -40,7 +40,7 @@ static NSString * const kDefaultAlertNibName = @"MWMDefaultAlert";
                     rightButtonTitle:L(@"ok")
                      leftButtonTitle:nil
                    rightButtonAction:nil
-                                 log:@"Route File Not Exist Alert"];
+                                 log:@"Route Not Found Alert"];
 }
 
 + (instancetype)routeNotFoundNoPublicTransportAlert

--- a/iphone/Maps/UI/ReusableComponents/CustomAlerts/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.mm
+++ b/iphone/Maps/UI/ReusableComponents/CustomAlerts/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.mm
@@ -65,9 +65,7 @@ CGFloat const kAnimationDuration = .05;
   MWMDownloadTransitMapAlert * alert = [self alertWithCountries:countries];
   switch (code)
   {
-  case routing::RouterResultCode::InconsistentMWMandRoute:
   case routing::RouterResultCode::RouteNotFound:
-  case routing::RouterResultCode::RouteFileNotExist:
     alert.titleLabel.text = L(@"dialog_routing_download_files");
     alert.messageLabel.text = L(@"dialog_routing_download_and_update_all");
     break;

--- a/libs/routing/async_router.cpp
+++ b/libs/routing/async_router.cpp
@@ -209,14 +209,12 @@ void AsyncRouter::LogCode(RouterResultCode code, double const elapsedSec)
   case RouterResultCode::EndPointNotFound: LOG(LWARNING, ("Can't find end point node")); break;
   case RouterResultCode::PointsInDifferentMWM: LOG(LWARNING, ("Points are in different MWMs")); break;
   case RouterResultCode::RouteNotFound: LOG(LWARNING, ("Route not found")); break;
-  case RouterResultCode::RouteFileNotExist: LOG(LWARNING, ("There is no routing file")); break;
   case RouterResultCode::NeedMoreMaps:
     LOG(LINFO, ("Routing can find a better way with additional maps, elapsed seconds:", elapsedSec));
     break;
   case RouterResultCode::Cancelled: LOG(LINFO, ("Route calculation cancelled, elapsed seconds:", elapsedSec)); break;
   case RouterResultCode::NoError: LOG(LINFO, ("Route found, elapsed seconds:", elapsedSec)); break;
   case RouterResultCode::NoCurrentPosition: LOG(LINFO, ("No current position")); break;
-  case RouterResultCode::InconsistentMWMandRoute: LOG(LINFO, ("Inconsistent mwm and route")); break;
   case RouterResultCode::InternalError: LOG(LINFO, ("Internal error")); break;
   case RouterResultCode::FileTooOld: LOG(LINFO, ("File too old")); break;
   case RouterResultCode::IntermediatePointNotFound: LOG(LWARNING, ("Can't find intermediate point node")); break;

--- a/libs/routing/routing_callbacks.hpp
+++ b/libs/routing/routing_callbacks.hpp
@@ -20,8 +20,10 @@ class Route;
 class RoutesResult;
 
 /// Routing possible statuses enumeration.
-/// \warning  this enum has JNI mirror!
-/// \see android/src/app/organicmaps/maps/routing/ResultCodesHelper.java
+/// \warning  this enum is mirrored by value in Java and Objective-C/Swift!
+/// \see android/sdk/src/main/java/app/organicmaps/sdk/routing/ResultCodes.java
+/// \see iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRouterResultCode.h
+/// Values 3 and 4 are retired, do not reuse or renumber the rest.
 enum class RouterResultCode
 {
   NoError = 0,

--- a/libs/routing/routing_callbacks.hpp
+++ b/libs/routing/routing_callbacks.hpp
@@ -22,14 +22,11 @@ class RoutesResult;
 /// Routing possible statuses enumeration.
 /// \warning  this enum has JNI mirror!
 /// \see android/src/app/organicmaps/maps/routing/ResultCodesHelper.java
-// TODO(bykoianko): Items become obsolete now should be removed from the enum.
 enum class RouterResultCode
 {
   NoError = 0,
   Cancelled = 1,
   NoCurrentPosition = 2,
-  InconsistentMWMandRoute = 3,
-  RouteFileNotExist = 4,
   StartPointNotFound = 5,
   EndPointNotFound = 6,
   PointsInDifferentMWM = 7,
@@ -93,8 +90,6 @@ inline std::string ToString(RouterResultCode code)
   case RouterResultCode::NoError: return "NoError";
   case RouterResultCode::Cancelled: return "Cancelled";
   case RouterResultCode::NoCurrentPosition: return "NoCurrentPosition";
-  case RouterResultCode::InconsistentMWMandRoute: return "InconsistentMWMandRoute";
-  case RouterResultCode::RouteFileNotExist: return "RouteFileNotExist";
   case RouterResultCode::StartPointNotFound: return "StartPointNotFound";
   case RouterResultCode::EndPointNotFound: return "EndPointNotFound";
   case RouterResultCode::PointsInDifferentMWM: return "PointsInDifferentMWM";


### PR DESCRIPTION
Removes the unproducible `InconsistentMWMandRoute` and `RouteFileNotExist` result codes from C++, Android, iOS, and CarPlay handling.

The remaining explicit numeric values are unchanged, so raw values 3 and 4 become holes and values 5–16 retain compatibility.

Issue: cleanup only; no linked issue.

Tested:
- Qt desktop build with CMake Debug
- routing tests
- `android/gradlew -p android assembleGoogleDebug -Parm64`
- arm64-only iOS Simulator archive with `EXCLUDED_ARCHS=x86_64`

Codex was used to audit and implement this cleanup.