### PR TITLE
[routing] Fix unrealistic ETA of alternative routes

### DIFF
--- a/libs/routing/edge_estimator.cpp
+++ b/libs/routing/edge_estimator.cpp
@@ -60,13 +60,12 @@ bool IsTransit(std::optional<HighwayType> type)
 
 template <class CalcSpeed>
 double CalcClimbSegment(EdgeEstimator::Purpose purpose, Segment const & segment, RoadGeometry const & road,
-                        CalcSpeed && calcSpeed)
+                        double distanceM, CalcSpeed && calcSpeed)
 {
-  double const distance = road.GetDistance(segment.GetSegmentIdx());
   double speedMpS = GetSpeedMpS(purpose, segment, road);
 
   static double constexpr kSmallDistanceM = 1;  // we have altitude threshold is 0.5m
-  if (distance > kSmallDistanceM && !IsTransit(road.GetHighwayType()))
+  if (distanceM > kSmallDistanceM && !IsTransit(road.GetHighwayType()))
   {
     LatLonWithAltitude const & from = road.GetJunction(segment.GetPointId(false /* front */));
     LatLonWithAltitude const & to = road.GetJunction(segment.GetPointId(true /* front */));
@@ -76,13 +75,14 @@ double CalcClimbSegment(EdgeEstimator::Purpose purpose, Segment const & segment,
 
     if (altitudeDiff != 0)
     {
-      speedMpS = calcSpeed(speedMpS, altitudeDiff / distance, to.GetAltitude());
+      speedMpS = calcSpeed(speedMpS, altitudeDiff / distanceM, to.GetAltitude());
       ASSERT_GREATER(speedMpS, 0.0, (segment));
     }
   }
 
-  return distance / speedMpS;
+  return distanceM / speedMpS;
 }
+
 }  // namespace
 
 double GetPedestrianClimbPenalty(EdgeEstimator::Purpose purpose, double tangent, geometry::Altitude altitudeM)
@@ -165,26 +165,38 @@ double GetCarClimbPenalty(EdgeEstimator::Purpose, double, geometry::Altitude)
 }
 
 // EdgeEstimator -----------------------------------------------------------------------------------
-EdgeEstimator::EdgeEstimator(double maxWeightSpeedKMpH, SpeedKMpH const & offroadSpeedKMpH,
-                             DataSource * /*dataSourcePtr*/, std::shared_ptr<NumMwmIds> /*numMwmIds*/)
+EdgeEstimator::EdgeEstimator(double maxWeightSpeedKMpH, double distanceBiasCapSpeedKMpH,
+                             SpeedKMpH const & offroadSpeedKMpH, DataSource * /*dataSourcePtr*/,
+                             std::shared_ptr<NumMwmIds> /*numMwmIds*/)
   : m_maxWeightSpeedMpS(KmphToMps(maxWeightSpeedKMpH))
+  , m_distanceBiasSecPerM(1.0 / KmphToMps(distanceBiasCapSpeedKMpH))
   , m_offroadSpeedKMpH(offroadSpeedKMpH)
 //, m_dataSourcePtr(dataSourcePtr)
 //, m_numMwmIds(numMwmIds)
 {
+  CHECK_GREATER(distanceBiasCapSpeedKMpH, 0.0, ());
+  CHECK_LESS_OR_EQUAL(distanceBiasCapSpeedKMpH, maxWeightSpeedKMpH, ());
   CHECK_GREATER(m_offroadSpeedKMpH.m_weight, 0.0, ());
   CHECK_GREATER(m_offroadSpeedKMpH.m_eta, 0.0, ());
+  // Pure fake edges bypass ApplyStrategy(), so their weight speed must also preserve the tight
+  // DistanceBiased heuristic bound.
+  CHECK_LESS_OR_EQUAL(m_offroadSpeedKMpH.m_weight, distanceBiasCapSpeedKMpH, ());
   CHECK_GREATER_OR_EQUAL(m_maxWeightSpeedMpS, KmphToMps(m_offroadSpeedKMpH.m_weight), ());
 
   if (m_offroadSpeedKMpH.m_eta != kNotUsed)
     CHECK_GREATER_OR_EQUAL(m_maxWeightSpeedMpS, KmphToMps(m_offroadSpeedKMpH.m_eta), ());
 }
 
-double EdgeEstimator::CalcHeuristic(ms::LatLon const & from, ms::LatLon const & to) const
+double EdgeEstimator::CalcHeuristic(ms::LatLon const & from, ms::LatLon const & to, bool tightAllowed) const
 {
   // For the correct A*, we should use maximum _possible_ speed here, including:
-  // default model, feature stored, unlimited autobahn, ferry or rail transit.
-  return TimeBetweenSec(from, to, m_maxWeightSpeedMpS);
+  // default model, feature stored, unlimited autobahn, ferry or rail transit. Under DistanceBiased
+  // every estimator weight is >= distance / cap, so the cap is the maximum possible speed — unless
+  // the search can also see leap, precomputed cross-mwm or guides edges, which are priced by other
+  // models (see the declaration).
+  bool const tight = tightAllowed && m_tightHeuristicAllowed && m_strategy == Strategy::DistanceBiased;
+  double const distanceM = ms::DistanceOnEarth(from, to);
+  return tight ? distanceM * m_distanceBiasSecPerM : distanceM / m_maxWeightSpeedMpS;
 }
 
 double EdgeEstimator::ComputeDefaultLeapWeightSpeed() const
