### PR TITLE
[android] Collapse search sheet when a category is tapped

### DIFF
--- a/android/app/src/main/java/app/organicmaps/search/SearchFragment.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchFragment.java
@@ -614,6 +614,8 @@ public class SearchFragment extends Fragment implements SearchListener, Categori
       mSearchViewModel.notifyHistoryChanged();
     }
     mToolbarController.setQuery(category, true);
+    mToolbarController.deactivate();
+    mSearchFragmentListener.onSearchClicked();
   }
 
   private void refreshSearchResults(@NonNull SearchResult[] results)
@@ -864,7 +866,10 @@ public class SearchFragment extends Fragment implements SearchListener, Categori
     {
       super.setQuery(query);
       if (!TextUtils.isEmpty(query))
+      {
+        deactivate();
         mSearchFragmentListener.onSearchClicked();
+      }
     }
 
     @Override

--- a/android/app/src/main/java/app/organicmaps/widget/SearchToolbarController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/SearchToolbarController.java
@@ -96,7 +96,7 @@ public class SearchToolbarController extends ToolbarController
     {
       mQueryLayout.setEndIconDrawable(R.drawable.ic_close_rounded);
       mQueryLayout.setEndIconContentDescription(R.string.clear_the_search);
-      mQueryLayout.setEndIconOnClickListener(v -> clear());
+      mQueryLayout.setEndIconOnClickListener(v -> onClearClick());
       mQueryLayout.setEndIconVisible(true);
     }
     else if (supportsVoiceSearch() && mVoiceInputSupported)
@@ -193,6 +193,13 @@ public class SearchToolbarController extends ToolbarController
   public void clear()
   {
     setQuery("");
+  }
+
+  // X button only: programmatic clear() (search close, back press) must not restore focus.
+  private void onClearClick()
+  {
+    clear();
+    activate();
   }
 
   public boolean hasQuery()


### PR DESCRIPTION
Tapping a category in the Categories tab left the search sheet fully expanded with the keyboard up, so the map and the result pins stayed hidden. iOS collapses the sheet to half screen and dismisses the keyboard for the same action; this brings Android in line.

The category path calls `setQuery(query, isCategory)` — the two-arg overload — which does not go through the one-arg override where the collapse lives. The fix reuses the exact sequence already used by the keyboard "Search" button (`onStartSearchClick`): dismiss the keyboard, then collapse. The order matters: while the IME is visible the insets listener in `SearchFragmentController` forces the sheet back to expanded.

Tapping the clear (X) button emptied the search field but left it without focus, so you had to tap the field again to keep typing. iOS returns first responder on clear.

The X now goes through a new `onClearClick()` hook that clears and re-activates the field. Programmatic `clear()` callers are left alone -- they run when search is being closed, where re-focusing would fight the close. The hook sits in `SearchToolbarController`, so the downloader, bookmarks list and editor filters get the same fix.