### PR TITLE
[platform] Don't report a cut-off Qt response as success

### DIFF
--- a/libs/platform/http_client.hpp
+++ b/libs/platform/http_client.hpp
@@ -43,6 +43,8 @@ public:
   static auto constexpr kWriteException = -2;
   static auto constexpr kInconsistentFileSize = -3;
   static auto constexpr kCancelled = -6;
+  // A status line arrived, but transport or content processing did not complete.
+  static auto constexpr kIncompleteResponse = -7;
 
   using Headers = std::unordered_map<std::string, std::string>;
 

--- a/libs/platform/http_client_qt.cpp
+++ b/libs/platform/http_client_qt.cpp
@@ -384,11 +384,26 @@ void HttpClientReply::OnFinished()
 
   if (noError || httpCode != 0)
   {
-    result.m_errorCode = httpCode != 0 ? httpCode : static_cast<int>(m_reply->error());
     // A complete HTTP response (even 4xx/5xx) means the connection was made successfully,
     // and callers expect m_success = true there, matching Apple/Android semantics. A
     // transport failure after the status line is not success: the body is truncated.
     result.m_success = IsCompleteResponse(m_reply->error(), httpCode);
+    if (result.m_success)
+    {
+      result.m_errorCode = httpCode;
+    }
+    else if (httpCode != 0)
+    {
+      // A failed transfer must not carry a successful HTTP status to callers. Keep the
+      // status in the log and expose an unambiguous transport error instead.
+      LOG(LWARNING, ("Incomplete response for", m_urlRequested, "HTTP status", httpCode,
+                     "Qt error:", static_cast<int>(m_reply->error()), m_reply->errorString().toStdString()));
+      result.m_errorCode = HttpClient::kIncompleteResponse;
+    }
+    else
+    {
+      result.m_errorCode = static_cast<int>(m_reply->error());
+    }
 
     // Use toEncoded() to preserve percent-encoding, matching Apple's absoluteString behavior.
     // toString() decodes %XX sequences, which breaks WasRedirected() URL comparison.

--- a/libs/platform/http_client_qt.cpp
+++ b/libs/platform/http_client_qt.cpp
@@ -76,6 +76,35 @@ QNetworkReply * IssueRequest(QNetworkAccessManager & manager, std::string const 
     return manager.head(request);
   return manager.sendCustomRequest(request, QByteArray::fromStdString(method), body);
 }
+
+// Qt converts completed HTTP error responses to NetworkError values in
+// QHttpThreadDelegate::statusCodeFromHttp(). Match the status and error together:
+// category ranges also contain failures such as ContentReSendError and
+// UnknownContentError from response decompression.
+bool IsHttpStatusError(QNetworkReply::NetworkError error, int httpCode)
+{
+  switch (httpCode)
+  {
+  case 400:
+  case 418: return error == QNetworkReply::ProtocolInvalidOperationError;
+  case 401: return error == QNetworkReply::AuthenticationRequiredError;
+  case 403: return error == QNetworkReply::ContentAccessDenied;
+  case 404: return error == QNetworkReply::ContentNotFoundError;
+  case 405: return error == QNetworkReply::ContentOperationNotPermittedError;
+  case 407: return error == QNetworkReply::ProxyAuthenticationRequiredError;
+  case 409: return error == QNetworkReply::ContentConflictError;
+  case 410: return error == QNetworkReply::ContentGoneError;
+  case 500: return error == QNetworkReply::InternalServerError;
+  case 501: return error == QNetworkReply::OperationNotImplementedError;
+  case 503: return error == QNetworkReply::ServiceUnavailableError;
+  default:
+    if (httpCode > 500)
+      return error == QNetworkReply::UnknownServerError;
+    if (httpCode >= 400)
+      return error == QNetworkReply::UnknownContentError;
+    return false;
+  }
+}
 }  // namespace
 
 namespace platform
@@ -172,6 +201,16 @@ bool HttpClientReply::ShouldRetry(QNetworkReply::NetworkError error, QString con
 
   default: return false;
   }
