### PR TITLE
[traffic] Integrate traffic data from TomTom

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -97,6 +97,7 @@ import app.organicmaps.sdk.location.LocationUtils;
 import app.organicmaps.sdk.location.SensorListener;
 import app.organicmaps.sdk.location.TrackRecorder;
 import app.organicmaps.sdk.maplayer.isolines.IsolinesState;
+import app.organicmaps.sdk.maplayer.traffic.TrafficManager;
 import app.organicmaps.sdk.routing.RoutingController;
 import app.organicmaps.sdk.routing.RoutingOptions;
 import app.organicmaps.sdk.search.SearchEngine;
@@ -609,7 +610,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     mNavigationController = new NavigationController(
         this, v -> onSettingsOptionSelected(), v -> openVoiceInstructionsSettings(), this::updateBottomWidgetsOffset);
-    // TrafficManager.INSTANCE.attach(mNavigationController);
+    TrafficManager.INSTANCE.attach(mNavigationController);
     initOnmapDownloader();
     initPositionChooser();
   }
@@ -1024,6 +1025,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mPostNotificationPermissionRequest = null;
     mPowerSaveSettings.unregister();
     mPowerSaveSettings = null;
+    TrafficManager.INSTANCE.detachAll();
     if (mRemoveDisplayListener && !isChangingConfigurations())
       mDisplayManager.removeListener(DisplayType.Device);
   }

--- a/android/app/src/main/java/app/organicmaps/maplayer/LayersUtils.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/LayersUtils.java
@@ -15,6 +15,10 @@ public class LayersUtils
     availableLayers.add(Mode.HIKING);
     availableLayers.add(Mode.CYCLING);
     availableLayers.add(Mode.SUBWAY);
+    // The Traffic toggle is a quick on/off for the layer; the data source key lives in Settings, so
+    // only offer the button once a key is set.
+    if (!Framework.nativeGetTrafficApiKey().isEmpty())
+      availableLayers.add(Mode.TRAFFIC);
     // The Satellite toggle is a quick on/off for an already-configured source; configuration lives in
     // Settings, so only offer the button once a server URL is set.
     if (!Framework.nativeGetBackgroundTilesUrl().isEmpty())

--- a/android/app/src/main/java/app/organicmaps/routing/NavigationController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/NavigationController.java
@@ -230,13 +230,13 @@ public class NavigationController implements TrafficManager.TrafficCallback, Nav
   @Override
   public void onEnabled()
   {
-    // mNavMenu.refreshTraffic();
+    // no op
   }
 
   @Override
   public void onDisabled()
   {
-    // mNavMenu.refreshTraffic();
+    // no op
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
@@ -136,6 +136,11 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment implements La
         getSettingsActivity().stackFragment(BgTilesSettingsFragment.class, getString(R.string.pref_bg_tiles_title),
                                             null);
       }
+      else if (key.equals(getString(R.string.pref_traffic_screen)))
+      {
+        getSettingsActivity().stackFragment(TrafficSettingsFragment.class, getString(R.string.pref_traffic_title),
+                                            null);
+      }
       else if (key.equals(getString(R.string.pref_help)))
       {
         startActivity(new Intent(requireActivity(), HelpActivity.class));

--- a/android/app/src/main/java/app/organicmaps/settings/TrafficSettingsFragment.kt
+++ b/android/app/src/main/java/app/organicmaps/settings/TrafficSettingsFragment.kt
@@ -1,0 +1,56 @@
+package app.organicmaps.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.widget.doAfterTextChanged
+import app.organicmaps.R
+import app.organicmaps.base.BaseMwmFragment
+import app.organicmaps.sdk.Framework
+import app.organicmaps.util.WindowInsetUtils.ScrollableContentInsetsListener
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+
+// Settings sub-screen for the live traffic data source (TomTom vector flow tiles API key).
+// The key is persisted in the C++ core (not SharedPreferences); an empty key falls back to
+// the built-in traffic source. Edits are applied in onPause() when the user leaves the screen.
+class TrafficSettingsFragment : BaseMwmFragment() {
+
+    private lateinit var keyInputLayout: TextInputLayout
+    private lateinit var keyField: TextInputEditText
+
+    private val currentKey: String
+        get() = keyField.text.toString().trim()
+
+    private val isKeyValid: Boolean
+        get() = currentKey.isEmpty() || Framework.nativeIsWellFormedTrafficApiKey(currentKey)
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
+        inflater.inflate(R.layout.fragment_traffic_settings, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        ViewCompat.setOnApplyWindowInsetsListener(view, ScrollableContentInsetsListener(view))
+
+        keyInputLayout = view.findViewById(R.id.traffic_api_key_input)
+        keyField = view.findViewById(R.id.traffic_api_key)
+        keyField.setText(Framework.nativeGetTrafficApiKey())
+        keyField.doAfterTextChanged { refreshValidation() }
+
+        refreshValidation()
+    }
+
+    override fun onPause() {
+        if (isKeyValid) {
+            Framework.nativeSetTrafficApiKey(currentKey)
+        }
+        super.onPause()
+    }
+
+    private fun refreshValidation() {
+        keyInputLayout.error = if (isKeyValid) null else getString(R.string.pref_traffic_key_error)
+    }
+}

--- a/android/app/src/main/res/layout/fragment_traffic_settings.xml
+++ b/android/app/src/main/res/layout/fragment_traffic_settings.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:background="?attr/cardBackground"
+  android:fillViewport="true"
+  android:scrollbars="none">
+
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:paddingStart="@dimen/margin_base"
+      android:paddingTop="@dimen/margin_half_plus"
+      android:paddingEnd="@dimen/margin_base"
+      android:paddingBottom="@dimen/margin_half">
+      <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/pref_traffic_api_key_title"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textColor="?android:attr/textColorPrimary"/>
+      <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/traffic_api_key_input"
+        style="@style/MwmWidget.Editor.CustomTextInput"
+        android:textColorHint="?android:textColorSecondary"
+        app:hintAnimationEnabled="false">
+        <com.google.android.material.textfield.TextInputEditText
+          android:id="@+id/traffic_api_key"
+          style="@style/MwmWidget.Editor.CustomTextInput"
+          android:importantForAutofill="no"
+          android:inputType="text"
+          android:singleLine="true"/>
+      </com.google.android.material.textfield.TextInputLayout>
+    </LinearLayout>
+
+    <include layout="@layout/list_divider"/>
+
+    <TextView
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:padding="@dimen/margin_base"
+      android:text="@string/pref_traffic_disclaimer"
+      android:textAppearance="?android:attr/textAppearanceSmall"
+      android:textColor="?android:attr/textColorSecondary"/>
+  </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/android/app/src/main/res/values/donottranslate.xml
+++ b/android/app/src/main/res/values/donottranslate.xml
@@ -19,6 +19,7 @@
   <string name="pref_tts_screen" translatable="false">TtsScreen</string>
   <string name="pref_tts_enabled" translatable="false">TtsEnabled</string>
   <string name="pref_bg_tiles_screen" translatable="false">BgTilesScreen</string>
+  <string name="pref_traffic_screen" translatable="false">TrafficScreen</string>
   <string name="pref_tts_street_names" translatable="false">TtsStreetNames</string>
   <string name="pref_tts_language" translatable="false">TtsLanguage</string>
   <string name="pref_tts_volume" translatable="false">TtsVolume</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -227,6 +227,14 @@
     <string name="pref_bg_tiles_opacity_title">Area objects opacity</string>
     <!-- Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure -->
     <string name="pref_bg_tiles_disclaimer">Custom tile sources are provided by you. Use only services you are allowed to access. You are responsible for attribution, license terms, API keys, quotas, and usage limits.</string>
+    <!-- Settings: title of the live traffic data screen -->
+    <string name="pref_traffic_title">Live Traffic Data</string>
+    <!-- Settings «Live Traffic Data»: title of the traffic provider API key input field -->
+    <string name="pref_traffic_api_key_title">API Key</string>
+    <!-- Settings «Live Traffic Data»: error shown when the entered API key has an invalid format -->
+    <string name="pref_traffic_key_error">The key format looks invalid (expected a short code of letters and digits).</string>
+    <!-- Settings «Live Traffic Data»: legal note about the third-party traffic data usage -->
+    <string name="pref_traffic_disclaimer">Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom\'s terms of use. An empty key falls back to the built-in traffic source.</string>
     <!-- Settings «Route» category: «Tts enabled» title -->
     <string name="pref_tts_enable_title">Voice Instructions</string>
     <!-- Settings «Route» category: «Tts announce street names» title -->

--- a/android/app/src/main/res/xml/prefs_main.xml
+++ b/android/app/src/main/res/xml/prefs_main.xml
@@ -132,6 +132,12 @@
       app:singleLineTitle="false"
       android:persistent="false"
       android:order="20"/>
+    <Preference
+      android:key="@string/pref_traffic_screen"
+      android:title="@string/pref_traffic_title"
+      app:singleLineTitle="false"
+      android:persistent="false"
+      android:order="21"/>
   </androidx.preference.PreferenceCategory>
 
   <androidx.preference.PreferenceCategory

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -907,6 +907,25 @@ JNIEXPORT jint Java_app_organicmaps_sdk_Framework_nativeGetBackgroundTilesAreaOp
   return static_cast<jint>(frm()->GetBackgroundTilesAreaOpacity());
 }
 
