### PR TITLE
[ios][drape] Actualize the macOS 13 / iOS 15 baselines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.22.1)
 
+# Must be set before project(): CMake bakes it into the toolchain checks. Ignored on non-Apple platforms.
+set(CMAKE_OSX_DEPLOYMENT_TARGET 13.0 CACHE STRING "Minimum supported macOS version")
+
 project(omim C CXX)
 
 set(CMAKE_CXX_STANDARD 23)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -155,6 +155,8 @@ sudo apk add \
 
 #### macOS
 
+**macOS 13 (Ventura)** or newer is required to run the desktop app.
+
 ```bash
 brew install cmake ninja qt@6
 ```

--- a/iphone/CLAUDE.md
+++ b/iphone/CLAUDE.md
@@ -91,7 +91,7 @@ Swift services/UI or legacy ObjC -> ObjC/ObjC++ wrappers (`MWM*`) -> CoreApi -> 
     -destination 'platform=iOS Simulator,name=<installed iPhone>' \
     build
   ```
-- Build settings: iOS 15.0, macOS 10.15, C++23, Swift 5.5
+- Build settings: iOS 15.0, macOS 13.0, C++23, Swift 5.5
 - App/build constants live in `xcode/common.xcconfig`, `xcode/common-debug.xcconfig`, and
   `xcode/common-release.xcconfig`
 - Entitlements: CarPlay, iCloud, Associated Domains (`applinks:omaps.app`), Push Notifications

--- a/iphone/CoreApi/CoreApi/Logger/Logger.mm
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.mm
@@ -119,61 +119,49 @@ static void * kFileLoggingQueueKey = &kFileLoggingQueueKey;
     }
     return [self getZippedLogFile:kLogFilePath];
   }
-  else
+
+  // Fetch logs from the OSLog store.
+  NSError * error;
+  OSLogStore * store = [OSLogStore storeWithScope:OSLogStoreCurrentProcessIdentifier error:&error];
+
+  if (error)
   {
-    // Fetch logs from the OSLog store.
-    if (@available(iOS 15.0, *))
+    LOG(LERROR, (error.localizedDescription.UTF8String));
+    return nil;
+  }
+
+  NSPredicate * predicate = [NSPredicate predicateWithFormat:@"subsystem == %@", kLoggerSubsystem];
+  OSLogEnumerator * enumerator = [store entriesEnumeratorWithOptions:{} position:nil predicate:predicate error:&error];
+
+  if (error)
+  {
+    LOG(LERROR, (error.localizedDescription.UTF8String));
+    return nil;
+  }
+
+  NSMutableString * logString = [NSMutableString string];
+  NSString * kNewLineStr = @"\n";
+
+  id object;
+  while (object = [enumerator nextObject])
+  {
+    if ([object isMemberOfClass:[OSLogEntryLog class]])
     {
-      NSError * error;
-      OSLogStore * store = [OSLogStore storeWithScope:OSLogStoreCurrentProcessIdentifier error:&error];
-
-      if (error)
-      {
-        LOG(LERROR, (error.localizedDescription.UTF8String));
-        return nil;
-      }
-
-      NSPredicate * predicate = [NSPredicate predicateWithFormat:@"subsystem == %@", kLoggerSubsystem];
-      OSLogEnumerator * enumerator = [store entriesEnumeratorWithOptions:{}
-                                                                position:nil
-                                                               predicate:predicate
-                                                                   error:&error];
-
-      if (error)
-      {
-        LOG(LERROR, (error.localizedDescription.UTF8String));
-        return nil;
-      }
-
-      NSMutableString * logString = [NSMutableString string];
-      NSString * kNewLineStr = @"\n";
-
-      id object;
-      while (object = [enumerator nextObject])
-      {
-        if ([object isMemberOfClass:[OSLogEntryLog class]])
-        {
-          [logString appendString:[object composedMessage]];
-          [logString appendString:kNewLineStr];
-        }
-      }
-
-      if (logString.length == 0)
-      {
-        LOG(LINFO, ("OSLog entry is empty."));
-        return nil;
-      }
-
-      [NSFileManager.defaultManager createFileAtPath:kLogFilePath
-                                            contents:[logString dataUsingEncoding:NSUTF8StringEncoding]
-                                          attributes:nil];
-      return [self getZippedLogFile:kLogFilePath];
-    }
-    else
-    {
-      return nil;
+      [logString appendString:[object composedMessage]];
+      [logString appendString:kNewLineStr];
     }
   }
+
+  if (logString.length == 0)
+  {
+    LOG(LINFO, ("OSLog entry is empty."));
+    return nil;
+  }
+
+  [NSFileManager.defaultManager createFileAtPath:kLogFilePath
+                                        contents:[logString dataUsingEncoding:NSUTF8StringEncoding]
+                                      attributes:nil];
+  return [self getZippedLogFile:kLogFilePath];
 }
 
 + (uint64_t)getLogFileSize

--- a/iphone/Maps/Core/CarPlay/Template Builders/ListTemplateBuilder.swift
+++ b/iphone/Maps/Core/CarPlay/Template Builders/ListTemplateBuilder.swift
@@ -105,14 +105,12 @@ final class ListTemplateBuilder {
       item.handler = Self.itemHandler
       return item
     }
-    if #available(iOS 15.0, *) {
-      let maxItemCount = CPListTemplate.maximumItemCount - 1
-      if items.count >= maxItemCount {
-        items = Array(items.prefix(maxItemCount))
-        let cropWarning = CPListItem(text: L("not_all_shown_bookmarks_carplay"), detailText: L("switch_to_phone_bookmarks_carplay"))
-        cropWarning.isEnabled = false
-        items.append(cropWarning)
-      }
+    let maxItemCount = CPListTemplate.maximumItemCount - 1
+    if items.count >= maxItemCount {
+      items = Array(items.prefix(maxItemCount))
+      let cropWarning = CPListItem(text: L("not_all_shown_bookmarks_carplay"), detailText: L("switch_to_phone_bookmarks_carplay"))
+      cropWarning.isEnabled = false
+      items.append(cropWarning)
     }
     let section = CPListSection(items: items)
     template.updateSections([section])

--- a/iphone/Maps/Core/Location/MWMLocationManager.mm
+++ b/iphone/Maps/Core/Location/MWMLocationManager.mm
@@ -507,22 +507,18 @@ void setShowLocationAlert(BOOL needShow)
     return;
 
 #if TARGET_OS_SIMULATOR
-  // There is no simulator < 15.0 in the new XCode.
-  if (@available(iOS 15.0, *))
-  {
-    // iOS Simulator doesn't provide any elevation in its locations. Mock it.
-    static MountainElevationGenerator generator;
-    location = [[CLLocation alloc] initWithCoordinate:location.coordinate
-                                             altitude:generator.NextElevation()
-                                   horizontalAccuracy:location.horizontalAccuracy
-                                     verticalAccuracy:location.horizontalAccuracy
-                                               course:location.course
-                                       courseAccuracy:location.courseAccuracy
-                                                speed:location.speed
-                                        speedAccuracy:location.speedAccuracy
-                                            timestamp:location.timestamp
-                                           sourceInfo:location.sourceInformation];
-  }
+  // iOS Simulator doesn't provide any elevation in its locations. Mock it.
+  static MountainElevationGenerator generator;
+  location = [[CLLocation alloc] initWithCoordinate:location.coordinate
+                                           altitude:generator.NextElevation()
+                                 horizontalAccuracy:location.horizontalAccuracy
+                                   verticalAccuracy:location.horizontalAccuracy
+                                             course:location.course
+                                     courseAccuracy:location.courseAccuracy
+                                              speed:location.speed
+                                      speedAccuracy:location.speedAccuracy
+                                          timestamp:location.timestamp
+                                         sourceInfo:location.sourceInformation];
 #endif
 
   self.lastLocationStatus = MWMLocationStatusNoError;

--- a/libs/drape/metal/metal_base_context.mm
+++ b/libs/drape/metal/metal_base_context.mm
@@ -5,13 +5,9 @@
 
 #include "base/assert.hpp"
 
-#include "std/target_os.hpp"
-
-#include <algorithm>
 #include <functional>
 #include <string>
 #include <utility>
-#include <vector>
 
 namespace dp
 {
@@ -68,52 +64,22 @@ std::string MetalBaseContext::GetRendererName() const
   return std::string([m_device.name UTF8String]);
 }
 
-// TODO(AB): Remove after min supported iOS version is 13+ and replace deprecated MTLFeatureSet with MTLGPUFamily.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 std::string MetalBaseContext::GetRendererVersion() const
 {
-  static std::vector<std::pair<MTLFeatureSet, std::string>> features;
-  if (features.empty())
-  {
-#ifdef OMIM_OS_MAC
-    features.emplace_back(MTLFeatureSet_macOS_GPUFamily1_v1, "macOS_GPUFamily1_v1");
-    features.emplace_back(MTLFeatureSet_macOS_GPUFamily1_v2, "macOS_GPUFamily1_v2");
-    if (@available(macOS 10.13, *))
-      features.emplace_back(MTLFeatureSet_macOS_GPUFamily1_v3, "macOS_GPUFamily1_v3");
-    if (@available(macOS 10.14, *))
-    {
-      features.emplace_back(MTLFeatureSet_macOS_GPUFamily1_v4, "macOS_GPUFamily1_v4");
-      features.emplace_back(MTLFeatureSet_macOS_GPUFamily2_v1, "macOS_GPUFamily2_v1");
-    }
-#else
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily1_v1, "iOS_GPUFamily1_v1");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily2_v1, "iOS_GPUFamily2_v1");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily1_v2, "iOS_GPUFamily1_v2");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily2_v2, "iOS_GPUFamily2_v2");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily3_v1, "iOS_GPUFamily3_v1");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily1_v3, "iOS_GPUFamily1_v3");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily2_v3, "iOS_GPUFamily2_v3");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily3_v2, "iOS_GPUFamily3_v2");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily1_v4, "iOS_GPUFamily1_v4");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily2_v4, "iOS_GPUFamily2_v4");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily3_v3, "iOS_GPUFamily3_v3");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily4_v1, "iOS_GPUFamily4_v1");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily1_v5, "iOS_GPUFamily1_v5");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily2_v5, "iOS_GPUFamily2_v5");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily3_v4, "iOS_GPUFamily3_v4");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily4_v2, "iOS_GPUFamily4_v2");
-    features.emplace_back(MTLFeatureSet_iOS_GPUFamily5_v1, "iOS_GPUFamily5_v1");
-#endif
-    std::sort(features.begin(), features.end(), [](auto const & s1, auto const & s2) { return s1.first > s2.first; });
-  }
+  // Ordered from the most specific family to the least: the first match is the most informative.
+  // Unsupported values simply return NO, so one list covers both iOS and macOS (Apple Silicon included).
+  static constexpr std::pair<MTLGPUFamily, char const *> kFamilies[] = {
+      {MTLGPUFamilyApple9, "Apple9"},  {MTLGPUFamilyApple8, "Apple8"},   {MTLGPUFamilyApple7, "Apple7"},
+      {MTLGPUFamilyApple6, "Apple6"},  {MTLGPUFamilyApple5, "Apple5"},   {MTLGPUFamilyApple4, "Apple4"},
+      {MTLGPUFamilyApple3, "Apple3"},  {MTLGPUFamilyApple2, "Apple2"},   {MTLGPUFamilyApple1, "Apple1"},
+      {MTLGPUFamilyMac2, "Mac2"},      {MTLGPUFamilyCommon3, "Common3"}, {MTLGPUFamilyCommon2, "Common2"},
+      {MTLGPUFamilyCommon1, "Common1"}};
 
-  for (auto featureSet : features)
-    if ([m_device supportsFeatureSet:featureSet.first])
-      return featureSet.second;
+  for (auto const & [family, name] : kFamilies)
+    if ([m_device supportsFamily:family])
+      return name;
   return "Unknown";
 }
-#pragma clang diagnostic pop
 
 void MetalBaseContext::PushDebugLabel(std::string const & label)
 {

--- a/xcode/common.xcconfig
+++ b/xcode/common.xcconfig
@@ -9,8 +9,8 @@ FRAMEWORK_SEARCH_PATHS[sdk=macosx*] = $(QT_PATH)/lib
 
 // Deployment target
 IPHONEOS_DEPLOYMENT_TARGET = 15.0
-// The minimum version that properly supports Qt6's std::filesystem for C++17
-MACOSX_DEPLOYMENT_TARGET = 10.15
+// macOS 11/12 are no longer supported; 13.0 is also the floor for Metal 3 APIs.
+MACOSX_DEPLOYMENT_TARGET = 13.0
 
 // Supported platforms
 SUPPORTED_PLATFORMS = macosx iphonesimulator iphoneos


### PR DESCRIPTION
Actualizes the macOS 13 / iOS 15 deployment baselines and removes the availability guards and deprecated Metal APIs they unlock.