@@ -265,7 +277,7 @@ class PedestrianEstimator final : public EdgeEstimator
 {
 public:
   PedestrianEstimator(double maxWeightSpeedKMpH, SpeedKMpH const & offroadSpeedKMpH)
-    : EdgeEstimator(maxWeightSpeedKMpH, offroadSpeedKMpH)
+    : EdgeEstimator(maxWeightSpeedKMpH, kDistanceBiasCapSpeedKMpH, offroadSpeedKMpH)
   {}
 
   // EdgeEstimator overrides:
@@ -283,16 +295,25 @@ public:
   double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road, Purpose purpose,
                            time_t arrivalTime) const override
   {
-    if (purpose == Purpose::Weight && GetStrategy() == Strategy::Shortest)
-      return road.GetDistance(segment.GetSegmentIdx()) / GetMaxWeightSpeedMpS();
-
-    double const weight =
-        CalcClimbSegment(purpose, segment, road, [purpose](double speedMpS, double tangent, geometry::Altitude altitude)
+    double const distanceM = road.GetDistance(segment.GetSegmentIdx());
+    double weight = CalcClimbSegment(purpose, segment, road, distanceM,
+                                     [purpose](double speedMpS, double tangent, geometry::Altitude altitude)
     { return speedMpS / GetPedestrianClimbPenalty(purpose, tangent, altitude); });
+
     // Bias the transit alternative away from walking (see SetTransitAltFactors). No-op (factor 1.0)
     // for standalone pedestrian routing and for the primary transit route.
-    return purpose == Purpose::Weight ? weight * GetTransitWalkWeightFactor() : weight;
+    if (purpose == Purpose::Weight)
+      weight *= GetTransitWalkWeightFactor();
+
+    return ApplyStrategy(purpose, weight, distanceM);
   }
+
+private:
+  // On flat, good surfaces, ordinary walkable ways tie by distance: footways (5.5),
+  // tracks/paths/living streets (5.0), residential/service (4.5), cycleways/tertiary (4.0).
+  // Secondary and bigger roads, steps, bridleways and ladders stay below the cap. Climb and surface
+  // penalties remain whenever they reduce the effective weight speed below the cap.
+  static double constexpr kDistanceBiasCapSpeedKMpH = 4.0;
 };
 
 // BicycleEstimator --------------------------------------------------------------------------------
@@ -300,7 +321,7 @@ class BicycleEstimator final : public EdgeEstimator
 {
 public:
   BicycleEstimator(double maxWeightSpeedKMpH, SpeedKMpH const & offroadSpeedKMpH)
-    : EdgeEstimator(maxWeightSpeedKMpH, offroadSpeedKMpH)
+    : EdgeEstimator(maxWeightSpeedKMpH, kDistanceBiasCapSpeedKMpH, offroadSpeedKMpH)
   {}
 
   // EdgeEstimator overrides:
@@ -318,11 +339,9 @@ public:
   double CalcSegmentWeight(Segment const & segment, RoadGeometry const & road, Purpose purpose,
                            time_t arrivalTime) const override
   {
-    if (purpose == Purpose::Weight && GetStrategy() == Strategy::Shortest)
-      return road.GetDistance(segment.GetSegmentIdx()) / GetMaxWeightSpeedMpS();
-
-    return CalcClimbSegment(purpose, segment, road,
-                            [purpose, this](double speedMpS, double tangent, geometry::Altitude altitude)
+    double const distanceM = road.GetDistance(segment.GetSegmentIdx());
+    double const weight = CalcClimbSegment(purpose, segment, road, distanceM,
+                                           [purpose, this](double speedMpS, double tangent, geometry::Altitude altitude)
     {
       auto const factor = GetBicycleClimbPenalty(purpose, tangent, altitude);
       ASSERT_GREATER(factor, 0.0, ());
@@ -351,7 +370,16 @@ public:
 
       return std::min(speedMpS, GetMaxWeightSpeedMpS());
     });
+
+    return ApplyStrategy(purpose, weight, distanceM);
   }
+
+private:
+  // On flat, good surfaces, cycleways and ordinary streets down to in-city
+  // residential/living_street (12) tie by distance. Primary (10), tracks (8-10), paths (6-7),
+  // dismount footways (2) and steps (1) stay below the cap. Climb and surface penalties remain
+  // whenever they reduce the effective weight speed below the cap.
+  static double constexpr kDistanceBiasCapSpeedKMpH = 12.0;
 };
 
 // CarEstimator ------------------------------------------------------------------------------------
@@ -365,7 +393,7 @@ public:
   CarEstimator(DataSource * dataSourcePtr, std::shared_ptr<NumMwmIds> numMwmIds,
                std::shared_ptr<TrafficStash> trafficStash, double maxWeightSpeedKMpH,
                SpeedKMpH const & offroadSpeedKMpH)
-    : EdgeEstimator(maxWeightSpeedKMpH, offroadSpeedKMpH, dataSourcePtr, numMwmIds)
+    : EdgeEstimator(maxWeightSpeedKMpH, kDistanceBiasCapSpeedKMpH, offroadSpeedKMpH, dataSourcePtr, numMwmIds)
     , m_trafficStash(std::move(trafficStash))
   {}
 
@@ -391,15 +419,17 @@ public:
   }
 
 private:
