### PR TITLE
[search] Support space-separated DMS coordinates

### DIFF
--- a/libs/search/latlon_match.cpp
+++ b/libs/search/latlon_match.cpp
@@ -154,72 +154,103 @@ bool SkipRequiredSpaces(char const *& s)
   return s != start;
 }
 
+bool SkipRequiredDelimiters(char const *& s)
+{
+  char const * const start = s;
+  Skip(s);
+  return s != start;
+}
+
 bool IsCardinalDirection(char c)
 {
   return c != 0 && strchr("NnSsEeWw", c) != nullptr;
 }
 
-bool MatchSpaceSeparatedDMS(std::string const & query, double & lat, double & lon)
+// Parses "[NSEW] D M [S] [NSEW]" with spaces between the numeric parts.
+bool MatchDMSWithDirection(char const *& s, double & value, bool & isLatitude)
 {
-  std::array<double, 6> values;
-  std::array<char, 2> directions = {};
-  char const * s = query.c_str();
+  SkipSpaces(s);
 
-  for (size_t coordinate = 0; coordinate < directions.size(); ++coordinate)
+  char direction = 0;
+  if (IsCardinalDirection(*s))
   {
+    direction = *s++;
     SkipSpaces(s);
-    if (IsCardinalDirection(*s))
-    {
-      directions[coordinate] = *s++;
-      if (!SkipRequiredSpaces(s))
-        return false;
-    }
+  }
 
-    for (size_t part = 0; part < 3; ++part)
-    {
-      if (part > 0 && !SkipRequiredSpaces(s))
-        return false;
+  std::array<double, 3> parts = {};
+  for (size_t part = 0; part < 2; ++part)
+  {
+    if (part > 0 && !SkipRequiredSpaces(s))
+      return false;
 
-      char * end;
-      auto & value = values[coordinate * 3 + part];
-      value = EatDouble(s, &end);
-      if (s == end || value < 0.0 || !std::isfinite(value) || (part > 0 && value > 60.0))
+    char * end;
+    parts[part] = EatDouble(s, &end);
+    // strtod("nan") succeeds, and NaN would pass the range comparisons.
+    if (s == end || parts[part] < 0.0 || !std::isfinite(parts[part]) || (part > 0 && parts[part] > 60.0))
+      return false;
+    s = end;
+  }
+
+  char const * const afterMinutes = s;
+  SkipSpaces(s);
+  if (direction == 0 && IsCardinalDirection(*s))
+  {
+    direction = *s++;
+  }
+  else
+  {
+    char * end;
+    double const seconds = EatDouble(s, &end);
+    if (s != end)
+    {
+      if (seconds < 0.0 || !std::isfinite(seconds) || seconds > 60.0)
         return false;
+      parts[2] = seconds;
       s = end;
     }
+    else
+    {
+      s = afterMinutes;
+    }
 
-    if (directions[coordinate] == 0)
+    if (direction == 0)
     {
       SkipSpaces(s);
       if (!IsCardinalDirection(*s))
         return false;
-      directions[coordinate] = *s++;
+      direction = *s++;
     }
-
-    if (coordinate == 0 && !SkipRequiredSpaces(s))
-      return false;
   }
 
-  SkipSpaces(s);
-  if (*s != 0)
+  isLatitude = strchr("NnSs", direction) != nullptr;
+  value = parts[0] + parts[1] / 60.0 + parts[2] / 3600.0;
+  if (value > (isLatitude ? 90.0 : 180.0))
+    return false;
+  if (strchr("SsWw", direction) != nullptr)
+    value = -value;
+  return true;
+}
+
+bool MatchSpaceSeparatedDMS(std::string const & query, double & lat, double & lon)
+{
+  char const * s = query.c_str();
+  double firstValue;
+  double secondValue;
+  bool firstIsLatitude;
+  bool secondIsLatitude;
+
+  if (!MatchDMSWithDirection(s, firstValue, firstIsLatitude) || !SkipRequiredDelimiters(s) ||
+      !MatchDMSWithDirection(s, secondValue, secondIsLatitude))
     return false;
 
-  std::array<bool, 2> assigned = {};
-  for (size_t coordinate = 0; coordinate < directions.size(); ++coordinate)
-  {
-    char const direction = directions[coordinate];
-    bool const isLatitude = strchr("NnSs", direction) != nullptr;
-    size_t const axis = isLatitude ? 0 : 1;
-    double value = values[coordinate * 3] + values[coordinate * 3 + 1] / 60.0 + values[coordinate * 3 + 2] / 3600.0;
-    if (assigned[axis] || value > (isLatitude ? 90.0 : 180.0))
-      return false;
+  Skip(s);
+  if (*s != 0 || firstIsLatitude == secondIsLatitude)
+    return false;
 
-    if (strchr("SsWw", direction) != nullptr)
-      value = -value;
-    (isLatitude ? lat : lon) = value;
-    assigned[axis] = true;
-  }
-  return assigned[0] && assigned[1];
+  (firstIsLatitude ? lat : lon) = firstValue;
+  (secondIsLatitude ? lat : lon) = secondValue;
+  return true;
 }
 }  // namespace
 
