### PR TITLE
[ios] Implement CarPlay HUD support

### DIFF
--- a/iphone/Maps/Core/CarPlay/CarPlayManeuverMapper.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayManeuverMapper.swift
@@ -1,0 +1,81 @@
+import CarPlay
+
+@available(iOS 17.4, *)
+enum CarPlayManeuverMapper {
+  private static let executeDistanceMeters = 50.0
+  private static let prepareDistanceMeters = 500.0
+
+  static func configure(_ maneuver: CPManeuver,
+                        direction: RouteTurnDirection,
+                        roadName: String,
+                        roundaboutExitNumber: Int = 0) {
+    maneuver.maneuverType = maneuverType(for: direction, roundaboutExitNumber: roundaboutExitNumber)
+    maneuver.roadFollowingManeuverVariants = roadName.isEmpty ? nil : [roadName]
+    maneuver.junctionType = isRoundabout(direction) ? .roundabout : .intersection
+  }
+
+  static func maneuverType(for direction: RouteTurnDirection,
+                           roundaboutExitNumber: Int = 0) -> CPManeuverType {
+    switch direction {
+    case .none:
+      return .noTurn
+    case .straight:
+      return .straightAhead
+    case .right:
+      return .rightTurn
+    case .sharpRight:
+      return .sharpRightTurn
+    case .slightRight:
+      return .slightRightTurn
+    case .left:
+      return .leftTurn
+    case .sharpLeft:
+      return .sharpLeftTurn
+    case .slightLeft:
+      return .slightLeftTurn
+    case .uTurnLeft, .uTurnRight:
+      return .uTurn
+    case .enterRoundabout:
+      return .enterRoundabout
+    case .leaveRoundabout:
+      guard (1 ... 19).contains(roundaboutExitNumber),
+            let type = CPManeuverType(
+              rawValue: CPManeuverType.roundaboutExit1.rawValue + UInt(roundaboutExitNumber - 1)
+            )
+      else {
+        return .exitRoundabout
+      }
+      return type
+    case .stayOnRoundabout:
+      return .followRoad
+    case .startAtEndOfStreet:
+      return .startRoute
+    case .destination:
+      return .arriveAtDestination
+    case .exitHighwayLeft:
+      return .highwayOffRampLeft
+    case .exitHighwayRight:
+      return .highwayOffRampRight
+    }
+  }
+
+  static func maneuverState(distanceToTurnMeters: Double) -> CPManeuverState {
+    switch distanceToTurnMeters {
+    case ...executeDistanceMeters:
+      return .execute
+    case ...prepareDistanceMeters:
+      return .prepare
+    default:
+      return .initial
+    }
+  }
+
+  private static func isRoundabout(_ direction: RouteTurnDirection) -> Bool {
+    switch direction {
+    case .enterRoundabout, .leaveRoundabout, .stayOnRoundabout:
+      return true
+    default:
+      return false
+    }
+  }
+}