+// Live traffic data source (Settings -> Live Traffic Data).
+JNIEXPORT jstring Java_app_organicmaps_sdk_Framework_nativeGetTrafficApiKey(JNIEnv * env, jclass)
+{
+  return jni::ToJavaString(env, Framework::GetTrafficApiKey());
+}
+
+// Persists the key and hot-swaps the running TrafficManager data source; an empty key restores
+// the built-in traffic source.
+JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeSetTrafficApiKey(JNIEnv * env, jclass, jstring apiKey)
+{
+  frm()->SetTrafficApiKey(jni::ToNativeString(env, apiKey));
+}
+
+JNIEXPORT jboolean Java_app_organicmaps_sdk_Framework_nativeIsWellFormedTrafficApiKey(JNIEnv * env, jclass,
+                                                                                      jstring apiKey)
+{
+  return static_cast<jboolean>(Framework::IsWellFormedTrafficApiKey(jni::ToNativeString(env, apiKey)));
+}
+
 JNIEXPORT jstring Java_app_organicmaps_sdk_Framework_nativeGetParsedBackUrl(JNIEnv * env, jclass)
 {
   std::string const & backUrl = frm()->GetParsedBackUrl();

--- a/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
@@ -189,6 +189,15 @@ public class Framework
   public static native int nativeGetBackgroundTilesCacheSizeMB();
   public static native boolean nativeIsBackgroundTilesEnabled();
   public static native int nativeGetBackgroundTilesAreaOpacity();
+
+  // Live traffic data source (Settings -> Live Traffic Data).
+  @NonNull
+  public static native String nativeGetTrafficApiKey();
+  // Persists the key and hot-swaps the running TrafficManager data source; an empty key restores
+  // the built-in traffic source.
+  public static native void nativeSetTrafficApiKey(@NonNull String apiKey);
+  // Basic check: non-empty, 8..128 ASCII letters and digits.
+  public static native boolean nativeIsWellFormedTrafficApiKey(@NonNull String apiKey);
   public static native ParsedSearchRequest nativeGetParsedSearchRequest();
   public static native @Nullable String nativeGetParsedAppName();
   public static native @Nullable String nativeGetParsedOAuth2Code();

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -7299,6 +7299,26 @@ vi = Nguồn ô tùy chỉnh do bạn cung cấp. Chỉ sử dụng các dịch 
 zh-Hans = 自定义瓦片源由您自行提供。请仅使用您有权访问的服务。署名、许可条款、API 密钥、配额和使用限制由您自行负责。
 zh-Hant = 自訂圖磚來源由您自行提供。請僅使用您有權存取的服務。出處標示、授權條款、API 金鑰、配額與使用限制由您自行負責。
 
+[pref_traffic_title]
+comment = Settings: title of the live traffic data screen
+tags = android-app,apple-maps
+en = Live Traffic Data
+
+[pref_traffic_api_key_title]
+comment = Settings «Live Traffic Data»: title of the traffic provider API key input field
+tags = android-app,apple-maps
+en = API Key
+
+[pref_traffic_key_error]
+comment = Settings «Live Traffic Data»: error shown when the entered API key has an invalid format
+tags = android-app,apple-maps
+en = The key format looks invalid (expected a short code of letters and digits).
+
+[pref_traffic_disclaimer]
+comment = Settings «Live Traffic Data»: legal note about the third-party traffic data usage
+tags = android-app,apple-maps
+en = Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.
+
 [pref_tts_enable_title]
 comment = Settings «Route» category: «Tts enabled» title
 tags = android-app,apple-maps

--- a/iphone/Maps/Bridging-Header.h
+++ b/iphone/Maps/Bridging-Header.h
@@ -56,6 +56,7 @@
 #import "MWMSearchNoResults.h"
 #import "MWMSearchSuggestionCell.h"
 #import "MWMSettings+MapTiles.h"
+#import "MWMSettings+Traffic.h"
 #import "MWMSettings.h"
 #import "MWMSideButtons.h"
 #import "MWMSpeedCameraManagerMode.h"

--- a/iphone/Maps/Core/Settings/MWMSettings+Traffic.h
+++ b/iphone/Maps/Core/Settings/MWMSettings+Traffic.h
@@ -1,0 +1,17 @@
+#import "MWMSettings.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(TrafficSettings)
+@protocol MWMTrafficSettings
+
++ (NSString *)trafficApiKey;
++ (void)setTrafficApiKey:(NSString *)apiKey;
++ (BOOL)isWellFormedTrafficApiKey:(NSString *)apiKey;
+
+@end
+
+@interface MWMSettings (Traffic) <MWMTrafficSettings>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iphone/Maps/Core/Settings/MWMSettings+Traffic.mm
+++ b/iphone/Maps/Core/Settings/MWMSettings+Traffic.mm
@@ -1,0 +1,22 @@
+#import "MWMSettings+Traffic.h"
+
+#include <CoreApi/Framework.h>
+
+@implementation MWMSettings (Traffic)
+
++ (NSString *)trafficApiKey
+{
+  return @(Framework::GetTrafficApiKey().c_str());
+}
+
++ (void)setTrafficApiKey:(NSString *)apiKey
+{
+  GetFramework().SetTrafficApiKey(apiKey.UTF8String);
+}
+
++ (BOOL)isWellFormedTrafficApiKey:(NSString *)apiKey
+{
+  return Framework::IsWellFormedTrafficApiKey(apiKey.UTF8String);
+}
+
+@end

--- a/iphone/Maps/LocalizedStrings/af.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/af.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Pasgemaakte teëlbronne word deur jou verskaf. Gebruik slegs dienste waartoe jy toegang mag hê. Jy is verantwoordelik vir erkenning, lisensievoorwaardes, API-sleutels, kwotas en gebruiksgrense.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Steminstruksies";
 

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "مصادر المربعات المخصصة مقدَّمة منك. استخدم فقط الخدمات المسموح لك بالوصول إليها. أنت مسؤول عن الإسناد وشروط الترخيص ومفاتيح API والحصص وحدود الاستخدام.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "تعليمات صوتية";
 

--- a/iphone/Maps/LocalizedStrings/ast.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ast.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Custom tile sources are provided by you. Use only services you are allowed to access. You are responsible for attribution, license terms, API keys, quotas, and usage limits.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Voice Instructions";
 

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Fərdi döşəmə mənbələrini siz təqdim edirsiniz. Yalnız daxil olmağa icazəniz olan xidmətlərdən istifadə edin. Mənbə göstərilməsi, lisenziya şərtləri, API açarları, kvotalar və istifadə limitlərinə görə siz məsuliyyət daşıyırsınız.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Səsli təlimatlar";
 

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Крыніцы ўласных плітак прадастаўляеце вы. Карыстайцеся толькі сэрвісамі, да якіх у вас ёсць доступ. Вы нясеце адказнасць за пазначэнне аўтарства, умовы ліцэнзіі, ключы API, квоты і абмежаванні выкарыстання.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Галасавыя інструкцыі";
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Източниците на персонализирани плочки се предоставят от вас. Използвайте само услуги, до които имате право на достъп. Вие носите отговорност за посочването на авторството, условията на лиценза, API ключовете, квотите и ограниченията за използване.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Гласови инструкции";
 

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Les fonts de tessel·les personalitzades les proporcioneu vosaltres. Utilitzeu només serveis als quals tingueu permís d'accés. Sou responsables de l'atribució, els termes de la llicència, les claus API, les quotes i els límits d'ús.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instruccions de veu";
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Zdroje vlastních dlaždic poskytujete vy. Používejte pouze služby, ke kterým máte oprávněný přístup. Nesete odpovědnost za uvedení autorství, licenční podmínky, klíče API, kvóty a omezení používání.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hlasové instrukce";
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Tilpassede flisekilder leveres af dig. Brug kun tjenester, du har tilladelse til at tilgå. Du er ansvarlig for kreditering, licensvilkår, API-nøgler, kvoter og forbrugsgrænser.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Stemmeinstruktioner";
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Eigene Kachelquellen werden von Ihnen bereitgestellt. Verwenden Sie nur Dienste, auf die Sie zugreifen dürfen. Sie sind verantwortlich für Namensnennung, Lizenzbedingungen, API-Schlüssel, Kontingente und Nutzungslimits.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Sprachanweisungen";
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Οι πηγές προσαρμοσμένων πλακιδίων παρέχονται από εσάς. Χρησιμοποιείτε μόνο υπηρεσίες στις οποίες επιτρέπεται να έχετε πρόσβαση. Είστε υπεύθυνοι για την αναφορά προέλευσης, τους όρους άδειας, τα κλειδιά API, τις ποσοστώσεις και τα όρια χρήσης.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Φωνητικές οδηγίες";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Custom tile sources are provided by you. Use only services you are allowed to access. You are responsible for attribution, license terms, API keys, quotas, and usage limits.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Voice Instructions";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Custom tile sources are provided by you. Use only services you are allowed to access. You are responsible for attribution, license terms, API keys, quotas, and usage limits.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Voice Instructions";
 

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Las fuentes de teselas personalizadas las proporciona usted. Use solo servicios a los que tenga permiso de acceso. Usted es responsable de la atribución, los términos de licencia, las claves API, las cuotas y los límites de uso.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instrucciones de voz";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Las fuentes de teselas personalizadas las proporciona usted. Use solo servicios a los que tenga permiso de acceso. Usted es responsable de la atribución, los términos de licencia, las claves API, las cuotas y los límites de uso.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instrucciones de voz";
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Kohandatud paaniallikad pakute teie. Kasutage ainult teenuseid, millele teil on lubatud juurde pääseda. Teie vastutate omistamise, litsentsitingimuste, API-võtmete, kvootide ja kasutuspiirangute eest.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hääljuhised";
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Lauza-iturri pertsonalizatuak zuk hornitzen dituzu. Erabili soilik sarbidea baimenduta duzun zerbitzuak. Zu zara egiletza-aitortzaren, lizentzia-baldintzen, API gakoen, kuoten eta erabilera-mugen arduraduna.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Ahots argibideak";
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "منابع کاشی‌های سفارشی را شما فراهم می‌کنید. فقط از سرویس‌هایی استفاده کنید که اجازهٔ دسترسی به آن‌ها را دارید. شما مسئول ذکر منبع، شرایط مجوز، کلیدهای API، سهمیه‌ها و محدودیت‌های استفاده هستید.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "دستور العمل صوتی";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Mukautetut ruutulähteet tarjoat sinä. Käytä vain palveluita, joihin sinulla on käyttöoikeus. Vastaat itse lähdemerkinnästä, lisenssiehdoista, API-avaimista, kiintiöistä ja käyttörajoituksista.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Ääniohjeistukset";
 

--- a/iphone/Maps/LocalizedStrings/fr-CA.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr-CA.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Les sources de tuiles personnalisées sont fournies par vous. N'utilisez que les services auxquels vous êtes autorisé à accéder. Vous êtes responsable de l'attribution, des conditions de licence, des clés API, des quotas et des limites d'utilisation.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instructions vocales";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Les sources de tuiles personnalisées sont fournies par vous. N'utilisez que les services auxquels vous êtes autorisé à accéder. Vous êtes responsable de l'attribution, des conditions de licence, des clés API, des quotas et des limites d'utilisation.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instructions vocales";
 

--- a/iphone/Maps/LocalizedStrings/gl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/gl.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "As fontes de teselas personalizadas fornéceas vostede. Utilice só servizos aos que teña permiso de acceso. Vostede é responsable da atribución, os termos da licenza, as claves API, as cotas e os límites de uso.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instrucións de voz";
 

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "מקורות אריחים מותאמים אישית מסופקים על ידך. השתמש רק בשירותים שמותר לך לגשת אליהם. האחריות על ייחוס, תנאי רישיון, מפתחות API, מכסות ומגבלות שימוש מוטלת עליך.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "הנחיות קוליות";
 

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "कस्टम टाइल स्रोत आपके द्वारा प्रदान किए जाते हैं। केवल उन्हीं सेवाओं का उपयोग करें जिन तक पहुँच की अनुमति आपको है। एट्रिब्यूशन, लाइसेंस शर्तों, API कुंजियों, कोटा और उपयोग सीमाओं के लिए आप ज़िम्मेदार हैं।";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "ध्वनि निर्देश";
 

--- a/iphone/Maps/LocalizedStrings/hr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hr.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Izvore prilagođenih pločica pružate vi. Koristite samo usluge kojima smijete pristupati. Vi ste odgovorni za pripisivanje, uvjete licence, API ključeve, kvote i ograničenja korištenja.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Glasovne upute";
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Az egyéni csempeforrásokat Ön biztosítja. Csak olyan szolgáltatásokat használjon, amelyekhez jogosult hozzáférni. Ön felel a forrásmegjelölésért, a licencfeltételekért, az API-kulcsokért, a kvótákért és a használati korlátokért.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hangutasítások";
 

--- a/iphone/Maps/LocalizedStrings/hy.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hy.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Հատուկ սալիկների աղբյուրները տրամադրում եք դուք։ Օգտագործեք միայն այն ծառայությունները, որոնց հասանելիության թույլտվություն ունեք։ Դուք պատասխանատու եք հղման, արտոնագրի պայմանների, API բանալիների, քվոտաների և օգտագործման սահմանափակումների համար։";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Ձայնային հրահանգներ";
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Sumber ubin khusus disediakan oleh Anda. Gunakan hanya layanan yang boleh Anda akses. Anda bertanggung jawab atas atribusi, ketentuan lisensi, kunci API, kuota, dan batas penggunaan.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Petunjuk Suara";
 

--- a/iphone/Maps/LocalizedStrings/is.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/is.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Sérsniðnar flísalindir eru útvegaðar af þér. Notaðu aðeins þjónustur sem þú hefur leyfi til að nota. Þú berð ábyrgð á tilvísun, leyfisskilmálum, API-lyklum, kvótum og notkunarmörkum.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Talaðar leiðbeiningar";
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Le fonti dei tasselli personalizzati sono fornite da te. Utilizza solo i servizi a cui sei autorizzato ad accedere. Sei responsabile dell'attribuzione, dei termini di licenza, delle chiavi API, delle quote e dei limiti di utilizzo.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Istruzioni vocali";
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "カスタムタイルのソースはご自身で用意するものです。アクセスが許可されているサービスのみを使用してください。帰属表示、ライセンス条件、APIキー、クォータ、利用制限についてはご自身の責任となります。";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "音声指示";
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "사용자 지정 타일 소스는 사용자가 제공합니다. 접근 권한이 있는 서비스만 사용하세요. 출처 표시, 라이선스 약관, API 키, 할당량 및 사용 한도는 사용자 책임입니다.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "음성 지침";
 

--- a/iphone/Maps/LocalizedStrings/lo.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/lo.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "ແຫຼ່ງແຜ່ນແບບກຳນົດເອງແມ່ນທ່ານເປັນຜູ້ສະໜອງ. ໃຊ້ສະເພາະບໍລິການທີ່ທ່ານໄດ້ຮັບອະນຸຍາດໃຫ້ເຂົ້າເຖິງ. ທ່ານຮັບຜິດຊອບຕໍ່ການລະບຸແຫຼ່ງທີ່ມາ, ເງື່ອນໄຂໃບອະນຸຍາດ, ກະແຈ API, ໂກຕາ ແລະ ຂີດຈຳກັດການນຳໃຊ້.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "ຄຳແນະນຳດ້ວຍສຽງ";
 

--- a/iphone/Maps/LocalizedStrings/lt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/lt.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Pasirinktinius plytelių šaltinius pateikiate jūs. Naudokite tik paslaugas, prie kurių turite teisę prisijungti. Jūs atsakote už autorystės nurodymą, licencijos sąlygas, API raktus, kvotas ir naudojimo apribojimus.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Balso instrukcijos";
 

--- a/iphone/Maps/LocalizedStrings/lv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/lv.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Pielāgotos flīžu avotus nodrošināt jūs. Izmantojiet tikai pakalpojumus, kuriem jums ir atļauta piekļuve. Jūs atbildat par autorības norādīšanu, licences noteikumiem, API atslēgām, kvotām un lietošanas ierobežojumiem.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Balss instrukcijas";
 

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "सानुकूल टाइल स्रोत आपण पुरवता. केवळ ज्या सेवांमध्ये प्रवेशाची परवानगी आपल्याला आहे त्याच वापरा. श्रेय, परवाना अटी, API की, कोटा आणि वापर मर्यादांसाठी आपण जबाबदार आहात.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "ध्वनी सूचना";
 

--- a/iphone/Maps/LocalizedStrings/mt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mt.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Is-sorsi tal-madum personalizzati jiġu pprovduti minnek. Uża biss servizzi li int permess taċċessa. Inti responsabbli għall-attribuzzjoni, it-termini tal-liċenzja, iċ-ċwievet API, il-kwoti u l-limiti tal-użu.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Istruzzjonijiet tal-vuċi";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Tilpassede flisekilder leveres av deg. Bruk kun tjenester du har tillatelse til å bruke. Du er ansvarlig for kreditering, lisensvilkår, API-nøkler, kvoter og bruksgrenser.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Taleinstrukser";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Aangepaste tegelbronnen worden door u aangeleverd. Gebruik alleen diensten waartoe u toegang mag hebben. U bent verantwoordelijk voor naamsvermelding, licentievoorwaarden, API-sleutels, quota en gebruikslimieten.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Gesproken instructies";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Źródła niestandardowych kafelków zapewniasz Ty. Korzystaj tylko z usług, do których masz uprawniony dostęp. Odpowiadasz za atrybucję, warunki licencji, klucze API, limity i ograniczenia użytkowania.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Komunikaty głosowe";
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "As fontes de blocos personalizados são fornecidas por você. Use apenas serviços que você tem permissão para acessar. Você é responsável pela atribuição, termos de licença, chaves de API, cotas e limites de uso.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Orientação por voz";
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "As fontes de mosaicos personalizados são fornecidas por si. Utilize apenas serviços a que tem permissão para aceder. É responsável pela atribuição, termos de licença, chaves de API, quotas e limites de utilização.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instruções de voz";
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Sursele de dale personalizate sunt furnizate de dvs. Folosiți doar servicii pe care aveți dreptul să le accesați. Sunteți responsabil pentru atribuire, termenii licenței, cheile API, cotele și limitele de utilizare.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instrucțiuni vocale";
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Источники пользовательских тайлов предоставляете вы. Используйте только сервисы, к которым у вас есть доступ. Вы несёте ответственность за указание авторства, условия лицензии, API-ключи, квоты и ограничения использования.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Голосовые инструкции";
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Zdroje vlastných dlaždíc poskytujete vy. Používajte iba služby, ku ktorým máte oprávnený prístup. Nesiete zodpovednosť za uvedenie autorstva, licenčné podmienky, kľúče API, kvóty a obmedzenia používania.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hlasové povely";
 

--- a/iphone/Maps/LocalizedStrings/sl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sl.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Vire ploščic po meri zagotavljate sami. Uporabljajte samo storitve, do katerih imate dovoljen dostop. Sami ste odgovorni za navedbo avtorstva, licenčne pogoje, ključe API, kvote in omejitve uporabe.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Glasovna navodila";
 

--- a/iphone/Maps/LocalizedStrings/sq.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sq.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Burimet e pllakave të personalizuara i jepni ju. Përdorni vetëm shërbime për të cilat keni leje qasjeje. Ju jeni përgjegjës për atribuimin, kushtet e licencës, çelësat API, kuotat dhe kufijtë e përdorimit.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Udhëzimet Zanore";
 

--- a/iphone/Maps/LocalizedStrings/sr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sr.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Изворе прилагођених плочица обезбеђујете ви. Користите само услуге којима смете да приступате. Ви сте одговорни за приписивање ауторства, услове лиценце, API кључеве, квоте и ограничења коришћења.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Гласовне инструкције";
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Anpassade rutkällor tillhandahålls av dig. Använd endast tjänster som du har behörighet att använda. Du ansvarar för upphovsangivelse, licensvillkor, API-nycklar, kvoter och användningsgränser.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Röstinstruktioner";
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Vyanzo vya vigae maalum vinatolewa na wewe. Tumia tu huduma ambazo unaruhusiwa kuzifikia. Wewe ndiye unayehusika na utoaji sifa, masharti ya leseni, funguo za API, mgao na vikomo vya matumizi.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Tangaza Majina ya Mitaa";
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "แหล่งไทล์ที่กำหนดเองนั้นคุณเป็นผู้จัดหาเอง ใช้เฉพาะบริการที่คุณได้รับอนุญาตให้เข้าถึงเท่านั้น คุณเป็นผู้รับผิดชอบการระบุแหล่งที่มา เงื่อนไขสัญญาอนุญาต คีย์ API โควตา และขีดจำกัดการใช้งาน";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "คำแนะนำด้วยเสียง";
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Özel döşeme kaynakları sizin tarafınızdan sağlanır. Yalnızca erişim izniniz olan hizmetleri kullanın. Atıf, lisans koşulları, API anahtarları, kotalar ve kullanım sınırlarından siz sorumlusunuz.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Sesli Yönlendirme";
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Ви самі додаєте джерела супутникових знімків (тайлів). Використовуйте лише ті сервіси, до яких у вас є доступ. Ви несете відповідальність за дотримання авторських прав, умов ліцензії, використання ключів API, квот та обмежень.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Голосові інструкції";
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "Nguồn ô tùy chỉnh do bạn cung cấp. Chỉ sử dụng các dịch vụ mà bạn được phép truy cập. Bạn chịu trách nhiệm về việc ghi công, điều khoản giấy phép, khóa API, hạn ngạch và giới hạn sử dụng.";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hướng dẫn bằng Giọng nói";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "自定义瓦片源由您自行提供。请仅使用您有权访问的服务。署名、许可条款、API 密钥、配额和使用限制由您自行负责。";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "语音指导";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -249,6 +249,18 @@
 /* Settings «Satellite Imagery»: legal note that the user is responsible for the custom tile source they configure */
 "pref_bg_tiles_disclaimer" = "自訂圖磚來源由您自行提供。請僅使用您有權存取的服務。出處標示、授權條款、API 金鑰、配額與使用限制由您自行負責。";
 
+/* Settings: title of the live traffic data screen */
+"pref_traffic_title" = "Live Traffic Data";
+
+/* Settings «Live Traffic Data»: title of the traffic provider API key input field */
+"pref_traffic_api_key_title" = "API Key";
+
+/* Settings «Live Traffic Data»: error shown when the entered API key has an invalid format */
+"pref_traffic_key_error" = "The key format looks invalid (expected a short code of letters and digits).";
+
+/* Settings «Live Traffic Data»: legal note about the third-party traffic data usage */
+"pref_traffic_disclaimer" = "Live traffic data is provided by TomTom. You are responsible for the API key, its quota and TomTom's terms of use. An empty key falls back to the built-in traffic source.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "語音提示";
 

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -44,6 +44,9 @@
 		A10000000000000000000018 /* MapTilesSettingsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000010 /* MapTilesSettingsInteractor.swift */; };
 		A10000000000000000000019 /* MapTilesSettingsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000011 /* MapTilesSettingsModels.swift */; };
 		A1000000000000000000001A /* MapTilesSettingsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000012 /* MapTilesSettingsPresenter.swift */; };
+		A1000000000000000000005D /* TrafficSettingsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005A /* TrafficSettingsInteractor.swift */; };
+		A1000000000000000000005E /* TrafficSettingsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005B /* TrafficSettingsModels.swift */; };
+		A1000000000000000000005F /* TrafficSettingsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005C /* TrafficSettingsPresenter.swift */; };
 		A10000000000000000000020 /* MobileInternetSettingsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000024 /* MobileInternetSettingsInteractor.swift */; };
 		A10000000000000000000021 /* MobileInternetSettingsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000025 /* MobileInternetSettingsModels.swift */; };
 		A10000000000000000000022 /* MobileInternetSettingsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000026 /* MobileInternetSettingsPresenter.swift */; };
@@ -615,6 +618,7 @@
 		ED82C8212F90186900FA103D /* Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C81C2F90186900FA103D /* Common.swift */; };
 		ED86256B2FEECAB70057BF82 /* SettingsMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED86256A2FEECAB70057BF82 /* SettingsMessageCell.swift */; };
 		ED86256C2FEECAB70057BF82 /* MWMSettings+MapTiles.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED86256E2FEECAB70057BF82 /* MWMSettings+MapTiles.mm */; };
+		ED86257A2FEECAB70057BF82 /* MWMSettings+Traffic.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED86257C2FEECAB70057BF82 /* MWMSettings+Traffic.mm */; };
 		ED8A91E02D759B50009E063B /* LocalizableTypes.strings in Resources */ = {isa = PBXBuildFile; fileRef = ED8A91DE2D759B50009E063B /* LocalizableTypes.strings */; };
 		ED8F0F852FE962BF00780C0F /* SettingsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8F0F842FE962BF00780C0F /* SettingsModels.swift */; };
 		ED91432C300168020081DF0B /* MainSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED91432B300168020081DF0B /* MainSceneDelegate.swift */; };
@@ -853,6 +857,9 @@
 		A10000000000000000000010 /* MapTilesSettingsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTilesSettingsInteractor.swift; sourceTree = "<group>"; };
 		A10000000000000000000011 /* MapTilesSettingsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTilesSettingsModels.swift; sourceTree = "<group>"; };
 		A10000000000000000000012 /* MapTilesSettingsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTilesSettingsPresenter.swift; sourceTree = "<group>"; };
+		A1000000000000000000005A /* TrafficSettingsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficSettingsInteractor.swift; sourceTree = "<group>"; };
+		A1000000000000000000005B /* TrafficSettingsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficSettingsModels.swift; sourceTree = "<group>"; };
+		A1000000000000000000005C /* TrafficSettingsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficSettingsPresenter.swift; sourceTree = "<group>"; };
 		A10000000000000000000024 /* MobileInternetSettingsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileInternetSettingsInteractor.swift; sourceTree = "<group>"; };
 		A10000000000000000000025 /* MobileInternetSettingsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileInternetSettingsModels.swift; sourceTree = "<group>"; };
 		A10000000000000000000026 /* MobileInternetSettingsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileInternetSettingsPresenter.swift; sourceTree = "<group>"; };
@@ -1655,6 +1662,8 @@
 		ED86256A2FEECAB70057BF82 /* SettingsMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMessageCell.swift; sourceTree = "<group>"; };
 		ED86256D2FEECAB70057BF82 /* MWMSettings+MapTiles.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MWMSettings+MapTiles.h"; sourceTree = "<group>"; };
 		ED86256E2FEECAB70057BF82 /* MWMSettings+MapTiles.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "MWMSettings+MapTiles.mm"; sourceTree = "<group>"; };
+		ED86257B2FEECAB70057BF82 /* MWMSettings+Traffic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MWMSettings+Traffic.h"; sourceTree = "<group>"; };
+		ED86257C2FEECAB70057BF82 /* MWMSettings+Traffic.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "MWMSettings+Traffic.mm"; sourceTree = "<group>"; };
 		ED8A91DF2D759B50009E063B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LocalizableTypes.strings; sourceTree = "<group>"; };
 		ED8A91E32D759B59009E063B /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/LocalizableTypes.strings; sourceTree = "<group>"; };
 		ED8A91E42D759B61009E063B /* az */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = az; path = az.lproj/LocalizableTypes.strings; sourceTree = "<group>"; };