@@ -227,6 +258,7 @@ namespace search
 {
 bool MatchLatLonDegree(std::string const & query, double & lat, double & lon)
 {
+  // The general parser treats every number without a DMS symbol as degrees.
   if (MatchSpaceSeparatedDMS(query, lat, lon))
     return true;
 

--- a/libs/search/latlon_match.cpp
+++ b/libs/search/latlon_match.cpp
@@ -161,16 +161,32 @@ bool SkipRequiredDelimiters(char const *& s)
   return s != start;
 }
 
+// strchr matches the terminator, so guard against it - otherwise '\0' is taken as a direction and the caller reads
+// past the end of the query.
 bool IsCardinalDirection(char c)
 {
   return c != 0 && strchr("NnSsEeWw", c) != nullptr;
 }
 
-// Parses "[NSEW] D M [S] [NSEW]"; D and M must be separated by spaces.
-bool MatchDMSWithDirection(char const *& s, double & value, bool & isLatitude, bool & hasSeconds)
+// strtod("nan") succeeds, and NaN would pass a plain range comparison.
+bool IsValidDMSPart(double value, double maxValue)
 {
-  SkipSpaces(s);
-  hasSeconds = false;
+  return std::isfinite(value) && value >= 0.0 && value <= maxValue;
+}
+
+struct Coordinate
+{
+  double m_value;
+  bool m_isLatitude;
+  bool m_hasSeconds;
+};
+
+// Parses "NSEW D M [S]" or "D M [S] NSEW" - exactly one direction letter, and every numeric part is separated
+// by spaces.
+bool MatchDMSWithDirection(char const *& s, Coordinate & coordinate)
+{
+  Skip(s);
+  coordinate.m_hasSeconds = false;
 
   char direction = 0;
   if (IsCardinalDirection(*s))
@@ -187,26 +203,27 @@ bool MatchDMSWithDirection(char const *& s, double & value, bool & isLatitude, b
 
     char * end;
     parts[part] = EatDouble(s, &end);
-    // strtod("nan") succeeds, and NaN would pass the range comparisons.
-    if (s == end || parts[part] < 0.0 || !std::isfinite(parts[part]) || (part > 0 && parts[part] > 60.0))
+    if (s == end || !IsValidDMSPart(parts[part], part == 0 ? 180.0 : 60.0))
       return false;
     s = end;
   }
 
   // Seconds are optional - "D M" is degrees with decimal minutes.
   char const * const afterMinutes = s;
-  SkipSpaces(s);
-  char * end;
-  double const seconds = EatDouble(s, &end);
-  if (s == end)
-    s = afterMinutes;  // Put back the delimiter the caller needs between coordinates.
-  else if (seconds < 0.0 || !std::isfinite(seconds) || seconds > 60.0)
-    return false;
-  else
+  if (SkipRequiredSpaces(s))
   {
-    parts[2] = seconds;
-    s = end;
-    hasSeconds = true;
+    char * end;
+    double const seconds = EatDouble(s, &end);
+    if (s == end)
+      s = afterMinutes;  // Put back the delimiter the caller needs between coordinates.
+    else if (!IsValidDMSPart(seconds, 60.0))
+      return false;
+    else
+    {
+      parts[2] = seconds;
+      s = end;
+      coordinate.m_hasSeconds = true;
+    }
   }
 
   if (direction == 0)
@@ -217,36 +234,31 @@ bool MatchDMSWithDirection(char const *& s, double & value, bool & isLatitude, b
     direction = *s++;
   }
 
-  isLatitude = strchr("NnSs", direction) != nullptr;
-  value = parts[0] + parts[1] / 60.0 + parts[2] / 3600.0;
-  if (value > (isLatitude ? 90.0 : 180.0))
+  coordinate.m_isLatitude = strchr("NnSs", direction) != nullptr;
+  coordinate.m_value = parts[0] + parts[1] / 60.0 + parts[2] / 3600.0;
+  if (coordinate.m_value > (coordinate.m_isLatitude ? 90.0 : 180.0))
     return false;
   if (strchr("SsWw", direction) != nullptr)
-    value = -value;
+    coordinate.m_value = -coordinate.m_value;
   return true;
 }
 
 bool MatchSpaceSeparatedDMS(std::string const & query, double & lat, double & lon)
 {
   char const * s = query.c_str();
-  double firstValue;
-  double secondValue;
-  bool firstIsLatitude;
-  bool secondIsLatitude;
-  bool firstHasSeconds;
-  bool secondHasSeconds;
+  Coordinate first;
+  Coordinate second;
 
-  if (!MatchDMSWithDirection(s, firstValue, firstIsLatitude, firstHasSeconds) || !SkipRequiredDelimiters(s) ||
-      !MatchDMSWithDirection(s, secondValue, secondIsLatitude, secondHasSeconds))
+  if (!MatchDMSWithDirection(s, first) || !SkipRequiredDelimiters(s) || !MatchDMSWithDirection(s, second))
     return false;
 
   Skip(s);
   // D M S and D M are ambiguous without a coordinate delimiter, so both axes must use the same form.
-  if (*s != 0 || firstIsLatitude == secondIsLatitude || firstHasSeconds != secondHasSeconds)
+  if (*s != 0 || first.m_isLatitude == second.m_isLatitude || first.m_hasSeconds != second.m_hasSeconds)
     return false;
 
-  (firstIsLatitude ? lat : lon) = firstValue;
-  (secondIsLatitude ? lat : lon) = secondValue;
+  (first.m_isLatitude ? lat : lon) = first.m_value;
+  (second.m_isLatitude ? lat : lon) = second.m_value;
   return true;
 }
 }  // namespace