+  // Between the default tertiary (35-37.5) and secondary (48+) weight speeds: secondary and faster
+  // roads tie, tertiary gets a mild penalty, while residential, service, tracks and bad surfaces
+  // keep their full cost (and jammed roads keep the traffic factor).
+  static double constexpr kDistanceBiasCapSpeedKMpH = 40.0;
+
   std::shared_ptr<TrafficStash> m_trafficStash;
 };
 
 double CarEstimator::CalcSegmentWeight(Segment const & segment, RoadGeometry const & road, Purpose purpose,
                                        time_t arrivalTime) const
 {
-  if (purpose == Purpose::Weight && GetStrategy() == Strategy::Shortest)
-    return road.GetDistance(segment.GetSegmentIdx()) / GetMaxWeightSpeedMpS();
-
   double const speed = GetSpeedMpS(purpose, segment, road, arrivalTime);
 
   // Debug log ETA calculated speed.
@@ -411,7 +441,8 @@ double CarEstimator::CalcSegmentWeight(Segment const & segment, RoadGeometry con
   }
 #endif
 
-  double result = road.GetDistance(segment.GetSegmentIdx()) / speed;
+  double const distanceM = road.GetDistance(segment.GetSegmentIdx());
+  double result = distanceM / speed;
 
   if (m_trafficStash)
   {
@@ -429,7 +460,7 @@ double CarEstimator::CalcSegmentWeight(Segment const & segment, RoadGeometry con
     }
   }
 
-  return result;
+  return ApplyStrategy(purpose, result, distanceM);
 }
 
 // EdgeEstimator -----------------------------------------------------------------------------------

--- a/libs/routing/edge_estimator.cpp
+++ b/libs/routing/edge_estimator.cpp
@@ -196,7 +196,7 @@ double EdgeEstimator::CalcHeuristic(ms::LatLon const & from, ms::LatLon const & 
   // models (see the declaration).
   bool const tight = tightAllowed && m_tightHeuristicAllowed && m_strategy == Strategy::DistanceBiased;
   double const distanceM = ms::DistanceOnEarth(from, to);
-  return tight ? distanceM * m_distanceBiasSecPerM : distanceM / m_maxWeightSpeedMpS;
+  return tight ? (distanceM * m_distanceBiasSecPerM) : (distanceM / m_maxWeightSpeedMpS);
 }
 
 double EdgeEstimator::ComputeDefaultLeapWeightSpeed() const

--- a/libs/routing/edge_estimator.hpp
+++ b/libs/routing/edge_estimator.hpp
@@ -9,6 +9,7 @@
 #include "geometry/latlon.hpp"
 #include "geometry/point_with_altitude.hpp"
 
+#include <algorithm>
 #include <memory>
 
 class DataSource;
@@ -28,21 +29,34 @@ public:
   };
 
   /// \brief Calculation strategy. Normal — full road model (speed, traffic, penalties, climb).
-  /// Shortest — the estimator's per-segment weight becomes distance-only (uses GetMaxWeightSpeedMpS()
-  /// as the constant divisor so the A* heuristic stays admissible); non-segment penalties applied at
-  /// the graph layer (u-turn, ferry, etc. in IndexGraph::CalcEdgeWeight) still take effect. Used to
-  /// compute a "shortest path" alternative alongside the normal route.
+  /// DistanceBiased — roads whose Normal weight speed is at or above the per-vehicle
+  /// |distanceBiasCapSpeedKMpH| are ranked purely by distance (weight = distance / cap), while
+  /// slower roads keep their Normal weight, so the search yields the shortest chain of reasonable
+  /// roads without gaining from segments the model considers unreasonably slow (tracks, footways,
+  /// steps, bad surfaces — see issue #12953). Weights never drop below distance / cap and thus
+  /// below distance / GetMaxWeightSpeedMpS(), so CalcHeuristic() stays admissible and may even
+  /// divide by the cap where no faster-priced edges exist (see |tightAllowed| there).
+  /// Non-segment penalties applied at the graph layer (u-turn, ferry, etc. in
+  /// IndexGraph::CalculateEdgeWeight) still take effect. Used to compute a reasonable,
+  /// distance-biased alternative alongside the normal route.
   enum class Strategy
   {
     Normal,
-    Shortest
+    DistanceBiased
   };
 
