### PR TITLE
Process alt routes selection if there is no active mark, but before regular PP.

### DIFF
--- a/libs/map/bookmark_manager.cpp
+++ b/libs/map/bookmark_manager.cpp
@@ -3240,8 +3240,7 @@ kml::GroupIdSet BookmarkManager::MarksChangesTracker::GetAllGroupIds() const
   auto const & groupIds = m_bmManager->GetUnsortedBmGroupsIdList();
   kml::GroupIdSet resultingSet(groupIds.begin(), groupIds.end());
 
-  static_assert(UserMark::BOOKMARK == 0);
-  for (uint32_t i = UserMark::BOOKMARK + 1; i < UserMark::USER_MARK_TYPES_COUNT; ++i)
+  for (uint32_t i = 1; i < UserMark::USER_MARK_TYPES_COUNT; ++i)
     resultingSet.insert(static_cast<kml::MarkGroupId>(i));
   return resultingSet;
 }

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -2343,32 +2343,33 @@ void Framework::DeactivateHotelSearchMark()
 
 void Framework::OnTapEvent(place_page::BuildInfo const & buildInfo)
 {
-  if (!buildInfo.m_isLongTap)
+  if (buildInfo.m_isLongTap)
   {
-    // Taps on an alternative route's ETA balloon (ROUTE_ALT mark) or on its polyline,
-    // swap the active variant instead of PP opening.
-
-    auto const umID = buildInfo.m_userMarkId;
-    if (umID != kml::kInvalidMarkId)
-    {
-      if (UserMark::GetMarkType(umID) == UserMark::Type::ROUTE_ALT)
-      {
-        if (auto const * mark = static_cast<RouteAltMark const *>(GetBookmarkManager().GetUserMark(umID)))
-          m_routingManager.SwapActiveAlternative(mark->GetRouteIdx());
-
-        // Always return because FillUserMarkInfo has no ROUTE_ALT handler and would CHECK-fail.
-        return;
-      }
-    }
-    else if (m_routingManager.TryTapOnAlternativeRoute(buildInfo.m_mercator, m_currentModelView.GetScale()))
-      return;
+    SwitchFullScreen();
+    return;
   }
 
+  // Taps on an alternative route's ETA balloon (ROUTE_ALT mark) or on its polyline,
+  // swap the active variant instead of PP opening.
+  auto const umID = buildInfo.m_userMarkId;
+  if (umID != kml::kInvalidMarkId)
+  {
+    if (UserMark::GetMarkType(umID) == UserMark::Type::ROUTE_ALT)
+    {
+      if (auto const * mark = static_cast<RouteAltMark const *>(GetBookmarkManager().GetUserMark(umID)))
+        m_routingManager.SwapActiveAlternative(mark->GetRouteIdx());
+
+      // Always return because FillUserMarkInfo has no ROUTE_ALT handler and would CHECK-fail.
+      return;
+    }
+  }
+  else if (m_routingManager.TryTapOnAlternativeRoute(buildInfo.m_mercator, m_currentModelView.GetScale()))
+    return;
+
   auto placePageInfo = BuildPlacePageInfo(buildInfo);
-  bool isRoutePoint = placePageInfo.IsRoutePoint();
 
   if (m_routingManager.IsRoutingActive() && m_routingManager.GetCurrentRouterType() == routing::RouterType::Ruler &&
-      !buildInfo.m_isLongTap && !isRoutePoint)
+      !placePageInfo.IsRoutePoint())
   {
     DeactivateMapSelection();
 
@@ -2390,47 +2391,40 @@ void Framework::OnTapEvent(place_page::BuildInfo const & buildInfo)
     else
       data.m_position = buildInfo.m_mercator;
 
-    if (!m_routingManager.ContinueRouteToPoint(std::move(data)))
-      return;
-
-    // Refresh route
-    m_routingManager.RemoveRoute(false /* deactivateFollowing */);
-    m_routingManager.BuildRoute();
+    if (m_routingManager.ContinueRouteToPoint(std::move(data)))
+    {
+      // Refresh route
+      m_routingManager.RemoveRoute(false /* deactivateFollowing */);
+      m_routingManager.BuildRoute();
+    }
 
     return;
   }
 