@@ -2018,6 +2027,16 @@
 				A10000000000000000000012 /* MapTilesSettingsPresenter.swift */,
 			);
 			path = MapTiles;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000060 /* Traffic */ = {
+			isa = PBXGroup;
+			children = (
+				A1000000000000000000005B /* TrafficSettingsModels.swift */,
+				A1000000000000000000005A /* TrafficSettingsInteractor.swift */,
+				A1000000000000000000005C /* TrafficSettingsPresenter.swift */,
+			);
+			path = Traffic;
 			sourceTree = "<group>";
 		};
 		A10000000000000000000027 /* MobileInternet */ = {
@@ -3457,6 +3476,7 @@
 				A1000000000000000000000A /* SettingsViewController.swift */,
 				ED0C36262FE5A37900CAF853 /* Root */,
 				A1000000000000000000001C /* MapTiles */,
+				A10000000000000000000060 /* Traffic */,
 				A10000000000000000000027 /* MobileInternet */,
 				A1000000000000000000002D /* DrivingOptions */,
 				A10000000000000000000034 /* BookmarksTextPlacement */,
@@ -3775,6 +3795,8 @@
 				ED82C6EA2F90186300FA103D /* MWMSettings.mm */,
 				ED86256D2FEECAB70057BF82 /* MWMSettings+MapTiles.h */,
 				ED86256E2FEECAB70057BF82 /* MWMSettings+MapTiles.mm */,
+				ED86257B2FEECAB70057BF82 /* MWMSettings+Traffic.h */,
+				ED86257C2FEECAB70057BF82 /* MWMSettings+Traffic.mm */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -4717,6 +4739,7 @@
 				ED82C7762F90186300FA103D /* MWMRoutingOptions.mm in Sources */,
 				ED82C7772F90186300FA103D /* MWMSettings.mm in Sources */,
 				ED86256C2FEECAB70057BF82 /* MWMSettings+MapTiles.mm in Sources */,
+				ED86257A2FEECAB70057BF82 /* MWMSettings+Traffic.mm in Sources */,
 				ED82C7782F90186300FA103D /* MWMStorage+UI.m in Sources */,
 				ED82C7792F90186300FA103D /* LocaleTranslator.mm in Sources */,
 				ED82C77A2F90186300FA103D /* MWMTextToSpeech.mm in Sources */,
@@ -4963,6 +4986,9 @@
 				A10000000000000000000018 /* MapTilesSettingsInteractor.swift in Sources */,
 				A10000000000000000000019 /* MapTilesSettingsModels.swift in Sources */,
 				A1000000000000000000001A /* MapTilesSettingsPresenter.swift in Sources */,
+				A1000000000000000000005D /* TrafficSettingsInteractor.swift in Sources */,
+				A1000000000000000000005E /* TrafficSettingsModels.swift in Sources */,
+				A1000000000000000000005F /* TrafficSettingsPresenter.swift in Sources */,
 				A10000000000000000000020 /* MobileInternetSettingsInteractor.swift in Sources */,
 				A10000000000000000000021 /* MobileInternetSettingsModels.swift in Sources */,
 				A10000000000000000000022 /* MobileInternetSettingsPresenter.swift in Sources */,

--- a/iphone/Maps/Resources/Images.xcassets/Layers/Menu/btn_menu_traffic.imageset/Contents.json
+++ b/iphone/Maps/Resources/Images.xcassets/Layers/Menu/btn_menu_traffic.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "filename" : "btn_menu_traffic_light.svg",
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "filename" : "btn_menu_traffic_dark.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
+  }
+}

--- a/iphone/Maps/Resources/Images.xcassets/Layers/Menu/btn_menu_traffic.imageset/btn_menu_traffic_dark.svg
+++ b/iphone/Maps/Resources/Images.xcassets/Layers/Menu/btn_menu_traffic.imageset/btn_menu_traffic_dark.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="54" height="54" viewBox="0 0 54 54" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect width="54" height="54" rx="10" ry="10" fill="#262222"/>
+  <g fill="none" stroke="#eda45f" stroke-width="2.4" stroke-linecap="round">
+    <rect x="19" y="9" width="16" height="36" rx="8"/>
+    <circle cx="27" cy="17" r="2.6" fill="#ef6259" stroke="none"/>
+    <circle cx="27" cy="27" r="2.6" fill="#f0b64b" stroke="none"/>
+    <circle cx="27" cy="37" r="2.6" fill="#67b569" stroke="none"/>
+  </g>
+</svg>

--- a/iphone/Maps/Resources/Images.xcassets/Layers/Menu/btn_menu_traffic.imageset/btn_menu_traffic_light.svg
+++ b/iphone/Maps/Resources/Images.xcassets/Layers/Menu/btn_menu_traffic.imageset/btn_menu_traffic_light.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="54" height="54" viewBox="0 0 54 54" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect width="54" height="54" rx="10" ry="10" fill="#ede8d6"/>
+  <g fill="none" stroke="#c96a2d" stroke-width="2.4" stroke-linecap="round">
+    <rect x="19" y="9" width="16" height="36" rx="8"/>
+    <circle cx="27" cy="17" r="2.6" fill="#d84a40" stroke="none"/>
+    <circle cx="27" cy="27" r="2.6" fill="#e0a63c" stroke="none"/>
+    <circle cx="27" cy="37" r="2.6" fill="#55a054" stroke="none"/>
+  </g>
+</svg>

--- a/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuLayersCell.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuLayersCell.swift
@@ -39,6 +39,12 @@ class BottomMenuLayersCell: UITableViewCell {
     }
   }
 