+}
+
+// static
+bool HttpClientReply::IsCompleteResponse(QNetworkReply::NetworkError error, int httpCode)
+{
+  if (httpCode == 0)
+    return false;
+  if (error == QNetworkReply::NoError)
+    return true;
+  return IsHttpStatusError(error, httpCode);
 }
 
 bool HttpClientReply::TryRetryOnGoAway()
@@ -346,10 +385,10 @@ void HttpClientReply::OnFinished()
   if (noError || httpCode != 0)
   {
     result.m_errorCode = httpCode != 0 ? httpCode : static_cast<int>(m_reply->error());
-    // Any HTTP response (even 4xx/5xx) means the connection was made successfully.
-    // Qt maps HTTP errors to QNetworkReply error codes, but callers expect m_success = true
-    // when they got an HTTP response (matching Apple/Android semantics).
-    result.m_success = (httpCode != 0);
+    // A complete HTTP response (even 4xx/5xx) means the connection was made successfully,
+    // and callers expect m_success = true there, matching Apple/Android semantics. A
+    // transport failure after the status line is not success: the body is truncated.
+    result.m_success = IsCompleteResponse(m_reply->error(), httpCode);
 
     // Use toEncoded() to preserve percent-encoding, matching Apple's absoluteString behavior.
     // toString() decodes %XX sequences, which breaks WasRedirected() URL comparison.
@@ -566,9 +605,8 @@ HttpClient::RequestHandle HttpClient::RunHttpRequestAsync(CompletionHandler hand
                             [=, handler = std::move(handler), cancelChecker = std::move(cancelChecker),
                              rebindCancel = std::move(rebindCancel)]() mutable
   {
-    // Check cancellation BEFORE creating the request — fixes the race where
-    // Cancel() is called between RunHttpRequestAsync() returning and this
-    // lambda executing on the network thread.
+    // Check cancellation before creating the request because Cancel() can run between
+    // RunHttpRequestAsync() returning and this lambda executing on the network thread.
     if (cancelChecker())
     {
       HttpClient::Result result;

--- a/libs/platform/http_client_qt.hpp
+++ b/libs/platform/http_client_qt.hpp
@@ -41,6 +41,10 @@ public:
   static bool ShouldRetry(QNetworkReply::NetworkError error, QString const & errorString, int httpCode,
                           bool anyBytesReceived, bool writeError, int retriesRemaining);
 
+  // True when the status and Qt error together describe a complete HTTP response.
+  // Qt reports HTTP error statuses through NetworkError too. Exposed for unit testing.
+  static bool IsCompleteResponse(QNetworkReply::NetworkError error, int httpCode);
+
 private slots:
   void OnReadyRead();
   void OnDownloadProgress(qint64 bytesReceived, qint64 bytesTotal);

--- a/libs/platform/platform_tests/CMakeLists.txt
+++ b/libs/platform/platform_tests/CMakeLists.txt
@@ -25,9 +25,7 @@ set(SRC
 # Qt HTTP backend tests are only valid where http_client_qt.cpp is compiled
 # (macOS uses http_client_apple.mm instead).
 if (PLATFORM_DESKTOP AND NOT PLATFORM_MAC)
-  list(APPEND SRC http_client_qt_retry_test.cpp)
-  list(APPEND SRC http_client_qt_response_test.cpp)
-  list(APPEND SRC http_client_qt_http2_test.cpp)
+  list(APPEND SRC http_client_qt_retry_test.cpp http_client_qt_response_test.cpp http_client_qt_http2_test.cpp)
 endif()
 
 omim_add_test(${PROJECT_NAME} ${SRC} REQUIRE_QT REQUIRE_SERVER)

--- a/libs/platform/platform_tests/CMakeLists.txt
+++ b/libs/platform/platform_tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SRC
 # (macOS uses http_client_apple.mm instead).
 if (PLATFORM_DESKTOP AND NOT PLATFORM_MAC)
   list(APPEND SRC http_client_qt_retry_test.cpp)
+  list(APPEND SRC http_client_qt_response_test.cpp)
   list(APPEND SRC http_client_qt_http2_test.cpp)
 endif()
 

--- a/libs/platform/platform_tests/http_client_qt_response_test.cpp
+++ b/libs/platform/platform_tests/http_client_qt_response_test.cpp
@@ -1,0 +1,61 @@
+#include "testing/testing.hpp"
+
+#include "platform/http_client_qt.hpp"
+
+namespace http_client_qt_response_test
+{
+using platform::HttpClientReply;
+
+UNIT_TEST(HttpClientQt_IsCompleteResponse_NoError)
+{
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::NoError, 200), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::NoError, 204), ());
+}
+
+UNIT_TEST(HttpClientQt_IsCompleteResponse_NoStatusLine)
+{
+  // Nothing was received, so there is no response to be complete.
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::NoError, 0), ());
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::HostNotFoundError, 0), ());
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::ConnectionRefusedError, 0), ());
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::TimeoutError, 0), ());
+}
+
+UNIT_TEST(HttpClientQt_IsCompleteResponse_HttpStatusErrorsAreComplete)
+{
+  // These pairs match Qt's HTTP-status-to-NetworkError mapping.
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::ProtocolInvalidOperationError, 400), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::ContentAccessDenied, 403), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::ContentNotFoundError, 404), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::AuthenticationRequiredError, 401), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::ContentOperationNotPermittedError, 405), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::ProxyAuthenticationRequiredError, 407), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::ContentConflictError, 409), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::ContentGoneError, 410), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::ProtocolInvalidOperationError, 418), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::UnknownContentError, 429), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::InternalServerError, 500), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::OperationNotImplementedError, 501), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::UnknownServerError, 502), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::ServiceUnavailableError, 503), ());
+  TEST(HttpClientReply::IsCompleteResponse(QNetworkReply::UnknownServerError, 599), ());
+}
+
+UNIT_TEST(HttpClientQt_IsCompleteResponse_TransportFailureAfterStatusLine)
+{
+  // Transport and content-processing errors can arrive after an ordinary status line.
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::TimeoutError, 200), ());
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::OperationCanceledError, 200), ());
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::RemoteHostClosedError, 200), ());
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::TemporaryNetworkFailureError, 200), ());
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::NetworkSessionFailedError, 206), ());
+  // HTTP/2 stream torn down mid-body after the headers arrived.
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::ProtocolFailure, 200), ());
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::SslHandshakeFailedError, 200), ());
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::UnknownContentError, 200), ());
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::ContentReSendError, 200), ());
+  // A status-mapping error paired with a different status indicates another failure.
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::UnknownContentError, 404), ());
+  TEST(!HttpClientReply::IsCompleteResponse(QNetworkReply::ContentNotFoundError, 200), ());
+}
+}  // namespace http_client_qt_response_test