-  EdgeEstimator(double maxWeightSpeedKMpH, SpeedKMpH const & offroadSpeedKMpH, DataSource * dataSourcePtr = nullptr,
-                std::shared_ptr<NumMwmIds> numMwmIds = nullptr);
+  EdgeEstimator(double maxWeightSpeedKMpH, double distanceBiasCapSpeedKMpH, SpeedKMpH const & offroadSpeedKMpH,
+                DataSource * dataSourcePtr = nullptr, std::shared_ptr<NumMwmIds> numMwmIds = nullptr);
   virtual ~EdgeEstimator() = default;
 
-  void SetStrategy(Strategy strategy) { m_strategy = strategy; }
+  /// |tightHeuristicAllowed| == false keeps CalcHeuristic() on the loose max-speed bound even under
+  /// DistanceBiased. Needed when guides are attached: guides edges are priced at max speed
+  /// (see GuidesGraph::CalcSegmentWeight), i.e. cheaper per meter than the cap.
+  void SetStrategy(Strategy strategy, bool tightHeuristicAllowed = true)
+  {
+    m_strategy = strategy;
+    m_tightHeuristicAllowed = tightHeuristicAllowed;
+  }
   Strategy GetStrategy() const { return m_strategy; }
 
   /// \brief Transit alternative route bias. Scales the routing weight (Purpose::Weight only, ETA
@@ -57,12 +71,18 @@ public:
   double GetTransitWalkWeightFactor() const { return m_transitWalkWeightFactor; }
   double GetTransitTransferFactor() const { return m_transitTransferFactor; }
 
-  double CalcHeuristic(ms::LatLon const & from, ms::LatLon const & to) const;
+  /// A* heuristic: straight-line time at the maximum possible speed. Under Strategy::DistanceBiased
+  /// every estimator weight is >= distance / cap, so when the caller guarantees the search sees no
+  /// edges priced by other models (leap edges and precomputed cross-mwm weights in
+  /// WorldGraphMode::LeapsOnly, guides edges — see SetStrategy), |tightAllowed| == true divides by
+  /// the cap instead, keeping the heuristic admissible while much tighter.
+  double CalcHeuristic(ms::LatLon const & from, ms::LatLon const & to, bool tightAllowed = false) const;
   // Estimates time in seconds it takes to go from point |from| to point |to| along a leap (fake)
   // edge |from|-|to| using real features.
   // Note 1. The result of the method should be used if it's necessary to add a leap (fake) edge
   // (|from|, |to|) in road graph.
-  // Note 2. The result of the method should be less or equal to CalcHeuristic(|from|, |to|).
+  // Note 2. In WorldGraphMode::LeapsOnly, CalcHeuristic(|from|, |to|) must be less than or equal to
+  // this result. The loose max-speed heuristic used in that mode provides this bound.
   // Note 3. It's assumed here that CalcLeapWeight(p1, p2) == CalcLeapWeight(p2, p1).
   double CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to, NumMwmId mwmId = kFakeNumMwmId);
 
@@ -85,10 +105,22 @@ public:
                                                std::shared_ptr<TrafficStash> trafficStash, DataSource * dataSourcePtr,
                                                std::shared_ptr<NumMwmIds> numMwmIds);
 
+protected:
+  /// Applies Strategy::DistanceBiased to a Normal |weight|: roads not slower than the cap tie by
+  /// pure distance, slower ones keep their full cost. No-op for Purpose::ETA and Strategy::Normal.
+  double ApplyStrategy(Purpose purpose, double weight, double distanceM) const
+  {
+    if (purpose == Purpose::Weight && m_strategy == Strategy::DistanceBiased)
+      return std::max(weight, distanceM * m_distanceBiasSecPerM);
+    return weight;
+  }
+
 private:
   double const m_maxWeightSpeedMpS;
+  double const m_distanceBiasSecPerM;
   SpeedKMpH const m_offroadSpeedKMpH;
   Strategy m_strategy = Strategy::Normal;
+  bool m_tightHeuristicAllowed = true;
   double m_transitWalkWeightFactor = 1.0;
   double m_transitTransferFactor = 1.0;
 

--- a/libs/routing/index_router.cpp
+++ b/libs/routing/index_router.cpp
@@ -74,6 +74,19 @@ double constexpr kLeapsStageContribution = 0.15;
 double constexpr kCandidatesStageContribution = 0.55;
 double constexpr kAlmostZeroContribution = 1e-7;
 
+// Distance-biased alternatives must not trade a small distance saving for an excessive ETA.
+// Transit alternatives are exempt because they intentionally trade time for less walking.
+double constexpr kMaxAltEtaRatio = 1.5;
+
+constexpr bool IsAlternativeEtaAcceptable(VehicleType vehicleType, double activeEtaSec, double alternativeEtaSec)
+{
+  return vehicleType == VehicleType::Transit || alternativeEtaSec <= kMaxAltEtaRatio * activeEtaSec;
+}
+
+static_assert(IsAlternativeEtaAcceptable(VehicleType::Car, 100.0, 150.0));
+static_assert(!IsAlternativeEtaAcceptable(VehicleType::Car, 100.0, 150.1));
+static_assert(IsAlternativeEtaAcceptable(VehicleType::Transit, 100.0, 150.1));
+
 // If user left the route within this range(meters), adjust the route. Else full rebuild.
 double constexpr kAdjustRangeM = 5000.0;
 // Full rebuild if distance(meters) is less.