+  @IBOutlet private var trafficButton: BottomMenuLayerButton! {
+    didSet {
+      updateTrafficButton()
+    }
+  }
+
   var onClose: (() -> Void)?
 
   override func awakeFromNib() {
@@ -55,6 +61,7 @@ class BottomMenuLayersCell: UITableViewCell {
     cyclingButton.setupWith(image: UIImage(resource: .btnMenuCycling), text: L("button_layer_cycling"))
     subwayButton.setupWith(image: UIImage(resource: .btnMenuSubway), text: L("button_layer_subway"))
     satelliteButton.setupWith(image: UIImage(resource: .btnMenuSatellite), text: L("button_layer_satellite"))
+    trafficButton.setupWith(image: UIImage(resource: .btnMenuTraffic), text: L("button_layer_traffic"))
   }
 
   deinit {
@@ -97,6 +104,13 @@ class BottomMenuLayersCell: UITableViewCell {
     satelliteButton.setLayerEnabled(Settings.backgroundTilesEnabled())
   }
 
+  private func updateTrafficButton() {
+    // The Traffic toggle is a quick on/off for the layer; the data source key lives in Settings,
+    // so only show the button once a key is set.
+    trafficButton.isHidden = Settings.trafficApiKey().isEmpty
+    trafficButton.setLayerEnabled(MapOverlayManager.trafficEnabled())
+  }
+
   @IBAction func onCloseButtonPressed(_: Any) {
     onClose?()
   }
@@ -137,6 +151,11 @@ class BottomMenuLayersCell: UITableViewCell {
     updateSatelliteButton()
   }
 
+  @IBAction func onTrafficButton(_: Any) {
+    MapOverlayManager.setTrafficEnabled(!MapOverlayManager.trafficEnabled())
+    updateTrafficButton()
+  }
+
   private func showUpdateToastIfNeeded() {
     if FrameworkHelper.needUpdateForRoutes() {
       Toast.show(withText: L("routes_update_maps_text"), alignment: .top)
@@ -152,6 +171,7 @@ extension BottomMenuLayersCell: MapOverlayManagerObserver {
     updateHikingButton()
     updateCyclingButton()
     updateSatelliteButton()
+    updateTrafficButton()
   }
 }
 

--- a/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuLayersCell.xib
+++ b/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuLayersCell.xib
@@ -116,6 +116,13 @@
                                     <action selector="onSubwayButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="xxM-kP-gT1"/>
                                 </connections>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tr1-af-l01" userLabel="Traffic Button" customClass="BottomMenuLayerButton" customModule="Organic_Maps" customModuleProvider="target">
+                                <rect key="frame" x="249.5" y="0.0" width="58.5" height="81"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <connections>
+                                    <action selector="onTrafficButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="tr2-ac-t01"/>
+                                </connections>
+                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sa1-te-l01" userLabel="Satellite Button" customClass="BottomMenuLayerButton" customModule="Organic_Maps" customModuleProvider="target">
                                 <rect key="frame" x="249.5" y="0.0" width="58.5" height="81"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -169,6 +176,7 @@
                 <outlet property="outdoorButton" destination="g13-pK-Eig" id="ib1-aw-Qv9"/>
                 <outlet property="satelliteButton" destination="sa1-te-l01" id="sa3-ou-t01"/>
                 <outlet property="subwayButton" destination="4US-fZ-cyg" id="eQB-HR-Wgl"/>
+                <outlet property="trafficButton" destination="tr1-af-l01" id="tr3-ou-t01"/>
             </connections>
             <point key="canvasLocation" x="137.6953125" y="201.953125"/>
         </tableViewCell>

--- a/iphone/Maps/UI/Settings/Root/RootSettingsInteractor.swift
+++ b/iphone/Maps/UI/Settings/Root/RootSettingsInteractor.swift
@@ -174,6 +174,7 @@ final class RootSettingsInteractor {
          .bookmarksTextPlacement,
          .appearance,
          .mapTiles,
+         .traffic,
          .voiceInstructions,
          .routingOptions:
       break

--- a/iphone/Maps/UI/Settings/Root/RootSettingsModels.swift
+++ b/iphone/Maps/UI/Settings/Root/RootSettingsModels.swift
@@ -22,6 +22,7 @@ enum RootSettings: String, Hashable {
   case appearance
   case iCloud
   case mapTiles
+  case traffic
   case logging
   case perspectiveView
   case autoZoom
@@ -67,6 +68,7 @@ extension RootSettings {
     case .appearance: return L("pref_appearance_title")
     case .iCloud: return "iCloud Synchronization (Beta)"
     case .mapTiles: return L("pref_bg_tiles_title")
+    case .traffic: return L("pref_traffic_title")
     case .logging: return L("enable_logging")
     case .perspectiveView: return L("pref_map_3d_title")
     case .autoZoom: return L("pref_map_auto_zoom")
@@ -89,6 +91,7 @@ extension RootSettings {
     case .voiceInstructions: return .voiceInstructions
     case .routingOptions: return .drivingOptions
     case .mapTiles: return .mapTiles
+    case .traffic: return .traffic
     case .zoomButtons,
          .buildings3D,
          .autoDownload,

--- a/iphone/Maps/UI/Settings/Root/RootSettingsPresenter.swift
+++ b/iphone/Maps/UI/Settings/Root/RootSettingsPresenter.swift
@@ -139,6 +139,8 @@ final class RootSettingsPresenter {
                             kind: .switcher(isOn: state.transliteration, isEnabled: true)),
       SettingsItemViewModel(setting: .mapTiles,
                             kind: .link),
+      SettingsItemViewModel(setting: .traffic,
+                            kind: .link),
     ]
   }
 

--- a/iphone/Maps/UI/Settings/SettingsBuilder.swift
+++ b/iphone/Maps/UI/Settings/SettingsBuilder.swift
@@ -8,6 +8,7 @@ enum SettingsScreen {
   case voiceInstructions
   case drivingOptions
   case mapTiles
+  case traffic
 }
 
 @objcMembers
@@ -43,6 +44,8 @@ final class SettingsBuilder: NSObject {
       return buildDrivingOptions()
     case .mapTiles:
       return buildMapTiles()
+    case .traffic:
+      return buildTraffic()
     }
   }
 
@@ -50,6 +53,15 @@ final class SettingsBuilder: NSObject {
     let viewController = MapTilesSettingsViewController()
     let presenter = MapTilesSettingsPresenter(viewController: viewController)
     let interactor = MapTilesSettingsInteractor()
+    interactor.presenter = presenter
+    viewController.configure(interactor: interactor)
+    return viewController
+  }
+
+  static func buildTraffic() -> UIViewController {
+    let viewController = TrafficSettingsViewController()
+    let presenter = TrafficSettingsPresenter(viewController: viewController)
+    let interactor = TrafficSettingsInteractor()
     interactor.presenter = presenter
     viewController.configure(interactor: interactor)
     return viewController

--- a/iphone/Maps/UI/Settings/Traffic/TrafficSettingsInteractor.swift
+++ b/iphone/Maps/UI/Settings/Traffic/TrafficSettingsInteractor.swift
@@ -1,0 +1,84 @@
+final class TrafficSettingsInteractor {
+  var presenter: TrafficSettingsPresenter?
+
+  private let settings: TrafficSettings.Type
+  private var state: TrafficSettingsState
+
+  init(settings: TrafficSettings.Type = Settings.self) {
+    self.settings = settings
+    state = Self.initialState(settings: settings)
+  }
+
+  func loadSettings() {
+    present(reconfiguredItems: [], animatingDifferences: false)
+  }
+
+  func saveSettings() {
+    let apiKey = Self.trimmed(state.apiKey)
+    guard apiKey != Self.trimmed(settings.trafficApiKey()) else { return }
+    guard state.isKeyValid else { return }
+    settings.setTrafficApiKey(apiKey)
+  }
+
+  private func changeAPIKey(_ apiKey: String) {
+    guard state.apiKey != apiKey else { return }
+    state.apiKey = apiKey
+    updateState(reconfiguredItems: [.apiKey], animatingDifferences: false)
+  }
+
+  private func endEditingAPIKey(_ apiKey: String) {
+    let apiKey = Self.trimmed(apiKey)
+    guard state.apiKey != apiKey else { return }
+    state.apiKey = apiKey
+    updateState(reconfiguredItems: [.apiKey], animatingDifferences: false)
+  }
+
+  private func present(reconfiguredItems: [TrafficSettingsItem],
+                       animatingDifferences: Bool) {
+    presenter?.present(state,
+                       reconfiguredItems: reconfiguredItems,
+                       animatingDifferences: animatingDifferences)
+  }
+
+  private func updateState(reconfiguredItems: [TrafficSettingsItem],
+                           animatingDifferences: Bool) {
+    state.isKeyValid = Self.isKeyValid(apiKey: state.apiKey, settings: settings)
+    present(reconfiguredItems: reconfiguredItems, animatingDifferences: animatingDifferences)
+  }
+
+  private static func initialState(settings: TrafficSettings.Type) -> TrafficSettingsState {
+    let apiKey = trimmed(settings.trafficApiKey())
+    return TrafficSettingsState(apiKey: apiKey,
+                                isKeyValid: isKeyValid(apiKey: apiKey, settings: settings))
+  }
+
+  /// An empty key is always valid: it falls back to the built-in traffic source.
+  private static func isKeyValid(apiKey: String, settings: TrafficSettings.Type) -> Bool {
+    let apiKey = trimmed(apiKey)
+    return apiKey.isEmpty || settings.isWellFormedTrafficApiKey(apiKey)
+  }
+
+  private static func trimmed(_ apiKey: String?) -> String {
+    (apiKey ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}
+
+extension TrafficSettingsInteractor: SettingsViewControllerInteractor {
+  typealias Section = TrafficSettingsSection
+  typealias Item = TrafficSettingsItem
+
+  func handle(_ action: SettingsViewControllerAction<TrafficSettingsItem>) {
+    switch action {
+    case .didLoad:
+      loadSettings()
+    case .willDisappear:
+      saveSettings()
+    case .didChangeText(.apiKey, text: let text):
+      changeAPIKey(text)
+    case .didEndEditingText(.apiKey, text: let text):
+      endEditingAPIKey(text)
+    default:
+      break
+    }
+  }
+}

--- a/iphone/Maps/UI/Settings/Traffic/TrafficSettingsModels.swift
+++ b/iphone/Maps/UI/Settings/Traffic/TrafficSettingsModels.swift
@@ -1,0 +1,31 @@
+enum TrafficSettingsSection: String {
+  case apiKey
+}
+
+extension TrafficSettingsSection {
+  var title: String? {
+    switch self {
+    case .apiKey: return L("pref_traffic_api_key_title")
+    }
+  }
+
+  var footer: String? {
+    switch self {
+    case .apiKey: L("pref_traffic_disclaimer")
+    }
+  }
+}
+
+enum TrafficSettingsItem {
+  case apiKey
+  case keyError
+}
+
+struct TrafficSettingsState: Equatable {
+  var apiKey: String
+  var isKeyValid: Bool
+}
+
+typealias TrafficSettingsViewController = SettingsViewController<TrafficSettingsSection, TrafficSettingsItem>
+typealias TrafficSettingsSectionViewModel = SettingsSectionViewModel<TrafficSettingsSection, TrafficSettingsItem>
+typealias TrafficSettingsItemViewModel = SettingsItemViewModel<TrafficSettingsItem>

--- a/iphone/Maps/UI/Settings/Traffic/TrafficSettingsPresenter.swift
+++ b/iphone/Maps/UI/Settings/Traffic/TrafficSettingsPresenter.swift
@@ -1,0 +1,44 @@
+final class TrafficSettingsPresenter {
+  private weak var viewController: TrafficSettingsViewController?
+
+  init(viewController: TrafficSettingsViewController) {
+    self.viewController = viewController
+  }
+
+  func present(_ state: TrafficSettingsState,
+               reconfiguredItems: [TrafficSettingsItem] = [],
+               animatingDifferences: Bool = true) {
+    viewController?.display(SettingsViewModel(title: RootSettings.traffic.title,
+                                              sections: sections(from: state),
+                                              reconfiguredItems: reconfiguredItems,
+                                              animatingDifferences: animatingDifferences))
+  }
+
+  private func sections(from state: TrafficSettingsState) -> [TrafficSettingsSectionViewModel] {
+    [section(.apiKey, items: keyItems(state))]
+  }
+
+  private func section(_ section: TrafficSettingsSection,
+                       items: [TrafficSettingsItemViewModel]) -> TrafficSettingsSectionViewModel {
+    SettingsSectionViewModel(section: section, header: section.title, footer: section.footer, items: items)
+  }
+
+  private func keyItems(_ state: TrafficSettingsState) -> [TrafficSettingsItemViewModel] {
+    if state.isKeyValid {
+      return [keyItem(state)]
+    }
+    return [keyItem(state), keyErrorItem()]
+  }
+
+  private func keyItem(_ state: TrafficSettingsState) -> TrafficSettingsItemViewModel {
+    SettingsItemViewModel(item: .apiKey,
+                          kind: .textField(text: state.apiKey,
+                                           placeholder: "",
+                                           isEnabled: true,
+                                           isValid: state.isKeyValid))
+  }
+
+  private func keyErrorItem() -> TrafficSettingsItemViewModel {
+    SettingsItemViewModel(item: .keyError, kind: .message(text: L("pref_traffic_key_error")))
+  }
+}

--- a/libs/coding/CMakeLists.txt
+++ b/libs/coding/CMakeLists.txt
@@ -46,6 +46,8 @@ set(SRC
   mmap_reader.hpp
   move_to_front.cpp
   move_to_front.hpp
+  mvt_reader.cpp
+  mvt_reader.hpp
   parse_xml.hpp
   point_coding.cpp
   point_coding.hpp

--- a/libs/coding/coding_tests/CMakeLists.txt
+++ b/libs/coding/coding_tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SRC
   mem_file_reader_test.cpp
   mem_file_writer_test.cpp
   move_to_front_tests.cpp
+  mvt_reader_test.cpp
   png_decoder_test.cpp
   point_coding_tests.cpp
   reader_cache_test.cpp

--- a/libs/coding/coding_tests/mvt_reader_test.cpp
+++ b/libs/coding/coding_tests/mvt_reader_test.cpp
@@ -1,0 +1,170 @@
+#include "coding/mvt_reader.hpp"
+#include "base/bits.hpp"
+
+#include "testing/testing.hpp"
+
+#include <string>
+#include <vector>
+
+namespace mvt_reader_test
+{
+using namespace mvt;
+
+namespace
+{
+// Geometry command ids from the MVT spec.
+uint64_t constexpr kMoveTo = 1;
+uint64_t constexpr kLineTo = 2;
+
+void WriteVarint(std::string & out, uint64_t v)
+{
+  while (v > 0x7F)
+  {
+    out.push_back(static_cast<char>((v & 0x7F) | 0x80));
+    v >>= 7;
+  }
+  out.push_back(static_cast<char>(v));
+}
+
+// Appends a protobuf field with a length-delimited payload.
+template <class Fn>
+void WriteField(std::string & out, uint64_t fieldNumber, Fn const & payloadWriter)
+{
+  std::string payload;
+  payloadWriter(payload);
+  WriteVarint(out, (fieldNumber << 3) | 2 /* wire type */);
+  WriteVarint(out, payload.size());
+  out += payload;
+}
+
+std::string MakeTestTile()
+{
+  // One layer "roads", extent 4096, one two-part linestring feature with tags.
+  std::string tile;
+  WriteField(tile, 3 /* Layer */, [](std::string & layer)
+  {
+    WriteVarint(layer, (15 << 3) | 0);  // version
+    WriteVarint(layer, 2);
+    WriteField(layer, 1 /* name */, [](std::string & s) { s = "Traffic flow"; });
+    WriteField(layer, 3 /* key */, [](std::string & s) { s = "traffic_level"; });
+    WriteField(layer, 3 /* key */, [](std::string & s) { s = "road_closure"; });
+    WriteField(layer, 4 /* value */, [](std::string & s)
+    {
+      WriteVarint(s, (3 << 3) | 1 /* double_value, fixed64 */);
+      double const d = 0.25;
+      for (size_t i = 0; i < sizeof(d); ++i)
+        s.push_back(static_cast<char>((reinterpret_cast<uint8_t const *>(&d))[i]));
+    });
+    WriteField(layer, 4 /* value */, [](std::string & s)
+    {
+      WriteVarint(s, (7 << 3) | 0 /* bool_value */);
+      WriteVarint(s, 1);
+    });
+    WriteVarint(layer, (5 << 3) | 0);  // extent, varint field
+    WriteVarint(layer, 4096);
+
+    WriteField(layer, 2 /* feature */, [&](std::string & f)
+    {
+      WriteVarint(f, (3 << 3) | 0);  // type
+      WriteVarint(f, static_cast<uint64_t>(GeomType::LineString));
+      WriteField(f, 2 /* tags */, [](std::string & t)
+      {
+        WriteVarint(t, 0);  // key: traffic_level
+        WriteVarint(t, 0);  // value: 0.25
+        WriteVarint(t, 1);  // key: road_closure
+        WriteVarint(t, 1);  // value: true
+      });
+      WriteField(f, 4 /* geometry */, [](std::string & g)
+      {
+        // Part 1: MoveTo(100, 200), LineTo(300, 400), LineTo(500, 600).
+        // Part 2: MoveTo(10, 20), LineTo(30, 40).
+        WriteVarint(g, (1 << 3) | kMoveTo);
+        WriteVarint(g, bits::ZigZagEncode(100));
+        WriteVarint(g, bits::ZigZagEncode(200));
+        WriteVarint(g, (2 << 3) | kLineTo);
+        WriteVarint(g, bits::ZigZagEncode(200));
+        WriteVarint(g, bits::ZigZagEncode(200));
+        WriteVarint(g, bits::ZigZagEncode(200));
+        WriteVarint(g, bits::ZigZagEncode(200));
+        WriteVarint(g, (1 << 3) | kMoveTo);
+        WriteVarint(g, bits::ZigZagEncode(-490));  // 500 -> 10
+        WriteVarint(g, bits::ZigZagEncode(-580));  // 600 -> 20
+        WriteVarint(g, (1 << 3) | kLineTo);
+        WriteVarint(g, bits::ZigZagEncode(20));
+        WriteVarint(g, bits::ZigZagEncode(20));
+      });
+    });
+  });
+  return tile;
+}
+}  // namespace
+
+UNIT_TEST(MvtReader_Decode)
+{
+  std::vector<Layer> layers;
+  TEST(Decode(MakeTestTile(), layers), ());
+  TEST_EQUAL(layers.size(), 1, ());
+  auto const & layer = layers[0];
+  TEST_EQUAL(layer.m_name, "Traffic flow", ());
+  TEST_EQUAL(layer.m_extent, 4096, ());
+  TEST_EQUAL(layer.m_keys, std::vector<std::string>({"traffic_level", "road_closure"}), ());
+  TEST_EQUAL(layer.m_features.size(), 1, ());
+
+  auto const & f = layer.m_features[0];
+  TEST_EQUAL(f.m_geomType, GeomType::LineString, ());
+  TEST_EQUAL(f.m_lines.size(), 2, ());
+  TEST_EQUAL(f.m_lines[0].size(), 3, ());
+  TEST_ALMOST_EQUAL_ABS(f.m_lines[0][0].x, 100.0, 1e-9, ());
+  TEST_ALMOST_EQUAL_ABS(f.m_lines[0][0].y, 200.0, 1e-9, ());
+  TEST_ALMOST_EQUAL_ABS(f.m_lines[0][2].x, 500.0, 1e-9, ());
+  TEST_ALMOST_EQUAL_ABS(f.m_lines[0][2].y, 600.0, 1e-9, ());
+  TEST_EQUAL(f.m_lines[1].size(), 2, ());
+  TEST_ALMOST_EQUAL_ABS(f.m_lines[1][0].x, 10.0, 1e-9, ());
+  TEST_ALMOST_EQUAL_ABS(f.m_lines[1][1].x, 30.0, 1e-9, ());
+
+  Value const * level = layer.GetTag(f, "traffic_level");
+  TEST(level != nullptr, ());
+  TEST_EQUAL(level->m_type, Value::Type::Double, ());
+  TEST_ALMOST_EQUAL_ABS(level->m_double, 0.25, 1e-9, ());
+
+  Value const * closure = layer.GetTag(f, "road_closure");
+  TEST(closure != nullptr && closure->m_type == Value::Type::Bool && closure->m_bool, ());
+
+  TEST(layer.GetTag(f, "nonexistent") == nullptr, ());
+}
+
+UNIT_TEST(MvtReader_Malformed)
+{
+  std::vector<Layer> layers;
+  TEST(!Decode("\x0a", layers), ());  // Truncated length-delimited header.
+  TEST(layers.empty(), ());
+
+  std::string truncated = MakeTestTile();
+  truncated.resize(truncated.size() / 2);
+  TEST(!Decode(truncated, layers), ());
+}
+
+// Every prefix of a valid tile must be handled gracefully: no crashes, no out-of-bounds
+// reads on malformed network payloads. Prefixes ending at a field boundary may decode
+// successfully, so only crash- and exception-freedom is asserted.
+UNIT_TEST(MvtReader_TruncatedPrefixes)
+{
+  std::string const tile = MakeTestTile();
+  std::vector<Layer> layers;
+  for (size_t size = 0; size < tile.size(); ++size)
+  {
+    layers.clear();
+    bool const ok = Decode(tile.substr(0, size), layers);
+    if (!ok)
+      TEST(layers.empty(), (size));
+  }
+}
+
+UNIT_TEST(MvtReader_EmptyLayerList)
+{
+  // A message with no fields decodes to zero layers (an empty but valid tile).
+  std::vector<Layer> layers;
+  TEST(Decode(std::string{}, layers), ());
+  TEST(layers.empty(), ());
+}
+}  // namespace mvt_reader_test

--- a/libs/coding/mvt_reader.cpp
+++ b/libs/coding/mvt_reader.cpp
@@ -1,0 +1,365 @@
+#include "coding/mvt_reader.hpp"
+
+#include "coding/reader.hpp"
+#include "coding/varint.hpp"
+
+#include "base/bits.hpp"
+
+#include <algorithm>
+
+namespace mvt
+{
+namespace
+{
+using Source = ReaderSource<MemReaderWithExceptions>;
+
+uint8_t constexpr kWireVarint = 0;
+uint8_t constexpr kWireFixed64 = 1;
+uint8_t constexpr kWireLen = 2;
+uint8_t constexpr kWireFixed32 = 5;
+
+// Geometry command ids.
+uint8_t constexpr kMoveTo = 1;
+uint8_t constexpr kLineTo = 2;
+uint8_t constexpr kClosePath = 7;
+
+bool ReadTag(Source & src, uint64_t & fieldNumber, uint8_t & wireType)
+{
+  if (src.Size() == 0)
+    return false;
+  uint64_t const tag = ReadVarUint<uint64_t>(src);
+  fieldNumber = tag >> 3;
+  wireType = static_cast<uint8_t>(tag & 7);
+  return true;
+}
+
+bool SkipFieldContent(Source & src, uint8_t wireType)
+{
+  switch (wireType)
+  {
+  case kWireVarint: UNUSED_VALUE(ReadVarUint<uint64_t>(src)); return true;
+  // ReaderSource::Skip() is not bounds-checked, so verify the size explicitly.
+  case kWireFixed64:
+    if (src.Size() < 8)
+      return false;
+    src.Skip(8);
+    return true;
+  case kWireFixed32:
+    if (src.Size() < 4)
+      return false;
+    src.Skip(4);
+    return true;
+  case kWireLen:
+  {
+    uint64_t const len = ReadVarUint<uint64_t>(src);
+    if (len > src.Size())
+      return false;
+    src.Skip(len);
+    return true;
+  }
+  default: return false;
+  }
+}
+
+std::string ReadString(Source & src)
+{
+  uint64_t const len = ReadVarUint<uint64_t>(src);
+  if (len > src.Size())
+    return {};
+  std::string s(len, '\0');
+  if (len > 0)
+    src.Read(&s[0], static_cast<size_t>(len));
+  return s;
+}
+
+Value ParseValue(Source & src)
+{
+  Value v;
+  while (src.Size() > 0)
+  {
+    uint64_t field;
+    uint8_t wire;
+    if (!ReadTag(src, field, wire))
+      break;
+    switch (field)
+    {
+    case 1:
+      if (wire != kWireLen)
+        return {};
+      v.m_type = Value::Type::String;
+      v.m_string = ReadString(src);
+      return v;
+    case 2:
+    {
+      if (wire != kWireFixed32)
+        return {};
+      float f;
+      src.Read(&f, sizeof(f));  // Fixed32 wire type holds a little-endian float.
+      v.m_double = f;
+      v.m_type = Value::Type::Double;
+      return v;
+    }
+    case 3:
+      if (wire != kWireFixed64)
+        return {};
+      src.Read(&v.m_double, sizeof(v.m_double));
+      v.m_type = Value::Type::Double;
+      return v;
+    case 4:
+    case 6:
+    case 7:
+    {
+      if (wire != kWireVarint)
+        return {};
+      uint64_t const raw = ReadVarUint<uint64_t>(src);
+      if (field == 7)
+      {
+        v.m_bool = raw != 0;
+        v.m_type = Value::Type::Bool;
+      }
+      else
+      {
+        v.m_double = field == 6 ? static_cast<double>(bits::ZigZagDecode(raw)) : static_cast<double>(raw);
+        v.m_type = Value::Type::Double;
+      }
+      return v;
+    }
+    case 5:
+      if (wire != kWireVarint)
+        return {};
+      v.m_double = static_cast<double>(ReadVarUint<uint64_t>(src));
+      v.m_type = Value::Type::Double;
+      return v;
+    default:
+      if (!SkipFieldContent(src, wire))
+        return {};
+      break;
+    }
+  }
+  return v;
+}
+
+bool ParseGeometry(Source & src, Feature & f)
+{
+  // Unsigned so that wrapping on absurd deltas from malformed tiles is well-defined.
+  uint64_t x = 0;
+  uint64_t y = 0;
+  std::vector<m2::PointD> current;
+  while (src.Size() > 0)
+  {
+    uint64_t const header = ReadVarUint<uint64_t>(src);
+    uint64_t const cmd = header & 7u;
+    uint64_t const count = header >> 3;
+    for (uint64_t i = 0; i < count; ++i)
+    {
+      switch (cmd)
+      {
+      case kMoveTo:
+      {
+        if (!current.empty())
+        {
+          f.m_lines.push_back(std::move(current));
+          current.clear();
+        }
+        x += bits::ZigZagDecode(ReadVarUint<uint64_t>(src));
+        y += bits::ZigZagDecode(ReadVarUint<uint64_t>(src));
+        current.emplace_back(static_cast<double>(x), static_cast<double>(y));
+        break;
+      }
+      case kLineTo:
+      {
+        if (current.empty())
+          return false;
+        x += bits::ZigZagDecode(ReadVarUint<uint64_t>(src));
+        y += bits::ZigZagDecode(ReadVarUint<uint64_t>(src));
+        current.emplace_back(static_cast<double>(x), static_cast<double>(y));
+        break;
+      }
+      case kClosePath:
+        // Polygon ring boundary: linestring consumers treat the part as ended.
+        if (!current.empty())
+        {
+          f.m_lines.push_back(std::move(current));
+          current.clear();
+        }
+        break;
+      default: return false;
+      }
+    }
+  }
+  if (!current.empty())
+    f.m_lines.push_back(std::move(current));
+  return !f.m_lines.empty();
+}
+
+bool ParseFeature(Source & src, Layer & layer, Feature & f)
+{
+  while (src.Size() > 0)
+  {
+    uint64_t field;
+    uint8_t wire;
+    if (!ReadTag(src, field, wire))
+      return false;
+    switch (field)
+    {
+    case 1:
+      if (wire != kWireVarint || !SkipFieldContent(src, wire))
+        return false;
+      break;
+    case 2:
+    {
+      if (wire != kWireLen)
+        return false;
+      uint64_t const len = ReadVarUint<uint64_t>(src);
+      if (len > src.Size())
+        return false;
+      Source tagsSrc(src.SubReader(len));
+      while (tagsSrc.Size() > 0)
+      {
+        auto const keyIdx = ReadVarUint<uint32_t>(tagsSrc);
+        auto const valIdx = ReadVarUint<uint32_t>(tagsSrc);
+        f.m_tags.emplace_back(keyIdx, valIdx);
+      }
+      break;
+    }
+    case 3:
+    {
+      if (wire != kWireVarint)
+        return false;
+      auto const t = ReadVarUint<uint64_t>(src);
+      if (t > static_cast<uint64_t>(GeomType::Polygon))
+        return false;
+      f.m_geomType = static_cast<GeomType>(t);
+      break;
+    }
+    case 4:
+    {
+      if (wire != kWireLen)
+        return false;
+      uint64_t const len = ReadVarUint<uint64_t>(src);
+      if (len > src.Size())
+        return false;
+      Source geomSrc(src.SubReader(len));
+      return ParseGeometry(geomSrc, f);
+    }
+    default:
+      if (!SkipFieldContent(src, wire))
+        return false;
+      break;
+    }
+  }
+  return false;
+}
+
+bool ParseLayer(Source & src, Layer & layer)
+{
+  bool hasName = false;
+  while (src.Size() > 0)
+  {
+    uint64_t field;
+    uint8_t wire;
+    if (!ReadTag(src, field, wire))
+      return false;
+    switch (field)
+    {
+    case 1:
+      if (wire != kWireLen)
+        return false;
+      layer.m_name = ReadString(src);
+      hasName = true;
+      break;
+    case 2:
+    {
+      if (wire != kWireLen)
+        return false;
+      uint64_t const len = ReadVarUint<uint64_t>(src);
+      if (len > src.Size())
+        return false;
+      Feature f;
+      Source featureSrc(src.SubReader(len));
+      if (!ParseFeature(featureSrc, layer, f))
+        return false;
+      layer.m_features.push_back(std::move(f));
+      break;
+    }
+    case 3:
+      if (wire != kWireLen)
+        return false;
+      layer.m_keys.push_back(ReadString(src));
+      break;
+    case 4:
+    {
+      if (wire != kWireLen)
+        return false;
+      uint64_t const len = ReadVarUint<uint64_t>(src);
+      if (len > src.Size())
+        return false;
+      Source valueSrc(src.SubReader(len));
+      layer.m_values.push_back(ParseValue(valueSrc));
+      break;
+    }
+    case 5:
+      if (wire != kWireVarint)
+        return false;
+      layer.m_extent = static_cast<uint32_t>(ReadVarUint<uint64_t>(src));
+      break;
+    case 15:
+      if (wire != kWireVarint || !SkipFieldContent(src, wire))
+        return false;
+      break;
+    default:
+      if (!SkipFieldContent(src, wire))
+        return false;
+      break;
+    }
+  }
+  return hasName && layer.m_extent > 0;
+}
+}  // namespace
+
+Value const * Layer::GetTag(Feature const & feature, std::string const & key) const
+{
+  auto const keyIt = std::find(m_keys.begin(), m_keys.end(), key);
+  if (keyIt == m_keys.end())
+    return nullptr;
+  uint32_t const keyIdx = static_cast<uint32_t>(std::distance(m_keys.begin(), keyIt));
+  for (auto const & tag : feature.m_tags)
+    if (tag.first == keyIdx && tag.second < m_values.size())
+      return &m_values[tag.second];
+  return nullptr;
+}
+
+bool Decode(std::string const & data, std::vector<Layer> & layers)
+{
+  layers.clear();
+  MemReaderWithExceptions reader(data.data(), data.size());
+  Source src(reader);
+  try
+  {
+    while (src.Size() > 0)
+    {
+      uint64_t field;
+      uint8_t wire;
+      if (!ReadTag(src, field, wire))
+        return false;
+      if (field != 3 || wire != kWireLen)
+        return false;
+      uint64_t const len = ReadVarUint<uint64_t>(src);
+      if (len > src.Size())
+        return false;
+      Layer layer;
+      Source layerSrc(src.SubReader(len));
+      if (!ParseLayer(layerSrc, layer))
+        return false;
+      layers.push_back(std::move(layer));
+    }
+  }
+  catch (Reader::Exception const &)
+  {
+    // Truncated or malformed tile.
+    layers.clear();
+    return false;
+  }
+  return true;
+}
+}  // namespace mvt

--- a/libs/coding/mvt_reader.hpp
+++ b/libs/coding/mvt_reader.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "geometry/point2d.hpp"
+
+#include "base/assert.hpp"
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace mvt
+{
+// Minimal decoder for the Mapbox Vector Tile format (protobuf), version 2.x.
+// https://github.com/mapbox/vector-tile-spec
+
+enum class GeomType : uint8_t
+{
+  Unknown = 0,
+  Point = 1,
+  LineString = 2,
+  Polygon = 3
+};
+
+struct Value
+{
+  enum class Type : uint8_t
+  {
+    String,
+    Double,
+    Bool,
+    Unsupported
+  };
+
+  Type m_type = Type::Unsupported;
+  std::string m_string;
+  double m_double = 0.0;
+  bool m_bool = false;
+};
+
+inline std::string DebugPrint(GeomType type)
+{
+  switch (type)
+  {
+  case GeomType::Unknown: return "Unknown";
+  case GeomType::Point: return "Point";
+  case GeomType::LineString: return "LineString";
+  case GeomType::Polygon: return "Polygon";
+  }
+  UNREACHABLE();
+}
+
+inline std::string DebugPrint(Value::Type type)
+{
+  switch (type)
+  {
+  case Value::Type::String: return "String";
+  case Value::Type::Double: return "Double";
+  case Value::Type::Bool: return "Bool";
+  case Value::Type::Unsupported: return "Unsupported";
+  }
+  UNREACHABLE();
+}
+
+struct Feature
+{
+  std::vector<std::vector<m2::PointD>> m_lines;       // decoded parts, coordinates in tile units
+  std::vector<std::pair<uint32_t, uint32_t>> m_tags;  // (key index, value index) pairs
+  GeomType m_geomType = GeomType::Unknown;
+};
+
+struct Layer
+{
+  std::string m_name;
+  uint32_t m_extent = 4096;
+  std::vector<Feature> m_features;
+  std::vector<std::string> m_keys;
+  std::vector<Value> m_values;
+
+  // Returns the value of the tag |key| for the feature, or nullptr if absent.
+  Value const * GetTag(Feature const & feature, std::string const & key) const;
+};
+
+// Decodes a tile into its layers. Returns false on malformed input.
+bool Decode(std::string const & data, std::vector<Layer> & layers);
+}  // namespace mvt

--- a/libs/drape_frontend/backend_renderer.cpp
+++ b/libs/drape_frontend/backend_renderer.cpp
@@ -475,6 +475,12 @@ void BackendRenderer::AcceptMessage(ref_ptr<Message> message)
     break;
   }
 
+  case Message::Type::InvalidateTrafficTiles:
+  {
+    m_readManager->InvalidateAll();
+    break;
+  }
+
   case Message::Type::ClearTrafficData:
   {
     ref_ptr<ClearTrafficDataMessage> msg = message;

--- a/libs/drape_frontend/drape_engine.cpp
+++ b/libs/drape_frontend/drape_engine.cpp
@@ -763,6 +763,12 @@ void DrapeEngine::EnableTraffic(bool trafficEnabled)
                                   make_unique_dp<EnableTrafficMessage>(trafficEnabled), MessagePriority::Normal);
 }
 
+void DrapeEngine::InvalidateTrafficTiles()
+{
+  m_threadCommutator->PostMessage(ThreadsCommutator::ResourceUploadThread,
+                                  make_unique_dp<InvalidateTrafficTilesMessage>(), MessagePriority::Normal);
+}
+
 void DrapeEngine::UpdateTraffic(traffic::TrafficInfo const & info)
 {
   if (info.GetColoring().empty())

--- a/libs/drape_frontend/drape_engine.hpp
+++ b/libs/drape_frontend/drape_engine.hpp
@@ -214,6 +214,7 @@ public:
   void RequestSymbolsSize(std::vector<std::string> const & symbols, TRequestSymbolsSizeCallback const & callback);
 
   void EnableTraffic(bool trafficEnabled);
+  void InvalidateTrafficTiles();
   void UpdateTraffic(traffic::TrafficInfo const & info);
   void ClearTrafficCache(MwmSet::MwmId const & mwmId);
   void SetSimplifiedTrafficColors(bool simplified);

--- a/libs/drape_frontend/message.hpp
+++ b/libs/drape_frontend/message.hpp
@@ -77,6 +77,7 @@ public:
     EnableTraffic,
     FlushTrafficGeometry,
     RegenerateTraffic,
+    InvalidateTrafficTiles,
     UpdateTraffic,
     FlushTrafficData,
     ClearTrafficData,

--- a/libs/drape_frontend/message_subclasses.hpp
+++ b/libs/drape_frontend/message_subclasses.hpp
@@ -1088,6 +1088,14 @@ public:
   Type GetType() const override { return Type::RegenerateTraffic; }
 };
 
+// Forces the backend to re-read currently rendered tiles so that traffic
+// geometry is regenerated with the latest colorings baked in.
+class InvalidateTrafficTilesMessage : public Message
+{
+public:
+  Type GetType() const override { return Type::InvalidateTrafficTiles; }
+};
+
 class UpdateTrafficMessage : public Message
 {
 public:

--- a/libs/map/CMakeLists.txt
+++ b/libs/map/CMakeLists.txt
@@ -23,6 +23,8 @@ set(SRC
   extrapolation/extrapolator.hpp
   features_fetcher.cpp
   features_fetcher.hpp
+  flow_tiles_provider.cpp
+  flow_tiles_provider.hpp
   framework.cpp
   framework.hpp
   gps_track_collection.cpp
@@ -71,6 +73,7 @@ set(SRC
   track_mark.hpp
   traffic_manager.cpp
   traffic_manager.hpp
+  traffic_provider.hpp
   transit/transit_display.cpp
   transit/transit_display.hpp
   transit/transit_reader.cpp

--- a/libs/map/flow_tiles_provider.cpp
+++ b/libs/map/flow_tiles_provider.cpp
@@ -1,0 +1,416 @@
+#include "map/flow_tiles_provider.hpp"
+
+#include "coding/mvt_reader.hpp"
+
+#include "indexer/feature.hpp"
+#include "indexer/scales.hpp"
+
+#include "geometry/mercator.hpp"
+#include "geometry/parametrized_segment.hpp"
+
+#include "platform/http_client.hpp"
+
+#include "base/assert.hpp"
+#include "base/logging.hpp"
+#include "base/math.hpp"
+
+#include "routing_common/car_model.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <utility>
+
+using namespace std::chrono;
+
+namespace traffic
+{
+namespace
+{
+// Vector flow tiles of the TomTom Traffic API. The tile scheme (XYZ grid,
+// Mapbox Vector Tile payload, relative speeds in [0..1], road_closure tag)
+// is shared by similar services; only the URL below is provider-specific.
+char constexpr kFlowTilesUrl[] = "https://api.tomtom.com/traffic/map/4/tile/flow/relative/";
+char constexpr kFlowLayerName[] = "Traffic flow";
+auto constexpr kTileRefreshInterval = minutes(2);
+
+size_t constexpr kMinRunVertices = 1;
+size_t constexpr kFlowTilesZoom = 12;
+size_t constexpr kMaxTilesPerFetch = 8;
+size_t constexpr kMaxCachedTiles = 256;
+
+double constexpr kMaxSnapDistanceMeters = 50.0;
+uint32_t constexpr kMaxSegmentIdx = (1 << 15) - 1;  // TrafficInfo::RoadSegmentId::m_idx is a 15-bit field.
+
+uint64_t TileKey(int zoom, int x, int y)
+{
+  return (static_cast<uint64_t>(zoom) << 50) | (static_cast<uint64_t>(x) << 25) | static_cast<uint64_t>(y);
+}
+
+// Web-mercator tile geometry over OM's map space: x equals longitude in
+// degrees, y is the Mercator Y scaled to [-180; 180] and grows northwards.
+m2::RectD TileRect(int zoom, int x, int y)
+{
+  double const size = 360.0 / (1 << zoom);
+  double const minX = mercator::Bounds::kMinX + x * size;
+  double const maxY = mercator::Bounds::kMaxY - y * size;
+  return m2::RectD(minX, maxY - size, minX + size, maxY);
+}
+
+struct TileRange
+{
+  int m_minX = 0;
+  int m_minY = 0;
+  int m_maxX = 0;
+  int m_maxY = 0;
+};
+
+TileRange TilesCovering(m2::RectD const & mercatorRect, int zoom)
+{
+  double const n = 1 << zoom;
+  auto const toTileX = [n](double mx)
+  { return static_cast<int>(math::Clamp(std::floor((mx - mercator::Bounds::kMinX) * n / 360.0), 0.0, n - 1.0)); };
+  auto const toTileY = [n](double my)
+  { return static_cast<int>(math::Clamp(std::floor((mercator::Bounds::kMaxY - my) * n / 360.0), 0.0, n - 1.0)); };
+  TileRange r;
+  r.m_minX = static_cast<int>(toTileX(mercatorRect.minX()));
+  r.m_minY = static_cast<int>(toTileY(mercatorRect.maxY()));
+  r.m_maxX = static_cast<int>(toTileX(mercatorRect.maxX()));
+  r.m_maxY = static_cast<int>(toTileY(mercatorRect.minY()));
+  return r;
+}
+
+struct RoadFeature
+{
+  FeatureID m_id;
+  std::vector<m2::PointD> m_points;
+  m2::RectD m_bbox = {};
+};
+
+void CollectRoads(DataSource const & dataSource, m2::RectD const & rect, std::vector<RoadFeature> & roads)
+{
+  auto const & carModel = routing::CarModel::AllLimitsInstance();
+  dataSource.ForEachInRect([&](FeatureType & ft)
+  {
+    feature::TypesHolder const types(ft);
+    if (!carModel.IsRoad(types))
+      return;
+    if (ft.GetGeomType() != feature::GeomType::Line)
+      return;
+    ft.ParseGeometry(FeatureType::BEST_GEOMETRY);
+    int const numPoints = static_cast<int>(ft.GetPointsCount());
+    if (numPoints < 2)
+      return;
+    RoadFeature rf;
+    rf.m_id = ft.GetID();
+    rf.m_points.reserve(static_cast<size_t>(numPoints));
+    for (int i = 0; i < numPoints; ++i)
+    {
+      m2::PointD const & p = ft.GetPoint(i);
+      rf.m_points.push_back(p);
+      rf.m_bbox.Add(p);
+    }
+    roads.push_back(std::move(rf));
+  }, rect, scales::GetUpperScale());
+}
+
+struct MatchedVertex
+{
+  uint32_t m_roadIdx;
+  uint32_t m_segIdx;
+  double m_orientation;
+};
+
+enum class TileDownload
+{
+  kSuccess,
+  kHttpError,
+  kBadPayload
+};
+}  // namespace
+
+SpeedGroup SpeedGroupFromFlow(double relativeSpeed, bool closed)
+{
+  if (closed)
+    return SpeedGroup::TempBlock;
+  if (!(relativeSpeed >= 0.0))
+    return SpeedGroup::Unknown;
+  return GetSpeedGroupByPercentage(math::Clamp(relativeSpeed, 0.0, 1.0) * 100.0);
+}
+
+void AddToColoring(TrafficInfo::Coloring & coloring, TrafficInfo::RoadSegmentId const & id, SpeedGroup group)
+{
+  auto [it, inserted] = coloring.try_emplace(id, group);
+  // Closures win over speed reports from neighboring tiles or line parts.
+  if (!inserted && it->second != SpeedGroup::TempBlock && group == SpeedGroup::TempBlock)
+    it->second = group;
+}
+
+void MergeColoring(TrafficInfo::Coloring & dst, TrafficInfo::Coloring const & src)
+{
+  for (auto const & [id, group] : src)
+    AddToColoring(dst, id, group);
+}
+
+namespace
+{
+// Downloads one flow tile, decodes it and snaps its road polylines to the
+// routable segments inside |colorings| (per MWM of each matched road).
+TileDownload DownloadAndMatchTile(DataSource const & dataSource, std::string const & apiKey, int zoom, int x, int y,
+                                  double snapToleranceMerc, std::map<MwmSet::MwmId, TrafficInfo::Coloring> & colorings)
+{
+  std::string const url =
+      kFlowTilesUrl + std::to_string(zoom) + "/" + std::to_string(x) + "/" + std::to_string(y) + ".pbf?key=" + apiKey;
+
+  platform::HttpClient request(url);
+  if (!request.RunHttpRequest())
+  {
+    LOG(LWARNING, ("Traffic flow tiles request failed:", url));
+    return TileDownload::kHttpError;
+  }
+  if (request.ErrorCode() != 200)
+  {
+    LOG(LWARNING, ("Traffic flow tiles request returned HTTP", request.ErrorCode(), "for", url,
+                   "body:", request.ServerResponse()));
+    return TileDownload::kHttpError;
+  }
+
+  std::vector<mvt::Layer> layers;
+  if (!mvt::Decode(request.ServerResponse(), layers))
+  {
+    LOG(LWARNING, ("Could not decode a traffic flow tile"));
+    return TileDownload::kBadPayload;
+  }
+
+  m2::RectD const tileRect = TileRect(zoom, x, y);
+  // Roads are collected per tile: the candidate set stays small (a city tile
+  // holds hundreds of roads) so matching does not blow up on large mwms.
+  m2::RectD const roadsRect = m2::Inflate(tileRect, {snapToleranceMerc, snapToleranceMerc});
+  std::vector<RoadFeature> roads;
+  CollectRoads(dataSource, roadsRect, roads);
+
+  bool flowLayerFound = false;
+  for (auto const & layer : layers)
+  {
+    if (layer.m_name != kFlowLayerName)
+      continue;
+    flowLayerFound = true;
+    for (auto const & feature : layer.m_features)
+    {
+      if (feature.m_geomType != mvt::GeomType::LineString)
+        continue;
+
+      mvt::Value const * levelTag = layer.GetTag(feature, "traffic_level");
+      mvt::Value const * closureTag = layer.GetTag(feature, "road_closure");
+      mvt::Value const * coverageTag = layer.GetTag(feature, "traffic_road_coverage");
+      bool const closed = closureTag != nullptr && closureTag->m_type == mvt::Value::Type::Bool && closureTag->m_bool;
+      double const relativeSpeed = levelTag != nullptr ? levelTag->m_double : 1.0;
+      // Full coverage means the whole road (one-way roads), otherwise the
+      // report covers one driving side and its direction is derived
+      // geometrically from the polyline orientation.
+      bool const fullCoverage = coverageTag == nullptr ||
+                                (coverageTag->m_type == mvt::Value::Type::String && coverageTag->m_string == "full");
+      SpeedGroup const group = SpeedGroupFromFlow(relativeSpeed, closed);
+
+      for (auto const & line : feature.m_lines)
+      {
+        if (line.size() < 2)
+          continue;
+
+        // Convert tile units (origin top-left, y down) to mercator.
+        std::vector<m2::PointD> points;
+        points.reserve(line.size());
+        for (auto const & p : line)
+        {
+          double const u = math::Clamp(p.x / layer.m_extent, -0.5, 1.5);
+          double const v = math::Clamp(p.y / layer.m_extent, -0.5, 1.5);
+          points.emplace_back(tileRect.minX() + u * tileRect.SizeX(), tileRect.maxY() - v * tileRect.SizeY());
+        }
+
+        // Snap each vertex to the nearest road segment within tolerance.
+        // Roads are pre-filtered by their bounding boxes: a full scan over
+        // every segment of ~10k roads per vertex is far too slow on dense
+        // city tiles.
+        std::vector<MatchedVertex> matches;
+        matches.reserve(points.size());
+        for (size_t i = 0; i < points.size(); ++i)
+        {
+          double bestDistSq = snapToleranceMerc * snapToleranceMerc;
+          m2::RectD const vertexRect(points[i].x - snapToleranceMerc, points[i].y - snapToleranceMerc,
+                                     points[i].x + snapToleranceMerc, points[i].y + snapToleranceMerc);
+          bool found = false;
+          MatchedVertex best{0, 0, 0.0};
+          for (size_t r = 0; r < roads.size(); ++r)
+          {
+            if (!roads[r].m_bbox.IsIntersect(vertexRect))
+              continue;
+            auto const & roadPoints = roads[r].m_points;
+            for (size_t s = 0; s + 1 < roadPoints.size(); ++s)
+            {
+              m2::ParametrizedSegment<m2::PointD> const segment(roadPoints[s], roadPoints[s + 1]);
+              double const distSq = segment.SquaredDistanceToPoint(points[i]);
+              if (!found || distSq < bestDistSq)
+              {
+                m2::PointD const flowDir =
+                    (i + 1 < points.size()) ? points[i + 1] - points[i] : points[i] - points[i - 1];
+                m2::PointD const segDir = roadPoints[s + 1] - roadPoints[s];
+                bestDistSq = distSq;
+                best =
+                    MatchedVertex{static_cast<uint32_t>(r), static_cast<uint32_t>(s), m2::DotProduct(flowDir, segDir)};
+                found = true;
+              }
+            }
+          }
+          if (found)
+            matches.push_back(best);
+        }
+        if (matches.empty())
+          continue;
+
+        // Consecutive matches on the same road form a run; emit one
+        // coloring entry per traversed segment of the run.
+        size_t runStart = 0;
+        while (runStart < matches.size())
+        {
+          size_t runEnd = runStart + 1;
+          while (runEnd < matches.size() && matches[runEnd].m_roadIdx == matches[runStart].m_roadIdx)
+            ++runEnd;
+
+          if (runEnd - runStart >= kMinRunVertices)
+          {
+            double orientationSum = 0.0;
+            for (size_t i = runStart; i < runEnd; ++i)
+              orientationSum += matches[i].m_orientation;
+            auto const dir = (fullCoverage || orientationSum >= 0.0) ? TrafficInfo::RoadSegmentId::kForwardDirection
+                                                                     : TrafficInfo::RoadSegmentId::kReverseDirection;
+            RoadFeature const & road = roads[matches[runStart].m_roadIdx];
+            for (size_t i = runStart; i < runEnd; ++i)
+            {
+              if (matches[i].m_segIdx > kMaxSegmentIdx)
+                continue;
+              TrafficInfo::Coloring & coloring = colorings[road.m_id.m_mwmId];
+              AddToColoring(
+                  coloring,
+                  TrafficInfo::RoadSegmentId(road.m_id.m_index, static_cast<uint16_t>(matches[i].m_segIdx), dir),
+                  group);
+            }
+          }
+          runStart = runEnd;
+        }
+      }
+    }
+  }
+  if (!flowLayerFound && !layers.empty())
+  {
+    std::string names;
+    for (auto const & layer : layers)
+      names += (names.empty() ? "" : ", ") + layer.m_name;
+    LOG(LWARNING, ("Flow tile has no '", kFlowLayerName, "' layer; layers present:", names));
+    return TileDownload::kBadPayload;
+  }
+  return TileDownload::kSuccess;
+}
+}  // namespace
+
+FlowTilesProvider::FlowTilesProvider(DataSource const & dataSource, std::string apiKey)
+  : m_dataSource(dataSource)
+  , m_apiKey(std::move(apiKey))
+{
+  CHECK(!m_apiKey.empty(), ("A flow tiles API key must be configured"));
+}
+
+FlowTilesProvider::FetchResult FlowTilesProvider::FetchColorings(
+    m2::RectD const & area, std::map<MwmSet::MwmId, TrafficInfo::Coloring> & colorings)
+{
+  colorings.clear();
+
+  FetchResult result;
+  if (!area.IsValid())
+  {
+    result.m_ok = true;
+    return result;
+  }
+  // Tolerance converted to mercator units at the area center.
+  double const metersPerUnit = mercator::DistanceOnEarth(area.Center(), area.Center() + m2::PointD(0.001, 0.0)) / 0.001;
+  double const snapToleranceMerc = kMaxSnapDistanceMeters / metersPerUnit;
+
+  // Select tiles covering the area, closest to its center first.
+  TileRange const range = TilesCovering(area, kFlowTilesZoom);
+  m2::PointD const center = area.Center();
+  std::vector<std::pair<int, int>> tiles;
+  for (int x = range.m_minX; x <= range.m_maxX; ++x)
+    for (int y = range.m_minY; y <= range.m_maxY; ++y)
+      tiles.emplace_back(x, y);
+  std::sort(tiles.begin(), tiles.end(), [&center](auto const & a, auto const & b)
+  {
+    m2::PointD const da = TileRect(kFlowTilesZoom, a.first, a.second).Center() - center;
+    m2::PointD const db = TileRect(kFlowTilesZoom, b.first, b.second).Center() - center;
+    return m2::DotProduct(da, da) < m2::DotProduct(db, db);
+  });
+  if (tiles.size() > kMaxTilesPerFetch)
+    tiles.resize(kMaxTilesPerFetch);
+
+  auto const now = steady_clock::now();
+  bool allDownloadsOk = true;
+  size_t tilesFetched = 0;
+  for (auto const & [tx, ty] : tiles)
+  {
+    uint64_t const key = TileKey(kFlowTilesZoom, tx, ty);
+    auto entryIt = m_tileCache.find(key);
+    if (entryIt == m_tileCache.end() || now - entryIt->second.m_fetchedAt >= kTileRefreshInterval)
+    {
+      std::map<MwmSet::MwmId, TrafficInfo::Coloring> tileColorings;
+      auto const status =
+          DownloadAndMatchTile(m_dataSource, m_apiKey, kFlowTilesZoom, tx, ty, snapToleranceMerc, tileColorings);
+      if (status == TileDownload::kHttpError)
+      {
+        allDownloadsOk = false;
+        // Fall through and serve the stale cached copy, if any.
+      }
+      else
+      {
+        ++tilesFetched;
+        // An unparsable payload keeps the previous copy when there is one:
+        // some services report quota exhaustion as HTTP 200 with a non-tile
+        // body, and wiping good data on such responses would be harmful.
+        if (status == TileDownload::kBadPayload && entryIt != m_tileCache.end())
+        {
+          entryIt->second.m_fetchedAt = now;
+        }
+        else
+        {
+          entryIt = m_tileCache.try_emplace(key).first;
+          entryIt->second.m_fetchedAt = now;
+          entryIt->second.m_colorings = std::move(tileColorings);
+          while (m_tileCache.size() > kMaxCachedTiles)
+          {
+            auto const oldest =
+                std::min_element(m_tileCache.begin(), m_tileCache.end(), [](auto const & a, auto const & b)
+            { return a.second.m_fetchedAt < b.second.m_fetchedAt; });
+            m_tileCache.erase(oldest);
+          }
+        }
+      }
+    }
+
+    // Always union the whole viewport's worth of cached data into the result,
+    // not just what this cycle downloaded: callers replace previously applied
+    // colorings with the result, so partial results would wipe segments that
+    // belong to still-fresh tiles.
+    if (entryIt != m_tileCache.end())
+      for (auto const & [mwmId, tileColoring] : entryIt->second.m_colorings)
+        MergeColoring(colorings[mwmId], tileColoring);
+  }
+
+  result.m_ok = allDownloadsOk;
+  result.m_hasFreshData = tilesFetched > 0;
+  return result;
+}
+
+std::unique_ptr<TrafficProvider> CreateFlowTilesProvider(DataSource const & dataSource, std::string apiKey)
+{
+  if (apiKey.empty())
+    return nullptr;
+  return std::make_unique<FlowTilesProvider>(dataSource, std::move(apiKey));
+}
+}  // namespace traffic

--- a/libs/map/flow_tiles_provider.hpp
+++ b/libs/map/flow_tiles_provider.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "map/traffic_provider.hpp"
+
+#include "indexer/data_source.hpp"
+#include "indexer/mwm_set.hpp"
+
+#include "geometry/point2d.hpp"
+#include "geometry/rect2d.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace traffic
+{
+// Retrieves live road-speed data from an HTTP vector-flow-tile service
+// (XYZ tile scheme, Mapbox Vector Tile protobuf payload, e.g. TomTom Traffic
+// Flow) and converts it to Organic Maps colorings by snapping the reported
+// road polylines to routable segments of the local maps.
+class FlowTilesProvider final : public TrafficProvider
+{
+public:
+  FlowTilesProvider(DataSource const & dataSource, std::string apiKey);
+
+  FetchResult FetchColorings(m2::RectD const & area,
+                             std::map<MwmSet::MwmId, TrafficInfo::Coloring> & colorings) override;
+
+private:
+  struct TileEntry
+  {
+    std::chrono::steady_clock::time_point m_fetchedAt;
+    std::map<MwmSet::MwmId, TrafficInfo::Coloring> m_colorings;
+  };
+
+  DataSource const & m_dataSource;
+  std::string m_apiKey;
+
+  // Recently downloaded tiles keyed by TileKey(). Lets pans and zooms reuse
+  // still-fresh tiles instead of refetching the whole viewport, and keeps
+  // FetchColorings() results complete for the requested area so callers may
+  // safely replace previously applied colorings with them.
+  std::map<uint64_t, TileEntry> m_tileCache;
+};
+
+void AddToColoring(TrafficInfo::Coloring & coloring, TrafficInfo::RoadSegmentId const & id, SpeedGroup group);
+void MergeColoring(TrafficInfo::Coloring & dst, TrafficInfo::Coloring const & src);
+
+SpeedGroup SpeedGroupFromFlow(double relativeSpeed, bool closed);
+
+std::unique_ptr<TrafficProvider> CreateFlowTilesProvider(DataSource const & dataSource, std::string apiKey);
+}  // namespace traffic

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -1,6 +1,7 @@
 #include "map/framework.hpp"
 #include "base/assert.hpp"
 #include "map/benchmark_tools.hpp"
+#include "map/flow_tiles_provider.hpp"
 #include "map/gps_tracker.hpp"
 #include "map/place_page_info.hpp"
 #include "map/raster_tile_provider.hpp"
@@ -98,6 +99,7 @@ std::string_view constexpr kAllow3dKey = "Allow3d";
 std::string_view constexpr kAllow3dBuildingsKey = "Buildings3d";
 std::string_view constexpr kAllowAutoZoom = "AutoZoom";
 std::string_view constexpr kTrafficEnabledKey = "TrafficEnabled";
+std::string_view constexpr kTrafficApiKeyKey = "TrafficApiKey";
 std::string_view constexpr kTransitSchemeEnabledKey = "TransitSchemeEnabled";
 std::string_view constexpr kIsolinesEnabledKey = "IsolinesEnabled";
 std::string_view constexpr kOutdoorsEnabledKey = "OutdoorsEnabled";
@@ -332,7 +334,8 @@ Framework::Framework(FrameworkParams const & params, bool loadMaps)
 { return m_stringsBundle; }, [this]() -> power_management::PowerManager const & { return m_powerManager; }),
                      static_cast<RoutingManager::Delegate &>(*this))
   , m_trafficManager(std::bind(&Framework::GetMwmsByRect, this, _1, false /* rough */), kMaxTrafficCacheSizeBytes,
-                     m_routingManager.RoutingSession())
+                     m_routingManager.RoutingSession(),
+                     traffic::CreateFlowTilesProvider(m_featuresFetcher.GetDataSource(), GetTrafficApiKey()))
   , m_lastReportedCountry(kInvalidCountryId)
   , m_descriptionsLoader(std::make_unique<descriptions::Loader>(m_featuresFetcher.GetDataSource()))
   , m_selectionProcessor(*this)
@@ -412,10 +415,10 @@ Framework::Framework(FrameworkParams const & params, bool loadMaps)
   editor.SetDelegate(std::make_unique<search::EditorDelegate>(m_featuresFetcher.GetDataSource()));
   editor.SetInvalidateFn([this]() { Invalidate(); });
 
-  /// @todo Uncomment when we will integrate a traffic provider.
-  // m_trafficManager.SetCurrentDataVersion(m_storage.GetCurrentDataVersion());
-  // m_trafficManager.SetSimplifiedColorScheme(LoadTrafficSimplifiedColors());
-  // m_trafficManager.SetEnabled(LoadTrafficEnabled());
+  m_trafficManager.SetCurrentDataVersion(m_storage.GetCurrentDataVersion());
+  m_trafficManager.SetSimplifiedColorScheme(LoadTrafficSimplifiedColors());
+  // Traffic downloads stay disabled until a data provider is configured (see TRAFFIC_DATA_BASE_URL).
+  m_trafficManager.SetEnabled(LoadTrafficEnabled());
 
   m_isolinesManager.SetEnabled(LoadIsolinesEnabled());
 
@@ -2927,6 +2930,30 @@ bool Framework::IsWellFormedBackgroundTilesURL(std::string const & url)
   // Require all three placeholders present literally (braces must not be percent-encoded).
   return url.find("{z}") != std::string::npos && url.find("{x}") != std::string::npos &&
          url.find("{y}") != std::string::npos;
+}
+
+std::string Framework::GetTrafficApiKey()
+{
+  std::string apiKey;
+  settings::TryGet(kTrafficApiKeyKey, apiKey);
+  return apiKey;
+}
+
+void Framework::SetTrafficApiKey(std::string const & apiKey)
+{
+  settings::Set(kTrafficApiKeyKey, apiKey);
+  m_trafficManager.SetProvider(traffic::CreateFlowTilesProvider(m_featuresFetcher.GetDataSource(), apiKey));
+}
+
+bool Framework::IsWellFormedTrafficApiKey(std::string const & apiKey)
+{
+  if (apiKey.size() < 8 || apiKey.size() > 128)
+    return false;
+  return std::all_of(apiKey.begin(), apiKey.end(), [](char c)
+  {
+    auto const uc = static_cast<strings::UniChar>(static_cast<uint8_t>(c));
+    return strings::IsASCIILatin(uc) || strings::IsASCIIDigit(uc);
+  });
 }
 
 void Framework::ApplyMapLanguageCode(std::string const & langCode)

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -747,6 +747,18 @@ public:
   // The settings UI calls this before committing and refuses to close on an enabled, malformed URL.
   static bool IsWellFormedBackgroundTilesURL(std::string const & url);
 
+  // Live traffic data source (user-provided flow-tiles API key). SetTrafficApiKey is the single
+  // apply entry point for the settings UI (call it when the traffic settings are committed):
+  // it persists the key (kept even when the layer is off) and hot-swaps the data source of the
+  // running TrafficManager. An empty key restores the legacy per-MWM traffic downloads.
+  // TrafficEnabled remains the runtime on/off toggle for the layer.
+  static std::string GetTrafficApiKey();
+  void SetTrafficApiKey(std::string const & apiKey);
+  // Basic sanity check for a user-entered API key: non-empty, 8..128 ASCII
+  // letters and digits (covers TomTom-style base62 keys and similar vendor keys).
+  // The settings UI calls this before committing.
+  static bool IsWellFormedTrafficApiKey(std::string const & apiKey);
+
   void SetLargeFontsSize(bool isLargeSize);
   // Multiplied on top of the SetLargeFontsSize (Large Fonts) factor.
   void SetFontScaleFactor(double scaleFactor);

--- a/libs/map/map_tests/CMakeLists.txt
+++ b/libs/map/map_tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SRC
   editor_notes_tests.cpp
   extrapolator_tests.cpp
   feature_getters_tests.cpp
+  flow_tiles_provider_test.cpp
   gps_track_collection_test.cpp
   gps_track_storage_test.cpp
   gps_track_test.cpp

--- a/libs/map/map_tests/flow_tiles_provider_test.cpp
+++ b/libs/map/map_tests/flow_tiles_provider_test.cpp
@@ -1,0 +1,84 @@
+#include "map/flow_tiles_provider.hpp"
+
+#include "testing/testing.hpp"
+
+namespace flow_tiles_provider_test
+{
+using namespace traffic;
+
+UNIT_TEST(FlowTiles_SpeedGroupFromFlow_Buckets)
+{
+  // Midpoints of the speed-group buckets defined by GetSpeedGroupByPercentage.
+  TEST_EQUAL(SpeedGroupFromFlow(0.0, false), SpeedGroup::G0, ());
+  TEST_EQUAL(SpeedGroupFromFlow(0.04, false), SpeedGroup::G0, ());
+  TEST_EQUAL(SpeedGroupFromFlow(0.12, false), SpeedGroup::G1, ());
+  TEST_EQUAL(SpeedGroupFromFlow(0.25, false), SpeedGroup::G2, ());
+  TEST_EQUAL(SpeedGroupFromFlow(0.45, false), SpeedGroup::G3, ());
+  TEST_EQUAL(SpeedGroupFromFlow(0.70, false), SpeedGroup::G4, ());
+  TEST_EQUAL(SpeedGroupFromFlow(0.95, false), SpeedGroup::G5, ());
+
+  // Free flow above the nominal range is clamped to the best bucket.
+  TEST_EQUAL(SpeedGroupFromFlow(1.0, false), SpeedGroup::G5, ());
+  TEST_EQUAL(SpeedGroupFromFlow(1.5, false), SpeedGroup::G5, ());
+}
+
+UNIT_TEST(FlowTiles_SpeedGroupFromFlow_Specials)
+{
+  // Closures win over any reported speed.
+  TEST_EQUAL(SpeedGroupFromFlow(1.0, true), SpeedGroup::TempBlock, ());
+  TEST_EQUAL(SpeedGroupFromFlow(0.0, true), SpeedGroup::TempBlock, ());
+
+  // Negative speeds are corrupt and map to Unknown.
+  TEST_EQUAL(SpeedGroupFromFlow(-1.0, false), SpeedGroup::Unknown, ());
+}
+
+UNIT_TEST(FlowTiles_AddToColoring_ClosurePriority)
+{
+  using Id = TrafficInfo::RoadSegmentId;
+
+  TrafficInfo::Coloring coloring;
+  AddToColoring(coloring, Id(1 /* fid */, 0 /* idx */, Id::kForwardDirection), SpeedGroup::G3);
+  TEST_EQUAL(coloring.size(), 1, ());
+  TEST_EQUAL(coloring[Id(1, 0, Id::kForwardDirection)], SpeedGroup::G3, ());
+
+  // A repeated report keeps the first value.
+  AddToColoring(coloring, Id(1, 0, Id::kForwardDirection), SpeedGroup::G0);
+  TEST_EQUAL(coloring.size(), 1, ());
+  TEST_EQUAL(coloring[Id(1, 0, Id::kForwardDirection)], SpeedGroup::G3, ());
+
+  // A closure from a neighboring tile overrides the stored speed ...
+  AddToColoring(coloring, Id(1, 0, Id::kForwardDirection), SpeedGroup::TempBlock);
+  TEST_EQUAL(coloring[Id(1, 0, Id::kForwardDirection)], SpeedGroup::TempBlock, ());
+
+  // ... but a later speed never downgrades an existing closure.
+  AddToColoring(coloring, Id(1, 0, Id::kForwardDirection), SpeedGroup::G5);
+  TEST_EQUAL(coloring.size(), 1, ());
+  TEST_EQUAL(coloring[Id(1, 0, Id::kForwardDirection)], SpeedGroup::TempBlock, ());
+}
+
+UNIT_TEST(FlowTiles_MergeColoring)
+{
+  using Id = TrafficInfo::RoadSegmentId;
+
+  TrafficInfo::Coloring dst;
+  AddToColoring(dst, Id(1, 0, Id::kForwardDirection), SpeedGroup::G2);
+
+  TrafficInfo::Coloring src;
+  AddToColoring(src, Id(1, 1, Id::kForwardDirection), SpeedGroup::G4);
+  AddToColoring(src, Id(2, 0, Id::kReverseDirection), SpeedGroup::TempBlock);
+
+  MergeColoring(dst, src);
+  TEST_EQUAL(dst.size(), 3, ());
+  TEST_EQUAL(dst[Id(1, 0, Id::kForwardDirection)], SpeedGroup::G2, ());
+  TEST_EQUAL(dst[Id(1, 1, Id::kForwardDirection)], SpeedGroup::G4, ());
+  TEST_EQUAL(dst[Id(2, 0, Id::kReverseDirection)], SpeedGroup::TempBlock, ());
+
+  // Merging a tile that reports a closure on an already-known segment wins
+  // over the previously merged speed.
+  TrafficInfo::Coloring closureTile;
+  AddToColoring(closureTile, Id(1, 0, Id::kForwardDirection), SpeedGroup::TempBlock);
+  MergeColoring(dst, closureTile);
+  TEST_EQUAL(dst.size(), 3, ());
+  TEST_EQUAL(dst[Id(1, 0, Id::kForwardDirection)], SpeedGroup::TempBlock, ());
+}
+}  // namespace flow_tiles_provider_test

--- a/libs/map/traffic_manager.cpp
+++ b/libs/map/traffic_manager.cpp
@@ -7,6 +7,8 @@
 
 #include "platform/platform.hpp"
 
+#include "base/stl_helpers.hpp"
+
 using namespace std::chrono;
 
 namespace
@@ -37,9 +39,11 @@ TrafficManager::CacheEntry::CacheEntry(time_point<steady_clock> const & requestT
 {}
 
 TrafficManager::TrafficManager(GetMwmsByRectFn const & getMwmsByRectFn, size_t maxCacheSizeBytes,
-                               traffic::TrafficObserver & observer)
+                               traffic::TrafficObserver & observer, std::unique_ptr<traffic::TrafficProvider> provider)
   : m_getMwmsByRectFn(getMwmsByRectFn)
   , m_observer(observer)
+  , m_provider(std::move(provider))
+  , m_hasProvider(m_provider != nullptr)
   , m_currentDataVersion(0)
   , m_state(TrafficState::Disabled)
   , m_maxCacheSizeBytes(maxCacheSizeBytes)
@@ -118,6 +122,22 @@ void TrafficManager::ClearImpl()
   m_activeRoutingMwms.clear();
   m_requestedMwms.clear();
   m_trafficETags.clear();
+}
+
+void TrafficManager::SetProvider(std::unique_ptr<traffic::TrafficProvider> provider)
+{
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_provider = std::move(provider);
+    m_hasProvider = (m_provider != nullptr);
+    m_providerLastFailure.reset();
+    // Drop cache entries fetched by the previous source so that no stale
+    // colorings linger after the switch.
+    ClearImpl();
+  }
+
+  if (IsEnabled())
+    Invalidate();
 }
 
 void TrafficManager::SetDrapeEngine(ref_ptr<df::DrapeEngine> engine)
@@ -214,6 +234,10 @@ void TrafficManager::UpdateMyPosition(MyPosition const & myPosition)
 void TrafficManager::UpdateViewport(ScreenBase const & screen)
 {
   m_currentModelView = {screen, true /* initialized */};
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_viewportRect = screen.ClipRect();
+  }
 
   if (!IsEnabled() || IsInvalidState() || m_isPaused)
     return;
@@ -230,36 +254,136 @@ void TrafficManager::ThreadRoutine()
   std::vector<MwmSet::MwmId> mwms;
   while (WaitForRequest(mwms))
   {
-    for (auto const & mwm : mwms)
+    auto provider = [&]()
     {
-      if (!mwm.IsAlive())
-        continue;
+      std::lock_guard<std::mutex> lock(m_mutex);
+      return m_provider;
+    }();
 
-      traffic::TrafficInfo info(mwm, m_currentDataVersion);
+    if (provider)
+    {
+      // External provider replaces per-MWM downloads entirely.
+      ThreadRoutineProvider(provider);
+    }
+    else
+    {
+      for (auto const & mwm : mwms)
+      {
+        if (!mwm.IsAlive())
+          continue;
 
-      std::string tag;
-      {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        tag = m_trafficETags[mwm];
-      }
+        traffic::TrafficInfo info(mwm, m_currentDataVersion);
 
-      if (info.ReceiveTrafficData(tag))
-      {
-        OnTrafficDataResponse(std::move(info));
-      }
-      else
-      {
-        LOG(LWARNING, ("Traffic request failed. Mwm =", mwm));
-        OnTrafficRequestFailed(std::move(info));
-      }
+        std::string tag;
+        {
+          std::lock_guard<std::mutex> lock(m_mutex);
+          tag = m_trafficETags[mwm];
+        }
 
-      {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_trafficETags[mwm] = tag;
+        if (info.ReceiveTrafficData(tag))
+        {
+          OnTrafficDataResponse(std::move(info));
+        }
+        else
+        {
+          LOG(LWARNING, ("Traffic request failed. Mwm =", mwm));
+          OnTrafficRequestFailed(std::move(info));
+        }
+
+        {
+          std::lock_guard<std::mutex> lock(m_mutex);
+          m_trafficETags[mwm] = tag;
+        }
       }
     }
     mwms.clear();
   }
+}
+
+void TrafficManager::ThreadRoutineProvider(std::shared_ptr<traffic::TrafficProvider> const & provider)
+{
+  ASSERT(provider != nullptr, ());
+
+  std::vector<MwmSet::MwmId> mwms;
+  m2::RectD viewportRect;
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    std::set<MwmSet::MwmId> activeMwms;
+    UniteActiveMwms(activeMwms);
+    mwms.assign(activeMwms.cbegin(), activeMwms.cend());
+    viewportRect = m_viewportRect;
+
+    // Back off after repeated failures but never latch permanently: retry
+    // once kNetworkErrorTimeout has passed since the last failure.
+    if (m_state == TrafficState::NetworkError)
+    {
+      auto const now = steady_clock::now();
+      if (m_providerLastFailure && now - *m_providerLastFailure < kNetworkErrorTimeout)
+        return;
+      m_providerLastFailure.reset();
+      for (auto const & mwm : mwms)
+      {
+        auto const it = m_mwmCache.find(mwm);
+        if (it != m_mwmCache.end())
+          it->second.m_retriesCount = 0;
+      }
+    }
+  }
+
+  base::EraseIf(mwms, [](MwmSet::MwmId const & mwm) { return !mwm.IsAlive(); });
+  if (mwms.empty() || !viewportRect.IsValid())
+    return;
+
+  std::map<MwmSet::MwmId, traffic::TrafficInfo::Coloring> colorings;
+  auto const fetchResult = provider->FetchColorings(viewportRect, colorings);
+
+  if (!fetchResult.m_ok)
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_providerLastFailure = steady_clock::now();
+    for (auto const & mwm : mwms)
+    {
+      auto it = m_mwmCache.find(mwm);
+      if (it == m_mwmCache.end())
+        continue;
+      it->second.m_isWaitingForResponse = false;
+      it->second.m_lastAvailability = traffic::TrafficInfo::Availability::Unknown;
+      ++it->second.m_retriesCount;
+    }
+    UpdateState();
+    return;
+  }
+
+  size_t totalEntries = 0;
+  for (auto & [mwmId, coloring] : colorings)
+  {
+    totalEntries += coloring.size();
+    ApplyTrafficColoring(mwmId, std::move(coloring));
+  }
+
+  if (totalEntries > 0 && fetchResult.m_hasFreshData)
+  {
+    // Traffic colors are baked into tile geometry during tile reads. Force
+    // re-reading of the rendered tiles so fresh data shows up without
+    // waiting for the next pan or zoom.
+    m_drapeEngine.SafeCall(&df::DrapeEngine::InvalidateTrafficTiles);
+  }
+
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_providerLastFailure.reset();
+  auto const now = steady_clock::now();
+  for (auto const & mwm : mwms)
+  {
+    auto it = m_mwmCache.find(mwm);
+    if (it == m_mwmCache.end())
+      continue;
+    it->second.m_isLoaded = true;
+    it->second.m_isWaitingForResponse = false;
+    it->second.m_lastResponseTime = now;
+    it->second.m_retriesCount = 0;
+    it->second.m_lastAvailability = traffic::TrafficInfo::Availability::IsAvailable;
+  }
+  UpdateState();
 }
 
 bool TrafficManager::WaitForRequest(std::vector<MwmSet::MwmId> & mwms)
@@ -316,10 +440,12 @@ void TrafficManager::RequestTrafficData()
   if ((m_activeDrapeMwms.empty() && m_activeRoutingMwms.empty()) || !IsEnabled() || IsInvalidState() || m_isPaused)
     return;
 
-  ForEachActiveMwm([this](MwmSet::MwmId const & mwmId)
+  bool const force = m_hasProvider.load();
+
+  ForEachActiveMwm([&](MwmSet::MwmId const & mwmId)
   {
     ASSERT(mwmId.IsAlive(), ());
-    RequestTrafficData(mwmId, false /* force */);
+    RequestTrafficData(mwmId, force);
   });
   UpdateState();
 }
@@ -358,6 +484,10 @@ void TrafficManager::OnTrafficDataResponse(traffic::TrafficInfo && info)
   {
     std::lock_guard<std::mutex> lock(m_mutex);
 
+    // Data can arrive without a preceding per-MWM request (e.g. injected by
+    // an external traffic data source), so create the cache entry on demand.
+    m_mwmCache.try_emplace(info.GetMwmId(), steady_clock::now());
+
     auto it = m_mwmCache.find(info.GetMwmId());
     if (it == m_mwmCache.end())
       return;
@@ -387,6 +517,14 @@ void TrafficManager::OnTrafficDataResponse(traffic::TrafficInfo && info)
     // Update traffic colors for routing.
     m_observer.OnTrafficInfoAdded(std::move(info));
   }
+}
+
+void TrafficManager::ApplyTrafficColoring(MwmSet::MwmId const & mwmId, traffic::TrafficInfo::Coloring && coloring)
+{
+  if (!mwmId.IsAlive() || coloring.empty())
+    return;
+
+  OnTrafficDataResponse(traffic::TrafficInfo(mwmId, std::move(coloring)));
 }
 
 void TrafficManager::UniteActiveMwms(std::set<MwmSet::MwmId> & activeMwms) const