--- a/libs/platform/platform_tests/http_client_test.cpp
+++ b/libs/platform/platform_tests/http_client_test.cpp
@@ -29,6 +29,9 @@ char constexpr kTestUrlBigFile[] = "http://localhost:24568/unit_tests/47kb.file"
 char constexpr kTestUrlEchoHeaders[] = "http://localhost:24568/unit_tests/echo_headers";
 char constexpr kTestUrlEchoCookies[] = "http://localhost:24568/unit_tests/echo_cookies";
 char constexpr kTestUrlTimeout[] = "http://localhost:24568/unit_tests/timeout";
+char constexpr kTestUrlTruncated[] = "http://localhost:24568/unit_tests/truncated_body";
+char constexpr kTestUrlCorruptGzip[] = "http://localhost:24568/unit_tests/corrupt_gzip";
+char constexpr kTestUrl400[] = "http://localhost:24568/unit_tests/400";
 char constexpr kTestUrl500[] = "http://localhost:24568/unit_tests/500";
 char constexpr kTestUrl403[] = "http://localhost:24568/unit_tests/403";
 char constexpr kTestUrlRedirect[] = "http://localhost:24568/unit_tests/redirect_to_1txt";
@@ -92,6 +95,13 @@ UNIT_TEST(HttpClient_SyncGet_403)
   HttpClient client(kTestUrl403);
   TEST(client.RunHttpRequest(), ());
   TEST_EQUAL(client.ErrorCode(), 403, ());
