### PR TITLE
[indexer] Fix standalone relation reads

### DIFF
--- a/libs/indexer/features_vector.cpp
+++ b/libs/indexer/features_vector.cpp
@@ -50,20 +50,12 @@ FeaturesVectorTest::FeaturesVectorTest(std::string const & filePath)
 FeaturesVectorTest::FeaturesVectorTest(FilesContainerR const & cont)
   : m_cont(cont)
   , m_header(m_cont)
-  , m_vector(m_cont, m_header, nullptr, nullptr, nullptr)
-{
-  m_vector.m_table = feature::FeaturesOffsetsTable::Load(m_cont, FEATURE_OFFSETS_FILE_TAG).release();
+  , m_ftTable(feature::FeaturesOffsetsTable::Load(m_cont, FEATURE_OFFSETS_FILE_TAG))
+  , m_relTable(m_cont.IsExist(RELATION_OFFSETS_FILE_TAG)
+                   ? feature::FeaturesOffsetsTable::Load(m_cont, RELATION_OFFSETS_FILE_TAG)
+                   : nullptr)
+  , m_metaDeserializer(m_cont.IsExist(METADATA_FILE_TAG) ? indexer::MetadataDeserializer::Load(m_cont) : nullptr)
+  , m_vector(m_cont, m_header, m_ftTable.get(), m_relTable.get(), m_metaDeserializer.get())
+{}
 
-  if (m_cont.IsExist(RELATION_OFFSETS_FILE_TAG))
-    m_vector.m_loadInfo.m_relTable = feature::FeaturesOffsetsTable::Load(m_cont, RELATION_OFFSETS_FILE_TAG).release();
-
-  if (m_cont.IsExist(METADATA_FILE_TAG))
-    m_vector.m_loadInfo.m_metaDeserializer = indexer::MetadataDeserializer::Load(m_cont).release();
-}
-
-FeaturesVectorTest::~FeaturesVectorTest()
-{
-  delete m_vector.m_table;
-  delete m_vector.m_loadInfo.m_metaDeserializer;
-  delete m_vector.m_loadInfo.m_relTable;
-}
+FeaturesVectorTest::~FeaturesVectorTest() = default;

--- a/libs/indexer/features_vector.hpp
+++ b/libs/indexer/features_vector.hpp
@@ -64,7 +64,6 @@ private:
 
   void InitRecordsReader();
 
-  friend class FeaturesVectorTest;
   using RecordReader = VarRecordReader<FilesContainerR::TReader>;
 
   feature::SharedLoadInfo m_loadInfo;
@@ -80,6 +79,9 @@ class FeaturesVectorTest
 
   FilesContainerR m_cont;
   feature::DataHeader m_header;
+  std::unique_ptr<feature::FeaturesOffsetsTable> m_ftTable;
+  std::unique_ptr<feature::FeaturesOffsetsTable> m_relTable;
+  std::unique_ptr<indexer::MetadataDeserializer> m_metaDeserializer;
   FeaturesVector m_vector;
 
 public:

--- a/libs/indexer/indexer_tests/features_vector_test.cpp
+++ b/libs/indexer/indexer_tests/features_vector_test.cpp
@@ -1,10 +1,13 @@
 #include "testing/testing.hpp"
 
-#include "indexer/data_source.hpp"
 #include "indexer/features_vector.hpp"
-#include "indexer/mwm_set.hpp"
+#include "indexer/route_relation.hpp"
 
-#include "platform/local_country_file.hpp"
+#include "platform/platform.hpp"
+
+#include "base/file_name_utils.hpp"
+
+#include "defines.hpp"
 
 #include <map>
 #include <string>
@@ -12,7 +15,6 @@
 
 namespace features_vector_test
 {
-using namespace platform;
 using namespace std;
 
 // Postcodes with frequencies.
@@ -34,27 +36,27 @@ UNIT_TEST(FeaturesVectorTest_ParseMetadata)
   for (auto const & p : kCodeFreq)
     expected[strings::to_string(p.first)] = p.second;
 
-  LocalCountryFile localFile = LocalCountryFile::MakeForTesting(kCountryName);
-
-  FrozenDataSource dataSource;
-  auto result = dataSource.RegisterMap(localFile);
-  TEST_EQUAL(result.second, MwmSet::RegResult::Success, ());
-
-  auto const & id = result.first;
-  MwmSet::MwmHandle handle = dataSource.GetMwmHandleById(id);
-  TEST(handle.IsAlive(), ());
-
-  auto const * value = handle.GetValue();
-  FeaturesVector fv(value->m_cont, value->GetHeader(), value->m_ftTable.get(), value->m_relTable.get(),
-                    value->m_metaDeserializer.get());
+  auto const path = base::JoinPath(GetPlatform().ResourcesDir(), kCountryName + DATA_FILE_EXTENSION);
+  FeaturesVectorTest features(path);
 
   map<string, int> actual;
-  fv.ForEach([&](FeatureType & ft, uint32_t index)
+  features.GetVector().ForEach([&](FeatureType & ft, uint32_t index)
   {
     string const postcode(ft.GetMetadata(feature::Metadata::FMD_POSTCODE));
     if (!postcode.empty())
       ++actual[postcode];
   });
   TEST_EQUAL(expected, actual, ());
+}
+
+UNIT_TEST(FeaturesVectorTest_ParseRelation)
+{
+  auto const path = base::JoinPath(GetPlatform().ResourcesDir(), "minsk-pass" DATA_FILE_EXTENSION);
+  FeaturesVectorTest features(path);
+  auto const relation = features.GetVector().GetRelation(2);
+
+  TEST(relation.GetType() == feature::RouteRelationBase::Type::Subway, ());
+  TEST_EQUAL(relation.GetRef(), "1", ());
+  TEST_EQUAL(relation.GetMembers().size(), 2, ());
 }
 }  // namespace features_vector_test

--- a/libs/indexer/shared_load_info.hpp
+++ b/libs/indexer/shared_load_info.hpp
@@ -56,10 +56,10 @@ public:
 private:
   FilesContainerR const & m_cont;
   DataHeader const & m_header;
+  feature::FeaturesOffsetsTable const * const m_relTable;
   std::optional<ModelReaderPtr> m_relsReader;
 
 public:
-  feature::FeaturesOffsetsTable const * m_relTable;
   indexer::MetadataDeserializer * m_metaDeserializer;
   feature::DatSectionHeader::Version m_version;
 


### PR DESCRIPTION
`FeaturesVectorTest` previously constructed `FeaturesVector` before loading its relation-offset table. `SharedLoadInfo` therefore did not open the relations reader, even though the table pointer was assigned afterward. Calling `GetRelation()` then asserted in Debug and dereferenced an empty optional in Release.

Make `FeaturesVectorTest` own its dependencies and pass them when constructing `FeaturesVector`. Keep the relation table immutable after construction, fail explicitly if its reader is unavailable, and add a regression test for standalone relation reading.

Found while investigating #13434 and #13435; this PR does not fix those rendering issues.

Tested: `indexer_tests --filter="FeaturesVectorTest_.*"`