--- a/libs/map/traffic_manager.hpp
+++ b/libs/map/traffic_manager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "map/traffic_provider.hpp"
 #include "traffic/traffic_info.hpp"
 
 #include "drape_frontend/drape_engine_safe_ptr.hpp"
@@ -11,6 +12,7 @@
 
 #include "geometry/point2d.hpp"
 #include "geometry/polyline2d.hpp"
+#include "geometry/rect2d.hpp"
 #include "geometry/screenbase.hpp"
 
 #include "base/thread.hpp"
@@ -21,6 +23,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <set>
@@ -55,8 +58,8 @@ public:
   using TrafficStateChangedFn = std::function<void(TrafficState)>;
   using GetMwmsByRectFn = std::function<std::vector<MwmSet::MwmId>(m2::RectD const &)>;
 
-  TrafficManager(GetMwmsByRectFn const & getMwmsByRectFn, size_t maxCacheSizeBytes,
-                 traffic::TrafficObserver & observer);
+  TrafficManager(GetMwmsByRectFn const & getMwmsByRectFn, size_t maxCacheSizeBytes, traffic::TrafficObserver & observer,
+                 std::unique_ptr<traffic::TrafficProvider> provider = nullptr);
   ~TrafficManager();
 
   void Teardown();
@@ -70,10 +73,17 @@ public:
   void SetEnabled(bool enabled);
   bool IsEnabled() const;
 
