### PR TITLE
[android] Fix map buttons cut off by system bars

### DIFF
--- a/android/app/src/main/java/app/organicmaps/maplayer/MapButtonsController.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/MapButtonsController.java
@@ -449,6 +449,19 @@ public class MapButtonsController extends Fragment
   }
 
   @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState)
+  {
+    super.onViewCreated(view, savedInstanceState);
+    // FragmentStateManager requests insets for the frame before onViewCreated(), but the dispatch
+    // itself only happens on the next layout pass — so a listener attached here still receives it.
+    // Attaching in onResume() is too late: the dispatch has already run and nothing re-requests
+    // insets for an already attached view, leaving the padding at zero.
+    ViewCompat.setOnApplyWindowInsetsListener(
+        view, WindowInsetUtils.PaddingInsetsListener.allSides(WindowInsetsCompat.Type.systemBars()
+                                                              | WindowInsetsCompat.Type.displayCutout()));
+  }
+
+  @Override
   public void onStart()
   {
     super.onStart();
@@ -465,6 +478,7 @@ public class MapButtonsController extends Fragment
     mMapButtonsViewModel.getTopButtonsMarginTop().observe(viewLifecycleOwner, mTopButtonMarginObserver);
   }
 
+  @Override
   public void onResume()
   {
     super.onResume();
@@ -473,19 +487,6 @@ public class MapButtonsController extends Fragment
     updateMenuBadge();
     updateLayerButton();
     updateHelpButtonIcon();
-    ViewCompat.setOnApplyWindowInsetsListener(
-        mFrame, WindowInsetUtils.PaddingInsetsListener.allSides(WindowInsetsCompat.Type.systemBars()
-                                                                | WindowInsetsCompat.Type.displayCutout()));
-    // Fixes insets on older Androids and with a search opened via API on all Androids.
-    if (mFrame.hasWindowFocus())
-      ViewCompat.requestApplyInsets(mFrame);
-  }
-
-  @Override
-  public void onPause()
-  {
-    ViewCompat.setOnApplyWindowInsetsListener(mFrame, null);
-    super.onPause();
   }
 
   @Override


### PR DESCRIPTION
Fixes #13382

## What

The map buttons frame could end up with zero padding and render under the status and navigation bars.

The inset listener was attached in `onResume()`. `FragmentStateManager` adds the frame to its container and calls `requestApplyInsets()` on it before that, but `requestApplyInsets()` only marks the tree and schedules a traversal -- the actual `dispatchApplyWindowInsets()` runs on the next layout pass. With the listener attached in `onResume()` that dispatch could run against a view that had no listener yet, and nothing re-requests insets for a view that is already attached, so the wrong padding stayed until something else triggered a window-wide dispatch -- which is why the reporter found that opening a place page fixed it (`PlacePageController` calls `requestApplyInsets`).

Attaching the listener in `onViewCreated()` puts it in place before that dispatch reaches the frame.

Also removed:
- the `hasWindowFocus()` guard -- it only mattered when the fragment was committed while the activity was already running, and in that case `FragmentStateManager` requests insets for the new view anyway, now with the listener already attached;
- the listener removal in `onPause()` -- it only lost inset changes.

## Testing

Pixel 6 / Android 17 and an Android 10 emulator: cold starts, rotation, and search with the keyboard open followed by rotation. Instrumented builds compared the frame padding against `getRootWindowInsets()` on every layout pass; no mismatch remained after the fix.

This is a race, not a fixed sequence of steps -- that is why nobody could write down reproduction steps.