+}
+
+UNIT_TEST(HttpClient_SyncGet_400)
+{
+  HttpClient client(kTestUrl400);
+  TEST(client.RunHttpRequest(), ());
+  TEST_EQUAL(client.ErrorCode(), 400, ());
 }
 
 UNIT_TEST(HttpClient_SyncGet_InvalidHost)
@@ -422,13 +432,37 @@ UNIT_TEST(HttpClient_RangeRequest_OpenEnded)
 UNIT_TEST(HttpClient_Timeout)
 {
   HttpClient client(kTestUrlTimeout);
-  client.SetTimeout(2);  // 2 second timeout, server sleeps 60s.
+  client.SetTimeout(2);  // The server responds after 3 seconds.
   auto const start = std::chrono::steady_clock::now();
   TEST(!client.RunHttpRequest(), ());
   auto const elapsed = std::chrono::steady_clock::now() - start;
   // Should return within ~5 seconds (generous margin for CI).
   TEST(elapsed < std::chrono::seconds(15), ());
 }
+
+UNIT_TEST(HttpClient_TruncatedBody)
+{
+  // The server answers with a valid status line and a Content-Length it never
+  // fulfils, then closes the connection. The status code is a perfectly ordinary 200, so a
+  // backend that judges success by the code alone reports a complete response
+  // whose body is missing -- callers that parse the body (OsmOAuth decides that
+  // credentials were rejected by finding "/login" in it) then read the truncation
+  // as a different answer rather than as a failure.
+  HttpClient client(kTestUrlTruncated);
+  TEST(!client.RunHttpRequest(), ("A body cut short must not be reported as success"));
+  TEST_NOT_EQUAL(client.ErrorCode(), 200, ("A failed request must not carry a successful HTTP status"));
+}
+
+#if defined(OMIM_OS_LINUX) || defined(OMIM_OS_WINDOWS)
+UNIT_TEST(HttpClient_Qt_CorruptCompressedBody)
+{
+  // Qt content decoding is part of receiving a complete response. A valid 200
+  // status must not hide a decompression failure that leaves callers without the body.
+  HttpClient client(kTestUrlCorruptGzip);
+  TEST(!client.RunHttpRequest(), ("A corrupt compressed body must not be reported as success"));
+  TEST_NOT_EQUAL(client.ErrorCode(), 200, ("A failed request must not carry a successful HTTP status"));
+}
+#endif
 
 // =====================================================================
 // ReceivedFile (download to file)
@@ -674,11 +708,9 @@ UNIT_TEST(HttpClient_NormalizeServerCookies)
 // =====================================================================
 
 #if defined(OMIM_OS_LINUX) || defined(OMIM_OS_WINDOWS)
-// Qt-specific: verify m_success is true for HTTP error responses (regression test).
+// Qt-specific: complete HTTP error responses are transport successes.
 UNIT_TEST(HttpClient_Qt_SuccessSemantics_HttpErrors)
 {
-  // Verify that HTTP 4xx/5xx responses still set m_success=true.
-  // This was a regression where Qt's QNetworkReply::error() != NoError for HTTP errors.
   {
     HttpClient client(kTestUrl404);
     auto result = RunAsync(client);
@@ -1054,7 +1086,7 @@ UNIT_TEST(HttpClient_NormalizeServerCookies_EdgeCases)
 }
 
 // =====================================================================
-// Regression: ProgressHandler must not prevent body accumulation
+// ProgressHandler with body accumulation
 // =====================================================================
 
 UNIT_TEST(HttpClient_ProgressHandler_PreservesBody)
@@ -1071,7 +1103,7 @@ UNIT_TEST(HttpClient_ProgressHandler_PreservesBody)
 }
 
 // =====================================================================
-// Regression: POST body must not leak into m_serverResponse when response goes to file
+// POST response written to a file keeps m_serverResponse empty
 // =====================================================================
 
 UNIT_TEST(HttpClient_Post_BodyData_ResponseToFile)
@@ -1098,7 +1130,7 @@ UNIT_TEST(HttpClient_Post_BodyData_ResponseToFile)
 }
 
 // =====================================================================
-// Regression: POST to 204 No Content must not return request body as response
+// POST to 204 No Content leaves the response body empty
 // =====================================================================
 
 char constexpr kTestUrl204[] = "http://localhost:24568/unit_tests/204";