+  // Hot-swaps the external traffic data source (nullptr restores the legacy
+  // per-MWM downloads). Safe to call at any time; caches are reset and active
+  // data is re-requested.
+  void SetProvider(std::unique_ptr<traffic::TrafficProvider> provider);
+
   void UpdateViewport(ScreenBase const & screen);
   void UpdateMyPosition(MyPosition const & myPosition);
 
   void Invalidate();
+
+  void ApplyTrafficColoring(MwmSet::MwmId const & mwmId, traffic::TrafficInfo::Coloring && coloring);
 
   void OnDestroySurface();
   void OnRecoverSurface();
@@ -107,6 +117,7 @@ private:
   };
 
   void ThreadRoutine();
+  void ThreadRoutineProvider(std::shared_ptr<traffic::TrafficProvider> const & provider);
   bool WaitForRequest(std::vector<MwmSet::MwmId> & mwms);
 
   void OnTrafficDataResponse(traffic::TrafficInfo && info);
@@ -148,6 +159,8 @@ private:
 
   GetMwmsByRectFn m_getMwmsByRectFn;
   traffic::TrafficObserver & m_observer;
+  std::shared_ptr<traffic::TrafficProvider> m_provider;
+  std::atomic<bool> m_hasProvider{false};
 
   df::DrapeEngineSafePtr m_drapeEngine;
   std::atomic<int64_t> m_currentDataVersion;