--- a/iphone/Maps/Core/CarPlay/CarPlayRouter.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayRouter.swift
@@ -12,8 +12,11 @@ protocol CarPlayRouterListener: AnyObject {
 
 @objc(MWMCarPlayRouter)
 final class CarPlayRouter: NSObject {
+  private static let initialManeuverRepublishDelay: TimeInterval = 0.5
+
   private let listenerContainer: ListenerContainer<CarPlayRouterListener>
   private var routeSession: CPNavigationSession?
+  private var registeredManeuvers = [CPManeuver]()
   private var initialSpeedCamSettings: SpeedCameraManagerMode
   private var isRoutingPresentationActive = false
   var currentTrip: CPTrip? {
@@ -212,7 +215,7 @@ final class CarPlayRouter: NSObject {
 // MARK: - Navigation session management
 
 extension CarPlayRouter {
-  func startNavigationSession(forTrip trip: CPTrip, template: CPMapTemplate) {
+  func startNavigationSession(forTrip trip: CPTrip, template: CPMapTemplate, isRestoring: Bool = false) {
     guard routeSession == nil else {
       let errorMessage = "Route session is already running."
       LOG(.error, errorMessage)
@@ -221,10 +224,12 @@ extension CarPlayRouter {
     }
     LOG(.info, "Starting a new navigation session")
     routeSession = template.startNavigationSession(for: trip)
-    routeSession?.pauseTrip(for: .loading, description: nil)
-    updateUpcomingManeuvers()
+    resetNavigationMetadata()
+    if isRestoring {
+      scheduleInitialManeuverRepublish()
+    }
     RoutingManager.routingManager.setOnNewTurnCallback { [weak self] in
-      self?.updateUpcomingManeuvers()
+      self?.advanceToNextManeuver()
     }
   }
 
@@ -232,6 +237,7 @@ extension CarPlayRouter {
     LOG(.info, "Сancelling navigation session")
     routeSession?.cancelTrip()
     routeSession = nil
+    registeredManeuvers.removeAll()
     RoutingManager.routingManager.resetOnNewTurnCallback()
   }
 
@@ -245,37 +251,117 @@ extension CarPlayRouter {
     LOG(.info, "Finishing trip")
     routeSession?.finishTrip()
     routeSession = nil
+    registeredManeuvers.removeAll()
     completeRouteAndRemovePoints()
     RoutingManager.routingManager.resetOnNewTurnCallback()
   }
 
-  func updateUpcomingManeuvers() {
-    let maneuvers = createUpcomingManeuvers()
-    routeSession?.upcomingManeuvers = maneuvers
-  }
-
-  func updateEstimates() {
-    guard let routeSession = routeSession,
-          let routeInfo = RoutingManager.routingManager.routeInfo,
-          let primaryManeuver = routeSession.upcomingManeuvers.first,
-          let estimates = createEstimates(routeInfo)
+  func updateUpcomingManeuvers(reusingPrimaryManeuver primaryManeuver: CPManeuver? = nil) {
+    guard let routeSession,
+          let routeInfo = RoutingManager.routingManager.routeInfo
     else {
       return
     }
-    routeSession.updateEstimates(estimates, for: primaryManeuver)
+
+    let maneuvers = createUpcomingManeuvers(routeInfo: routeInfo, primaryManeuver: primaryManeuver)
+    if #available(iOS 17.4, *) {
+      let newManeuvers = primaryManeuver == nil ? maneuvers : Array(maneuvers.dropFirst())
+      if !newManeuvers.isEmpty {
+        routeSession.add(newManeuvers)
+      }
+    }
+    registeredManeuvers = maneuvers
+    routeSession.upcomingManeuvers = maneuvers
+    if #available(iOS 17.4, *) {
+      updateCurrentNavigationMetadata(routeSession: routeSession, routeInfo: routeInfo)
+    }
   }
 
-  private func createEstimates(_ routeInfo: RouteInfo) -> CPTravelEstimates? {
+  func updateEstimates(_ routeInfo: RouteInfo) {
+    guard let routeSession = routeSession,
+          let primaryManeuver = registeredManeuvers.first
+    else {
+      return
+    }
+    routeSession.updateEstimates(createEstimates(routeInfo), for: primaryManeuver)
+    if #available(iOS 17.4, *) {
+      updateCurrentNavigationMetadata(routeSession: routeSession, routeInfo: routeInfo)
+    }
+  }
+
+  private func createEstimates(_ routeInfo: RouteInfo) -> CPTravelEstimates {
     let measurement = Measurement(value: routeInfo.distanceToTurn, unit: routeInfo.turnUnits)
     return CPTravelEstimates(distanceRemaining: measurement, timeRemaining: 0.0)
   }
 
-  private func createUpcomingManeuvers() -> [CPManeuver] {
-    guard let routeInfo = RoutingManager.routingManager.routeInfo else {
-      return []
+  @available(iOS 17.4, *)
+  private func replaceNavigationMetadata(routeInfo: RouteInfo) {
+    guard let routeSession else { return }
+
+    let maneuvers = createUpcomingManeuvers(routeInfo: routeInfo)
+
+    let tripEstimates = CPTravelEstimates(
+      distanceRemaining: Measurement(value: routeInfo.targetDistance, unit: routeInfo.targetUnits),
+      timeRemaining: routeInfo.timeToTarget
+    )
+    // CPRouteInformation requires a current lane guidance even when the app has no lane data.
+    let emptyLaneGuidance = CPLaneGuidance()
+    emptyLaneGuidance.lanes = []
+    emptyLaneGuidance.instructionVariants = maneuvers[0].instructionVariants
+    let routeInformation = CPRouteInformation(
+      maneuvers: maneuvers,
+      laneGuidances: [],
+      currentManeuvers: maneuvers,
+      currentLaneGuidance: emptyLaneGuidance,
+      trip: tripEstimates,
+      maneuverTravelEstimates: createEstimates(routeInfo)
+    )
+
+    routeSession.pauseTrip(for: .rerouting, description: nil)
+    routeSession.resumeTrip(updatedRouteInformation: routeInformation)
+    registeredManeuvers = maneuvers
+    routeSession.upcomingManeuvers = maneuvers
+    updateCurrentNavigationMetadata(routeSession: routeSession, routeInfo: routeInfo)
+  }
+
+  private func resetNavigationMetadata() {
+    registeredManeuvers.removeAll()
+    updateUpcomingManeuvers()
+  }
+
+  private func advanceToNextManeuver() {
+    // Reuse the already registered secondary maneuver when it becomes primary to avoid adding it twice.
+    let nextManeuver = registeredManeuvers.count > 1 ? registeredManeuvers[1] : nil
+    updateUpcomingManeuvers(reusingPrimaryManeuver: nextManeuver)
+  }
+
+  private func scheduleInitialManeuverRepublish() {
+    guard let routeSession else { return }
+    // Even after the root template is installed, a restored session's initial maneuvers
+    // may not be picked up by the instrument cluster. Republish them once after session setup.
+    DispatchQueue.main.asyncAfter(deadline: .now() + Self.initialManeuverRepublishDelay) { [weak self, weak routeSession] in
+      guard let self, let routeSession,
+            self.routeSession === routeSession,
+            !self.registeredManeuvers.isEmpty
+      else {
+        return
+      }
+      routeSession.upcomingManeuvers = self.registeredManeuvers
     }
-    var maneuvers = [CPManeuver]()
-    let primaryManeuver = CPManeuver()
+  }
+
+  @available(iOS 17.4, *)
+  private func updateCurrentNavigationMetadata(routeSession: CPNavigationSession, routeInfo: RouteInfo) {
+    routeSession.currentRoadNameVariants = routeInfo.currentStreetName.isEmpty ? [] : [routeInfo.currentStreetName]
+
+    let distanceMeters = Measurement(value: routeInfo.distanceToTurn, unit: routeInfo.turnUnits)
+      .converted(to: .meters).value
+    routeSession.maneuverState = CarPlayManeuverMapper.maneuverState(distanceToTurnMeters: distanceMeters)
+  }
+
+  private func createUpcomingManeuvers(routeInfo: RouteInfo,
+                                       primaryManeuver: CPManeuver? = nil) -> [CPManeuver] {
+    let primaryManeuver = primaryManeuver ?? CPManeuver()
     primaryManeuver.userInfo = CPConstants.Maneuvers.primary
     var instructionVariant = routeInfo.streetName
     if routeInfo.roundExitNumber != 0 {
@@ -286,25 +372,40 @@ extension CarPlayRouter {
       instructionVariant = instructionVariant.isEmpty ? exitNumber : (exitNumber + ", " + instructionVariant)
     }
     primaryManeuver.instructionVariants = [instructionVariant]
+    primaryManeuver.symbolImage = nil
+    primaryManeuver.dashboardSymbolImage = nil
     if let imageName = routeInfo.turnImageName,
        let symbol = UIImage(named: imageName) {
       primaryManeuver.symbolImage = symbol.withRenderingMode(.alwaysOriginal)
       primaryManeuver.dashboardSymbolImage = symbol.withRenderingMode(.alwaysTemplate)
     }
-    if let estimates = createEstimates(routeInfo) {
-      primaryManeuver.initialTravelEstimates = estimates
+    primaryManeuver.initialTravelEstimates = createEstimates(routeInfo)
+    if #available(iOS 17.4, *) {
+      CarPlayManeuverMapper.configure(primaryManeuver,
+                                      direction: routeInfo.turnDirection,
+                                      roadName: routeInfo.streetName,
+                                      roundaboutExitNumber: routeInfo.roundExitNumber)
+      primaryManeuver.trafficSide = routeInfo.isLeftHandTraffic ? .left : .right
     }
-    maneuvers.append(primaryManeuver)
-    if let imageName = routeInfo.nextTurnImageName,
-       let symbol = UIImage(named: imageName) {
-      let secondaryManeuver = CPManeuver()
-      secondaryManeuver.userInfo = CPConstants.Maneuvers.secondary
-      secondaryManeuver.instructionVariants = [L("then_turn")]
-      secondaryManeuver.symbolImage = symbol.withRenderingMode(.alwaysOriginal) // always white on green
-      secondaryManeuver.dashboardSymbolImage = symbol.withRenderingMode(.alwaysTemplate) // black/white on transparent
-      maneuvers.append(secondaryManeuver)
+
+    guard let imageName = routeInfo.nextTurnImageName,
+          let symbol = UIImage(named: imageName)
+    else {
+      return [primaryManeuver]
     }
-    return maneuvers
+
+    let secondaryManeuver = CPManeuver()
+    secondaryManeuver.userInfo = CPConstants.Maneuvers.secondary
+    secondaryManeuver.instructionVariants = [L("then_turn")]
+    secondaryManeuver.symbolImage = symbol.withRenderingMode(.alwaysOriginal) // always white on green
+    secondaryManeuver.dashboardSymbolImage = symbol.withRenderingMode(.alwaysTemplate) // black/white on transparent
+    if #available(iOS 17.4, *) {
+      CarPlayManeuverMapper.configure(secondaryManeuver,
+                                      direction: routeInfo.nextTurnDirection,
+                                      roadName: routeInfo.nextStreetName)
+      secondaryManeuver.trafficSide = routeInfo.isLeftHandTraffic ? .left : .right
+    }
+    return [primaryManeuver, secondaryManeuver]
   }
 
   func createTrip(startPoint: MWMRoutePoint, endPoint: MWMRoutePoint, routeInfo: RouteInfo? = nil) -> CPTrip {
@@ -360,10 +461,14 @@ extension CarPlayRouter: RoutingManagerListener {
                               trip: trip)
           }
         } else {
+          if #available(iOS 17.4, *) {
+            replaceNavigationMetadata(routeInfo: info)
+          } else {
+            resetNavigationMetadata()
+          }
           listenerContainer.forEach {
             $0.didUpdateRouteInfo(info, forTrip: trip)
           }
-          updateUpcomingManeuvers()
         }
       }
     default:

--- a/iphone/Maps/Core/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Core/CarPlay/CarPlayService.swift
@@ -393,7 +393,7 @@ final class CarPlayService: NSObject {
 
     if let (trip, routeInfo) = router.restoredNavigationSession() {
       MapTemplateBuilder.configureNavigationUI(mapTemplate, positionMode: currentPositionMode)
-      router.startNavigationSession(forTrip: trip, template: mapTemplate)
+      router.startNavigationSession(forTrip: trip, template: mapTemplate, isRestoring: true)
       if let estimates = createEstimates(routeInfo: routeInfo) {
         mapTemplate.updateEstimates(estimates, for: trip)
       }
@@ -694,9 +694,11 @@ final class CarPlayService: NSObject {
       if success {
         restoreCarPlayTemplateUI()
         updatePhoneModeAlert()
+        router?.startNavigationSession(forTrip: trip, template: mapTemplate, isRestoring: true)
+      } else if error == nil {
+        LOG(.warning, "CarPlay failed to install the navigation root template")
       }
     }
-    router?.startNavigationSession(forTrip: trip, template: mapTemplate)
     if let estimates = createEstimates(routeInfo: routeInfo) {
       mapTemplate.tripEstimateStyle = rootTemplateStyle
       mapTemplate.updateEstimates(estimates, for: trip)
@@ -1053,6 +1055,12 @@ extension CarPlayService: CPMapTemplateDelegate {
     return .leadingSymbol
   }
 
+  @available(iOS 17.4, *)
+  func mapTemplateShouldProvideNavigationMetadata(_: CPMapTemplate) -> Bool {
+    // Enables semantic maneuver metadata for the vehicle's instrument cluster and HUD.
+    true
+  }
+
   func mapTemplate(_ mapTemplate: CPMapTemplate,
                    selectedPreviewFor trip: CPTrip,
                    using routeChoice: CPRouteChoice) {
@@ -1140,7 +1148,7 @@ extension CarPlayService: CarPlayRouterListener {
     else {
       return
     }
-    router.updateEstimates()
+    router.updateEstimates(routeInfo)
     if let estimates = createEstimates(routeInfo: routeInfo) {
       template.updateEstimates(estimates, for: trip)
     }

--- a/iphone/Maps/Core/CarPlay/Templates Data/RouteInfo.swift
+++ b/iphone/Maps/Core/CarPlay/Templates Data/RouteInfo.swift
@@ -5,36 +5,51 @@ class RouteInfo: NSObject {
   let targetUnits: UnitLength
   let distanceToTurn: Double
   let turnUnits: UnitLength
+  let currentStreetName: String
   let streetName: String
+  let nextStreetName: String
+  let turnDirection: RouteTurnDirection
+  let nextTurnDirection: RouteTurnDirection
   let turnImageName: String?
   let nextTurnImageName: String?
   let speedMps: Double
   let speedLimitMps: Double?
   let roundExitNumber: Int
+  let isLeftHandTraffic: Bool
 
   @objc init(timeToTarget: TimeInterval,
              targetDistance: Double,
              targetUnitsIndex: UInt8,
              distanceToTurn: Double,
              turnUnitsIndex: UInt8,
+             currentStreetName: String,
              streetName: String,
+             nextStreetName: String,
+             turnDirection: RouteTurnDirection,
+             nextTurnDirection: RouteTurnDirection,
              turnImageName: String?,
              nextTurnImageName: String?,
              speedMps: Double,
              speedLimitMps: Double,
-             roundExitNumber: Int) {
+             roundExitNumber: Int,
+             isLeftHandTraffic: Bool) {
     self.timeToTarget = timeToTarget
     self.targetDistance = targetDistance
     targetUnits = RouteInfo.unitLength(for: targetUnitsIndex)
     self.distanceToTurn = distanceToTurn
     turnUnits = RouteInfo.unitLength(for: turnUnitsIndex)
+    self.currentStreetName = currentStreetName
     self.streetName = streetName
+    self.nextStreetName = nextStreetName
+    self.turnDirection = turnDirection
+    self.nextTurnDirection = nextTurnDirection
     self.turnImageName = turnImageName
     self.nextTurnImageName = nextTurnImageName
     self.speedMps = speedMps
     // speedLimitMps >= 0 means known limited speed.
     self.speedLimitMps = speedLimitMps < 0 ? nil : speedLimitMps
     self.roundExitNumber = roundExitNumber
+    self.isLeftHandTraffic = isLeftHandTraffic
   }
 
   /// > Warning: Order of enum values MUST BE the same with
@@ -53,4 +68,25 @@ class RouteInfo: NSObject {
       return .meters
     }
   }
+}
+
+@objc(MWMRouteTurnDirection)
+enum RouteTurnDirection: Int {
+  case none
+  case straight
+  case right
+  case sharpRight
+  case slightRight
+  case left
+  case sharpLeft
+  case slightLeft
+  case uTurnLeft
+  case uTurnRight
+  case enterRoundabout
+  case leaveRoundabout
+  case stayOnRoundabout
+  case startAtEndOfStreet
+  case destination
+  case exitHighwayLeft
+  case exitHighwayRight
 }

--- a/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
+++ b/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
@@ -10,9 +10,55 @@
 
 #include <CoreApi/Framework.h>
 
+#include "geometry/mercator.hpp"
+#include "indexer/feature_meta.hpp"
+#include "platform/country_file.hpp"
+#include "storage/country_info_getter.hpp"
+
+namespace
+{
+MWMRouteTurnDirection RouteTurnDirection(routing::turns::CarDirection turn)
+{
+  using namespace routing::turns;
+  switch (turn)
+  {
+  case CarDirection::None:
+  case CarDirection::Count: return MWMRouteTurnDirectionNone;
+  case CarDirection::GoStraight: return MWMRouteTurnDirectionStraight;
+  case CarDirection::TurnRight: return MWMRouteTurnDirectionRight;
+  case CarDirection::TurnSharpRight: return MWMRouteTurnDirectionSharpRight;
+  case CarDirection::TurnSlightRight: return MWMRouteTurnDirectionSlightRight;
+  case CarDirection::TurnLeft: return MWMRouteTurnDirectionLeft;
+  case CarDirection::TurnSharpLeft: return MWMRouteTurnDirectionSharpLeft;
+  case CarDirection::TurnSlightLeft: return MWMRouteTurnDirectionSlightLeft;
+  case CarDirection::UTurnLeft: return MWMRouteTurnDirectionUTurnLeft;
+  case CarDirection::UTurnRight: return MWMRouteTurnDirectionUTurnRight;
+  case CarDirection::EnterRoundAbout: return MWMRouteTurnDirectionEnterRoundabout;
+  case CarDirection::LeaveRoundAbout: return MWMRouteTurnDirectionLeaveRoundabout;
+  case CarDirection::StayOnRoundAbout: return MWMRouteTurnDirectionStayOnRoundabout;
+  case CarDirection::StartAtEndOfStreet: return MWMRouteTurnDirectionStartAtEndOfStreet;
+  case CarDirection::ReachedYourDestination: return MWMRouteTurnDirectionDestination;
+  case CarDirection::ExitHighwayToLeft: return MWMRouteTurnDirectionExitHighwayLeft;
+  case CarDirection::ExitHighwayToRight: return MWMRouteTurnDirectionExitHighwayRight;
+  }
+  return MWMRouteTurnDirectionNone;
+}
+
+bool IsLeftHandTraffic(storage::CountryId const & countryId)
+{
+  auto & framework = GetFramework();
+  auto const mwmId = framework.GetDataSource().GetMwmIdByCountryFile(platform::CountryFile(countryId));
+  auto const & info = mwmId.GetInfo();
+  return info && info->GetRegionData().Get(feature::RegionData::RD_DRIVING) == "l";
+}
+}  // namespace
+
 @interface MWMRoutingManager () <MWMFrameworkRouteBuilderObserver, MWMLocationObserver>
 @property(nonatomic, readonly) RoutingManager & rm;
 @property(strong, nonatomic) NSHashTable<id<MWMRoutingManagerListener>> * listeners;
+@property(nonatomic) storage::CountryInfoGetterBase::RegionId trafficRegionId;
+@property(nonatomic) BOOL isLeftHandTraffic;
+@property(strong, nonatomic) CLLocation * trafficSideLocation;
 @end
 
 @implementation MWMRoutingManager
@@ -31,6 +77,7 @@
   if (self)
   {
     self.listeners = [NSHashTable<id<MWMRoutingManagerListener>> weakObjectsHashTable];
+    self.trafficRegionId = storage::CountryInfoGetterBase::kInvalidId;
     [MWMFrameworkListener addObserver:self];
     [MWMLocationManager addObserver:self];
   }
@@ -93,6 +140,7 @@
   if (!info.IsValid())
     return nil;
   CLLocation * lastLocation = [MWMLocationManager lastLocation];
+  [self updateTrafficSideAtLocation:lastLocation];
   double speedMps = 0;
   if (lastLocation && lastLocation.speed >= 0)
     speedMps = lastLocation.speed;
@@ -104,19 +152,33 @@
     roundExitNumber = info.m_exitNum;
   }
 
-  MWMRouteInfo * objCInfo =
-      [[MWMRouteInfo alloc] initWithTimeToTarget:info.m_time
-                                  targetDistance:info.m_distToTarget.GetDistance()
-                                targetUnitsIndex:static_cast<UInt8>(info.m_distToTarget.GetUnits())
-                                  distanceToTurn:info.m_distToTurn.GetDistance()
-                                  turnUnitsIndex:static_cast<UInt8>(info.m_distToTurn.GetUnits())
-                                      streetName:@(info.m_nextStreetName.c_str())
-                                   turnImageName:[self turnImageName:info.m_turn isPrimary:YES]
-                               nextTurnImageName:[self turnImageName:info.m_nextTurn isPrimary:NO]
-                                        speedMps:speedMps
-                                   speedLimitMps:info.m_speedLimitMps
-                                 roundExitNumber:roundExitNumber];
-  return objCInfo;
+  auto nextTurnDirection = routing::turns::CarDirection::None;
+  if (info.m_nextTurn != routing::turns::CarDirection::None)
+  {
+    // m_nextTurn controls when the "then" maneuver is shown, but its cached direction can lag behind the route.
+    auto const * route = self.rm.RoutingSession().GetRoute();
+    double distanceToNextTurnMeters = 0.0;
+    routing::turns::TurnItem nextTurn;
+    if (route && route->GetNextTurn(distanceToNextTurnMeters, nextTurn))
+      nextTurnDirection = nextTurn.m_turn;
+  }
+
+  return [[MWMRouteInfo alloc] initWithTimeToTarget:info.m_time
+                                     targetDistance:info.m_distToTarget.GetDistance()
+                                   targetUnitsIndex:static_cast<UInt8>(info.m_distToTarget.GetUnits())
+                                     distanceToTurn:info.m_distToTurn.GetDistance()
+                                     turnUnitsIndex:static_cast<UInt8>(info.m_distToTurn.GetUnits())
+                                  currentStreetName:@(info.m_currentStreetName.c_str())
+                                         streetName:@(info.m_nextStreetName.c_str())
+                                     nextStreetName:@(info.m_nextNextStreetName.c_str())
+                                      turnDirection:RouteTurnDirection(info.m_turn)
+                                  nextTurnDirection:RouteTurnDirection(nextTurnDirection)
+                                      turnImageName:[self turnImageName:info.m_turn isPrimary:YES]
+                                  nextTurnImageName:[self turnImageName:nextTurnDirection isPrimary:NO]
+                                           speedMps:speedMps
+                                      speedLimitMps:info.m_speedLimitMps
+                                    roundExitNumber:roundExitNumber
+                                  isLeftHandTraffic:self.isLeftHandTraffic];
 }
 
 - (MWMRouterType)type
@@ -282,6 +344,35 @@
   NSArray<id<MWMRoutingManagerListener>> * objects = self.listeners.allObjects;
   for (id<MWMRoutingManagerListener> object in objects)
     [object didLocationUpdate:turnNotifications];
+}
+
+- (void)updateTrafficSideAtLocation:(CLLocation *)location
+{
+  if (!location)
+    return;
+  if ([self.trafficSideLocation isEqual:location])
+    return;
+  self.trafficSideLocation = location;
+
+  auto & countryInfoGetter = GetFramework().GetCountryInfoGetter();
+  auto const coordinate = location.coordinate;
+  auto const position = mercator::FromLatLon(coordinate.latitude, coordinate.longitude);
+  if (self.trafficRegionId != storage::CountryInfoGetterBase::kInvalidId &&
+      countryInfoGetter.BelongsToAnyRegion(position, {self.trafficRegionId}))
+  {
+    return;
+  }
+
+  auto const countryId = countryInfoGetter.GetRegionCountryId(position);
+  if (countryId.empty())
+  {
+    self.trafficRegionId = storage::CountryInfoGetterBase::kInvalidId;
+    self.isLeftHandTraffic = NO;
+    return;
+  }
+
+  self.trafficRegionId = countryInfoGetter.GetRegionId(countryId);
+  self.isLeftHandTraffic = IsLeftHandTraffic(countryId);
 }
 
 - (NSString *)turnImageName:(routing::turns::CarDirection)turn isPrimary:(BOOL)isPrimary

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		A10000000000000000000055 /* TTSLanguageSettingsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000058 /* TTSLanguageSettingsModels.swift */; };
 		A10000000000000000000056 /* TTSLanguageSettingsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000059 /* TTSLanguageSettingsPresenter.swift */; };
 		A630D1EA207CA95900976DEA /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = A630D1E8207CA95900976DEA /* Localizable.stringsdict */; };
+		A13418010000000000000002 /* CarPlayManeuverMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13418010000000000000001 /* CarPlayManeuverMapper.swift */; };
+		A13418010000000000000004 /* CarPlayManeuverMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13418010000000000000003 /* CarPlayManeuverMapperTests.swift */; };
 		B26883EF0814407A8B1D73AF /* PlacePageUserDescriptionWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4584F20AAF794B9683B14087 /* PlacePageUserDescriptionWebViewTests.swift */; };
 		BB25B1A71FB32767007276FA /* transit_colors.txt in Resources */ = {isa = PBXBuildFile; fileRef = BB25B1A51FB32767007276FA /* transit_colors.txt */; };
 		BB7626B61E85599C0031D71C /* icudt78l.dat in Resources */ = {isa = PBXBuildFile; fileRef = BB7626B41E8559980031D71C /* icudt78l.dat */; };
@@ -925,6 +927,8 @@
 		AC89C2362F2CF86000368057 /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Localizable.strings; sourceTree = "<group>"; };
 		AC89C2372F2CF86000368057 /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = lo; path = lo.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		AC89C2382F2CF86100368057 /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/LocalizableTypes.strings; sourceTree = "<group>"; };