@@ -448,9 +461,11 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
       code = DoCalculateRoute(checkpoints, startDirection, delegate, route);
 
       // Compute an alternative alongside the Normal route. Only on a full (non-adjust) build and only
-      // within a reasonable distance budget — alt computation roughly doubles latency. Road vehicles
-      // get a Shortest-strategy alternative; transit gets a less-walking / fewer-transfers alternative
-      // (e.g. a direct bus instead of subway + walk).
+      // within a reasonable distance budget — the alternative search costs about 0.5-1x of the
+      // normal one (measured; the tight DistanceBiased heuristic keeps it cheap, see
+      // EdgeEstimator::CalcHeuristic). Non-transit profiles get a distance-biased alternative;
+      // transit gets a less-walking / fewer-transfers alternative (e.g. a direct bus instead of
+      // subway + walk).
       double const altMaxDistanceM = m_vehicleType == VehicleType::Car ? 300'000.0 : 100'000.0;
       if ((code == RouterResultCode::NoError || code == RouterResultCode::HasWarnings) && !delegate.IsCancelled() &&
           mercator::DistanceOnEarth(startPoint, finalPoint) <= altMaxDistanceM)
@@ -477,7 +492,10 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
         }
         else
         {
-          m_estimator->SetStrategy(EdgeEstimator::Strategy::Shortest);
+          // Guides edges are priced at max speed (see SetGuidesGraphParams call below), above the
+          // DistanceBiased cap, so the tighter heuristic is only valid without attached guides.
+          m_estimator->SetStrategy(EdgeEstimator::Strategy::DistanceBiased,
+                                   !m_guides.IsAttached() /* tightHeuristicAllowed */);
         }
         altCode = DoCalculateRoute(checkpoints, startDirection, delegate, altRoute);
       }
@@ -496,7 +514,8 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
     // Transit is distinguished by fake transit (subway/bus) segments, so compare by geometry;
     // road vehicles compare by real-road feature identity.
     std::optional<m2::PointD> diffMidpoint;
-    if ((altCode == RouterResultCode::NoError || altCode == RouterResultCode::HasWarnings) && altRoute.IsValid())
+    if ((altCode == RouterResultCode::NoError || altCode == RouterResultCode::HasWarnings) && altRoute.IsValid() &&
+        IsAlternativeEtaAcceptable(m_vehicleType, route.GetTotalTimeSec(), altRoute.GetTotalTimeSec()))
     {
       diffMidpoint = m_vehicleType == VehicleType::Transit
                        ? altRoute.FindMaxDiffMidpointByGeometry(route.GetRouteSegments())

--- a/libs/routing/index_router.cpp
+++ b/libs/routing/index_router.cpp
@@ -78,14 +78,10 @@ double constexpr kAlmostZeroContribution = 1e-7;
 // Transit alternatives are exempt because they intentionally trade time for less walking.
 double constexpr kMaxAltEtaRatio = 1.5;
 
-constexpr bool IsAlternativeEtaAcceptable(VehicleType vehicleType, double activeEtaSec, double alternativeEtaSec)
+bool IsAlternativeEtaAcceptable(VehicleType vehicleType, double activeEtaSec, double alternativeEtaSec)
 {
   return vehicleType == VehicleType::Transit || alternativeEtaSec <= kMaxAltEtaRatio * activeEtaSec;
 }
-
-static_assert(IsAlternativeEtaAcceptable(VehicleType::Car, 100.0, 150.0));
-static_assert(!IsAlternativeEtaAcceptable(VehicleType::Car, 100.0, 150.1));
-static_assert(IsAlternativeEtaAcceptable(VehicleType::Transit, 100.0, 150.1));
 
 // If user left the route within this range(meters), adjust the route. Else full rebuild.
 double constexpr kAdjustRangeM = 5000.0;

--- a/libs/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/libs/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -469,4 +469,22 @@ UNIT_TEST(Germany_BicycleYes_VehicleNo)
                                    mercator::FromLatLon(48.074355, 11.2472321), 551.705);
 }
 
+// https://github.com/organicmaps/organicmaps/issues/12953
+// A useful distance-biased alternative exists on this flat route. It should remain shorter than
+// the active route without incurring an excessive ETA penalty on slow roads.
+UNIT_TEST(Germany_Munich_AlternativeRouteEta)
+{
+  auto & components = GetVehicleComponents(VehicleType::Bicycle);
+  Checkpoints const checkpoints(mercator::FromLatLon(48.1312306, 11.6872422),
+                                mercator::FromLatLon(48.2043364, 11.4145979));
+  auto const result = CalculateRoutes(components, checkpoints);
+  TEST_EQUAL(result.second, RouterResultCode::NoError, ());
+  TEST_EQUAL(result.first.size(), 2, ());
+
+  auto const & active = *result.first[0];
+  auto const & alternative = *result.first[1];
+  TEST_LESS(alternative.GetTotalDistanceMeters(), active.GetTotalDistanceMeters(), ());
+  TEST_LESS(alternative.GetTotalTimeSec(), 1.25 * active.GetTotalTimeSec(), ());
+}
+
 }  // namespace bicycle_route_test