@@ -155,6 +168,7 @@ private:
   // These fields have a flag of their initialization.
   std::pair<MyPosition, bool> m_currentPosition = {MyPosition(), false};
   std::pair<ScreenBase, bool> m_currentModelView = {ScreenBase(), false};
+  m2::RectD m_viewportRect = {};
 
   std::atomic<TrafficState> m_state;
   TrafficStateChangedFn m_onStateChangedFn;
@@ -182,6 +196,7 @@ private:
   std::atomic<bool> m_isPaused;
 
   std::vector<MwmSet::MwmId> m_requestedMwms;
+  std::optional<std::chrono::steady_clock::time_point> m_providerLastFailure;
   std::mutex m_mutex;
   threads::SimpleThread m_thread;
 };

--- a/libs/map/traffic_provider.hpp
+++ b/libs/map/traffic_provider.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "traffic/traffic_info.hpp"
+
+#include "geometry/rect2d.hpp"
+
+#include "indexer/mwm_set.hpp"
+
+#include <map>
+
+namespace traffic
+{
+// An abstract source of live traffic data that is independent of the MWM
+// format, e.g. an HTTP road-speed API. FetchColorings() is called on the
+// traffic manager's worker thread only, so implementations need no
+// synchronization unless they are shared with other threads.
+class TrafficProvider
+{
+public:
+  struct FetchResult
+  {
+    bool m_ok = false;
+    bool m_hasFreshData = false;
+  };
+
+  virtual ~TrafficProvider() = default;
+  virtual FetchResult FetchColorings(m2::RectD const & area,
+                                     std::map<MwmSet::MwmId, TrafficInfo::Coloring> & colorings) = 0;
+};
+}  // namespace traffic