@@ -1365,11 +1397,10 @@ UNIT_TEST(HttpClient_Segment_MissingTarget_WriteException)
   TEST_EQUAL(result.m_errorCode, HttpClient::kWriteException, ());
 }
 
-UNIT_TEST(HttpClient_Segment_NoSegment_ExistingBehaviorUnchanged)
+UNIT_TEST(HttpClient_Segment_PlainReceivedFile)
 {
-  // Regression guard: without SetReceivedFileSegment, SetReceivedFile still truncates
-  // and writes the full body as before.
-  string const path = GetPlatform().TmpPathForFile("http_segment_regression_", ".tmp");
+  // SetReceivedFile writes the complete response when segment mode is not configured.
+  string const path = GetPlatform().TmpPathForFile("http_segment_plain_", ".tmp");
 
   HttpClient client(kTestUrl1);
   client.SetReceivedFile(path);

--- a/tools/python/test_server/server/ResponseProvider.py
+++ b/tools/python/test_server/server/ResponseProvider.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import gzip
 import jsons
 import logging
 import os
@@ -34,6 +35,27 @@ def synthetic_mwm_content(file_name):
     # content[i] == (i + seed) % 256, built by tiling one period instead of per-byte.
     period = bytes((i + seed) % 256 for i in range(256))
     return (period * (size // 256 + 1))[:size]
+
+
+# A response cut short mid-body: the status line and headers promise
+# TRUNCATED_BODY_ADVERTISED bytes, only TRUNCATED_BODY_SENT are written, then the
+# connection is closed. Both server implementations serve it directly instead of
+# through a Payload, which always sends a truthful Content-Length.
+TRUNCATED_BODY_URL = "/unit_tests/truncated_body"
+TRUNCATED_BODY_ADVERTISED = 1000
+TRUNCATED_BODY_SENT = 50
+
+# Qt reports decompression failures as UnknownContentError after receiving the
+# HTTP status. The body is corrupt but its Content-Length is truthful.
+CORRUPT_GZIP_URL = "/unit_tests/corrupt_gzip"
+_corrupt_gzip_body = bytearray(gzip.compress(b"complete response body" * 100, mtime=0))
+_corrupt_gzip_body[len(_corrupt_gzip_body) // 2] ^= 0xff
+CORRUPT_GZIP_BODY = bytes(_corrupt_gzip_body)
+
+
+def truncated_body_head():
+    return ("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n"
+            "Content-Length: {}\r\n\r\n".format(TRUNCATED_BODY_ADVERTISED)).encode()
 
 
 class Payload:
@@ -186,6 +208,8 @@ class ResponseProvider:
                 "/unit_tests/echo_headers": self.echo_headers,
                 "/unit_tests/echo_cookies": self.echo_cookies,
                 "/unit_tests/timeout": self.test_timeout,
+                CORRUPT_GZIP_URL: self.test_corrupt_gzip,
+                "/unit_tests/400": self.test_400,
                 "/unit_tests/500": self.test_500,
                 "/unit_tests/403": self.test_403,
                 "/unit_tests/redirect_to_1txt": self.test_redirect_to_1txt,
@@ -357,6 +381,12 @@ class ResponseProvider:
         import time
         time.sleep(3)
         return Payload("should not reach")
+
+    def test_corrupt_gzip(self):
+        return Payload(CORRUPT_GZIP_BODY, 200, {"Content-Encoding": "gzip"})
+
+    def test_400(self):
+        return Payload("Bad Request", response_code=400)
 
     def test_500(self):
         return Payload("Internal Server Error", response_code=500)

--- a/tools/python/test_server/server/testserver.py
+++ b/tools/python/test_server/server/testserver.py
@@ -18,6 +18,9 @@ from http.server import BaseHTTPRequestHandler
 from http.server import HTTPServer
 from socketserver import ThreadingMixIn
 from ResponseProvider import Payload
+from ResponseProvider import TRUNCATED_BODY_SENT
+from ResponseProvider import TRUNCATED_BODY_URL
+from ResponseProvider import truncated_body_head
 from ResponseProvider import ResponseProvider
 from ResponseProvider import ResponseProviderMixin
 from threading import Timer
@@ -150,9 +153,8 @@ class PostHandler(BaseHTTPRequestHandler, ResponseProviderMixin):
 
     def init_vars(self):
         self.response_provider = ResponseProvider(self)
-        # Every request must extend the server's lifespan. Previously only
-        # do_POST reset the timer, so long GET-only test runs could die at
-        # the LIFESPAN boundary on slow CI.
+        # Every request extends the server's lifespan so long GET-only test runs
+        # cannot reach the LIFESPAN boundary on slow CI.
         self.server.reset_selfdestruct_timer()
 
 
@@ -181,7 +183,17 @@ class PostHandler(BaseHTTPRequestHandler, ResponseProviderMixin):
     def do_GET(self):
         headers = self.prepare_headers()
         self.init_vars()
+        if self.path == TRUNCATED_BODY_URL:
+            self.send_truncated_body()
+            return
         self.dispatch_response(self.response_provider.response_for_url_and_headers(self.path, headers))
+
+
+    def send_truncated_body(self):
+        # Bypasses dispatch_response so that Content-Length can lie about the size.
+        self.wfile.write(truncated_body_head() + b"x" * TRUNCATED_BODY_SENT)
+        self.wfile.flush()
+        self.close_connection = True
 
 
     def prepare_headers(self):

--- a/tools/python/test_server/server/tornado_handler.py
+++ b/tools/python/test_server/server/tornado_handler.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
 
 from ResponseProvider import Payload
+from ResponseProvider import TRUNCATED_BODY_SENT
+from ResponseProvider import TRUNCATED_BODY_URL
+from ResponseProvider import truncated_body_head
 from ResponseProvider import ResponseProvider
 from ResponseProvider import ResponseProviderMixin
 from threading import Timer
@@ -57,8 +60,19 @@ class MainHandler(tornado.web.RequestHandler, ResponseProviderMixin):
 
 
     def get(self, param):
+        if self.request.path == TRUNCATED_BODY_URL:
+            self.send_truncated_body()
+            return
         self.dispatch_response(self.response_provider.response_for_url_and_headers(self.request.uri, self.headers))
-        
+
+
+    def send_truncated_body(self):
+        # Detaches the stream so that Tornado's Content-Length accounting, which
+        # would refuse to send fewer bytes than advertised, is out of the way.
+        stream = self.detach()
+        stream.write(truncated_body_head() + b"x" * TRUNCATED_BODY_SENT).add_done_callback(
+            lambda _: stream.close())
+
 
     def post(self, param):
         payload = self.response_provider.response_for_url_and_headers(self.request.uri, self.headers)


### PR DESCRIPTION
Qt sends the status line before the body, so a transfer aborted mid-body still carries an ordinary HTTP code. `OnFinished` judged success by that code alone:

```cpp
result.m_success = (httpCode != 0);
```

A request that timed out after the headers arrived was therefore reported as a successful 200 with a truncated or empty body. `IsCompleteResponse()` now also requires the error to be one Qt raises *because of* the status (content 201-299, server 401-499, plus `NoError`); anything else is a transport failure. Failures no longer carry the 2xx code out either — they report the new `kIncompleteResponse` and log the status, so `!m_success` implies a negative code on every backend, as Android already assumes.

This is what made `osm_auth_tests` fail so oddly on the Linux legs: `LoginUserPassword` detects bad credentials by finding `/login` in the response body, so a truncated body read as a *successful* login and the error surfaced two requests later as `FetchRequestToken Redirect url han unexpected prefix`. The Apple backend never had the bug — it reports the transport error instead.

## Testing

- New live test in `http_client_test.cpp`: the server promises 1000 bytes, writes 50 and closes; the request must fail with a negative code. Runs on every backend, and passed on the Qt leg in CI. The route is in both test server implementations (tornado when installed, `BaseHTTPServer` otherwise).
- `http_client_qt_response_test.cpp` unit-tests the predicate, 24 cases.
- `platform_tests`, `storage_tests` and `map_tests` pass locally; the predicate was also checked against real Qt 6 enums in a standalone TU.