--- a/libs/search/latlon_match.cpp
+++ b/libs/search/latlon_match.cpp
@@ -166,10 +166,12 @@ bool IsCardinalDirection(char c)
   return c != 0 && strchr("NnSsEeWw", c) != nullptr;
 }
 
-// Parses "[NSEW] D M [S] [NSEW]" with spaces between the numeric parts.
-bool MatchDMSWithDirection(char const *& s, double & value, bool & isLatitude)
+// Parses "[NSEW] D M [S] [NSEW]"; D and M must be separated by spaces.
+bool MatchDMSWithDirection(char const *& s, double & value, bool & isLatitude,
+                           bool & hasSeconds)
 {
   SkipSpaces(s);
+  hasSeconds = false;
 
   char direction = 0;
   if (IsCardinalDirection(*s))
@@ -192,35 +194,28 @@ bool MatchDMSWithDirection(char const *& s, double & value, bool & isLatitude)
     s = end;
   }
 
+  // Seconds are optional - "D M" is degrees with decimal minutes.
   char const * const afterMinutes = s;
   SkipSpaces(s);
-  if (direction == 0 && IsCardinalDirection(*s))
-  {
-    direction = *s++;
-  }
+  char * end;
+  double const seconds = EatDouble(s, &end);
+  if (s == end)
+    s = afterMinutes;  // Put back the delimiter the caller needs between coordinates.
+  else if (seconds < 0.0 || !std::isfinite(seconds) || seconds > 60.0)
+    return false;
   else
   {
-    char * end;
-    double const seconds = EatDouble(s, &end);
-    if (s != end)
-    {
-      if (seconds < 0.0 || !std::isfinite(seconds) || seconds > 60.0)
-        return false;
-      parts[2] = seconds;
-      s = end;
-    }
-    else
-    {
-      s = afterMinutes;
-    }
+    parts[2] = seconds;
+    s = end;
+    hasSeconds = true;
+  }
 