+		A13418010000000000000001 /* CarPlayManeuverMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayManeuverMapper.swift; sourceTree = "<group>"; };
+		A13418010000000000000003 /* CarPlayManeuverMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayManeuverMapperTests.swift; sourceTree = "<group>"; };
 		BB25B1A51FB32767007276FA /* transit_colors.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = transit_colors.txt; path = ../../data/transit_colors.txt; sourceTree = "<group>"; };
 		BB7626B41E8559980031D71C /* icudt78l.dat */ = {isa = PBXFileReference; lastKnownFileType = file; name = icudt78l.dat; path = ../../data/icudt78l.dat; sourceTree = "<group>"; };
 		DB05F1BC1BF340DE002C974C /* drules_default.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = drules_default.bin; path = ../../data/drules_default.bin; sourceTree = "<group>"; };
@@ -2000,6 +2004,7 @@
 		4B4153B92BF970BD00EE4B02 /* CarPlay */ = {
 			isa = PBXGroup;
 			children = (
+				A13418010000000000000003 /* CarPlayManeuverMapperTests.swift */,
 				ED914331300168CF0081DF0B /* CarPlaySceneDelegateTests.swift */,
 				ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */,
 			);
@@ -3561,6 +3566,7 @@
 				ED82C67E2F90186300FA103D /* Template Builders */,
 				ED82C6852F90186300FA103D /* Templates Data */,
 				ED82C6862F90186300FA103D /* CarplayPlaceholderView.swift */,
+				A13418010000000000000001 /* CarPlayManeuverMapper.swift */,
 				ED82C6872F90186300FA103D /* CarPlayRouter.swift */,
 				AB0CA7A50000000000000001 /* CarPlaySceneDelegate.swift */,
 				AB0DB0040000000000000001 /* CarPlayMapOwnershipState.swift */,
@@ -4665,6 +4671,7 @@
 				ED82C74C2F90186300FA103D /* RouteInfo.swift in Sources */,
 				ED82C74D2F90186300FA103D /* SearchResultInfo.swift in Sources */,
 				ED82C74E2F90186300FA103D /* CarplayPlaceholderView.swift in Sources */,
+				A13418010000000000000002 /* CarPlayManeuverMapper.swift in Sources */,
 				ED82C74F2F90186300FA103D /* CarPlayRouter.swift in Sources */,
 				AB0CA7A50000000000000002 /* CarPlaySceneDelegate.swift in Sources */,
 				AB0DB0010000000000000002 /* CarPlayDashboardMapViewController.swift in Sources */,
@@ -4993,6 +5000,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A13418010000000000000004 /* CarPlayManeuverMapperTests.swift in Sources */,
 				B26883EF0814407A8B1D73AF /* PlacePageUserDescriptionWebViewTests.swift in Sources */,
 				EDF838C12C00B9D6007E4E67 /* iCloudDirectoryMonitorTests.swift in Sources */,
 				EDF838C02C00B9D0007E4E67 /* DefaultLocalDirectoryMonitorTests.swift in Sources */,

--- a/iphone/Maps/Tests/Classes/CarPlay/CarPlayManeuverMapperTests.swift
+++ b/iphone/Maps/Tests/Classes/CarPlay/CarPlayManeuverMapperTests.swift
@@ -1,0 +1,66 @@
+import CarPlay
+@testable import Organic_Maps__Debug_
+import XCTest
+
+@available(iOS 17.4, *)
+final class CarPlayManeuverMapperTests: XCTestCase {
+  func testManeuverTypeMapping() {
+    let expectedTypes: [(RouteTurnDirection, CPManeuverType)] = [
+      (.none, .noTurn),
+      (.straight, .straightAhead),
+      (.right, .rightTurn),
+      (.sharpRight, .sharpRightTurn),
+      (.slightRight, .slightRightTurn),
+      (.left, .leftTurn),
+      (.sharpLeft, .sharpLeftTurn),
+      (.slightLeft, .slightLeftTurn),
+      (.uTurnLeft, .uTurn),
+      (.uTurnRight, .uTurn),
+      (.enterRoundabout, .enterRoundabout),
+      (.stayOnRoundabout, .followRoad),
+      (.startAtEndOfStreet, .startRoute),
+      (.destination, .arriveAtDestination),
+      (.exitHighwayLeft, .highwayOffRampLeft),
+      (.exitHighwayRight, .highwayOffRampRight),
+    ]
+
+    for (direction, expectedType) in expectedTypes {
+      XCTAssertEqual(CarPlayManeuverMapper.maneuverType(for: direction), expectedType)
+    }
+  }
+
+  func testRoundaboutExitManeuverTypeMapping() {
+    XCTAssertEqual(CarPlayManeuverMapper.maneuverType(for: .leaveRoundabout), .exitRoundabout)
+    XCTAssertEqual(CarPlayManeuverMapper.maneuverType(for: .leaveRoundabout, roundaboutExitNumber: 1),
+                   .roundaboutExit1)
+    XCTAssertEqual(CarPlayManeuverMapper.maneuverType(for: .leaveRoundabout, roundaboutExitNumber: 19),
+                   .roundaboutExit19)
+    XCTAssertEqual(CarPlayManeuverMapper.maneuverType(for: .leaveRoundabout, roundaboutExitNumber: 20),
+                   .exitRoundabout)
+  }
+
+  func testManeuverMetadata() {
+    let maneuver = CPManeuver()
+
+    CarPlayManeuverMapper.configure(maneuver, direction: .left, roadName: "Main Street")
+
+    XCTAssertEqual(maneuver.maneuverType, .leftTurn)
+    XCTAssertEqual(maneuver.roadFollowingManeuverVariants, ["Main Street"])
+    XCTAssertEqual(maneuver.junctionType, .intersection)
+
+    CarPlayManeuverMapper.configure(maneuver,
+                                    direction: .leaveRoundabout,
+                                    roadName: "Roundabout Road",
+                                    roundaboutExitNumber: 3)
+
+    XCTAssertEqual(maneuver.maneuverType, .roundaboutExit3)
+    XCTAssertEqual(maneuver.junctionType, .roundabout)
+  }
+
+  func testManeuverStateDistanceThresholds() {
+    XCTAssertEqual(CarPlayManeuverMapper.maneuverState(distanceToTurnMeters: 50), .execute)
+    XCTAssertEqual(CarPlayManeuverMapper.maneuverState(distanceToTurnMeters: 50.1), .prepare)
+    XCTAssertEqual(CarPlayManeuverMapper.maneuverState(distanceToTurnMeters: 500), .prepare)
+    XCTAssertEqual(CarPlayManeuverMapper.maneuverState(distanceToTurnMeters: 500.1), .initial)
+  }
+}

--- a/iphone/Maps/Tests/Classes/CarPlay/CarPlayServiceTests.swift
+++ b/iphone/Maps/Tests/Classes/CarPlay/CarPlayServiceTests.swift
@@ -21,12 +21,17 @@ final class CarPlayServiceTests: XCTestCase {
                               targetUnitsIndex: 1, // km
                               distanceToTurn: 0.5,
                               turnUnitsIndex: 0, // m
+                              currentStreetName: "Bahdanoviča Street",
                               streetName: "Niamiha",
+                              nextStreetName: "Internacyjanalnaja Street",
+                              turnDirection: .left,
+                              nextTurnDirection: .right,
                               turnImageName: nil,
                               nextTurnImageName: nil,
                               speedMps: 40.5,
                               speedLimitMps: 60,
-                              roundExitNumber: 0)
+                              roundExitNumber: 0,
+                              isLeftHandTraffic: false)
     let estimates = carPlayService.createEstimates(routeInfo: routeInfo)
 
     guard let estimates else {


### PR DESCRIPTION
Closes #753, #13381

Organic Maps already displayed navigation instructions in CarPlay templates, but did not provide the semantic maneuver metadata that supported vehicles need to render turn guidance in an instrument cluster or HUD.

This PR maps Organic Maps turn directions to `CPManeuverType`, supplies road, junction, traffic-side, maneuver-state, and travel-estimate metadata, and refreshes that metadata after rerouting. The mapper and maneuver-state boundaries have focused unit tests. The previous `.loading` pause was removed because this path already has a built route and immediately publishes its initial maneuvers.

When CarPlay restores navigation that is already active on the iPhone, the first maneuver can be registered in the navigation session but not picked up as the current instrument-cluster maneuver. The restore path therefore republishes the same maneuver list once, 0.5 seconds after session setup. This workaround is limited to `isRestoring`; navigation started directly in CarPlay publishes immediately without a delay. An immediate dispatch was tested and left the HUD empty until the next maneuver update, and CarPlay provides no public instrument-cluster readiness callback.

Tested with a physical iPhone running iOS 26 connected to the standalone CarPlay Simulator (not a vehicle head unit):
- starting navigation directly in CarPlay;
- switching an active navigation session from the iPhone to CarPlay;
- instrument-cluster maneuver type, road name, distance, and updates;
- rerouting and subsequent maneuver updates.

LLM tools were used to assist with implementation and review.

<img width="2288" height="1492" alt="image" src="https://github.com/user-attachments/assets/38c8b942-cca8-4a35-8ebe-3e6d3a71f8f0" />