--- a/libs/routing/routing_tests/edge_estimator_tests.cpp
+++ b/libs/routing/routing_tests/edge_estimator_tests.cpp
@@ -1,7 +1,15 @@
 #include "testing/testing.hpp"
 
 #include "routing/edge_estimator.hpp"
+#include "routing/geometry.hpp"
+#include "routing/segment.hpp"
 
+#include "routing_common/maxspeed_conversion.hpp"
+#include "routing_common/vehicle_model.hpp"
+
+#include "platform/measurement_utils.hpp"
+
+#include "geometry/mercator.hpp"
 #include "geometry/point_with_altitude.hpp"
 
 #include <cmath>
@@ -74,6 +82,88 @@ UNIT_TEST(ClimbPenalty_HighAboveSeaLevel)
 
     TEST_GREATER_OR_EQUAL(penalty2500Bicyclce, 6.0, ());
     TEST_ALMOST_EQUAL_ABS(GetCarClimbPenalty(purpose, kTan, 2500), 1.0, kAccuracyEps, ());
+  }
+}
+
+// Distance-biased strategy: roads at/above the per-vehicle cap speed tie by pure distance, slower
+// roads keep their Normal weight, the weight never drops below distance / maxWeightSpeed (A*
+// heuristic admissibility) and ETA does not depend on the strategy.
+UNIT_TEST(DistanceBiasedStrategy_CapsFastRoadsKeepsSlowRoads)
+{
+  auto const makeRoad = [](uint16_t speedKmPH)
+  {
+    return RoadGeometry(true /* oneWay */, Maxspeed(measurement_utils::Units::Metric, speedKmPH, kInvalidSpeed),
+                        RoadGeometry::Points({{0.0, 0.0}, {0.0, 0.01}}));
+  };
+
+  struct VehicleCase
+  {
+    VehicleType m_type;
+    double m_maxWeightSpeedKMpH;
+    SpeedKMpH m_offroad;
+    // Both fast speeds are above the vehicle's distance-bias cap, the slow one is below.
+    uint16_t m_fast1, m_fast2, m_slow;
+  };
+  std::initializer_list<VehicleCase> const cases = {
+      {VehicleType::Car, 200.0, {0.01 /* weight */, kNotUsed /* eta */}, 120, 80, 5},
+      {VehicleType::Bicycle, 100.0, {1.5, 3.0}, 25, 18, 2},
+      {VehicleType::Pedestrian, 60.0, {0.5, 3.0}, 7, 6, 3},
+  };
+
+  Segment const segment(0 /* mwmId */, 0 /* featureId */, 0 /* segmentIdx */, true /* forward */);
+  for (auto const & c : cases)
+  {
+    auto const estimator =
+        EdgeEstimator::Create(c.m_type, c.m_maxWeightSpeedKMpH, c.m_offroad, nullptr /* trafficStash */,
+                              nullptr /* dataSourcePtr */, nullptr /* numMwmIds */);
+    auto const roadFast1 = makeRoad(c.m_fast1);
+    auto const roadFast2 = makeRoad(c.m_fast2);
+    auto const roadSlow = makeRoad(c.m_slow);
+    double const distanceM = roadFast1.GetDistance(0);
+
+    auto const calc = [&](RoadGeometry const & road, EdgeEstimator::Purpose purpose)
+    { return estimator->CalcSegmentWeight(segment, road, purpose, 0 /* arrivalTime */); };
+
+    double const etaFast = calc(roadFast1, EdgeEstimator::Purpose::ETA);
+    double const normalFast1 = calc(roadFast1, EdgeEstimator::Purpose::Weight);
+    double const normalFast2 = calc(roadFast2, EdgeEstimator::Purpose::Weight);
+    double const normalSlow = calc(roadSlow, EdgeEstimator::Purpose::Weight);
+    TEST_NOT_EQUAL(normalFast1, normalFast2, (c.m_type));
+
+    estimator->SetStrategy(EdgeEstimator::Strategy::DistanceBiased);
+    double const distanceBiasedFast1 = calc(roadFast1, EdgeEstimator::Purpose::Weight);
+    double const distanceBiasedFast2 = calc(roadFast2, EdgeEstimator::Purpose::Weight);
+    double const distanceBiasedSlow = calc(roadSlow, EdgeEstimator::Purpose::Weight);
+
+    // Above-cap roads are ranked by pure distance: equal weights, higher than their Normal ones.
+    TEST_ALMOST_EQUAL_ABS(distanceBiasedFast1, distanceBiasedFast2, kAccuracyEps, (c.m_type));
+    TEST_GREATER(distanceBiasedFast1, normalFast1, (c.m_type));
+    // A below-cap road keeps its Normal weight and stays more expensive than any capped road.
+    TEST_ALMOST_EQUAL_ABS(distanceBiasedSlow, normalSlow, kAccuracyEps, (c.m_type));
+    TEST_GREATER(distanceBiasedSlow, distanceBiasedFast1, (c.m_type));
+    // Weights never drop below the A* heuristic bound.
+    TEST_GREATER_OR_EQUAL(distanceBiasedFast1, distanceM / measurement_utils::KmphToMps(c.m_maxWeightSpeedKMpH),
+                          (c.m_type));
+    // ETA is strategy-independent.
+    TEST_ALMOST_EQUAL_ABS(calc(roadFast1, EdgeEstimator::Purpose::ETA), etaFast, kAccuracyEps, (c.m_type));
+
+    // The tight heuristic engages only under DistanceBiased with |tightAllowed|: it grows, but
+    // exactly to the cheapest capped road weight over the same distance (stays admissible).
+    ms::LatLon const fromLL = mercator::ToLatLon(m2::PointD(0.0, 0.0));
+    ms::LatLon const toLL = mercator::ToLatLon(m2::PointD(0.0, 0.01));
+    double const looseHeuristic = estimator->CalcHeuristic(fromLL, toLL);
+    double const tightHeuristic = estimator->CalcHeuristic(fromLL, toLL, true /* tightAllowed */);
+    TEST_GREATER_OR_EQUAL(tightHeuristic, looseHeuristic, (c.m_type));
+    TEST_ALMOST_EQUAL_ABS(tightHeuristic, distanceBiasedFast1, kAccuracyEps, (c.m_type));
+
+    // Guides gate: tightHeuristicAllowed == false keeps the loose bound even under DistanceBiased.
+    estimator->SetStrategy(EdgeEstimator::Strategy::DistanceBiased, false /* tightHeuristicAllowed */);
+    TEST_ALMOST_EQUAL_ABS(estimator->CalcHeuristic(fromLL, toLL, true /* tightAllowed */), looseHeuristic, kAccuracyEps,
+                          (c.m_type));
+
+    estimator->SetStrategy(EdgeEstimator::Strategy::Normal);
+    TEST_ALMOST_EQUAL_ABS(estimator->CalcHeuristic(fromLL, toLL, true /* tightAllowed */), looseHeuristic, kAccuracyEps,
+                          (c.m_type));
   }
 }
 }  // namespace