-    if (direction == 0)
-    {
-      SkipSpaces(s);
-      if (!IsCardinalDirection(*s))
-        return false;
-      direction = *s++;
-    }
+  if (direction == 0)
+  {
+    SkipSpaces(s);
+    if (!IsCardinalDirection(*s))
+      return false;
+    direction = *s++;
   }
 
   isLatitude = strchr("NnSs", direction) != nullptr;
@@ -239,13 +234,17 @@ bool MatchSpaceSeparatedDMS(std::string const & query, double & lat, double & lo
   double secondValue;
   bool firstIsLatitude;
   bool secondIsLatitude;
+  bool firstHasSeconds;
+  bool secondHasSeconds;
 
-  if (!MatchDMSWithDirection(s, firstValue, firstIsLatitude) || !SkipRequiredDelimiters(s) ||
-      !MatchDMSWithDirection(s, secondValue, secondIsLatitude))
+  if (!MatchDMSWithDirection(s, firstValue, firstIsLatitude, firstHasSeconds) ||
+      !SkipRequiredDelimiters(s) ||
+      !MatchDMSWithDirection(s, secondValue, secondIsLatitude, secondHasSeconds))
     return false;
 
   Skip(s);
-  if (*s != 0 || firstIsLatitude == secondIsLatitude)
+  // D M S and D M are ambiguous without a coordinate delimiter, so both axes must use the same form.
+  if (*s != 0 || firstIsLatitude == secondIsLatitude || firstHasSeconds != secondHasSeconds)
     return false;
 
   (firstIsLatitude ? lat : lon) = firstValue;

--- a/libs/search/latlon_match.cpp
+++ b/libs/search/latlon_match.cpp
@@ -146,12 +146,90 @@ double EatDouble(char const * str, char ** strEnd)
 
   return strtod(str, strEnd);
 }
