### PR TITLE
[routing] Merge lanes info for before the maneuver.

### DIFF
--- a/libs/routing/car_directions.cpp
+++ b/libs/routing/car_directions.cpp
@@ -138,6 +138,23 @@ size_t CarDirectionsEngine::GetTurnDirection(IRoutingResult const & result, size
     auto const & loadedSegments = result.GetSegments();
     auto const & ingoingSegment = loadedSegments[outgoingSegmentIndex - 1];
     turnItem.m_lanes = ingoingSegment.m_lanes;
+
+    // A short ingoing segment usually appears when a dedicated lane (e.g. an U-turn pocket) forks off
+    // just before the turn and the way is split there. The driver receives the maneuver banner while
+    // still on the previous segment, so show its lanes if the current ones are a contiguous part of them.
+    double constexpr kShortLanesSegmentDistM = 30.0;
+    if (outgoingSegmentIndex >= 2 && !turnItem.m_lanes.empty() &&
+        CalcRouteDistanceM(ingoingSegment.m_path, 0, static_cast<uint32_t>(ingoingSegment.m_path.size())) <
+            kShortLanesSegmentDistM)
+    {
+      auto const & prevLanes = loadedSegments[outgoingSegmentIndex - 2].m_lanes;
+      if (prevLanes.size() > turnItem.m_lanes.size() &&
+          std::search(prevLanes.begin(), prevLanes.end(), turnItem.m_lanes.begin(), turnItem.m_lanes.end()) !=
+              prevLanes.end())
+      {
+        turnItem.m_lanes = prevLanes;
+      }
+    }
   }
 
   return skipTurnSegments;

--- a/libs/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/libs/routing/routing_integration_tests/routing_test_tools.cpp
@@ -345,6 +345,12 @@ TestTurn const & TestTurn::TestOneOfDirections(set<routing::turns::CarDirection>
   return *this;
 }
 
+TestTurn const & TestTurn::TestLanes(turns::lanes::LanesInfo const & expectedLanes) const
+{
+  TEST_EQUAL(m_lanes, expectedLanes, ());
+  return *this;
+}
+
 TestTurn const & TestTurn::TestRoundAboutExitNum(uint32_t expectedRoundAboutExitNum) const
 {
   TEST_EQUAL(m_roundAboutExitNum, expectedRoundAboutExitNum, ());
@@ -362,7 +368,7 @@ TestTurn GetNthTurn(routing::Route const & route, uint32_t turnNumber)
   }
 
   TurnItem const & turn = turns[turnNumber];
-  return TestTurn(route.GetPoly().GetPoint(turn.m_index), turn.m_turn, turn.m_exitNum);
+  return TestTurn(route.GetPoly().GetPoint(turn.m_index), turn.m_turn, turn.m_lanes, turn.m_exitNum);
 }
 
 bool IsSubwayExists(Route const & route)

--- a/libs/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/libs/routing/routing_integration_tests/routing_test_tools.hpp
@@ -165,13 +165,15 @@ class TestTurn
 
   m2::PointD const m_point;
   CarDirection const m_direction;
+  turns::lanes::LanesInfo const m_lanes;
   uint32_t const m_roundAboutExitNum;
   bool const m_isValid;
 
   TestTurn() : m_point({0.0, 0.0}), m_direction(CarDirection::None), m_roundAboutExitNum(0), m_isValid(false) {}
-  TestTurn(m2::PointD const & pnt, CarDirection direction, uint32_t roundAboutExitNum)
+  TestTurn(m2::PointD const & pnt, CarDirection direction, turns::lanes::LanesInfo lanes, uint32_t roundAboutExitNum)
     : m_point(pnt)
     , m_direction(direction)
+    , m_lanes(std::move(lanes))
     , m_roundAboutExitNum(roundAboutExitNum)
     , m_isValid(true)
   {}
@@ -182,6 +184,7 @@ public:
   TestTurn const & TestPoint(m2::PointD const & expectedPoint, double inaccuracyMeters = 3.) const;
   TestTurn const & TestDirection(CarDirection expectedDirection) const;
   TestTurn const & TestOneOfDirections(std::set<CarDirection> const & expectedDirections) const;
+  TestTurn const & TestLanes(turns::lanes::LanesInfo const & expectedLanes) const;
   TestTurn const & TestRoundAboutExitNum(uint32_t expectedRoundAboutExitNum) const;
 };
 

--- a/libs/routing/routing_integration_tests/turn_test.cpp
+++ b/libs/routing/routing_integration_tests/turn_test.cpp
@@ -1455,4 +1455,103 @@ UNIT_TEST(Segregated_MergeLeftRightTurns)
   }
 }
 