--- a/libs/routing/routing_tests/index_graph_tools.hpp
+++ b/libs/routing/routing_tests/index_graph_tools.hpp
@@ -159,7 +159,7 @@ public:
   // maxSpeedKMpH doesn't matter, but should be greater then any road speed in all tests.
   // offroadSpeedKMpH doesn't matter, but should be > 0 and <= maxSpeedKMpH.
   explicit WeightedEdgeEstimator(std::map<Segment, double> const & segmentWeights)
-    : EdgeEstimator(1e10 /* maxSpeedKMpH */, 1.0 /* offroadSpeedKMpH */)
+    : EdgeEstimator(1e10 /* maxSpeedKMpH */, 1e10 /* distanceBiasCapSpeedKMpH */, 1.0 /* offroadSpeedKMpH */)
     , m_segmentWeights(segmentWeights)
   {}
 

--- a/libs/routing/single_vehicle_world_graph.cpp
+++ b/libs/routing/single_vehicle_world_graph.cpp
@@ -131,7 +131,9 @@ bool SingleVehicleWorldGraph::IsPassThroughAllowed(NumMwmId mwmId, uint32_t feat
 
 RouteWeight SingleVehicleWorldGraph::HeuristicCostEstimate(ms::LatLon const & from, ms::LatLon const & to)
 {
-  return RouteWeight(m_estimator->CalcHeuristic(from, to));
+  // In LeapsOnly mode the search sees leap edges and precomputed cross-mwm weights whose effective
+  // speeds exceed the DistanceBiased cap, so the tighter heuristic is only valid without leaps.
+  return RouteWeight(m_estimator->CalcHeuristic(from, to, m_mode != WorldGraphMode::LeapsOnly /* tightAllowed */));
 }
 
 RouteWeight SingleVehicleWorldGraph::CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose)


### PR DESCRIPTION
Alternative (shortest) routes often showed huge, unrealistic ETAs — up to ~2× the active route's time to save a few percent of distance.

**Root cause:** the alternative was searched with pure-distance weights (`distance / max vehicle speed`), so A* ignored road class, surface, maxspeed and dismount rules entirely and freely used 5 km/h tracks, sidewalks and even steps. The displayed ETA is the honest full-model time of that geometry — the bug was in route selection, not in ETA calculation.

**Fix:** the alternative search is now distance-biased instead of pure shortest: roads with weight speed at/above a per-vehicle cap (car 40, bicycle 12, pedestrian 4 km/h) tie per meter, slower roads keep their full weight. An additional acceptance bound drops alternatives above 1.5× of the active route's ETA, so the user-visible property holds by construction (transit is exempt: its alternative trades time for less walking). The A* heuristic stays admissible; ETA calculation is untouched.

### Examples on real maps (before → after)