-  if (buildInfo.m_isLongTap)
-  {
-    SwitchFullScreen();
-  }
-  else
-  {
-    auto const prevTrackId = m_currentPlacePageInfo ? m_currentPlacePageInfo->GetTrackId() : kml::kInvalidTrackId;
-    DeactivateHotelSearchMark();
+  auto const prevTrackId = m_currentPlacePageInfo ? m_currentPlacePageInfo->GetTrackId() : kml::kInvalidTrackId;
+  DeactivateHotelSearchMark();
 
-    m_currentPlacePageInfo = placePageInfo;
+  m_currentPlacePageInfo = placePageInfo;
 
-    auto const newTrackId = m_currentPlacePageInfo->GetTrackId();
-    if (newTrackId != kml::kInvalidTrackId)
+  auto const newTrackId = m_currentPlacePageInfo->GetTrackId();
+  if (newTrackId != kml::kInvalidTrackId)
+  {
+    // For user tracks: tapping the same track at a different point just moves the selection circle.
+    // Temp relation tracks always reuse the same ID, so always update the PlacePage for them.
+    if (newTrackId == prevTrackId && newTrackId != kml::kTempRelationTrackId)
     {
-      // For user tracks: tapping the same track at a different point just moves the selection circle.
-      // Temp relation tracks always reuse the same ID, so always update the PlacePage for them.
-      if (newTrackId == prevTrackId && newTrackId != kml::kTempRelationTrackId)
+      if (m_drapeEngine)
       {
-        if (m_drapeEngine)
-        {
-          m_drapeEngine->SelectObject(df::SelectionShape::ESelectedObject::OBJECT_TRACK,
-                                      m_currentPlacePageInfo->GetMercator(), FeatureID(), false /* isAnim */,
-                                      false /* isGeometrySelectionAllowed */, true /* isSelectionShapeVisible */);
-        }
-        return;
+        m_drapeEngine->SelectObject(df::SelectionShape::ESelectedObject::OBJECT_TRACK,
+                                    m_currentPlacePageInfo->GetMercator(), FeatureID(), false /* isAnim */,
+                                    false /* isGeometrySelectionAllowed */, true /* isSelectionShapeVisible */);
       }
-      GetBookmarkManager().UpdateElevationMyPosition(newTrackId, true /* ignoreLocationCache */);
+      return;
     }
-
-    ActivateMapSelection();
+    GetBookmarkManager().UpdateElevationMyPosition(newTrackId, true /* ignoreLocationCache */);
   }
+
+  ActivateMapSelection();
 }
 
 void Framework::InvalidateRendering()

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -2343,22 +2343,25 @@ void Framework::DeactivateHotelSearchMark()
 
 void Framework::OnTapEvent(place_page::BuildInfo const & buildInfo)
 {
-  // Intercept taps on alternative-route ETA balloons before BuildPlacePageInfo: swap the active
-  // variant and return. Always return — even when SwapActiveAlternative declines (tap on the
-  // already-active balloon) — because FillUserMarkInfo has no ROUTE_ALT handler and would CHECK-fail.
-  if (!buildInfo.m_isLongTap && buildInfo.m_userMarkId != kml::kInvalidMarkId &&
-      UserMark::GetMarkType(buildInfo.m_userMarkId) == UserMark::Type::ROUTE_ALT)
+  if (!buildInfo.m_isLongTap)
   {
-    if (auto const * mark = static_cast<RouteAltMark const *>(GetBookmarkManager().GetUserMark(buildInfo.m_userMarkId)))
-      m_routingManager.SwapActiveAlternative(mark->GetRouteIdx());
-    return;
-  }
+    // Taps on an alternative route's ETA balloon (ROUTE_ALT mark) or on its polyline,
+    // swap the active variant instead of PP opening.
 
-  // Same swap when the tap lands on an alternative route's polyline rather than its balloon.
-  if (!buildInfo.m_isLongTap &&
-      m_routingManager.TryTapOnAlternativeRoute(buildInfo.m_mercator, m_currentModelView.GetScale()))
-  {
-    return;
+    auto const umID = buildInfo.m_userMarkId;
+    if (umID != kml::kInvalidMarkId)
+    {
+      if (UserMark::GetMarkType(umID) == UserMark::Type::ROUTE_ALT)
+      {
+        if (auto const * mark = static_cast<RouteAltMark const *>(GetBookmarkManager().GetUserMark(umID)))
+          m_routingManager.SwapActiveAlternative(mark->GetRouteIdx());
+
+        // Always return because FillUserMarkInfo has no ROUTE_ALT handler and would CHECK-fail.
+        return;
+      }
+    }
+    else if (m_routingManager.TryTapOnAlternativeRoute(buildInfo.m_mercator, m_currentModelView.GetScale()))
+      return;
   }
 
   auto placePageInfo = BuildPlacePageInfo(buildInfo);

--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -449,7 +449,7 @@ Bookmark const * GetBookmark(Framework & fm, m2::PointD const & pt)
 bool IsValidBookmark(Framework & fm, m2::PointD const & pt)
 {
   auto const * mark = GetMark(fm, pt);
-  return (mark != nullptr) && (mark->GetMarkType() == UserMark::BOOKMARK);
+  return (mark && mark->GetMarkType() == UserMark::BOOKMARK);
 }
 }  // namespace
 