+// Zemlyanoy Val street (northbound) in Moscow: turn:lanes = through|through|through|through|right|reverse,
+// where the last (right side) lane is a dedicated U-turn loop to the opposite carriageway.
+// After the U-turn fork there is a short (~20m) segment with turn:lanes = through|through|through|through|right
+// before the right turn to Staraya Basmannaya street. Both maneuvers below should show the same
+// 6 lanes the driver actually sees on approach, with ReverseLeft as the last lane.
+UNIT_TEST(Russia_Moscow_ZemlyanoyVal_LanesTest)
+{
+  using namespace integration;
+  using namespace routing::turns::lanes;
+
+  LaneInfo const through = {{LaneWay::Through}, LaneWay::None};
+
+  // Turn right to Staraya Basmannaya street.
+  {
+    TRouteResult const res = CalculateRoute(GetVehicleComponents(VehicleType::Car), FromLatLon(55.763544, 37.6567575),
+                                            {0., 0.}, FromLatLon(55.7642684, 37.6569801));
+
+    TEST_EQUAL(res.second, RouterResultCode::NoError, ());
+    Route const & route = *res.first;
+
+    TestTurnCount(route, 1 /* expectedTurnCount */);
+    GetNthTurn(route, 0)
+        .TestValid()
+        .TestDirection(CarDirection::TurnRight)
+        .TestLanes({through,
+                    through,
+                    through,
+                    through,
+                    {{LaneWay::Right}, LaneWay::Right},
+                    // The "reverse" tag does not specify the U-turn side, so the lane is parsed into both
+                    // ReverseLeft and ReverseRight. It is disambiguated by FixRecommendedReverseLane only
+                    // when a U-turn maneuver recommends this lane (see the U-turn case below).
+                    {{LaneWay::ReverseLeft, LaneWay::ReverseRight}, LaneWay::None}});
+  }
+
+  // U-turn to the southbound carriageway of Zemlyanoy Val.
+  {
+    TRouteResult const res = CalculateRoute(GetVehicleComponents(VehicleType::Car), FromLatLon(55.763544, 37.6567575),
+                                            {0., 0.}, FromLatLon(55.7635125, 37.6564447));
+
+    TEST_EQUAL(res.second, RouterResultCode::NoError, ());
+    Route const & route = *res.first;
+
+    TestTurnCount(route, 1 /* expectedTurnCount */);
+    GetNthTurn(route, 0)
+        .TestValid()
+        .TestDirection(CarDirection::UTurnLeft)
+        .TestLanes({through,
+                    through,
+                    through,
+                    through,
+                    {{LaneWay::Right}, LaneWay::None},
+                    {{LaneWay::ReverseLeft}, LaneWay::ReverseLeft}});
+  }
+}
+
+// https://github.com/organicmaps/organicmaps/issues/9429
+// P. Luksio street: turn:lanes:backward = left;through|right. The combined left;through lane must be kept as is.
+UNIT_TEST(Lithuania_Vilnius_LuksioKalvariju_LanesTest)
+{
+  using namespace integration;
+  using namespace routing::turns::lanes;
+
+  TRouteResult const res = CalculateRoute(GetVehicleComponents(VehicleType::Car), FromLatLon(54.71331, 25.28847),
+                                          {0., 0.}, FromLatLon(54.71400, 25.28690));
+
+  TEST_EQUAL(res.second, RouterResultCode::NoError, ());
+  Route const & route = *res.first;
+
+  TestTurnCount(route, 1 /* expectedTurnCount */);
+  GetNthTurn(route, 0)
+      .TestValid()
+      .TestDirection(CarDirection::TurnRight)
+      .TestLanes({{{LaneWay::Left, LaneWay::Through}, LaneWay::None}, {{LaneWay::Right}, LaneWay::Right}});
+}
+
+// https://github.com/organicmaps/organicmaps/issues/10327
+// Golovec tunnel: turn:lanes = slight_left|slight_left;slight_right|slight_right on 4 consecutive ways
+// before the fork. Exit to the left link recommends both slight_left lanes.
+UNIT_TEST(Slovenia_Ljubljana_GolovecTunnelExit_LanesTest)
+{
+  using namespace integration;
+  using namespace routing::turns::lanes;
+
+  TRouteResult const res = CalculateRoute(GetVehicleComponents(VehicleType::Car), FromLatLon(46.02200, 14.56335),
+                                          {0., 0.}, FromLatLon(46.01511, 14.55709));
+
+  TEST_EQUAL(res.second, RouterResultCode::NoError, ());
+  Route const & route = *res.first;
+
+  TestTurnCount(route, 1 /* expectedTurnCount */);
+  GetNthTurn(route, 0)
+      .TestValid()
+      .TestDirection(CarDirection::ExitHighwayToLeft)
+      .TestLanes({{{LaneWay::SlightLeft}, LaneWay::SlightLeft},
+                  {{LaneWay::SlightLeft, LaneWay::SlightRight}, LaneWay::SlightLeft},
+                  {{LaneWay::SlightRight}, LaneWay::None}});
+}
+
 }  // namespace turn_test


### PR DESCRIPTION
I don't like the straightforward lanes-info merging with some distance threshold.
At the same time I suppose we can fix some open issues with lanes - should search and test.

Closes https://github.com/organicmaps/organicmaps/issues/9429
Closes https://github.com/organicmaps/organicmaps/issues/10327