### PR TITLE
[ge0] Escape backslashes in shared URLs

### DIFF
--- a/libs/ge0/ge0_tests/url_generator_tests.cpp
+++ b/libs/ge0/ge0_tests/url_generator_tests.cpp
@@ -339,6 +339,12 @@ UNIT_TEST(GenerateShortShowMapUrl_ControlCharsAreEscaped)
   TEST_EQUAL("om://8wAAAAAAAA/Hello%09World%0A", res, ());
 }
 
+UNIT_TEST(GenerateShortShowMapUrl_BackslashIsEscaped)
+{
+  string res = GenerateShortShowMapUrl(0, 0, 19, "A\\B");
+  TEST_EQUAL("om://8wAAAAAAAA/A%5CB", res, ());
+}
+
 UNIT_TEST(GenerateShortShowMapUrl_Unicode)
 {
   string res = GenerateShortShowMapUrl(0, 0, 19, "\xe2\x98\x84");

--- a/libs/ge0/url_generator.cpp
+++ b/libs/ge0/url_generator.cpp
@@ -26,7 +26,7 @@ std::string TransformName(std::string const & s)
 // URL restricted / unsafe / unwise characters are %-encoded.
 // See rfc3986, rfc1738, rfc2396.
 //
-// Not compatible with the url encode function from coding/.
+// Unlike url::UrlEncode(), keeps non-ASCII bytes raw so shared links stay short and readable.
 std::string UrlEncodeString(std::string const & s)
 {
   std::string result;

--- a/libs/ge0/url_generator.cpp
+++ b/libs/ge0/url_generator.cpp
@@ -94,6 +94,7 @@ std::string UrlEncodeString(std::string const & s)
     case ']':
     case '{':
     case '}':
+    case '\\':
     case '|':
     case '^':
     case '`':


### PR DESCRIPTION
Place names containing a backslash produce links where URL consumers may interpret the character as a path separator, changing the decoded place name on every platform.

This PR adds backslash to the existing ge0 unsafe-character switch and adds focused generator coverage.

Testing: `clang-format --dry-run --Werror` and `git diff --check`; project tests were not run locally.