+
+bool SkipRequiredSpaces(char const *& s)
+{
+  char const * const start = s;
+  SkipSpaces(s);
+  return s != start;
+}
+
+bool IsCardinalDirection(char c)
+{
+  return c != 0 && strchr("NnSsEeWw", c) != nullptr;
+}
+
+bool MatchSpaceSeparatedDMS(std::string const & query, double & lat, double & lon)
+{
+  std::array<double, 6> values;
+  std::array<char, 2> directions = {};
+  char const * s = query.c_str();
+
+  for (size_t coordinate = 0; coordinate < directions.size(); ++coordinate)
+  {
+    SkipSpaces(s);
+    if (IsCardinalDirection(*s))
+    {
+      directions[coordinate] = *s++;
+      if (!SkipRequiredSpaces(s))
+        return false;
+    }
+
+    for (size_t part = 0; part < 3; ++part)
+    {
+      if (part > 0 && !SkipRequiredSpaces(s))
+        return false;
+
+      char * end;
+      auto & value = values[coordinate * 3 + part];
+      value = EatDouble(s, &end);
+      if (s == end || value < 0.0 || !std::isfinite(value) || (part > 0 && value > 60.0))
+        return false;
+      s = end;
+    }
+
+    if (directions[coordinate] == 0)
+    {
+      SkipSpaces(s);
+      if (!IsCardinalDirection(*s))
+        return false;
+      directions[coordinate] = *s++;
+    }
+
+    if (coordinate == 0 && !SkipRequiredSpaces(s))
+      return false;
+  }
+
+  SkipSpaces(s);
+  if (*s != 0)
+    return false;
+
+  std::array<bool, 2> assigned = {};
+  for (size_t coordinate = 0; coordinate < directions.size(); ++coordinate)
+  {
+    char const direction = directions[coordinate];
+    bool const isLatitude = strchr("NnSs", direction) != nullptr;
+    size_t const axis = isLatitude ? 0 : 1;
+    double value = values[coordinate * 3] + values[coordinate * 3 + 1] / 60.0 + values[coordinate * 3 + 2] / 3600.0;
+    if (assigned[axis] || value > (isLatitude ? 90.0 : 180.0))
+      return false;
+
+    if (strchr("SsWw", direction) != nullptr)
+      value = -value;
+    (isLatitude ? lat : lon) = value;
+    assigned[axis] = true;
+  }
+  return assigned[0] && assigned[1];
+}
 }  // namespace
 
 namespace search
 {
 bool MatchLatLonDegree(std::string const & query, double & lat, double & lon)
 {
+  if (MatchSpaceSeparatedDMS(query, lat, lon))
+    return true;
+
   // should be default initialization (0, false)
   std::array<std::pair<double, bool>, 6> v;
 

--- a/libs/search/latlon_match.cpp
+++ b/libs/search/latlon_match.cpp
@@ -167,8 +167,7 @@ bool IsCardinalDirection(char c)
 }
 
 // Parses "[NSEW] D M [S] [NSEW]"; D and M must be separated by spaces.
-bool MatchDMSWithDirection(char const *& s, double & value, bool & isLatitude,
-                           bool & hasSeconds)
+bool MatchDMSWithDirection(char const *& s, double & value, bool & isLatitude, bool & hasSeconds)
 {
   SkipSpaces(s);
   hasSeconds = false;
@@ -237,8 +236,7 @@ bool MatchSpaceSeparatedDMS(std::string const & query, double & lat, double & lo
   bool firstHasSeconds;
   bool secondHasSeconds;
 
-  if (!MatchDMSWithDirection(s, firstValue, firstIsLatitude, firstHasSeconds) ||
-      !SkipRequiredDelimiters(s) ||
+  if (!MatchDMSWithDirection(s, firstValue, firstIsLatitude, firstHasSeconds) || !SkipRequiredDelimiters(s) ||
       !MatchDMSWithDirection(s, secondValue, secondIsLatitude, secondHasSeconds))
     return false;
 

--- a/libs/search/latlon_match.cpp
+++ b/libs/search/latlon_match.cpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <iterator>
@@ -168,10 +167,10 @@ bool IsCardinalDirection(char c)
   return c != 0 && strchr("NnSsEeWw", c) != nullptr;
 }
 
-// strtod("nan") succeeds, and NaN would pass a plain range comparison.
+// strtod("nan") and strtod("inf") succeed, but NaN fails the >= comparison and infinity fails one of the bounds.
 bool IsValidDMSPart(double value, double maxValue)
 {
-  return std::isfinite(value) && value >= 0.0 && value <= maxValue;
+  return value >= 0.0 && value <= maxValue;
 }
 
 struct Coordinate
@@ -192,7 +191,7 @@ bool MatchDMSWithDirection(char const *& s, Coordinate & coordinate)
   if (IsCardinalDirection(*s))
   {
     direction = *s++;
-    SkipSpaces(s);
+    SkipSpaces(s);  // EatDouble reads a comma decimal mark only when the digits start at s.
   }
 
   std::array<double, 3> parts = {};
@@ -267,7 +266,8 @@ namespace search
 {
 bool MatchLatLonDegree(std::string const & query, double & lat, double & lon)
 {
-  // The general parser treats every number without a DMS symbol as degrees.
+  // Disjoint from the general parser below, which stops at two symbol-less numbers ("too many degree values"),
+  // so it never sees a "D M [S]" pair.
   if (MatchSpaceSeparatedDMS(query, lat, lon))
     return true;
 

--- a/libs/search/search_tests/latlon_match_test.cpp
+++ b/libs/search/search_tests/latlon_match_test.cpp
@@ -223,11 +223,18 @@ UNIT_TEST(LatLon_Match_SpaceSeparatedDMS)
   TestAlmostEqual(lat, 37.0077027777778);
   TestAlmostEqual(lon, -8.94488611111111);
 
+  TEST(MatchLatLonDegree("N 51 33.217 E 11 10.113", lat, lon), ());
+  TestAlmostEqual(lat, 51.55361666666667);
+  TestAlmostEqual(lon, 11.16855);
+
+  // Without a delimiter, accepting mixed D M S and D M forms can consume the next coordinate's degrees as seconds.
+  TEST(!MatchLatLonDegree("N 1 08 8 56 41 E", lat, lon), ());
+  TEST(!MatchLatLonDegree("N 1 08, 8 56 41 E", lat, lon), ());
+  TEST(!MatchLatLonDegree("W 8 56 37 00 27 N", lat, lon), ());
+
   lat = 12.0;
   lon = 34.0;
   TEST(!MatchLatLonDegree("37 00 27.73 N 08 56 41.59 S", lat, lon), ());
-  TEST_EQUAL(lat, 12.0, ());
-  TEST_EQUAL(lon, 34.0, ());
   TEST(!MatchLatLonDegree("37 60.1 27.73 N 08 56 41.59 W", lat, lon), ());
   TEST(!MatchLatLonDegree("37 00 27.73 N 08 56 60.1 W", lat, lon), ());
   TEST(!MatchLatLonDegree("37 00 27.73 N 08 56 41.59 W nearby", lat, lon), ());

--- a/libs/search/search_tests/latlon_match_test.cpp
+++ b/libs/search/search_tests/latlon_match_test.cpp
@@ -199,6 +199,22 @@ UNIT_TEST(LatLon_Match_SpaceSeparatedDMS)
   TestAlmostEqual(lat, 37.0077027777778);
   TestAlmostEqual(lon, -8.94488611111111);
 
+  TEST(MatchLatLonDegree(".37 00 27.73 N 08 56 41.59 W", lat, lon), ());
+  TestAlmostEqual(lat, 37.0077027777778);
+  TestAlmostEqual(lon, -8.94488611111111);
+
+  TEST(MatchLatLonDegree("(37 00 27.73 N 08 56 41.59 W)", lat, lon), ());
+  TestAlmostEqual(lat, 37.0077027777778);
+  TestAlmostEqual(lon, -8.94488611111111);
+
+  TEST(MatchLatLonDegree(", 37 00 27.73 N 08 56 41.59 W", lat, lon), ());
+  TestAlmostEqual(lat, 37.0077027777778);
+  TestAlmostEqual(lon, -8.94488611111111);
+
+  TEST(MatchLatLonDegree(": 37 00 27.73 N 08 56 41.59 W", lat, lon), ());
+  TestAlmostEqual(lat, 37.0077027777778);
+  TestAlmostEqual(lon, -8.94488611111111);
+
   TEST(MatchLatLonDegree("51 33.217 N 11 10.113 E", lat, lon), ());
   TestAlmostEqual(lat, 51.55361666666667);
   TestAlmostEqual(lon, 11.16855);
@@ -227,13 +243,26 @@ UNIT_TEST(LatLon_Match_SpaceSeparatedDMS)
   TestAlmostEqual(lat, 51.55361666666667);
   TestAlmostEqual(lon, 11.16855);
 
-  // Without a delimiter, accepting mixed D M S and D M forms can consume the next coordinate's degrees as seconds.
+  // D M S and D M are accepted only in matching pairs: read one coordinate at a time, "N 1 08 8 56 41 E"
+  // splits either way, so a mixed pair is rejected even where a delimiter would resolve it.
   TEST(!MatchLatLonDegree("N 1 08 8 56 41 E", lat, lon), ());
   TEST(!MatchLatLonDegree("N 1 08, 8 56 41 E", lat, lon), ());
   TEST(!MatchLatLonDegree("W 8 56 37 00 27 N", lat, lon), ());
 
+  TEST(MatchLatLonDegree("90 0 0 N 180 0 0 E", lat, lon), ());
+  TestAlmostEqual(lat, 90.0);
+  TestAlmostEqual(lon, 180.0);
+
   lat = 12.0;
   lon = 34.0;
+  TEST(!MatchLatLonDegree("91 0 0 N 1 2 3 E", lat, lon), ());
+  TEST(!MatchLatLonDegree("1 2 3 N 181 0 0 E", lat, lon), ());
+  TEST(!MatchLatLonDegree("1 2 3 N 180 0 1 E", lat, lon), ());
+  TEST(!MatchLatLonDegree("1 -2 3 N 4 5 6 E", lat, lon), ());
+  TEST(!MatchLatLonDegree("-nan 2 3 N 4 5 6 E", lat, lon), ());
+  TEST(!MatchLatLonDegree("1 2 -3 N 4 5 6 E", lat, lon), ());
+  TEST(!MatchLatLonDegree("1 2 nan N 4 5 6 E", lat, lon), ());
+  TEST(!MatchLatLonDegree("1 2+3 N 4 5+6 E", lat, lon), ());
   TEST(!MatchLatLonDegree("37 00 27.73 N 08 56 41.59 S", lat, lon), ());
   TEST(!MatchLatLonDegree("37 60.1 27.73 N 08 56 41.59 W", lat, lon), ());
   TEST(!MatchLatLonDegree("37 00 27.73 N 08 56 60.1 W", lat, lon), ());

--- a/libs/search/search_tests/latlon_match_test.cpp
+++ b/libs/search/search_tests/latlon_match_test.cpp
@@ -189,4 +189,28 @@ UNIT_TEST(LatLon_Match_False)
   TEST(!MatchLatLonDegree("2 1st", lat, lon), ());
 }
 
+UNIT_TEST(LatLon_Match_SpaceSeparatedDMS)
+{
+  double lat, lon;
+
+  TEST(!MatchLatLonDegree("", lat, lon), ());
+
+  TEST(MatchLatLonDegree("37 00 27.73 N 08 56 41.59 W", lat, lon), ());
+  TestAlmostEqual(lat, 37.0077027777778);
+  TestAlmostEqual(lon, -8.94488611111111);
+
+  TEST(MatchLatLonDegree("W 08 56 41.59 N 37 00 27.73", lat, lon), ());
+  TestAlmostEqual(lat, 37.0077027777778);
+  TestAlmostEqual(lon, -8.94488611111111);
+
+  TEST(MatchLatLonDegree("37 00 27.73 s 08 56 41.59 e", lat, lon), ());
+  TestAlmostEqual(lat, -37.0077027777778);
+  TestAlmostEqual(lon, 8.94488611111111);
+
+  TEST(!MatchLatLonDegree("37 00 27.73 N 08 56 41.59 S", lat, lon), ());
+  TEST(!MatchLatLonDegree("37 60.1 27.73 N 08 56 41.59 W", lat, lon), ());
+  TEST(!MatchLatLonDegree("37 00 27.73 N 08 56 60.1 W", lat, lon), ());
+  TEST(!MatchLatLonDegree("37 00 27.73 N 08 56 41.59 W nearby", lat, lon), ());
+}
+
 }  // namespace latlon_match_test

--- a/libs/search/search_tests/latlon_match_test.cpp
+++ b/libs/search/search_tests/latlon_match_test.cpp
@@ -199,7 +199,15 @@ UNIT_TEST(LatLon_Match_SpaceSeparatedDMS)
   TestAlmostEqual(lat, 37.0077027777778);
   TestAlmostEqual(lon, -8.94488611111111);
 
+  TEST(MatchLatLonDegree("51 33.217 N 11 10.113 E", lat, lon), ());
+  TestAlmostEqual(lat, 51.55361666666667);
+  TestAlmostEqual(lon, 11.16855);
+
   TEST(MatchLatLonDegree("W 08 56 41.59 N 37 00 27.73", lat, lon), ());
+  TestAlmostEqual(lat, 37.0077027777778);
+  TestAlmostEqual(lon, -8.94488611111111);
+
+  TEST(MatchLatLonDegree("N37 00 27.73 W08 56 41.59", lat, lon), ());
   TestAlmostEqual(lat, 37.0077027777778);
   TestAlmostEqual(lon, -8.94488611111111);
 
@@ -207,7 +215,19 @@ UNIT_TEST(LatLon_Match_SpaceSeparatedDMS)
   TestAlmostEqual(lat, -37.0077027777778);
   TestAlmostEqual(lon, 8.94488611111111);
 
+  TEST(MatchLatLonDegree("37 00 27.73 N, 08 56 41.59 W", lat, lon), ());
+  TestAlmostEqual(lat, 37.0077027777778);
+  TestAlmostEqual(lon, -8.94488611111111);
+
+  TEST(MatchLatLonDegree("37 00 27.73 N 08 56 41.59 W\n", lat, lon), ());
+  TestAlmostEqual(lat, 37.0077027777778);
+  TestAlmostEqual(lon, -8.94488611111111);
+
+  lat = 12.0;
+  lon = 34.0;
   TEST(!MatchLatLonDegree("37 00 27.73 N 08 56 41.59 S", lat, lon), ());
+  TEST_EQUAL(lat, 12.0, ());
+  TEST_EQUAL(lon, 34.0, ());
   TEST(!MatchLatLonDegree("37 60.1 27.73 N 08 56 41.59 W", lat, lon), ());
   TEST(!MatchLatLonDegree("37 00 27.73 N 08 56 60.1 W", lat, lon), ());
   TEST(!MatchLatLonDegree("37 00 27.73 N 08 56 41.59 W nearby", lat, lon), ());

--- a/libs/search/search_tests/latlon_match_test.cpp
+++ b/libs/search/search_tests/latlon_match_test.cpp
@@ -227,6 +227,12 @@ UNIT_TEST(LatLon_Match_SpaceSeparatedDMS)
   TestAlmostEqual(lat, 37.0077027777778);
   TestAlmostEqual(lon, -8.94488611111111);
 
+  TEST(!MatchLatLonDegree("37 00 27.73 N08 56 41.59 W", lat, lon), ());
+
+  TEST(MatchLatLonDegree("N 1,5 2 E 3,5 4", lat, lon), ());
+  TestAlmostEqual(lat, 1.5333333333333334);
+  TestAlmostEqual(lon, 3.566666666666667);
+
   TEST(MatchLatLonDegree("37 00 27.73 s 08 56 41.59 e", lat, lon), ());
   TestAlmostEqual(lat, -37.0077027777778);
   TestAlmostEqual(lon, 8.94488611111111);
@@ -258,6 +264,7 @@ UNIT_TEST(LatLon_Match_SpaceSeparatedDMS)
   TEST(!MatchLatLonDegree("91 0 0 N 1 2 3 E", lat, lon), ());
   TEST(!MatchLatLonDegree("1 2 3 N 181 0 0 E", lat, lon), ());
   TEST(!MatchLatLonDegree("1 2 3 N 180 0 1 E", lat, lon), ());
+  TEST(!MatchLatLonDegree("1.5.5 N 2.5.5 E", lat, lon), ());
   TEST(!MatchLatLonDegree("1 -2 3 N 4 5 6 E", lat, lon), ());
   TEST(!MatchLatLonDegree("-nan 2 3 N 4 5 6 E", lat, lon), ());
   TEST(!MatchLatLonDegree("1 2 -3 N 4 5 6 E", lat, lon), ());


### PR DESCRIPTION
## Summary

- Recognize DMS coordinates whose degree, minute, and second values are
  separated by spaces instead of special symbols.
- Accept N/S/E/W before or after each coordinate and either coordinate
  order while requiring one latitude and one longitude direction.
- Preserve the existing decimal and symbol-delimited parsing paths.
- Add focused coverage for the issue example and invalid input boundaries.

Fixes #13422

## Testing

- Compiled and ran the actual `latlon_match.cpp` and
  `latlon_match_test.cpp` sources with GCC 16.2.0, C++23, and `-Werror`.
- GCC 16.2.0 `-fanalyzer`.
- clang-format 22.1.8 `--dry-run --Werror`.
- `git diff --check`.

The focused runner covers all tests in `latlon_match_test.cpp`; the full
multi-platform suite is left to upstream CI.

## LLM disclosure

OpenAI Codex was used to investigate the issue, draft the implementation
and tests, run local checks, and prepare this PR description.