| Route                                                                                                                                                                                                                                                                                                 | Active           | Alternative before                                                                | Alternative after                                                                              |
| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| Munich, Trudering → NW suburbs 🚲 (route from #12953 logs) [OSM](https://www.openstreetmap.org/directions?engine=fossgis_osrm_bike&route=48.13123%2C11.68724%3B48.20434%2C11.41460) · [OM](https://omaps.app/route?sll=48.13123,11.68724&saddr=Start&dll=48.20434,11.41460&daddr=Finish&type=bicycle) | 26.0 km / 94 min | 25.1 km / **131 min (1.39×)** — 26 min on sidewalks at 4 km/h, plus steps         | 25.4 km / **96 min (1.02×)**, still shorter                                                    |
| Munich, Trudering → SE (Glonn area) 🚲 (screenshot from #12953) [OSM](https://www.openstreetmap.org/directions?engine=fossgis_osrm_bike&route=48.128%2C11.693%3B48.02414%2C11.85932) · [OM](https://omaps.app/route?sll=48.128,11.693&saddr=Start&dll=48.02414,11.85932&daddr=Finish&type=bicycle)    | 20.5 km / 79 min | 19.7 km / **147 min (1.86×)** — 88 min on 6.3 km of unpaved-bad tracks/paths      | 20.3 km / **79 min (1.00×)** — a sane, slightly shorter alternative                   |
| Villages NE of Gomel, Belarus 🚗 [OSM](https://www.openstreetmap.org/directions?engine=fossgis_osrm_car&route=52.60%2C31.05%3B52.65%2C31.20) · [OM](https://omaps.app/route?sll=52.60,31.05&saddr=Start&dll=52.65,31.20&daddr=Finish&type=vehicle)                                                    | 23.3 km / 33 min | 22.4 km / **63 min (1.93×)** — 35 min on 2.9 km of a 5 km/h track, to save 0.9 km | not shown: converges to the active route                                                       |
| Jinan → Tai'an, China 🚗 [OSM](https://www.openstreetmap.org/directions?engine=fossgis_osrm_car&route=36.6512%2C117.1201%3B36.2020%2C117.0870) · [OM](https://omaps.app/route?sll=36.6512,117.1201&saddr=Start&dll=36.2020,117.0870&daddr=Finish&type=vehicle)                                        | 80.7 km / 57 min | 71.6 km / **127 min (2.24×)**                                                     | 74.5 km / **65 min (1.15×)** — a useful non-motorway option, 6 km shorter                      |
| Boston Downtown → Harvard Square, USA 🚗 [OSM](https://www.openstreetmap.org/directions?engine=fossgis_osrm_car&route=42.3550%2C-71.0656%3B42.3736%2C-71.1190) · [OM](https://omaps.app/route?sll=42.3550,-71.0656&saddr=Start&dll=42.3736,-71.1190&daddr=Finish&type=vehicle)                        | 8.3 km / 9.2 min | 7.3 km / **13.5 min (1.48×)**                                                     | 8.2 km / **9.3 min (1.01×)** — surface alternative to the I-90/I-93 tunnels                    |
| Khoiniki → Bragin, Belarus 🚗 [OSM](https://www.openstreetmap.org/directions?engine=fossgis_osrm_car&route=51.8908%2C29.9645%3B51.7869%2C30.2666) · [OM](https://omaps.app/route?sll=51.8908,29.9645&saddr=Start&dll=51.7869,30.2666&daddr=Finish&type=vehicle)                                       | 27.3 km / 26 min | none shown                                                                        | **new**: 26.7 km / 25.4 min — shorter *and* faster; pure-shortest hid it behind a track detour |

The OSM links open the same start/finish pair for orientation (OSRM's own routing there will differ); the OM links build the same route in the app on current maps. Numbers above were measured by driving `IndexRouter` directly over 2026-05 maps.

**Tested:** new unit test for the capped weight semantics (all routing_tests pass); new integration regression on the first Munich route above (fails at 1.39× before the fix, passes after); manual verification over ~15 routes in 7 regions across car/bicycle/pedestrian profiles.

Note: the A* heuristic is strategy-aware (it divides by the cap where the search sees no leap, precomputed cross-mwm or guides edges, which are priced by other models), so the alternative search costs about 0.5–1× of the normal one (measured: Gomel–Rechytsa 340 ms vs 700 ms, Jinan–Tai'an 1099 ms vs 1273 ms).

Fixes #12953

### Related issues

- #11191 — the [2026-07-17 comment](https://github.com/organicmaps/organicmaps/issues/11191#issuecomment-5005703334) reports this same symptom (near-identical alternative with wildly different time); the issue's core — hike/bike ETA model accuracy — is intentionally not changed here.
- #11907 — the distance-biased alternative now offers the "reasonably shorter" route next to the fastest one; worth re-testing on the reported Slovakia routes, may become closable.
- #13205 — remembering the chosen alternative across full reroutes is a separate bug, not addressed here.
- #3974 (closed) — this completes the "solved by alternate routes" plan mentioned there; #1183 / #12773 (more alternative types) and #2153 (easiest route) remain open — the reworked `Strategy` enum is the extension point for those.