--- a/libs/map/user_mark.cpp
+++ b/libs/map/user_mark.cpp
@@ -3,8 +3,6 @@
 
 #include "drape_frontend/visual_params.hpp"
 
-#include "indexer/scales.hpp"
-
 #include "geometry/mercator.hpp"
 
 UserMark::UserMark(kml::MarkId id, m2::PointD const & ptOrg, UserMark::Type type)

--- a/libs/map/user_mark.hpp
+++ b/libs/map/user_mark.hpp
@@ -55,6 +55,7 @@ public:
     USER_MARK_TYPES_COUNT,
     USER_MARK_TYPES_COUNT_MAX = 1000,
   };
+  static_assert(BOOKMARK == 0);
 
   UserMark(kml::MarkId id, m2::PointD const & ptOrg, UserMark::Type type);
   UserMark(m2::PointD const & ptOrg, UserMark::Type type);

--- a/libs/map/user_mark_id_storage.cpp
+++ b/libs/map/user_mark_id_storage.cpp
@@ -6,7 +6,9 @@
 
 namespace
 {
-uint32_t const kMarkIdTypeBitsCount = 4;
+uint32_t constexpr kMarkIdTypeBitsCount = 4;
+static_assert(UserMark::USER_MARK_TYPES_COUNT <= (1 << kMarkIdTypeBitsCount));
+
 std::string const kLastBookmarkId = "LastBookmarkId";
 std::string const kLastTrackId = "LastTrackId";
 std::string const kLastBookmarkCategoryId = "LastBookmarkCategoryId";
@@ -96,9 +98,6 @@ bool UserMarkIdStorage::CheckIds(kml::FileData const & fileData) const
 
 kml::MarkId UserMarkIdStorage::GetNextUserMarkId(UserMark::Type type)
 {
-  static_assert(UserMark::Type::USER_MARK_TYPES_COUNT <= (1 << kMarkIdTypeBitsCount),
-                "Not enough bits for user mark type.");
-
   auto const typeBits = static_cast<uint64_t>(type) << (sizeof(kml::MarkId) * 8 - kMarkIdTypeBitsCount);
   if (type == UserMark::Type::BOOKMARK)
   {


### PR DESCRIPTION
## What changed

User marks now take priority over alternative-route polyline selection. Tapping a route ETA balloon still selects its variant; when no user mark was hit, alternative-route polyline selection runs before regular place-page selection.

Long taps now exit immediately after toggling full screen. The PR also keeps user-mark ID/group invariants as compile-time checks near the code they constrain.

Related implementation: #12808 (replaces #3447 and closes #12832), #12918.
Related feature discussions: #3975, #1183, #12773, #2237.

## Testing

- Local arm64 macOS Debug build and `map_tests`
- Android F-Droid/Web, iOS Debug/Release, macOS, and Linux CI
- Android lint, code style, and DCO checks