--- a/libs/routing/index_router.cpp
+++ b/libs/routing/index_router.cpp
@@ -140,10 +140,10 @@ std::unique_ptr<DirectionsEngine> CreateDirectionsEngine(VehicleType vehicleType
   UNREACHABLE();
 }
 
-std::shared_ptr<TrafficStash> CreateTrafficStash(VehicleType, std::shared_ptr<NumMwmIds>, traffic::TrafficCache const &)
+std::shared_ptr<TrafficStash> CreateTrafficStash(VehicleType vehicleType, std::shared_ptr<NumMwmIds> numMwmIds,
+                                                 traffic::TrafficCache const & trafficCache)
 {
-  return nullptr;
-  // return (vehicleType == VehicleType::Car ? make_shared<TrafficStash>(trafficCache, numMwmIds) : nullptr);
+  return (vehicleType == VehicleType::Car ? make_shared<TrafficStash>(trafficCache, numMwmIds) : nullptr);
 }
 
 void PushPassedSubroutes(Checkpoints const & checkpoints, std::vector<Route::SubrouteAttrs> & subroutes)

--- a/libs/traffic/traffic_info.cpp
+++ b/libs/traffic/traffic_info.cpp
@@ -128,6 +128,12 @@ TrafficInfo::TrafficInfo(MwmSet::MwmId const & mwmId, int64_t currentDataVersion
   }
 }
 
+TrafficInfo::TrafficInfo(MwmSet::MwmId const & mwmId, Coloring && coloring)
+  : m_coloring(std::move(coloring))
+  , m_mwmId(mwmId)
+  , m_availability(Availability::IsAvailable)
+{}
+
 // static
 TrafficInfo TrafficInfo::BuildForTesting(Coloring && coloring)
 {

--- a/libs/traffic/traffic_info.hpp
+++ b/libs/traffic/traffic_info.hpp
@@ -74,6 +74,7 @@ public:
   TrafficInfo() = default;
 
   TrafficInfo(MwmSet::MwmId const & mwmId, int64_t currentDataVersion);
+  TrafficInfo(MwmSet::MwmId const & mwmId, Coloring && coloring);
 
   static TrafficInfo BuildForTesting(Coloring && coloring);
   void SetTrafficKeysForTesting(std::vector<RoadSegmentId> const & keys);

--- a/qt/mainwindow.cpp
+++ b/qt/mainwindow.cpp
@@ -284,10 +284,9 @@ void MainWindow::CreateNavigationBar()
   {
     m_layers = new PopupMenuHolder(this);
 
-    /// @todo Uncomment when we will integrate a traffic provider.
-    // m_layers->addAction(QIcon(":/navig64/traffic.png"), tr("Traffic"),
-    //                     std::bind(&MainWindow::OnLayerEnabled, this, TRAFFIC), true);
-    // m_layers->setChecked(TRAFFIC, Framework::LoadTrafficEnabled());
+    m_layers->addAction(QIcon(":/navig64/traffic.png"), tr("Traffic"),
+                        std::bind(&MainWindow::OnLayerEnabled, this, TRAFFIC), true);
+    m_layers->setChecked(TRAFFIC, Framework::LoadTrafficEnabled());
 
     m_layers->addAction(QIcon(":/navig64/subway.png"), tr("Public transport"),
                         std::bind(&MainWindow::OnLayerEnabled, this, TRANSIT), true);
@@ -910,11 +909,10 @@ void MainWindow::SetLayerEnabled(LayerType type, bool enable)
   auto & frm = m_pDrawWidget->GetFramework();
   switch (type)
   {
-  // @todo Uncomment when we will integrate a traffic provider.
-  // case TRAFFIC:
-  //   frm.GetTrafficManager().SetEnabled(enable);
-  //   frm.SaveTrafficEnabled(enable);
-  //   break;
+  case TRAFFIC:
+    frm.GetTrafficManager().SetEnabled(enable);
+    frm.SaveTrafficEnabled(enable);
+    break;
   case TRANSIT:
     frm.GetTransitManager().EnableTransitSchemeMode(enable);
     frm.SaveTransitSchemeEnabled(enable);

--- a/qt/mainwindow.hpp
+++ b/qt/mainwindow.hpp
@@ -69,9 +69,8 @@ private:
 
   enum LayerType : uint8_t
   {
-    /// @todo Uncomment when we will integrate a traffic provider.
-    // TRAFFIC = 0,
-    TRANSIT = 0,  // Metro scheme
+    TRAFFIC = 0,
+    TRANSIT,  // Metro scheme
     ISOLINES,
     OUTDOORS,
     HIKING,

--- a/qt/preferences_dialog.cpp
+++ b/qt/preferences_dialog.cpp
@@ -257,6 +257,41 @@ PreferencesDialog::PreferencesDialog(QWidget * parent, Framework & framework)
     tilesBox->setLayout(layout);
   }
 
+  QGroupBox * trafficBox = new QGroupBox("Live Traffic Data");
+  {
+    QVBoxLayout * layout = new QVBoxLayout();
+
+    QLineEdit * keyEdit = new QLineEdit();
+    keyEdit->setPlaceholderText(tr("TomTom traffic API key"));
+    keyEdit->setText(QString::fromStdString(framework.GetTrafficApiKey()));
+
+    QLabel * statusLabel = new QLabel();
+    auto const updateStatus = [&framework, statusLabel](QString const & text)
+    {
+      std::string const apiKey = text.toStdString();
+      if (apiKey.empty() || framework.IsWellFormedTrafficApiKey(apiKey))
+        statusLabel->clear();
+      else
+        statusLabel->setText(tr("The key format looks invalid (expected a short code of letters and digits)."));
+    };
+    updateStatus(keyEdit->text());
+    connect(keyEdit, &QLineEdit::textChanged, updateStatus);
+
+    // Apply the key together with the rest of the settings when the dialog is closed.
+    connect(this, &QDialog::finished,
+            [&framework, keyEdit](int) { framework.SetTrafficApiKey(keyEdit->text().toStdString()); });
+
+    QLabel * disclaimer =
+        new QLabel(tr("Live traffic data is provided by TomTom. You are responsible for the API key, its quota "
+                      "and TomTom's terms of use. An empty key falls back to the built-in traffic source."));
+    disclaimer->setWordWrap(true);
+
+    layout->addWidget(keyEdit);
+    layout->addWidget(statusLabel);
+    layout->addWidget(disclaimer);
+    trafficBox->setLayout(layout);
+  }
+
 #ifdef BUILD_DESIGNER
   QCheckBox * indexRegenCheckBox = new QCheckBox("Enable auto regeneration of geometry index");
   {
@@ -292,6 +327,7 @@ PreferencesDialog::PreferencesDialog(QWidget * parent, Framework & framework)
   finalLayout->addWidget(bookmarksPlacementCB);
   finalLayout->addWidget(nightModeRadioBox);
   finalLayout->addWidget(tilesBox);
+  finalLayout->addWidget(trafficBox);
 #ifdef BUILD_DESIGNER
   finalLayout->addWidget(indexRegenCheckBox);
 #endif

--- a/xcode/coding/coding.xcodeproj/project.pbxproj
+++ b/xcode/coding/coding.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		39D5293523D60C6F006F00DA /* bwt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39D5293323D60C6F006F00DA /* bwt.cpp */; };
 		39D5293823D60C78006F00DA /* move_to_front.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39D5293623D60C78006F00DA /* move_to_front.cpp */; };
 		39D5293923D60C78006F00DA /* move_to_front.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 39D5293723D60C78006F00DA /* move_to_front.hpp */; };
+		7AF10B000000000000000002 /* mvt_reader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AF10B000000000000000001 /* mvt_reader.cpp */; };
+		7AF10B000000000000000004 /* mvt_reader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7AF10B000000000000000003 /* mvt_reader.hpp */; };
 		39D5293C23D60C91006F00DA /* bwt_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39D5293A23D60C91006F00DA /* bwt_tests.cpp */; };
 		39D5293D23D60C91006F00DA /* move_to_front_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39D5293B23D60C91006F00DA /* move_to_front_tests.cpp */; };
 		39D5293E23D60C9A006F00DA /* serdes_json_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB87BF8322F9E2D1008A8A72 /* serdes_json_test.cpp */; };
@@ -214,6 +216,8 @@
 		39D5293323D60C6F006F00DA /* bwt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bwt.cpp; sourceTree = "<group>"; };
 		39D5293623D60C78006F00DA /* move_to_front.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = move_to_front.cpp; sourceTree = "<group>"; };
 		39D5293723D60C78006F00DA /* move_to_front.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = move_to_front.hpp; sourceTree = "<group>"; };
+		7AF10B000000000000000001 /* mvt_reader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mvt_reader.cpp; sourceTree = "<group>"; };
+		7AF10B000000000000000003 /* mvt_reader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = mvt_reader.hpp; sourceTree = "<group>"; };
 		39D5293A23D60C91006F00DA /* bwt_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bwt_tests.cpp; sourceTree = "<group>"; };
 		39D5293B23D60C91006F00DA /* move_to_front_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = move_to_front_tests.cpp; sourceTree = "<group>"; };
 		39F376C4207D327B0058E8E0 /* geometry_coding.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = geometry_coding.cpp; sourceTree = "<group>"; };
@@ -505,6 +509,8 @@
 				675342581A3F588B00A0A8C3 /* mmap_reader.cpp */,
 				39D5293723D60C78006F00DA /* move_to_front.hpp */,
 				39D5293623D60C78006F00DA /* move_to_front.cpp */,
+				7AF10B000000000000000003 /* mvt_reader.hpp */,
+				7AF10B000000000000000001 /* mvt_reader.cpp */,
 				6753425C1A3F588B00A0A8C3 /* parse_xml.hpp */,
 				39C3C0BA21A43060003B4712 /* point_coding.hpp */,
 				39C3C0BB21A43061003B4712 /* point_coding.cpp */,
@@ -587,6 +593,7 @@
 				347F33381C4540F0009758CC /* compressed_bit_vector.hpp in Headers */,
 				675342B21A3F588C00A0A8C3 /* parse_xml.hpp in Headers */,
 				39D5293923D60C78006F00DA /* move_to_front.hpp in Headers */,
+				7AF10B000000000000000004 /* mvt_reader.hpp in Headers */,
 				675342AF1A3F588C00A0A8C3 /* mmap_reader.hpp in Headers */,
 				4563B061205909290057556D /* serdes_binary_header.hpp in Headers */,
 				675342B81A3F588C00A0A8C3 /* reader_wrapper.hpp in Headers */,
@@ -783,6 +790,7 @@
 				BB537C5F1E8490120074D9D3 /* transliteration.cpp in Sources */,
 				39D5293523D60C6F006F00DA /* bwt.cpp in Sources */,
 				39D5293823D60C78006F00DA /* move_to_front.cpp in Sources */,
+				7AF10B000000000000000002 /* mvt_reader.cpp in Sources */,
 				675342BB1A3F588C00A0A8C3 /* reader.cpp in Sources */,
 				670BAACB1D0B0C1E000302DA /* huffman.cpp in Sources */,
 				675342A71A3F588C00A0A8C3 /* hex.cpp in Sources */,

--- a/xcode/map/map.xcodeproj/project.pbxproj
+++ b/xcode/map/map.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		5F5CEB79A933763811137BEA /* share.hpp in Headers */ = {isa = PBXBuildFile; fileRef = CE6D8A55305278317BD00A6C /* share.hpp */; };
 		347B60761DD9926D0050FA24 /* traffic_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 347B60741DD9926D0050FA24 /* traffic_manager.cpp */; };
 		347B60771DD9926D0050FA24 /* traffic_manager.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 347B60751DD9926D0050FA24 /* traffic_manager.hpp */; };
+		7AF10A000000000000000002 /* flow_tiles_provider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AF10A000000000000000001 /* flow_tiles_provider.cpp */; };
+		7AF10A000000000000000004 /* flow_tiles_provider.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7AF10A000000000000000003 /* flow_tiles_provider.hpp */; };
+		7AF10A000000000000000006 /* traffic_provider.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7AF10A000000000000000005 /* traffic_provider.hpp */; };
 		348AB57C1D7EE0C6009F8301 /* chart_generator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 348AB57A1D7EE0C6009F8301 /* chart_generator.cpp */; };
 		348AB57D1D7EE0C6009F8301 /* chart_generator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 348AB57B1D7EE0C6009F8301 /* chart_generator.hpp */; };
 		34921F661BFA0A6900737D6E /* api_mark_point.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 34921F611BFA0A6900737D6E /* api_mark_point.hpp */; };
@@ -162,6 +165,9 @@
 		CE6D8A55305278317BD00A6C /* share.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = share.hpp; sourceTree = "<group>"; };
 		347B60741DD9926D0050FA24 /* traffic_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = traffic_manager.cpp; sourceTree = "<group>"; };
 		347B60751DD9926D0050FA24 /* traffic_manager.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = traffic_manager.hpp; sourceTree = "<group>"; };
+		7AF10A000000000000000001 /* flow_tiles_provider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = flow_tiles_provider.cpp; sourceTree = "<group>"; };
+		7AF10A000000000000000003 /* flow_tiles_provider.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = flow_tiles_provider.hpp; sourceTree = "<group>"; };
+		7AF10A000000000000000005 /* traffic_provider.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = traffic_provider.hpp; sourceTree = "<group>"; };
 		348AB57A1D7EE0C6009F8301 /* chart_generator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = chart_generator.cpp; sourceTree = "<group>"; };
 		348AB57B1D7EE0C6009F8301 /* chart_generator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = chart_generator.hpp; sourceTree = "<group>"; };
 		34921F611BFA0A6900737D6E /* api_mark_point.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = api_mark_point.hpp; sourceTree = "<group>"; };
@@ -416,6 +422,8 @@
 				56C1165F2090E5670068BBC0 /* extrapolator.hpp */,
 				39E3C60223312BA800FB0C37 /* features_fetcher.cpp */,
 				39E3C60123312BA800FB0C37 /* features_fetcher.hpp */,
+				7AF10A000000000000000001 /* flow_tiles_provider.cpp */,
+				7AF10A000000000000000003 /* flow_tiles_provider.hpp */,
 				675345F51A4054E800A0A8C3 /* framework.cpp */,
 				675345F61A4054E800A0A8C3 /* framework.hpp */,
 				F6B282FB1C1B03320081957A /* gps_track_collection.cpp */,
@@ -462,6 +470,7 @@
 				ED85D1CB2D5F4B5B00D8075D /* track_statistics.hpp */,
 				347B60741DD9926D0050FA24 /* traffic_manager.cpp */,
 				347B60751DD9926D0050FA24 /* traffic_manager.hpp */,
+				7AF10A000000000000000005 /* traffic_provider.hpp */,
 				BB4E5F201FCC663700A77250 /* transit */,
 				BBA014B020754996007402E4 /* user_mark_id_storage.cpp */,
 				BBA014AF20754996007402E4 /* user_mark_id_storage.hpp */,
@@ -497,6 +506,8 @@
 			files = (
 				BB4E5F261FCC664A00A77250 /* transit_display.hpp in Headers */,
 				347B60771DD9926D0050FA24 /* traffic_manager.hpp in Headers */,
+				7AF10A000000000000000004 /* flow_tiles_provider.hpp in Headers */,
+				7AF10A000000000000000006 /* traffic_provider.hpp in Headers */,
 				45F6EE9E1FB1C77600019892 /* mwm_tree.hpp in Headers */,
 				F6B283081C1B03320081957A /* gps_track_storage.hpp in Headers */,
 				675346A21A4054E800A0A8C3 /* user_mark.hpp in Headers */,
@@ -698,6 +709,7 @@
 				BB4E5F251FCC664A00A77250 /* transit_display.cpp in Sources */,
 				675346741A4054E800A0A8C3 /* mwm_url.cpp in Sources */,
 				347B60761DD9926D0050FA24 /* traffic_manager.cpp in Sources */,
+				7AF10A000000000000000002 /* flow_tiles_provider.cpp in Sources */,
 				BBFC7E3A202D29C000531BE7 /* user_mark_layer.cpp in Sources */,
 				F6B283091C1B03320081957A /* gps_track.cpp in Sources */,
 				34583BCF1C88556800F94664 /* place_page_info.cpp in Sources */,


### PR DESCRIPTION
Closes #1160 

For now, I only tested with TomTom but other providers might work too. We can remove the hardcoded URL in the future and make it customizable similar to how Satellite Imagery is implemented.

<table>
  <tr>
    <td>
<img width="1920" height="1035" alt="Screenshot from 2026-08-23 23-18-12" src="https://github.com/user-attachments/assets/ec9350db-aaf5-426c-a5d6-77f60ce83ccf" /></td>
    <td><img width="1915" height="1034" alt="Screenshot from 2026-08-24 09-50-42" src="https://github.com/user-attachments/assets/24572eb1-db24-46c6-8922-10096fe4549d" /></td>
  </tr>
  <tr>
    <td><img width="1919" height="1033" alt="Screenshot from 2026-08-24 11-28-40" src="https://github.com/user-attachments/assets/0b60a208-8a93-4717-94ba-1e373e57b181" /></td>
    <td><img width="1919" height="1034" alt="Screenshot from 2026-08-24 11-29-39" src="https://github.com/user-attachments/assets/e4a85af9-4a95-440e-b24c-58fe712fa31f" /></td>
  </tr>
</table>