### PR TITLE
[ios] Logging improvements and fixes

### DIFF
--- a/iphone/CoreApi/CoreApi.xcodeproj/project.pbxproj
+++ b/iphone/CoreApi/CoreApi.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		9957FADC237ACB1100855F48 /* DeepLinkSearchData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9957FADA237ACB1100855F48 /* DeepLinkSearchData.mm */; };
 		9957FAE8237AE5B000855F48 /* Logger.h in Headers */ = {isa = PBXBuildFile; fileRef = 9957FAE6237AE5B000855F48 /* Logger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9957FAE9237AE5B000855F48 /* Logger.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9957FAE7237AE5B000855F48 /* Logger.mm */; };
+		AB10ADAD2026081200000012 /* LogFileWriter.mm in Sources */ = {isa = PBXBuildFile; fileRef = AB10ADAD2026081200000011 /* LogFileWriter.mm */; };
 		9974CA2923DF1968003FE824 /* ElevationProfileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 9974CA2723DF1968003FE824 /* ElevationProfileData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9974CA2A23DF1968003FE824 /* ElevationProfileData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9974CA2823DF1968003FE824 /* ElevationProfileData.mm */; };
 		9974CA2D23DF197B003FE824 /* ElevationProfileData+Core.h in Headers */ = {isa = PBXBuildFile; fileRef = 9974CA2B23DF197B003FE824 /* ElevationProfileData+Core.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -198,6 +199,8 @@
 		9957FADA237ACB1100855F48 /* DeepLinkSearchData.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DeepLinkSearchData.mm; sourceTree = "<group>"; };
 		9957FAE6237AE5B000855F48 /* Logger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Logger.h; sourceTree = "<group>"; };
 		9957FAE7237AE5B000855F48 /* Logger.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Logger.mm; sourceTree = "<group>"; };
+		AB10ADAD2026081200000010 /* LogFileWriter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LogFileWriter.h; sourceTree = "<group>"; };
+		AB10ADAD2026081200000011 /* LogFileWriter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LogFileWriter.mm; sourceTree = "<group>"; };
 		9974CA2723DF1968003FE824 /* ElevationProfileData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ElevationProfileData.h; sourceTree = "<group>"; };
 		9974CA2823DF1968003FE824 /* ElevationProfileData.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ElevationProfileData.mm; sourceTree = "<group>"; };
 		9974CA2B23DF197B003FE824 /* ElevationProfileData+Core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ElevationProfileData+Core.h"; sourceTree = "<group>"; };
@@ -473,6 +476,8 @@
 		9957FAE5237AE59C00855F48 /* Logger */ = {
 			isa = PBXGroup;
 			children = (
+				AB10ADAD2026081200000010 /* LogFileWriter.h */,
+				AB10ADAD2026081200000011 /* LogFileWriter.mm */,
 				9957FAE6237AE5B000855F48 /* Logger.h */,
 				9957FAE7237AE5B000855F48 /* Logger.mm */,
 			);
@@ -704,6 +709,7 @@
 				EDA1A0022F12345600ABCD01 /* RouteElevationPreviewData.mm in Sources */,
 				ED46DE3A2D09BE21007CACD6 /* PlacePageTrackData.mm in Sources */,
 				47CA68DE2502022400671019 /* MWMBookmark.mm in Sources */,
+				AB10ADAD2026081200000012 /* LogFileWriter.mm in Sources */,
 				9957FAE9237AE5B000855F48 /* Logger.mm in Sources */,
 				ED965B222CD8F5AA0049E39E /* DurationFormatter.mm in Sources */,
 			);

--- a/iphone/CoreApi/CoreApi/Logger/LogFileWriter.h
+++ b/iphone/CoreApi/CoreApi/Logger/LogFileWriter.h
@@ -1,0 +1,33 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Manages the current and rotated diagnostic log files. Its caller is responsible for invoking
+/// every method except totalFileSize from one queue.
+@interface LogFileWriter : NSObject
+
+@property(nonatomic, readonly) NSString * currentFilePath;
+@property(nonatomic, readonly) NSString * rotatedFilePath;
+@property(nonatomic, readonly, getter=isOpen) BOOL open;
+
+- (instancetype)initWithDirectoryPath:(NSString *)directoryPath maxFileSize:(uint64_t)maxFileSize;
+- (instancetype)initWithDirectoryPath:(NSString *)directoryPath
+                          maxFileSize:(uint64_t)maxFileSize
+                          fileManager:(NSFileManager *)fileManager NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+- (BOOL)openWithError:(NSError * __autoreleasing _Nullable * _Nullable)error;
+- (BOOL)writeData:(NSData *)data error:(NSError * __autoreleasing _Nullable * _Nullable)error;
+- (BOOL)closeWithError:(NSError * __autoreleasing _Nullable * _Nullable)error;
+- (BOOL)closeAndRemoveFilesWithError:(NSError * __autoreleasing _Nullable * _Nullable)error;
+
+/// Copies the rotated file, when present, followed by the required current file.
+- (nullable NSArray<NSString *> *)copyLogFilesToDirectory:(NSString *)directoryPath
+                                                    error:(NSError * __autoreleasing _Nullable * _Nullable)error;
+
+/// Reads only immutable paths and filesystem attributes, so callers may use it from any queue.
+- (uint64_t)totalFileSize;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iphone/CoreApi/CoreApi/Logger/LogFileWriter.h
+++ b/iphone/CoreApi/CoreApi/Logger/LogFileWriter.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSString * rotatedFilePath;
 @property(nonatomic, readonly, getter=isOpen) BOOL open;
 
+/// |maxFileSize| is the per-file cap. One rotated file may also be retained.
 - (instancetype)initWithDirectoryPath:(NSString *)directoryPath maxFileSize:(uint64_t)maxFileSize;
 - (instancetype)initWithDirectoryPath:(NSString *)directoryPath
                           maxFileSize:(uint64_t)maxFileSize
@@ -21,11 +22,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)closeWithError:(NSError * __autoreleasing _Nullable * _Nullable)error;
 - (BOOL)closeAndRemoveFilesWithError:(NSError * __autoreleasing _Nullable * _Nullable)error;
 
-/// Copies the rotated file, when present, followed by the required current file.
+/// Copies every existing log file, with the rotated file first. Returns an empty array when no log
+/// file exists. The current file may be absent after a failed rotation reopen.
 - (nullable NSArray<NSString *> *)copyLogFilesToDirectory:(NSString *)directoryPath
                                                     error:(NSError * __autoreleasing _Nullable * _Nullable)error;
 
-/// Reads only immutable paths and filesystem attributes, so callers may use it from any queue.
+/// Does not access queue-confined in-memory state, so callers may use it from any queue.
 - (uint64_t)totalFileSize;
 
 @end

--- a/iphone/CoreApi/CoreApi/Logger/LogFileWriter.mm
+++ b/iphone/CoreApi/CoreApi/Logger/LogFileWriter.mm
@@ -1,0 +1,202 @@
+#import "LogFileWriter.h"
+
+namespace
+{
+NSString * const kCurrentLogFileName = @"log.txt";
+NSString * const kRotatedLogFileName = @"log.1.txt";
+NSString * const kLogFileWriterErrorDomain = @"app.organicmaps.LogFileWriter";
+
+typedef NS_ERROR_ENUM(kLogFileWriterErrorDomain, LogFileWriterError){
+    LogFileWriterErrorInvalidCurrentFile = 1,
+    LogFileWriterErrorOpenFailed,
+    LogFileWriterErrorNotOpen,
+};
+
+BOOL SetError(NSError * __autoreleasing _Nullable * _Nullable error, LogFileWriterError code, NSString * description)
+{
+  if (error != nullptr)
+    *error = [NSError errorWithDomain:kLogFileWriterErrorDomain
+                                 code:code
+                             userInfo:@{NSLocalizedDescriptionKey: description}];
+  return NO;
+}
+}  // namespace
+
+@interface LogFileWriter ()
+
+@property(nonatomic) NSString * directoryPath;
+@property(nonatomic) uint64_t maxFileSize;
+@property(nonatomic) NSFileManager * fileManager;
+@property(nullable, nonatomic) NSFileHandle * fileHandle;
+@property(nonatomic) uint64_t currentFileSize;
+
+@end
+
+@implementation LogFileWriter
+
+- (instancetype)initWithDirectoryPath:(NSString *)directoryPath maxFileSize:(uint64_t)maxFileSize
+{
+  return [self initWithDirectoryPath:directoryPath maxFileSize:maxFileSize fileManager:NSFileManager.defaultManager];
+}
+
+- (instancetype)initWithDirectoryPath:(NSString *)directoryPath
+                          maxFileSize:(uint64_t)maxFileSize
+                          fileManager:(NSFileManager *)fileManager
+{
+  NSParameterAssert(directoryPath.length > 0);
+  NSParameterAssert(maxFileSize > 0);
+  NSParameterAssert(fileManager != nil);
+  self = [super init];
+  if (self)
+  {
+    _directoryPath = [directoryPath copy];
+    _maxFileSize = maxFileSize;
+    _fileManager = fileManager;
+    _currentFilePath = [_directoryPath stringByAppendingPathComponent:kCurrentLogFileName];
+    _rotatedFilePath = [_directoryPath stringByAppendingPathComponent:kRotatedLogFileName];
+  }
+  return self;
+}
+
+- (void)dealloc
+{
+  [_fileHandle closeAndReturnError:nil];
+}
+
+- (BOOL)isOpen
+{
+  return self.fileHandle != nil;
+}
+
+- (BOOL)openWithError:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
+  if (self.isOpen)
+    return YES;
+
+  if (![self.fileManager createDirectoryAtPath:self.directoryPath
+                   withIntermediateDirectories:YES
+                                    attributes:nil
+                                         error:error])
+    return NO;
+
+  // A diagnostic log can contain locations, so it must never reach a backup. Set on every open, so
+  // that a directory recreated behind our back does not silently lose the flag.
+  NSURL * directoryURL = [NSURL fileURLWithPath:self.directoryPath isDirectory:YES];
+  if (![directoryURL setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:error])
+    return NO;
+
+  BOOL isDirectory = NO;
+  BOOL const exists = [self.fileManager fileExistsAtPath:self.currentFilePath isDirectory:&isDirectory];
+  if (exists && isDirectory)
+    return SetError(error, LogFileWriterErrorInvalidCurrentFile, @"The current log path is a directory.");
+
+  if (!exists && ![self.fileManager createFileAtPath:self.currentFilePath contents:nil attributes:nil])
+    return SetError(error, LogFileWriterErrorOpenFailed, @"Failed to create the current log file.");
+
+  NSFileHandle * fileHandle = [NSFileHandle fileHandleForWritingAtPath:self.currentFilePath];
+  if (fileHandle == nil)
+    return SetError(error, LogFileWriterErrorOpenFailed, @"Failed to open the current log file.");
+
+  unsigned long long offset = 0;
+  if (![fileHandle seekToEndReturningOffset:&offset error:error])
+  {
+    [fileHandle closeAndReturnError:nil];
+    return NO;
+  }
+
+  self.fileHandle = fileHandle;
+  self.currentFileSize = offset;
+  return YES;
+}
+
+- (BOOL)writeData:(NSData *)data error:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
+  if (!self.isOpen)
+    return SetError(error, LogFileWriterErrorNotOpen, @"The log file is not open.");
+
+  uint64_t const dataSize = data.length;
+  if (self.currentFileSize > 0 && self.currentFileSize + dataSize > self.maxFileSize && ![self rotateWithError:error])
+    return NO;
+
+  if (![self.fileHandle writeData:data error:error])
+    return NO;
+
+  self.currentFileSize += dataSize;
+  return YES;
+}
+
+- (BOOL)closeWithError:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
+  NSFileHandle * fileHandle = self.fileHandle;
+  self.fileHandle = nil;
+  self.currentFileSize = 0;
+  return fileHandle == nil || [fileHandle closeAndReturnError:error];
+}
+
+- (BOOL)closeAndRemoveFilesWithError:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
+  NSError * firstError = nil;
+  // Continue removing the files after a close error so an explicit disable leaves no diagnostic data behind.
+  [self closeWithError:&firstError];
+
+  for (NSString * filePath in @[self.currentFilePath, self.rotatedFilePath])
+  {
+    if (![self.fileManager fileExistsAtPath:filePath])
+      continue;
+
+    NSError * removeError = nil;
+    if (![self.fileManager removeItemAtPath:filePath error:&removeError] && firstError == nil)
+      firstError = removeError;
+  }
+
+  if (error != nullptr)
+    *error = firstError;
+  return firstError == nil;
+}
+
+- (nullable NSArray<NSString *> *)copyLogFilesToDirectory:(NSString *)directoryPath
+                                                    error:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
+  // The rotated file is optional, the current one is required.
+  NSArray<NSString *> * sourcePaths = [self.fileManager fileExistsAtPath:self.rotatedFilePath]
+                                        ? @[self.rotatedFilePath, self.currentFilePath]
+                                        : @[self.currentFilePath];
+  NSMutableArray<NSString *> * copies = [NSMutableArray arrayWithCapacity:sourcePaths.count];
+  for (NSString * sourcePath in sourcePaths)
+  {
+    NSString * destinationPath = [directoryPath stringByAppendingPathComponent:sourcePath.lastPathComponent];
+    if (![self.fileManager copyItemAtPath:sourcePath toPath:destinationPath error:error])
+      return nil;
+    [copies addObject:destinationPath];
+  }
+  return copies;
+}
+
+- (uint64_t)totalFileSize
+{
+  uint64_t totalSize = 0;
+  for (NSString * filePath in @[self.currentFilePath, self.rotatedFilePath])
+  {
+    NSDictionary<NSFileAttributeKey, id> * attributes = [self.fileManager attributesOfItemAtPath:filePath error:nil];
+    totalSize += attributes.fileSize;
+  }
+  return totalSize;
+}
+
+- (BOOL)rotateWithError:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
+  if (![self closeWithError:error])
+    return NO;
+
+  if ([self.fileManager fileExistsAtPath:self.rotatedFilePath] &&
+      ![self.fileManager removeItemAtPath:self.rotatedFilePath error:error])
+    return NO;
+
+  if (![self.fileManager moveItemAtPath:self.currentFilePath toPath:self.rotatedFilePath error:error])
+    return NO;
+
+  // The current file is gone after the move, and opening recreates it.
+  return [self openWithError:error];
+}
+
+@end

--- a/iphone/CoreApi/CoreApi/Logger/LogFileWriter.mm
+++ b/iphone/CoreApi/CoreApi/Logger/LogFileWriter.mm
@@ -157,10 +157,12 @@ BOOL SetError(NSError * __autoreleasing _Nullable * _Nullable error, LogFileWrit
 - (nullable NSArray<NSString *> *)copyLogFilesToDirectory:(NSString *)directoryPath
                                                     error:(NSError * __autoreleasing _Nullable * _Nullable)error
 {
-  // The rotated file is optional, the current one is required.
-  NSArray<NSString *> * sourcePaths = [self.fileManager fileExistsAtPath:self.rotatedFilePath]
-                                        ? @[self.rotatedFilePath, self.currentFilePath]
-                                        : @[self.currentFilePath];
+  NSMutableArray<NSString *> * sourcePaths = [NSMutableArray arrayWithCapacity:2];
+  if ([self.fileManager fileExistsAtPath:self.rotatedFilePath])
+    [sourcePaths addObject:self.rotatedFilePath];
+  if ([self.fileManager fileExistsAtPath:self.currentFilePath])
+    [sourcePaths addObject:self.currentFilePath];
+
   NSMutableArray<NSString *> * copies = [NSMutableArray arrayWithCapacity:sourcePaths.count];
   for (NSString * sourcePath in sourcePaths)
   {

--- a/iphone/CoreApi/CoreApi/Logger/Logger.h
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.h
@@ -16,11 +16,28 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 /// Reading it back reports the state the logger is actually in: enabling fails if the log
 /// file cannot be opened.
 @property(class, nonatomic) BOOL fileLoggingEnabled;
+@property(class, readonly, nonatomic) NSNotificationName fileLoggingStateDidChangeNotification;
 
 + (void)log:(LogLevel)level message:(NSString *)message;
 + (BOOL)canLog:(LogLevel)level;
-+ (nullable NSURL *)getLogFileURL;
+
+/// Creates a zipped diagnostic log, or rebuilds one from the system log when file logging is off.
+/// The completion runs on a background queue with nil if the archive cannot be created.
++ (void)getLogArchiveWithCompletion:(void (^)(NSData * _Nullable archiveData))completion;
+
+/// Calls |completion| on the file logging queue after all previously submitted writes finish.
++ (void)flushWithCompletion:(dispatch_block_t)completion;
+
+/// Waits for all previously submitted writes. Lifecycle code should prefer the asynchronous flush
+/// whenever the process is expected to continue running.
++ (void)flushSynchronously;
+
+/// Total size of the diagnostic log files.
 + (uint64_t)getLogFileSize;
+
+/// Removes the log that versions before the move to Application Support left in Documents, which is
+/// user-visible and backed up. Documents is writable by the user, so run this migration only once.
++ (void)removeLegacyLogFile;
 
 @end
 

--- a/iphone/CoreApi/CoreApi/Logger/Logger.h
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.h
@@ -12,9 +12,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
 @interface Logger : NSObject
 
+/// Detailed diagnostic logging into a file. Enabling it also unlocks the debug log level.
+/// Reading it back reports the state the logger is actually in: enabling fails if the log
+/// file cannot be opened.
+@property(class, nonatomic) BOOL fileLoggingEnabled;
+
 + (void)log:(LogLevel)level message:(NSString *)message;
 + (BOOL)canLog:(LogLevel)level;
-+ (void)setFileLoggingEnabled:(BOOL)fileLoggingEnabled;
 + (nullable NSURL *)getLogFileURL;
 + (uint64_t)getLogFileSize;
 

--- a/iphone/CoreApi/CoreApi/Logger/Logger.h
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.h
@@ -10,20 +10,27 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
   LogLevelCritical
 };
 
+typedef void (^LogArchiveCompletion)(NSData * _Nullable archiveData, NSError * _Nullable error);
+
 @interface Logger : NSObject
 
 /// Detailed diagnostic logging into a file. Enabling it also unlocks the debug log level.
 /// Reading it back reports the state the logger is actually in: enabling fails if the log
 /// file cannot be opened.
 @property(class, nonatomic) BOOL fileLoggingEnabled;
+/// The notification object is the error that stopped file logging, or nil for a requested state
+/// change.
 @property(class, readonly, nonatomic) NSNotificationName fileLoggingStateDidChangeNotification;
+
+/// Applies the requested state synchronously and reports an open, close or removal failure.
++ (BOOL)setFileLoggingEnabled:(BOOL)enabled error:(NSError * __autoreleasing _Nullable * _Nullable)error;
 
 + (void)log:(LogLevel)level message:(NSString *)message;
 + (BOOL)canLog:(LogLevel)level;
 
-/// Creates a zipped diagnostic log, or rebuilds one from the system log when file logging is off.
-/// The completion runs on a background queue with nil if the archive cannot be created.
-+ (void)getLogArchiveWithCompletion:(void (^)(NSData * _Nullable archiveData))completion;
+/// Creates a zipped diagnostic report from the system log and every retained file log. Exactly one
+/// completion argument is nonnull, and the completion always runs on a background utility queue.
++ (void)getLogArchiveWithCompletion:(LogArchiveCompletion)completion;
 
 /// Calls |completion| on the file logging queue after all previously submitted writes finish.
 + (void)flushWithCompletion:(dispatch_block_t)completion;

--- a/iphone/CoreApi/CoreApi/Logger/Logger.mm
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.mm
@@ -1,29 +1,37 @@
 #import "Logger.h"
 #import <OSLog/OSLog.h>
-#import <UIKit/UIKit.h>
+#import "LogFileWriter.h"
 
 #include "base/assert.hpp"
+#include "base/exception.hpp"
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
+#include "coding/file_writer.hpp"
 #include "coding/zip_creator.hpp"
 
 #include <atomic>
 #include <string>
+#include <vector>
 
 @interface Logger ()
 
-@property(nullable, nonatomic) NSFileHandle * fileHandle;
+@property(nonnull, nonatomic) LogFileWriter * fileWriter;
 @property(nonnull, nonatomic) os_log_t osLogger;
 @property(class, readonly, nonatomic) dispatch_queue_t fileLoggingQueue;
 
 + (Logger *)logger;
 + (void)enableFileLogging;
 + (void)disableFileLogging;
++ (void)setFileLoggingState:(BOOL)enabled;
++ (void)handleFileLoggingError:(NSError *)error;
 + (void)runSyncOnFileLoggingQueue:(dispatch_block_t)block;
 + (void)logMessageWithLevel:(base::LogLevel)level src:(base::SrcPoint const &)src message:(std::string const &)message;
 + (void)tryWriteToFile:(std::string const &)logString;
-+ (NSURL *)getZippedLogFile:(NSString *)logFilePath;
++ (nullable NSString *)createTemporaryDirectory;
++ (nullable NSData *)archiveFiles:(NSArray<NSString *> *)filePaths inDirectory:(NSString *)directoryPath;
++ (nullable NSData *)archiveOSLogStoreReport;
 + (void)removeFileAtPath:(NSString *)filePath;
++ (void)reportSystemMessage:(NSString *)message type:(os_log_type_t)type;
 + (base::LogLevel)baseLevel:(LogLevel)level;
 
 @end
@@ -32,11 +40,20 @@
 NSString * const kLoggerSubsystem = [[NSBundle mainBundle] bundleIdentifier];
 NSString * const kLoggerCategory = @"OM";
 NSString * const kLogFileName = @"log.txt";
-NSString * const kZipLogFileExtension = @"zip";
-NSString * const kLogFilePath = [[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)
+NSString * const kZipLogFileName = @"log.zip";
+
+// A diagnostic log is collected on request and has to survive until the user sends it, so it cannot
+// live in Caches, which the system purges under storage pressure. Application Support is not
+// exposed to the Files app the way Documents is, and LogFileWriter excludes it from backups.
+NSString * const kLogDirectoryPath =
+    [[NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) firstObject]
+        stringByAppendingPathComponent:@"Logs"];
+NSString * const kLegacyLogFilePath = [[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)
     firstObject] stringByAppendingPathComponent:kLogFileName];
-// TODO: (KK) Review and change this limit after some testing.
-NSUInteger const kMaxLogFileSize = 1024 * 1024 * 100;  // 100 MB;
+
+// Rotate a nonempty current file before a write would cross 16 MiB. One rotated file is retained.
+// Oversized records stay intact and may exceed this target.
+uint64_t constexpr kMaxLogFileSize = 16 * 1024 * 1024;
 
 // The unified logging implementation silently cuts a single record and renders the loss as "<…>"
 // on retrieval. The observed limit is 1015 bytes, but it is not a public constant, so stay below
@@ -48,7 +65,7 @@ size_t constexpr kMaxSystemLogRecordSize = 900;
 static std::string TruncateForSystemLog(std::string const & logString)
 {
   auto const marker = " [truncated, " + std::to_string(logString.size()) +
-                      " bytes total, enable logging in Settings to get the full record]";
+                      " bytes total; diagnostic file logging preserves full records when enabled]";
   ASSERT_LESS(marker.size(), kMaxSystemLogRecordSize, ());
   auto const prefix = strings::TruncateUtf8(logString, kMaxSystemLogRecordSize - marker.size());
   return std::string{prefix} + marker;
@@ -75,6 +92,7 @@ static os_log_type_t OSLogTypeFor(base::LogLevel level)
 /// Read from any thread on every log call, mutated on the fileLoggingQueue only.
 static std::atomic<bool> _fileLoggingEnabled{false};
 static void * kFileLoggingQueueKey = &kFileLoggingQueueKey;
+NSNotificationName const kFileLoggingStateDidChangeNotification = @"FileLoggingStateDidChangeNotification";
 
 + (void)initialize
 {
@@ -82,15 +100,6 @@ static void * kFileLoggingQueueKey = &kFileLoggingQueueKey;
   {
     SetLogMessageFn(&LogMessage);
     SetAssertFunction(&AssertMessage);
-    // Ordinary records are written asynchronously, so the ones that are still queued would be lost
-    // if the app is killed while suspended. An empty block on the serial queue waits for them.
-    [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidEnterBackgroundNotification
-                                                    object:nil
-                                                     queue:nil
-                                                usingBlock:^(NSNotification *) {
-                                                  if ([self fileLoggingEnabled])
-                                                    [self runSyncOnFileLoggingQueue:^{}];
-                                                }];
   }
 }
 
@@ -119,7 +128,10 @@ static void * kFileLoggingQueueKey = &kFileLoggingQueueKey;
 {
   self = [super init];
   if (self)
+  {
     _osLogger = os_log_create(kLoggerSubsystem.UTF8String, kLoggerCategory.UTF8String);
+    _fileWriter = [[LogFileWriter alloc] initWithDirectoryPath:kLogDirectoryPath maxFileSize:kMaxLogFileSize];
+  }
   return self;
 }
 
@@ -127,18 +139,25 @@ static void * kFileLoggingQueueKey = &kFileLoggingQueueKey;
 
 + (void)setFileLoggingEnabled:(BOOL)fileLoggingEnabled
 {
+  BOOL const wasEnabled = self.fileLoggingEnabled;
   fileLoggingEnabled ? [self enableFileLogging] : [self disableFileLogging];
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
+  BOOL const isEnabled = self.fileLoggingEnabled;
+  if (!wasEnabled && isEnabled)
+  {
     LOG_SHORT(LINFO, ("Local time:", NSDate.date.description.UTF8String,
                       ", Time Zone:", NSTimeZone.defaultTimeZone.abbreviation.UTF8String));
-  });
-  LOG(LINFO, ("File logging is enabled:", [self fileLoggingEnabled] ? "YES" : "NO"));
+  }
+  LOG(LINFO, ("File logging is enabled:", isEnabled ? "YES" : "NO"));
 }
 
 + (BOOL)fileLoggingEnabled
 {
   return _fileLoggingEnabled.load(std::memory_order_relaxed);
+}
+
++ (NSNotificationName)fileLoggingStateDidChangeNotification
+{
+  return kFileLoggingStateDidChangeNotification;
 }
 
 + (void)log:(LogLevel)level message:(NSString *)message
@@ -151,84 +170,62 @@ static void * kFileLoggingQueueKey = &kFileLoggingQueueKey;
   return [Logger baseLevel:level] >= base::g_LogLevel;
 }
 
-+ (nullable NSURL *)getLogFileURL
++ (void)getLogArchiveWithCompletion:(void (^)(NSData * _Nullable archiveData))completion
 {
-  if ([self fileLoggingEnabled])
+  // Files can outlive an enabled session: a write error stops logging but keeps them. Do not test
+  // the size alone - a session that has just been enabled has an empty file and still owns it.
+  if (![self fileLoggingEnabled] && [self getLogFileSize] == 0)
   {
-    // Drain the writes that are already submitted to the serial queue.
-    [self runSyncOnFileLoggingQueue:^{}];
-    if (![NSFileManager.defaultManager fileExistsAtPath:kLogFilePath])
-    {
-      LOG(LERROR, ("Log file doesn't exist while file logging is enabled:", kLogFilePath.UTF8String));
-      return nil;
-    }
-    return [self getZippedLogFile:kLogFilePath];
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{ completion([self archiveOSLogStoreReport]); });
+    return;
   }
-  else
-  {
-    // Fetch logs from the OSLog store.
-    if (@available(iOS 15.0, *))
+
+  // Only the snapshot runs on the file logging queue: it drains the writes that are already
+  // submitted and excludes the later ones. Archiving is seconds of work on a full log set, and
+  // synchronous error records would be stuck behind it.
+  dispatch_async([self fileLoggingQueue], ^{
+    NSString * directoryPath = [self createTemporaryDirectory];
+    if (directoryPath == nil)
     {
-      NSError * error;
-      OSLogStore * store = [OSLogStore storeWithScope:OSLogStoreCurrentProcessIdentifier error:&error];
-
-      if (error)
-      {
-        LOG(LERROR, (error.localizedDescription.UTF8String));
-        return nil;
-      }
-
-      NSPredicate * predicate = [NSPredicate predicateWithFormat:@"subsystem == %@", kLoggerSubsystem];
-      OSLogEnumerator * enumerator = [store entriesEnumeratorWithOptions:{}
-                                                                position:nil
-                                                               predicate:predicate
-                                                                   error:&error];
-
-      if (error)
-      {
-        LOG(LERROR, (error.localizedDescription.UTF8String));
-        return nil;
-      }
-
-      NSMutableString * logString = [NSMutableString string];
-      NSString * kNewLineStr = @"\n";
-
-      id object;
-      while (object = [enumerator nextObject])
-      {
-        if ([object isMemberOfClass:[OSLogEntryLog class]])
-        {
-          [logString appendString:[object composedMessage]];
-          [logString appendString:kNewLineStr];
-        }
-      }
-
-      if (logString.length == 0)
-      {
-        LOG(LINFO, ("OSLog entry is empty."));
-        return nil;
-      }
-
-      [NSFileManager.defaultManager createFileAtPath:kLogFilePath
-                                            contents:[logString dataUsingEncoding:NSUTF8StringEncoding]
-                                          attributes:nil];
-      return [self getZippedLogFile:kLogFilePath];
+      completion(nil);
+      return;
     }
-    else
+
+    NSError * error = nil;
+    NSArray<NSString *> * copies = [[self logger].fileWriter copyLogFilesToDirectory:directoryPath error:&error];
+    if (copies == nil)
     {
-      return nil;
+      [self reportSystemMessage:[NSString stringWithFormat:@"Failed to snapshot the diagnostic log: %@",
+                                                           error.localizedDescription]
+                           type:OS_LOG_TYPE_ERROR];
+      [self removeFileAtPath:directoryPath];
+      completion(nil);
+      return;
     }
-  }
+
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0),
+                   ^{ completion([self archiveFiles:copies inDirectory:directoryPath]); });
+  });
+}
+
++ (void)flushWithCompletion:(dispatch_block_t)completion
+{
+  dispatch_async([self fileLoggingQueue], completion);
+}
+
++ (void)flushSynchronously
+{
+  [self runSyncOnFileLoggingQueue:^{}];
 }
 
 + (uint64_t)getLogFileSize
 {
-  __block uint64_t fileSize = 0;
-  [self runSyncOnFileLoggingQueue:^{
-    NSFileHandle * fileHandle = [self logger].fileHandle;
-    fileSize = fileHandle != nil ? [fileHandle offsetInFile] : 0;
-  }];
-  return fileSize;
+  return [self logger].fileWriter.totalFileSize;
+}
+
++ (void)removeLegacyLogFile
+{
+  dispatch_async([self fileLoggingQueue], ^{ [self removeFileAtPath:kLegacyLogFilePath]; });
 }
 
 // MARK: - C++ injection
@@ -250,45 +247,54 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
 + (void)enableFileLogging
 {
   [self runSyncOnFileLoggingQueue:^{
-    Logger * logger = [self logger];
-    NSFileManager * fileManager = [NSFileManager defaultManager];
+    if ([self fileLoggingEnabled])
+      return;
 
-    // Create a log file if it doesn't exist and setup file handle for writing.
-    if (![fileManager fileExistsAtPath:kLogFilePath])
-      [fileManager createFileAtPath:kLogFilePath contents:nil attributes:nil];
-    NSFileHandle * fileHandle = [NSFileHandle fileHandleForWritingAtPath:kLogFilePath];
-    if (fileHandle == nil)
+    NSError * error = nil;
+    if (![[self logger].fileWriter openWithError:&error])
     {
-      LOG(LERROR, ("Failed to open log file for writing", kLogFilePath.UTF8String));
-      [self disableFileLogging];
+      [self handleFileLoggingError:error];
       return;
     }
-    // Clean up the file if it exceeds the maximum size.
-    if ([fileManager contentsAtPath:kLogFilePath].length > kMaxLogFileSize)
-      [fileHandle truncateFileAtOffset:0];
-
-    logger.fileHandle = fileHandle;
-
-    _fileLoggingEnabled.store(true, std::memory_order_relaxed);
-    // Debug records are worth formatting only when there is a file to keep them in, so the level
-    // follows the state the logger is actually in. Mirrors Android's
-    // LogsManager.nativeToggleCoreDebugLogs().
-    base::g_LogLevel = base::LDEBUG;
+    [self setFileLoggingState:YES];
   }];
 }
 
 + (void)disableFileLogging
 {
   [self runSyncOnFileLoggingQueue:^{
-    Logger * logger = [self logger];
-
-    _fileLoggingEnabled.store(false, std::memory_order_relaxed);
-    base::g_LogLevel = base::GetDefaultLogLevel();
-
-    [logger.fileHandle closeFile];
-    logger.fileHandle = nil;
-    [self removeFileAtPath:kLogFilePath];
+    [self setFileLoggingState:NO];
+    NSError * error = nil;
+    if (![[self logger].fileWriter closeAndRemoveFilesWithError:&error])
+      [self reportSystemMessage:error.localizedDescription type:OS_LOG_TYPE_ERROR];
   }];
+}
+
++ (void)setFileLoggingState:(BOOL)enabled
+{
+  dispatch_assert_queue([self fileLoggingQueue]);
+  bool const changed = _fileLoggingEnabled.exchange(enabled, std::memory_order_relaxed) != enabled;
+  // Debug records are formatted only when a file can retain them. This mirrors Android's
+  // LogsManager.nativeToggleCoreDebugLogs().
+  base::g_LogLevel = enabled ? base::LDEBUG : base::GetDefaultLogLevel();
+  if (!changed)
+    return;
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [NSNotificationCenter.defaultCenter postNotificationName:kFileLoggingStateDidChangeNotification object:nil];
+  });
+}
+
++ (void)handleFileLoggingError:(NSError *)error
+{
+  dispatch_assert_queue([self fileLoggingQueue]);
+  [self setFileLoggingState:NO];
+
+  // Stop writing, but keep whatever was collected: the failure can be transient (a full disk), and
+  // those records are what the user enabled logging for. Only an explicit disable removes them.
+  [[self logger].fileWriter closeWithError:nil];
+  [self reportSystemMessage:[@"File logging failed: " stringByAppendingString:error.localizedDescription]
+                       type:OS_LOG_TYPE_ERROR];
 }
 
 + (void)logMessageWithLevel:(base::LogLevel)level src:(base::SrcPoint const &)src message:(std::string const &)message
@@ -324,12 +330,13 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
 + (void)tryWriteToFile:(std::string const &)logString
 {
   dispatch_assert_queue([self fileLoggingQueue]);
-  NSFileHandle * fileHandle = [self logger].fileHandle;
-  if (fileHandle != nil)
-  {
-    [fileHandle seekToEndOfFile];
-    [fileHandle writeData:[NSData dataWithBytes:logString.c_str() length:logString.length()]];
-  }
+  if (![self fileLoggingEnabled])
+    return;
+
+  NSError * error = nil;
+  NSData * data = [NSData dataWithBytes:logString.data() length:logString.size()];
+  if (![[self logger].fileWriter writeData:data error:&error])
+    [self handleFileLoggingError:error];
 }
 
 + (void)runSyncOnFileLoggingQueue:(dispatch_block_t)block
@@ -340,30 +347,122 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
     dispatch_sync([self fileLoggingQueue], block);
 }
 
-+ (NSURL *)getZippedLogFile:(NSString *)logFilePath
+/// @return A new uniquely named temporary directory, so that repeated or concurrent reports cannot
+/// overwrite or delete each other's files, or nil if it cannot be created.
++ (nullable NSString *)createTemporaryDirectory
 {
-  NSString * zipFileName = [[logFilePath.lastPathComponent stringByDeletingPathExtension]
-      stringByAppendingPathExtension:kZipLogFileExtension];
-  NSString * zipFilePath =
-      [[NSFileManager.defaultManager temporaryDirectory] URLByAppendingPathComponent:zipFileName].path;
-  auto const success = CreateZipFromFiles({logFilePath.UTF8String}, zipFilePath.UTF8String);
-  if (!success)
+  NSString * directoryPath = [NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString];
+  NSError * error = nil;
+  if ([NSFileManager.defaultManager createDirectoryAtPath:directoryPath
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:&error])
+    return directoryPath;
+
+  [self reportSystemMessage:[NSString stringWithFormat:@"Failed to create a temporary directory: %@",
+                                                       error.localizedDescription]
+                       type:OS_LOG_TYPE_ERROR];
+  return nil;
+}
+
+/// Archives |filePaths|, loads the result, and removes |directoryPath| on every return path.
++ (nullable NSData *)archiveFiles:(NSArray<NSString *> *)filePaths inDirectory:(NSString *)directoryPath
+{
+  std::vector<std::string> files;
+  files.reserve(filePaths.count);
+  for (NSString * filePath in filePaths)
+    files.emplace_back(filePath.UTF8String);
+
+  NSData * archiveData = nil;
+  NSString * archivePath = [directoryPath stringByAppendingPathComponent:kZipLogFileName];
+  if (!CreateZipFromFiles(files, archivePath.UTF8String))
   {
-    LOG(LERROR, ("Failed to zip log file:", kLogFilePath.UTF8String, ". The original file will be returned."));
-    return [NSURL fileURLWithPath:logFilePath];
+    [self reportSystemMessage:@"Failed to archive the log files." type:OS_LOG_TYPE_ERROR];
   }
-  return [NSURL fileURLWithPath:zipFilePath];
+  else
+  {
+    NSError * error = nil;
+    archiveData = [NSData dataWithContentsOfFile:archivePath options:0 error:&error];
+    if (archiveData == nil)
+      [self reportSystemMessage:[@"Failed to read the log archive: " stringByAppendingString:error.localizedDescription]
+                           type:OS_LOG_TYPE_ERROR];
+  }
+
+  [self removeFileAtPath:directoryPath];
+  return archiveData;
+}
+
+/// Rebuilds a report from the system log for users who have not enabled file logging. The entries
+/// are streamed into a file instead of being accumulated in memory first.
++ (nullable NSData *)archiveOSLogStoreReport
+{
+  NSError * error = nil;
+  OSLogStore * store = [OSLogStore storeWithScope:OSLogStoreCurrentProcessIdentifier error:&error];
+  if (store == nil)
+  {
+    [self reportSystemMessage:error.localizedDescription type:OS_LOG_TYPE_ERROR];
+    return nil;
+  }
+
+  NSPredicate * predicate = [NSPredicate predicateWithFormat:@"subsystem == %@", kLoggerSubsystem];
+  OSLogEnumerator * enumerator = [store entriesEnumeratorWithOptions:{} position:nil predicate:predicate error:&error];
+  if (enumerator == nil)
+  {
+    [self reportSystemMessage:error.localizedDescription type:OS_LOG_TYPE_ERROR];
+    return nil;
+  }
+
+  NSString * directoryPath = [self createTemporaryDirectory];
+  if (directoryPath == nil)
+    return nil;
+
+  // Never the persistent log path: a later file logging session would append to a stale report.
+  NSString * reportFilePath = [directoryPath stringByAppendingPathComponent:kLogFileName];
+  bool isEmpty = true;
+  try
+  {
+    // FileWriter buffers through stdio, so a report of tens of thousands of entries does not turn
+    // into one write(2) per entry, and nothing is accumulated in memory.
+    FileWriter reportFile(reportFilePath.UTF8String);
+    for (id entry in enumerator)
+    {
+      if (![entry isKindOfClass:OSLogEntryLog.class])
+        continue;
+      isEmpty = false;
+      reportFile << [entry composedMessage].UTF8String << "\n";
+    }
+  }
+  catch (RootException const & e)
+  {
+    [self reportSystemMessage:[NSString stringWithFormat:@"Failed to write the system log report: %s", e.Msg().c_str()]
+                         type:OS_LOG_TYPE_ERROR];
+    [self removeFileAtPath:directoryPath];
+    return nil;
+  }
+
+  if (isEmpty)
+  {
+    [self reportSystemMessage:@"The system log has no records to export." type:OS_LOG_TYPE_DEFAULT];
+    [self removeFileAtPath:directoryPath];
+    return nil;
+  }
+
+  return [self archiveFiles:@[reportFilePath] inDirectory:directoryPath];
 }
 
 + (void)removeFileAtPath:(NSString *)filePath
 {
-  if ([NSFileManager.defaultManager fileExistsAtPath:filePath])
-  {
-    NSError * error;
-    [NSFileManager.defaultManager removeItemAtPath:filePath error:&error];
-    if (error)
-      LOG(LERROR, (error.localizedDescription.UTF8String));
-  }
+  NSError * error = nil;
+  if ([NSFileManager.defaultManager removeItemAtPath:filePath error:&error])
+    return;
+  if ([error.domain isEqualToString:NSCocoaErrorDomain] && error.code == NSFileNoSuchFileError)
+    return;
+  [self reportSystemMessage:error.localizedDescription type:OS_LOG_TYPE_ERROR];
+}
+
++ (void)reportSystemMessage:(NSString *)message type:(os_log_type_t)type
+{
+  os_log_with_type([self logger].osLogger, type, "%{public}s", message.UTF8String);
 }
 
 + (base::LogLevel)baseLevel:(LogLevel)level

--- a/iphone/CoreApi/CoreApi/Logger/Logger.mm
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.mm
@@ -20,11 +20,15 @@
 
 @end
 
+namespace
+{
 // Subsystem and category are used for the OSLog.
 NSString * const kLoggerSubsystem = [[NSBundle mainBundle] bundleIdentifier];
 NSString * const kLoggerCategory = @"OM";
 NSString * const kLogFileName = @"log.txt";
+NSString * const kSystemLogFileName = @"system-log.txt";
 NSString * const kZipLogFileName = @"log.zip";
+NSString * const kLoggerErrorDomain = @"app.organicmaps.Logger";
 
 // A diagnostic log is collected on request and has to survive until the user sends it, so it cannot
 // live in Caches, which the system purges under storage pressure. Application Support is not
@@ -44,9 +48,22 @@ uint64_t constexpr kMaxLogFileSize = 16 * 1024 * 1024;
 // it with a margin and spend a part of the budget on saying what was lost.
 size_t constexpr kMaxSystemLogRecordSize = 900;
 
+typedef NS_ERROR_ENUM(kLoggerErrorDomain, LoggerError){
+    LoggerErrorCreateTemporaryDirectory = 1,
+    LoggerErrorSystemLogUnavailable,
+    LoggerErrorNoLogs,
+    LoggerErrorArchiveFailed,
+    LoggerErrorReadArchiveFailed,
+};
+
+NSError * MakeLoggerError(LoggerError code, NSString * description)
+{
+  return [NSError errorWithDomain:kLoggerErrorDomain code:code userInfo:@{NSLocalizedDescriptionKey: description}];
+}
+
 /// @return |logString| shortened to kMaxSystemLogRecordSize bytes, marker included, so that the
 /// truncation is explicit instead of being silently applied by the system.
-static std::string TruncateForSystemLog(std::string const & logString)
+std::string TruncateForSystemLog(std::string const & logString)
 {
   auto const marker = " [truncated, " + std::to_string(logString.size()) +
                       " bytes total; diagnostic file logging preserves full records when enabled]";
@@ -55,13 +72,13 @@ static std::string TruncateForSystemLog(std::string const & logString)
   return std::string{prefix} + marker;
 }
 
-static os_log_type_t OSLogTypeFor(base::LogLevel level)
+os_log_type_t OSLogTypeFor(base::LogLevel level)
 {
   switch (level)
   {
   case base::LDEBUG: return OS_LOG_TYPE_DEBUG;
-  // Deliberately not OS_LOG_TYPE_INFO: unlike the default one it is not persisted, and bug
-  // reports are reconstructed from the OSLog store when file logging is off.
+  // Deliberately not OS_LOG_TYPE_INFO: unlike the default one it is not persisted, and every bug
+  // report includes the OSLog store.
   case base::LINFO:
   case base::LWARNING: return OS_LOG_TYPE_DEFAULT;
   // OS_LOG_TYPE_FAULT is reserved for system-level failures, LCRITICAL is a process-level one.
@@ -71,12 +88,13 @@ static os_log_type_t OSLogTypeFor(base::LogLevel level)
   }
 }
 
-@implementation Logger
-
 /// Read from any thread on every log call, mutated on the fileLoggingQueue only.
-static std::atomic<bool> _fileLoggingEnabled{false};
-static void * kFileLoggingQueueKey = &kFileLoggingQueueKey;
+std::atomic<bool> g_fileLoggingEnabled{false};
+void * kFileLoggingQueueKey = &kFileLoggingQueueKey;
 NSNotificationName const kFileLoggingStateDidChangeNotification = @"FileLoggingStateDidChangeNotification";
+}  // namespace
+
+@implementation Logger
 
 + (void)initialize
 {
@@ -123,8 +141,15 @@ NSNotificationName const kFileLoggingStateDidChangeNotification = @"FileLoggingS
 
 + (void)setFileLoggingEnabled:(BOOL)fileLoggingEnabled
 {
+  [self setFileLoggingEnabled:fileLoggingEnabled error:nil];
+}
+
++ (BOOL)setFileLoggingEnabled:(BOOL)fileLoggingEnabled error:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
   BOOL const wasEnabled = self.fileLoggingEnabled;
-  fileLoggingEnabled ? [self enableFileLogging] : [self disableFileLogging];
+  NSError * operationError = nil;
+  BOOL const succeeded = fileLoggingEnabled ? [self enableFileLoggingWithError:&operationError]
+                                            : [self disableFileLoggingWithError:&operationError];
   BOOL const isEnabled = self.fileLoggingEnabled;
   if (!wasEnabled && isEnabled)
   {
@@ -132,11 +157,14 @@ NSNotificationName const kFileLoggingStateDidChangeNotification = @"FileLoggingS
                       ", Time Zone:", NSTimeZone.defaultTimeZone.abbreviation.UTF8String));
   }
   LOG(LINFO, ("File logging is enabled:", isEnabled ? "YES" : "NO"));
+  if (error != nullptr)
+    *error = operationError;
+  return succeeded;
 }
 
 + (BOOL)fileLoggingEnabled
 {
-  return _fileLoggingEnabled.load(std::memory_order_relaxed);
+  return g_fileLoggingEnabled.load(std::memory_order_relaxed);
 }
 
 + (NSNotificationName)fileLoggingStateDidChangeNotification
@@ -154,41 +182,58 @@ NSNotificationName const kFileLoggingStateDidChangeNotification = @"FileLoggingS
   return [Logger baseLevel:level] >= base::g_LogLevel;
 }
 
-+ (void)getLogArchiveWithCompletion:(void (^)(NSData * _Nullable archiveData))completion
++ (void)getLogArchiveWithCompletion:(LogArchiveCompletion)completion
 {
-  // Files can outlive an enabled session: a write error stops logging but keeps them. Do not test
-  // the size alone - a session that has just been enabled has an empty file and still owns it.
-  if (![self fileLoggingEnabled] && [self getLogFileSize] == 0)
-  {
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{ completion([self archiveOSLogStoreReport]); });
-    return;
-  }
-
-  // Only the snapshot runs on the file logging queue: it drains the writes that are already
-  // submitted and excludes the later ones. Archiving is seconds of work on a full log set, and
-  // synchronous error records would be stuck behind it.
-  dispatch_async([self fileLoggingQueue], ^{
-    NSString * directoryPath = [self createTemporaryDirectory];
+  dispatch_queue_t utilityQueue = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
+  dispatch_async(utilityQueue, ^{
+    NSError * error = nil;
+    NSString * directoryPath = [self createTemporaryDirectoryWithError:&error];
     if (directoryPath == nil)
     {
-      completion(nil);
+      [self reportSystemMessage:error.localizedDescription type:OS_LOG_TYPE_ERROR];
+      completion(nil, error);
       return;
     }
 
-    NSError * error = nil;
-    NSArray<NSString *> * copies = [[self logger].fileWriter copyLogFilesToDirectory:directoryPath error:&error];
-    if (copies == nil)
-    {
-      [self reportSystemMessage:[NSString stringWithFormat:@"Failed to snapshot the diagnostic log: %@",
-                                                           error.localizedDescription]
-                           type:OS_LOG_TYPE_ERROR];
-      [self removeFileAtPath:directoryPath];
-      completion(nil);
-      return;
-    }
+    // Only the snapshot runs on the file logging queue: it drains the writes that are already
+    // submitted and excludes the later ones. Archiving and OSLog enumeration stay off this queue
+    // so synchronous error records cannot be stuck behind them.
+    dispatch_async([self fileLoggingQueue], ^{
+      NSError * snapshotError = nil;
+      NSArray<NSString *> * copies = [[self logger].fileWriter copyLogFilesToDirectory:directoryPath
+                                                                                 error:&snapshotError];
+      if (copies == nil)
+      {
+        [self reportSystemMessage:[NSString stringWithFormat:@"Failed to snapshot the diagnostic log: %@",
+                                                             snapshotError.localizedDescription]
+                             type:OS_LOG_TYPE_ERROR];
+        copies = @[];
+      }
 
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0),
-                   ^{ completion([self archiveFiles:copies inDirectory:directoryPath]); });
+      dispatch_async(utilityQueue, ^{
+        NSMutableArray<NSString *> * reportFiles = [copies mutableCopy];
+        NSError * systemLogError = nil;
+        NSString * systemLogPath = [self writeOSLogStoreReportToDirectory:directoryPath error:&systemLogError];
+        if (systemLogPath != nil)
+          [reportFiles addObject:systemLogPath];
+        else
+          [self reportSystemMessage:systemLogError.localizedDescription type:OS_LOG_TYPE_ERROR];
+
+        if (reportFiles.count == 0)
+        {
+          [self removeFileAtPath:directoryPath];
+          NSError * error = snapshotError ?: systemLogError;
+          completion(nil, error ?: MakeLoggerError(LoggerErrorNoLogs, @"No diagnostic logs are available."));
+          return;
+        }
+
+        NSError * archiveError = nil;
+        NSData * archiveData = [self archiveFiles:reportFiles inDirectory:directoryPath error:&archiveError];
+        if (archiveData == nil)
+          [self reportSystemMessage:archiveError.localizedDescription type:OS_LOG_TYPE_ERROR];
+        completion(archiveData, archiveError);
+      });
+    });
   });
 }
 
@@ -228,36 +273,49 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
 
 // MARK: - Private
 
-+ (void)enableFileLogging
++ (BOOL)enableFileLoggingWithError:(NSError * __autoreleasing _Nullable * _Nullable)outError
 {
+  __block BOOL succeeded = YES;
+  __block NSError * operationError = nil;
   [self runSyncOnFileLoggingQueue:^{
     if ([self fileLoggingEnabled])
       return;
 
-    NSError * error = nil;
-    if (![[self logger].fileWriter openWithError:&error])
+    if (![[self logger].fileWriter openWithError:&operationError])
     {
-      [self handleFileLoggingError:error];
+      succeeded = NO;
+      [self handleFileLoggingError:operationError];
       return;
     }
-    [self setFileLoggingState:YES];
+    ASSERT([self logger].fileWriter.isOpen, ());
+    [self setFileLoggingState:YES error:nil];
   }];
+  if (outError != nullptr)
+    *outError = operationError;
+  return succeeded;
 }
 
-+ (void)disableFileLogging
++ (BOOL)disableFileLoggingWithError:(NSError * __autoreleasing _Nullable * _Nullable)outError
 {
+  __block BOOL succeeded = YES;
+  __block NSError * operationError = nil;
   [self runSyncOnFileLoggingQueue:^{
-    [self setFileLoggingState:NO];
-    NSError * error = nil;
-    if (![[self logger].fileWriter closeAndRemoveFilesWithError:&error])
-      [self reportSystemMessage:error.localizedDescription type:OS_LOG_TYPE_ERROR];
+    [self setFileLoggingState:NO error:nil];
+    if (![[self logger].fileWriter closeAndRemoveFilesWithError:&operationError])
+    {
+      succeeded = NO;
+      [self reportSystemMessage:operationError.localizedDescription type:OS_LOG_TYPE_ERROR];
+    }
   }];
+  if (outError != nullptr)
+    *outError = operationError;
+  return succeeded;
 }
 
-+ (void)setFileLoggingState:(BOOL)enabled
++ (void)setFileLoggingState:(BOOL)enabled error:(nullable NSError *)error
 {
   dispatch_assert_queue([self fileLoggingQueue]);
-  bool const changed = _fileLoggingEnabled.exchange(enabled, std::memory_order_relaxed) != enabled;
+  bool const changed = g_fileLoggingEnabled.exchange(enabled, std::memory_order_relaxed) != enabled;
   // Debug records are formatted only when a file can retain them. This mirrors Android's
   // LogsManager.nativeToggleCoreDebugLogs().
   base::g_LogLevel = enabled ? base::LDEBUG : base::GetDefaultLogLevel();
@@ -265,14 +323,14 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
     return;
 
   dispatch_async(dispatch_get_main_queue(), ^{
-    [NSNotificationCenter.defaultCenter postNotificationName:kFileLoggingStateDidChangeNotification object:nil];
+    [NSNotificationCenter.defaultCenter postNotificationName:kFileLoggingStateDidChangeNotification object:error];
   });
 }
 
 + (void)handleFileLoggingError:(NSError *)error
 {
   dispatch_assert_queue([self fileLoggingQueue]);
-  [self setFileLoggingState:NO];
+  [self setFileLoggingState:NO error:error];
 
   // Stop writing, but keep whatever was collected: the failure can be transient (a full disk), and
   // those records are what the user enabled logging for. Only an explicit disable removes them.
@@ -298,7 +356,7 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
   os_log_with_type([self logger].osLogger, OSLogTypeFor(level), "%{public}s",
                    truncated.empty() ? logString.c_str() : truncated.c_str());
 
-  if (!_fileLoggingEnabled.load(std::memory_order_relaxed))
+  if (!g_fileLoggingEnabled.load(std::memory_order_relaxed))
     return;
 
   // Copy the record once: blocks retain the NSData instead of copying the std::string again.
@@ -319,6 +377,7 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
   dispatch_assert_queue([self fileLoggingQueue]);
   if (![self fileLoggingEnabled])
     return;
+  ASSERT([self logger].fileWriter.isOpen, ());
 
   NSError * error = nil;
   if (![[self logger].fileWriter writeData:data error:&error])
@@ -335,7 +394,7 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
 
 /// @return A new uniquely named temporary directory, so that repeated or concurrent reports cannot
 /// overwrite or delete each other's files, or nil if it cannot be created.
-+ (nullable NSString *)createTemporaryDirectory
++ (nullable NSString *)createTemporaryDirectoryWithError:(NSError * __autoreleasing _Nullable * _Nullable)outError
 {
   NSString * directoryPath = [NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString];
   NSError * error = nil;
@@ -345,15 +404,21 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
                                                     error:&error])
     return directoryPath;
 
-  [self reportSystemMessage:[NSString stringWithFormat:@"Failed to create a temporary directory: %@",
-                                                       error.localizedDescription]
-                       type:OS_LOG_TYPE_ERROR];
+  if (outError != nullptr)
+  {
+    *outError = MakeLoggerError(
+        LoggerErrorCreateTemporaryDirectory,
+        [NSString stringWithFormat:@"Failed to create a temporary directory: %@", error.localizedDescription]);
+  }
   return nil;
 }
 
 /// Archives |filePaths|, loads the result, and removes |directoryPath| on every return path.
-+ (nullable NSData *)archiveFiles:(NSArray<NSString *> *)filePaths inDirectory:(NSString *)directoryPath
++ (nullable NSData *)archiveFiles:(NSArray<NSString *> *)filePaths
+                      inDirectory:(NSString *)directoryPath
+                            error:(NSError * __autoreleasing _Nullable * _Nullable)outError
 {
+  ASSERT_GREATER(filePaths.count, 0, ());
   std::vector<std::string> files;
   files.reserve(filePaths.count);
   for (NSString * filePath in filePaths)
@@ -363,30 +428,35 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
   NSString * archivePath = [directoryPath stringByAppendingPathComponent:kZipLogFileName];
   if (!CreateZipFromFiles(files, archivePath.UTF8String))
   {
-    [self reportSystemMessage:@"Failed to archive the log files." type:OS_LOG_TYPE_ERROR];
+    if (outError != nullptr)
+      *outError = MakeLoggerError(LoggerErrorArchiveFailed, @"Failed to archive the diagnostic logs.");
   }
   else
   {
     NSError * error = nil;
     archiveData = [NSData dataWithContentsOfFile:archivePath options:0 error:&error];
-    if (archiveData == nil)
-      [self reportSystemMessage:[@"Failed to read the log archive: " stringByAppendingString:error.localizedDescription]
-                           type:OS_LOG_TYPE_ERROR];
+    if (archiveData == nil && outError != nullptr)
+    {
+      *outError =
+          MakeLoggerError(LoggerErrorReadArchiveFailed, [@"Failed to read the diagnostic archive: "
+                                                            stringByAppendingString:error.localizedDescription]);
+    }
   }
 
   [self removeFileAtPath:directoryPath];
   return archiveData;
 }
 
-/// Rebuilds a report from the system log for users who have not enabled file logging. The entries
-/// are streamed into a file instead of being accumulated in memory first.
-+ (nullable NSData *)archiveOSLogStoreReport
+/// Streams the system log into |directoryPath| instead of accumulating it in memory.
++ (nullable NSString *)writeOSLogStoreReportToDirectory:(NSString *)directoryPath
+                                                  error:(NSError * __autoreleasing _Nullable * _Nullable)outError
 {
   NSError * error = nil;
   OSLogStore * store = [OSLogStore storeWithScope:OSLogStoreCurrentProcessIdentifier error:&error];
   if (store == nil)
   {
-    [self reportSystemMessage:error.localizedDescription type:OS_LOG_TYPE_ERROR];
+    if (outError != nullptr)
+      *outError = error ?: MakeLoggerError(LoggerErrorSystemLogUnavailable, @"The system log is unavailable.");
     return nil;
   }
 
@@ -394,16 +464,12 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
   OSLogEnumerator * enumerator = [store entriesEnumeratorWithOptions:{} position:nil predicate:predicate error:&error];
   if (enumerator == nil)
   {
-    [self reportSystemMessage:error.localizedDescription type:OS_LOG_TYPE_ERROR];
+    if (outError != nullptr)
+      *outError = error ?: MakeLoggerError(LoggerErrorSystemLogUnavailable, @"The system log is unavailable.");
     return nil;
   }
 
-  NSString * directoryPath = [self createTemporaryDirectory];
-  if (directoryPath == nil)
-    return nil;
-
-  // Never the persistent log path: a later file logging session would append to a stale report.
-  NSString * reportFilePath = [directoryPath stringByAppendingPathComponent:kLogFileName];
+  NSString * reportFilePath = [directoryPath stringByAppendingPathComponent:kSystemLogFileName];
   bool isEmpty = true;
   try
   {
@@ -420,20 +486,23 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
   }
   catch (RootException const & e)
   {
-    [self reportSystemMessage:[NSString stringWithFormat:@"Failed to write the system log report: %s", e.Msg().c_str()]
-                         type:OS_LOG_TYPE_ERROR];
-    [self removeFileAtPath:directoryPath];
+    if (outError != nullptr)
+    {
+      *outError =
+          MakeLoggerError(LoggerErrorSystemLogUnavailable,
+                          [NSString stringWithFormat:@"Failed to write the system log report: %s", e.Msg().c_str()]);
+    }
     return nil;
   }
 
   if (isEmpty)
   {
-    [self reportSystemMessage:@"The system log has no records to export." type:OS_LOG_TYPE_DEFAULT];
-    [self removeFileAtPath:directoryPath];
+    if (outError != nullptr)
+      *outError = MakeLoggerError(LoggerErrorNoLogs, @"The system log has no records to export.");
     return nil;
   }
 
-  return [self archiveFiles:@[reportFilePath] inDirectory:directoryPath];
+  return reportFilePath;
 }
 
 + (void)removeFileAtPath:(NSString *)filePath

--- a/iphone/CoreApi/CoreApi/Logger/Logger.mm
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.mm
@@ -26,7 +26,7 @@
 + (void)handleFileLoggingError:(NSError *)error;
 + (void)runSyncOnFileLoggingQueue:(dispatch_block_t)block;
 + (void)logMessageWithLevel:(base::LogLevel)level src:(base::SrcPoint const &)src message:(std::string const &)message;
-+ (void)tryWriteToFile:(std::string const &)logString;
++ (void)tryWriteToFile:(NSData *)data;
 + (nullable NSString *)createTemporaryDirectory;
 + (nullable NSData *)archiveFiles:(NSArray<NSString *> *)filePaths inDirectory:(NSString *)directoryPath;
 + (nullable NSData *)archiveOSLogStoreReport;
@@ -304,7 +304,7 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
   base::LogHelper::WriteProlog(output, level);
   base::LogHelper::WriteLog(output, src, message);
 
-  auto const logString = output.str();
+  auto const logString = std::move(output).str();
 
   // Log the message into the system log. Oversized records are rare, so nothing is copied here
   // unless one has to be rebuilt with a truncation marker.
@@ -317,24 +317,26 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
   if (!_fileLoggingEnabled.load(std::memory_order_relaxed))
     return;
 
+  // Copy the record once: blocks retain the NSData instead of copying the std::string again.
+  NSData * data = [NSData dataWithBytes:logString.data() length:logString.size()];
+
   // Write errors synchronously: an error is often the last record before the process dies - through
   // the abort in LogMessage, or in the code that reported it - and that is exactly the record a
   // diagnostic log is collected for. Everything else goes asynchronously to keep the calling
   // (usually the main) thread out of the file I/O. The queue is serial, so the order is preserved.
   if (level >= base::LERROR)
-    [self runSyncOnFileLoggingQueue:^{ [self tryWriteToFile:logString]; }];
+    [self runSyncOnFileLoggingQueue:^{ [self tryWriteToFile:data]; }];
   else
-    dispatch_async([self fileLoggingQueue], ^{ [self tryWriteToFile:logString]; });
+    dispatch_async([self fileLoggingQueue], ^{ [self tryWriteToFile:data]; });
 }
 
-+ (void)tryWriteToFile:(std::string const &)logString
++ (void)tryWriteToFile:(NSData *)data
 {
   dispatch_assert_queue([self fileLoggingQueue]);
   if (![self fileLoggingEnabled])
     return;
 
   NSError * error = nil;
-  NSData * data = [NSData dataWithBytes:logString.data() length:logString.size()];
   if (![[self logger].fileWriter writeData:data error:&error])
     [self handleFileLoggingError:error];
 }

--- a/iphone/CoreApi/CoreApi/Logger/Logger.mm
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.mm
@@ -1,9 +1,12 @@
 #import "Logger.h"
 #import <OSLog/OSLog.h>
+#import <UIKit/UIKit.h>
 
 #include "base/assert.hpp"
 #include "base/logging.hpp"
 #include "coding/zip_creator.hpp"
+
+#include <atomic>
 
 @interface Logger ()
 
@@ -38,7 +41,8 @@ NSUInteger const kMaxLogFileSize = 1024 * 1024 * 100;  // 100 MB;
 
 @implementation Logger
 
-static BOOL _fileLoggingEnabled = NO;
+/// Read from any thread on every log call, mutated on the fileLoggingQueue only.
+static std::atomic<bool> _fileLoggingEnabled{false};
 static void * kFileLoggingQueueKey = &kFileLoggingQueueKey;
 
 + (void)initialize
@@ -47,6 +51,15 @@ static void * kFileLoggingQueueKey = &kFileLoggingQueueKey;
   {
     SetLogMessageFn(&LogMessage);
     SetAssertFunction(&AssertMessage);
+    // Ordinary records are written asynchronously, so the ones that are still queued would be lost
+    // if the app is killed while suspended. An empty block on the serial queue waits for them.
+    [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidEnterBackgroundNotification
+                                                    object:nil
+                                                     queue:nil
+                                                usingBlock:^(NSNotification *) {
+                                                  if ([self fileLoggingEnabled])
+                                                    [self runSyncOnFileLoggingQueue:^{}];
+                                                }];
   }
 }
 
@@ -94,9 +107,7 @@ static void * kFileLoggingQueueKey = &kFileLoggingQueueKey;
 
 + (BOOL)fileLoggingEnabled
 {
-  __block BOOL fileLoggingEnabled = NO;
-  [self runSyncOnFileLoggingQueue:^{ fileLoggingEnabled = _fileLoggingEnabled; }];
-  return fileLoggingEnabled;
+  return _fileLoggingEnabled.load(std::memory_order_relaxed);
 }
 
 + (void)log:(LogLevel)level message:(NSString *)message
@@ -113,6 +124,8 @@ static void * kFileLoggingQueueKey = &kFileLoggingQueueKey;
 {
   if ([self fileLoggingEnabled])
   {
+    // Drain the writes that are already submitted to the serial queue.
+    [self runSyncOnFileLoggingQueue:^{}];
     if (![NSFileManager.defaultManager fileExistsAtPath:kLogFilePath])
     {
       LOG(LERROR, ("Log file doesn't exist while file logging is enabled:", kLogFilePath.UTF8String));
@@ -225,7 +238,7 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
 
     logger.fileHandle = fileHandle;
 
-    _fileLoggingEnabled = YES;
+    _fileLoggingEnabled.store(true, std::memory_order_relaxed);
   }];
 }
 
@@ -234,11 +247,11 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
   [self runSyncOnFileLoggingQueue:^{
     Logger * logger = [self logger];
 
+    _fileLoggingEnabled.store(false, std::memory_order_relaxed);
+
     [logger.fileHandle closeFile];
     logger.fileHandle = nil;
     [self removeFileAtPath:kLogFilePath];
-
-    _fileLoggingEnabled = NO;
   }];
 }
 
@@ -254,10 +267,17 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
   // Log the message into the system log.
   os_log([self logger].osLogger, "%{public}s", logString.c_str());
 
-  if (level < LINFO)
-    dispatch_async([self fileLoggingQueue], ^{ [self tryWriteToFile:logString]; });
-  else
+  if (!_fileLoggingEnabled.load(std::memory_order_relaxed))
+    return;
+
+  // Write errors synchronously: an error is often the last record before the process dies - through
+  // the abort in LogMessage, or in the code that reported it - and that is exactly the record a
+  // diagnostic log is collected for. Everything else goes asynchronously to keep the calling
+  // (usually the main) thread out of the file I/O. The queue is serial, so the order is preserved.
+  if (level >= base::LERROR)
     [self runSyncOnFileLoggingQueue:^{ [self tryWriteToFile:logString]; }];
+  else
+    dispatch_async([self fileLoggingQueue], ^{ [self tryWriteToFile:logString]; });
 }
 
 + (void)tryWriteToFile:(std::string const &)logString

--- a/iphone/CoreApi/CoreApi/Logger/Logger.mm
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.mm
@@ -17,22 +17,6 @@
 
 @property(nonnull, nonatomic) LogFileWriter * fileWriter;
 @property(nonnull, nonatomic) os_log_t osLogger;
-@property(class, readonly, nonatomic) dispatch_queue_t fileLoggingQueue;
-
-+ (Logger *)logger;
-+ (void)enableFileLogging;
-+ (void)disableFileLogging;
-+ (void)setFileLoggingState:(BOOL)enabled;
-+ (void)handleFileLoggingError:(NSError *)error;
-+ (void)runSyncOnFileLoggingQueue:(dispatch_block_t)block;
-+ (void)logMessageWithLevel:(base::LogLevel)level src:(base::SrcPoint const &)src message:(std::string const &)message;
-+ (void)tryWriteToFile:(NSData *)data;
-+ (nullable NSString *)createTemporaryDirectory;
-+ (nullable NSData *)archiveFiles:(NSArray<NSString *> *)filePaths inDirectory:(NSString *)directoryPath;
-+ (nullable NSData *)archiveOSLogStoreReport;
-+ (void)removeFileAtPath:(NSString *)filePath;
-+ (void)reportSystemMessage:(NSString *)message type:(os_log_type_t)type;
-+ (base::LogLevel)baseLevel:(LogLevel)level;
 
 @end
 

--- a/iphone/CoreApi/CoreApi/Logger/Logger.mm
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.mm
@@ -12,9 +12,6 @@
 
 @property(nullable, nonatomic) NSFileHandle * fileHandle;
 @property(nonnull, nonatomic) os_log_t osLogger;
-/// This property is introduced to avoid the CoreApi => Maps target dependency and stores the
-/// MWMSettings.isFileLoggingEnabled value.
-@property(class, nonatomic) BOOL fileLoggingEnabled;
 @property(class, readonly, nonatomic) dispatch_queue_t fileLoggingQueue;
 
 + (Logger *)logger;
@@ -38,6 +35,22 @@ NSString * const kLogFilePath = [[NSSearchPathForDirectoriesInDomains(NSDocument
     firstObject] stringByAppendingPathComponent:kLogFileName];
 // TODO: (KK) Review and change this limit after some testing.
 NSUInteger const kMaxLogFileSize = 1024 * 1024 * 100;  // 100 MB;
+
+static os_log_type_t OSLogTypeFor(base::LogLevel level)
+{
+  switch (level)
+  {
+  case base::LDEBUG: return OS_LOG_TYPE_DEBUG;
+  // Deliberately not OS_LOG_TYPE_INFO: unlike the default one it is not persisted, and bug
+  // reports are reconstructed from the OSLog store when file logging is off.
+  case base::LINFO:
+  case base::LWARNING: return OS_LOG_TYPE_DEFAULT;
+  // OS_LOG_TYPE_FAULT is reserved for system-level failures, LCRITICAL is a process-level one.
+  case base::LERROR:
+  case base::LCRITICAL: return OS_LOG_TYPE_ERROR;
+  case base::NUM_LOG_LEVELS: return OS_LOG_TYPE_DEFAULT;
+  }
+}
 
 @implementation Logger
 
@@ -239,6 +252,10 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
     logger.fileHandle = fileHandle;
 
     _fileLoggingEnabled.store(true, std::memory_order_relaxed);
+    // Debug records are worth formatting only when there is a file to keep them in, so the level
+    // follows the state the logger is actually in. Mirrors Android's
+    // LogsManager.nativeToggleCoreDebugLogs().
+    base::g_LogLevel = base::LDEBUG;
   }];
 }
 
@@ -248,6 +265,7 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
     Logger * logger = [self logger];
 
     _fileLoggingEnabled.store(false, std::memory_order_relaxed);
+    base::g_LogLevel = base::GetDefaultLogLevel();
 
     [logger.fileHandle closeFile];
     logger.fileHandle = nil;
@@ -265,7 +283,7 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
   auto const logString = output.str();
 
   // Log the message into the system log.
-  os_log([self logger].osLogger, "%{public}s", logString.c_str());
+  os_log_with_type([self logger].osLogger, OSLogTypeFor(level), "%{public}s", logString.c_str());
 
   if (!_fileLoggingEnabled.load(std::memory_order_relaxed))
     return;

--- a/iphone/CoreApi/CoreApi/Logger/Logger.mm
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.mm
@@ -4,9 +4,11 @@
 
 #include "base/assert.hpp"
 #include "base/logging.hpp"
+#include "base/string_utils.hpp"
 #include "coding/zip_creator.hpp"
 
 #include <atomic>
+#include <string>
 
 @interface Logger ()
 
@@ -35,6 +37,22 @@ NSString * const kLogFilePath = [[NSSearchPathForDirectoriesInDomains(NSDocument
     firstObject] stringByAppendingPathComponent:kLogFileName];
 // TODO: (KK) Review and change this limit after some testing.
 NSUInteger const kMaxLogFileSize = 1024 * 1024 * 100;  // 100 MB;
+
+// The unified logging implementation silently cuts a single record and renders the loss as "<…>"
+// on retrieval. The observed limit is 1015 bytes, but it is not a public constant, so stay below
+// it with a margin and spend a part of the budget on saying what was lost.
+size_t constexpr kMaxSystemLogRecordSize = 900;
+
+/// @return |logString| shortened to kMaxSystemLogRecordSize bytes, marker included, so that the
+/// truncation is explicit instead of being silently applied by the system.
+static std::string TruncateForSystemLog(std::string const & logString)
+{
+  auto const marker = " [truncated, " + std::to_string(logString.size()) +
+                      " bytes total, enable logging in Settings to get the full record]";
+  ASSERT_LESS(marker.size(), kMaxSystemLogRecordSize, ());
+  auto const prefix = strings::TruncateUtf8(logString, kMaxSystemLogRecordSize - marker.size());
+  return std::string{prefix} + marker;
+}
 
 static os_log_type_t OSLogTypeFor(base::LogLevel level)
 {
@@ -282,8 +300,13 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
 
   auto const logString = output.str();
 
-  // Log the message into the system log.
-  os_log_with_type([self logger].osLogger, OSLogTypeFor(level), "%{public}s", logString.c_str());
+  // Log the message into the system log. Oversized records are rare, so nothing is copied here
+  // unless one has to be rebuilt with a truncation marker.
+  std::string truncated;
+  if (logString.size() > kMaxSystemLogRecordSize)
+    truncated = TruncateForSystemLog(logString);
+  os_log_with_type([self logger].osLogger, OSLogTypeFor(level), "%{public}s",
+                   truncated.empty() ? logString.c_str() : truncated.c_str());
 
   if (!_fileLoggingEnabled.load(std::memory_order_relaxed))
     return;

--- a/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
+++ b/iphone/Maps/Core/AppDelegate/MapsAppDelegate.mm
@@ -19,6 +19,7 @@
 #import <UserNotifications/UserNotifications.h>
 
 #import <CoreApi/Framework.h>
+#import <CoreApi/Logger.h>
 #import <CoreApi/MWMFrameworkHelper.h>
 
 #include "map/gps_tracker.hpp"
@@ -189,6 +190,7 @@ using namespace osm_auth_ios;
   [self.mapViewController onTerminate];
   // Global cleanup
   DeleteFramework();
+  [Logger flushSynchronously];
 }
 
 - (void)handleApplicationDidEnterBackground:(NSNotification *)notification
@@ -201,6 +203,27 @@ using namespace osm_auth_ios;
 
   [MWMRouter saveRouteIfNeeded];
   LOG(LINFO, ("applicationDidEnterBackground - end"));
+
+  [self drainDiagnosticLog];
+}
+
+/// A suspended app can be killed without any further notification, so the queued records are written
+/// out while a background task keeps the process alive.
+- (void)drainDiagnosticLog
+{
+  if (!Logger.fileLoggingEnabled)
+    return;
+
+  UIApplication * application = UIApplication.sharedApplication;
+  __block UIBackgroundTaskIdentifier taskId = UIBackgroundTaskInvalid;
+  dispatch_block_t endBackgroundTask = ^{
+    if (taskId == UIBackgroundTaskInvalid)
+      return;
+    [application endBackgroundTask:taskId];
+    taskId = UIBackgroundTaskInvalid;
+  };
+  taskId = [application beginBackgroundTaskWithName:@"Drain diagnostic log" expirationHandler:endBackgroundTask];
+  [Logger flushWithCompletion:^{ dispatch_async(dispatch_get_main_queue(), endBackgroundTask); }];
 }
 
 - (void)handleApplicationWillResignActive:(NSNotification *)notification

--- a/iphone/Maps/Core/Settings/MWMSettings.h
+++ b/iphone/Maps/Core/Settings/MWMSettings.h
@@ -79,7 +79,7 @@ NS_SWIFT_NAME(Settings)
 
 + (void)initializeLogging;
 + (BOOL)isFileLoggingEnabled;
-+ (void)setFileLoggingEnabled:(BOOL)fileLoggingEnabled;
++ (NSError * _Nullable)setFileLoggingEnabled:(BOOL)fileLoggingEnabled;
 + (uint64_t)logFileSize;
 
 + (BOOL)didShowICloudSynchronizationEnablingAlert;

--- a/iphone/Maps/Core/Settings/MWMSettings.mm
+++ b/iphone/Maps/Core/Settings/MWMSettings.mm
@@ -23,6 +23,7 @@ NSString * const kSpotlightLocaleLanguageId = @"SpotlightLocaleLanguageId";
 NSString * const kUDTrackWarningAlertWasShown = @"TrackWarningAlertWasShown";
 NSString * const kiCLoudSynchronizationEnabledKey = @"iCLoudSynchronizationEnabled";
 NSString * const kUDFileLoggingEnabledKey = @"FileLoggingEnabledKey";
+NSString * const kUDLegacyLogFileRemoved = @"LegacyLogFileRemoved";
 NSString * const kUDDidShowICloudSynchronizationEnablingAlert = @"kUDDidShowICloudSynchronizationEnablingAlert";
 }  // namespace
 
@@ -308,19 +309,29 @@ NSString * const kUDDidShowICloudSynchronizationEnablingAlert = @"kUDDidShowIClo
 + (void)initializeLogging
 {
   static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{ [self setFileLoggingEnabled:[self isFileLoggingEnabled]]; });
+  dispatch_once(&onceToken, ^{
+    NSUserDefaults * defaults = NSUserDefaults.standardUserDefaults;
+    if (![defaults boolForKey:kUDLegacyLogFileRemoved])
+    {
+      [Logger removeLegacyLogFile];
+      [defaults setBool:YES forKey:kUDLegacyLogFileRemoved];
+    }
+    Logger.fileLoggingEnabled = [defaults boolForKey:kUDFileLoggingEnabledKey];
+  });
 }
 
+/// @return Whether the logger is actually writing a file, which is what the setting switch shows.
 + (BOOL)isFileLoggingEnabled
 {
-  return [NSUserDefaults.standardUserDefaults boolForKey:kUDFileLoggingEnabledKey];
+  return Logger.fileLoggingEnabled;
 }
 
 + (void)setFileLoggingEnabled:(BOOL)fileLoggingEnabled
 {
+  // The stored value is what the user asked for, not what the logger managed to do, so an enable
+  // that fails on a transient error is retried on the next launch instead of turning itself off.
+  [NSUserDefaults.standardUserDefaults setBool:fileLoggingEnabled forKey:kUDFileLoggingEnabledKey];
   Logger.fileLoggingEnabled = fileLoggingEnabled;
-  // Enabling fails if the log file cannot be opened, so persist what the logger is actually doing.
-  [NSUserDefaults.standardUserDefaults setBool:Logger.fileLoggingEnabled forKey:kUDFileLoggingEnabledKey];
 }
 
 + (uint64_t)logFileSize

--- a/iphone/Maps/Core/Settings/MWMSettings.mm
+++ b/iphone/Maps/Core/Settings/MWMSettings.mm
@@ -326,12 +326,14 @@ NSString * const kUDDidShowICloudSynchronizationEnablingAlert = @"kUDDidShowIClo
   return Logger.fileLoggingEnabled;
 }
 
-+ (void)setFileLoggingEnabled:(BOOL)fileLoggingEnabled
++ (NSError * _Nullable)setFileLoggingEnabled:(BOOL)fileLoggingEnabled
 {
   // The stored value is what the user asked for, not what the logger managed to do, so an enable
   // that fails on a transient error is retried on the next launch instead of turning itself off.
   [NSUserDefaults.standardUserDefaults setBool:fileLoggingEnabled forKey:kUDFileLoggingEnabledKey];
-  Logger.fileLoggingEnabled = fileLoggingEnabled;
+  NSError * error = nil;
+  [Logger setFileLoggingEnabled:fileLoggingEnabled error:&error];
+  return error;
 }
 
 + (uint64_t)logFileSize

--- a/iphone/Maps/Core/Settings/MWMSettings.mm
+++ b/iphone/Maps/Core/Settings/MWMSettings.mm
@@ -318,8 +318,9 @@ NSString * const kUDDidShowICloudSynchronizationEnablingAlert = @"kUDDidShowIClo
 
 + (void)setFileLoggingEnabled:(BOOL)fileLoggingEnabled
 {
-  [NSUserDefaults.standardUserDefaults setBool:fileLoggingEnabled forKey:kUDFileLoggingEnabledKey];
-  [Logger setFileLoggingEnabled:fileLoggingEnabled];
+  Logger.fileLoggingEnabled = fileLoggingEnabled;
+  // Enabling fails if the log file cannot be opened, so persist what the logger is actually doing.
+  [NSUserDefaults.standardUserDefaults setBool:Logger.fileLoggingEnabled forKey:kUDFileLoggingEnabledKey];
 }
 
 + (uint64_t)logFileSize

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -5347,6 +5347,10 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../CoreApi/CoreApi/Logger",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = app.organicmaps.tests;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Organic Maps (Debug).app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Organic Maps (Debug)";
@@ -5361,6 +5365,10 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../CoreApi/CoreApi/Logger",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = app.organicmaps.tests;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Organic Maps (Debug).app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Organic Maps (Debug)";

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -633,6 +633,8 @@
 		EDF838C02C00B9D0007E4E67 /* DefaultLocalDirectoryMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF838AE2C00B9C7007E4E67 /* DefaultLocalDirectoryMonitorTests.swift */; };
 		EDF838C12C00B9D6007E4E67 /* iCloudDirectoryMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF838B22C00B9C7007E4E67 /* iCloudDirectoryMonitorTests.swift */; };
 		EDF838C22C00B9D6007E4E67 /* MetadataItemStubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF838B42C00B9C7007E4E67 /* MetadataItemStubs.swift */; };
+		AB10ADAD2026072600000004 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB10ADAD2026072600000003 /* LoggerTests.swift */; };
+		AB10ADAD2026081200000021 /* LogFileWriterTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = AB10ADAD2026081200000020 /* LogFileWriterTests.mm */; };
 		EDF838C32C00B9D6007E4E67 /* UbiquitousDirectoryMonitorDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF838B12C00B9C7007E4E67 /* UbiquitousDirectoryMonitorDelegateMock.swift */; };
 		EDF838C42C00B9D6007E4E67 /* FileManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF838B32C00B9C7007E4E67 /* FileManagerMock.swift */; };
 		F623DA6C1C9C2731006A3436 /* opening_hours_how_to_edit.html in Resources */ = {isa = PBXBuildFile; fileRef = F623DA6A1C9C2731006A3436 /* opening_hours_how_to_edit.html */; };
@@ -1719,6 +1721,8 @@
 		EDF838B22C00B9C7007E4E67 /* iCloudDirectoryMonitorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = iCloudDirectoryMonitorTests.swift; sourceTree = "<group>"; };
 		EDF838B32C00B9C7007E4E67 /* FileManagerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileManagerMock.swift; sourceTree = "<group>"; };
 		EDF838B42C00B9C7007E4E67 /* MetadataItemStubs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetadataItemStubs.swift; sourceTree = "<group>"; };
+		AB10ADAD2026072600000003 /* LoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
+		AB10ADAD2026081200000020 /* LogFileWriterTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LogFileWriterTests.mm; sourceTree = "<group>"; };
 		EE026F0511D6AC0D00645242 /* classificator.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = classificator.txt; path = ../../data/classificator.txt; sourceTree = SOURCE_ROOT; };
 		F623DA6A1C9C2731006A3436 /* opening_hours_how_to_edit.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = opening_hours_how_to_edit.html; path = ../../data/opening_hours_how_to_edit.html; sourceTree = "<group>"; };
 		F6C3A1B121AC22810060EEC8 /* Alert 5.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Alert 5.m4a"; sourceTree = "<group>"; };
@@ -1979,6 +1983,8 @@
 				ED9DDF982D6F6D8000645BC8 /* TrackRecorder */,
 				EDF838AB2C00B9C7007E4E67 /* iCloudTests */,
 				4B4153B72BF970A000EE4B02 /* TextToSpeech */,
+				AB10ADAD2026081200000020 /* LogFileWriterTests.mm */,
+				AB10ADAD2026072600000003 /* LoggerTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -5011,6 +5017,8 @@
 				ED810EC52D566E9B00ECDE2C /* SearchOnMapTests.swift in Sources */,
 				4B83AE4B2C2E642100B0C3BC /* TTSTesterTest.m in Sources */,
 				EDF838C22C00B9D6007E4E67 /* MetadataItemStubs.swift in Sources */,
+				AB10ADAD2026081200000021 /* LogFileWriterTests.mm in Sources */,
+				AB10ADAD2026072600000004 /* LoggerTests.swift in Sources */,
 				EDC4E3612C5E2576009286A2 /* RecentlyDeletedCategoriesViewModelTests.swift in Sources */,
 				4B4153B52BF9695500EE4B02 /* MWMTextToSpeechTests.mm in Sources */,
 				EDF838C42C00B9D6007E4E67 /* FileManagerMock.swift in Sources */,

--- a/iphone/Maps/Tests/Core/LogFileWriterTests.mm
+++ b/iphone/Maps/Tests/Core/LogFileWriterTests.mm
@@ -2,13 +2,19 @@
 
 #import "../../../CoreApi/CoreApi/Logger/LogFileWriter.h"
 
-@interface MoveFailingFileManager : NSFileManager
+@interface FailingFileManager : NSFileManager
 
 @property(nonatomic) BOOL failMove;
+@property(nonatomic) BOOL failCreate;
 
 @end
 
-@implementation MoveFailingFileManager
+@implementation FailingFileManager
+
+- (BOOL)createFileAtPath:(NSString *)path contents:(NSData *)data attributes:(NSDictionary *)attributes
+{
+  return self.failCreate ? NO : [super createFileAtPath:path contents:data attributes:attributes];
+}
 
 - (BOOL)moveItemAtPath:(NSString *)sourcePath
                 toPath:(NSString *)destinationPath
@@ -104,7 +110,7 @@
 
 - (void)testMoveFailureStopsTheWriterWithoutTruncatingTheCurrentFile
 {
-  MoveFailingFileManager * fileManager = [[MoveFailingFileManager alloc] init];
+  FailingFileManager * fileManager = [[FailingFileManager alloc] init];
   LogFileWriter * writer = [[LogFileWriter alloc] initWithDirectoryPath:self.directoryPath
                                                             maxFileSize:4
                                                             fileManager:fileManager];
@@ -120,7 +126,35 @@
   XCTAssertFalse([fileManager fileExistsAtPath:writer.rotatedFilePath]);
 }
 
-- (void)testSnapshotIsChronologicalAndRequiresTheCurrentFile
+- (void)testSnapshotAcceptsRotatedFileAfterReopenFailure
+{
+  FailingFileManager * fileManager = [[FailingFileManager alloc] init];
+  LogFileWriter * writer = [[LogFileWriter alloc] initWithDirectoryPath:self.directoryPath
+                                                            maxFileSize:4
+                                                            fileManager:fileManager];
+  NSError * error = nil;
+  XCTAssertTrue([writer openWithError:&error], @"%@", error);
+  XCTAssertTrue([writer writeData:[self data:@"1234"] error:&error], @"%@", error);
+
+  fileManager.failCreate = YES;
+  XCTAssertFalse([writer writeData:[self data:@"5"] error:&error]);
+  XCTAssertFalse(writer.isOpen);
+  XCTAssertFalse([fileManager fileExistsAtPath:writer.currentFilePath]);
+  XCTAssertTrue([fileManager fileExistsAtPath:writer.rotatedFilePath]);
+
+  NSString * snapshotPath = [self.directoryPath stringByAppendingPathComponent:@"snapshot"];
+  XCTAssertTrue([fileManager createDirectoryAtPath:snapshotPath
+                       withIntermediateDirectories:NO
+                                        attributes:nil
+                                             error:&error],
+                @"%@", error);
+  NSArray<NSString *> * copies = [writer copyLogFilesToDirectory:snapshotPath error:&error];
+  XCTAssertEqual(copies.count, 1);
+  XCTAssertEqualObjects(copies.firstObject.lastPathComponent, writer.rotatedFilePath.lastPathComponent);
+  XCTAssertEqualObjects([NSData dataWithContentsOfFile:copies.firstObject], [self data:@"1234"]);
+}
+
+- (void)testSnapshotIsChronologicalAndReturnsEveryExistingFile
 {
   LogFileWriter * writer = [[LogFileWriter alloc] initWithDirectoryPath:self.directoryPath maxFileSize:4];
   NSError * error = nil;
@@ -148,8 +182,19 @@
                                                          attributes:nil
                                                               error:&error],
                 @"%@", error);
-  XCTAssertNil([writer copyLogFilesToDirectory:secondSnapshotPath error:&error]);
-  XCTAssertNotNil(error);
+  copies = [writer copyLogFilesToDirectory:secondSnapshotPath error:&error];
+  XCTAssertEqual(copies.count, 1);
+  XCTAssertEqualObjects(copies.firstObject.lastPathComponent, writer.rotatedFilePath.lastPathComponent);
+
+  XCTAssertTrue([NSFileManager.defaultManager removeItemAtPath:writer.rotatedFilePath error:&error], @"%@", error);
+  NSString * emptySnapshotPath = [self.directoryPath stringByAppendingPathComponent:@"empty-snapshot"];
+  XCTAssertTrue([NSFileManager.defaultManager createDirectoryAtPath:emptySnapshotPath
+                                        withIntermediateDirectories:NO
+                                                         attributes:nil
+                                                              error:&error],
+                @"%@", error);
+  copies = [writer copyLogFilesToDirectory:emptySnapshotPath error:&error];
+  XCTAssertEqual(copies.count, 0);
 }
 
 - (NSData *)data:(NSString *)string

--- a/iphone/Maps/Tests/Core/LogFileWriterTests.mm
+++ b/iphone/Maps/Tests/Core/LogFileWriterTests.mm
@@ -1,6 +1,6 @@
 #import <XCTest/XCTest.h>
 
-#import "../../../CoreApi/CoreApi/Logger/LogFileWriter.h"
+#import "LogFileWriter.h"
 
 @interface FailingFileManager : NSFileManager
 

--- a/iphone/Maps/Tests/Core/LogFileWriterTests.mm
+++ b/iphone/Maps/Tests/Core/LogFileWriterTests.mm
@@ -1,0 +1,160 @@
+#import <XCTest/XCTest.h>
+
+#import "../../../CoreApi/CoreApi/Logger/LogFileWriter.h"
+
+@interface MoveFailingFileManager : NSFileManager
+
+@property(nonatomic) BOOL failMove;
+
+@end
+
+@implementation MoveFailingFileManager
+
+- (BOOL)moveItemAtPath:(NSString *)sourcePath
+                toPath:(NSString *)destinationPath
+                 error:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
+  if (!self.failMove)
+    return [super moveItemAtPath:sourcePath toPath:destinationPath error:error];
+
+  if (error != nullptr)
+  {
+    *error = [NSError errorWithDomain:NSCocoaErrorDomain
+                                 code:NSFileWriteUnknownError
+                             userInfo:@{NSLocalizedDescriptionKey: @"Injected move failure"}];
+  }
+  return NO;
+}
+
+@end
+
+@interface LogFileWriterTests : XCTestCase
+
+@property(nonatomic) NSString * directoryPath;
+
+@end
+
+@implementation LogFileWriterTests
+
+- (void)setUp
+{
+  [super setUp];
+  self.directoryPath = [NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString];
+}
+
+- (void)tearDown
+{
+  [NSFileManager.defaultManager removeItemAtPath:self.directoryPath error:nil];
+  [super tearDown];
+}
+
+- (void)testWritesAppendToTheCurrentFile
+{
+  LogFileWriter * writer = [[LogFileWriter alloc] initWithDirectoryPath:self.directoryPath maxFileSize:8];
+  NSError * error = nil;
+  XCTAssertTrue([writer openWithError:&error], @"%@", error);
+  XCTAssertTrue([writer writeData:[self data:@"abc"] error:&error], @"%@", error);
+  XCTAssertTrue([writer writeData:[self data:@"def"] error:&error], @"%@", error);
+
+  XCTAssertEqualObjects([NSData dataWithContentsOfFile:writer.currentFilePath], [self data:@"abcdef"]);
+  XCTAssertEqual(writer.totalFileSize, 6);
+}
+
+- (void)testReopeningAppendsToTheExistingFile
+{
+  LogFileWriter * writer = [[LogFileWriter alloc] initWithDirectoryPath:self.directoryPath maxFileSize:8];
+  NSError * error = nil;
+  XCTAssertTrue([writer openWithError:&error], @"%@", error);
+  XCTAssertTrue([writer writeData:[self data:@"abc"] error:&error], @"%@", error);
+  XCTAssertTrue([writer closeWithError:&error], @"%@", error);
+
+  writer = [[LogFileWriter alloc] initWithDirectoryPath:self.directoryPath maxFileSize:8];
+  XCTAssertTrue([writer openWithError:&error], @"%@", error);
+  XCTAssertTrue([writer writeData:[self data:@"def"] error:&error], @"%@", error);
+
+  XCTAssertEqualObjects([NSData dataWithContentsOfFile:writer.currentFilePath], [self data:@"abcdef"]);
+}
+
+- (void)testRotationKeepsRecordsWholeAndReplacesTheOlderFile
+{
+  LogFileWriter * writer = [[LogFileWriter alloc] initWithDirectoryPath:self.directoryPath maxFileSize:8];
+  NSError * error = nil;
+  XCTAssertTrue([writer openWithError:&error], @"%@", error);
+  XCTAssertTrue([writer writeData:[self data:@"123456"] error:&error], @"%@", error);
+  XCTAssertTrue([writer writeData:[self data:@"abcdef"] error:&error], @"%@", error);
+  XCTAssertEqualObjects([NSData dataWithContentsOfFile:writer.rotatedFilePath], [self data:@"123456"]);
+  XCTAssertEqualObjects([NSData dataWithContentsOfFile:writer.currentFilePath], [self data:@"abcdef"]);
+
+  XCTAssertTrue([writer writeData:[self data:@"XY"] error:&error], @"%@", error);
+  XCTAssertTrue([writer writeData:[self data:@"Z"] error:&error], @"%@", error);
+  XCTAssertEqualObjects([NSData dataWithContentsOfFile:writer.rotatedFilePath], [self data:@"abcdefXY"]);
+  XCTAssertEqualObjects([NSData dataWithContentsOfFile:writer.currentFilePath], [self data:@"Z"]);
+}
+
+- (void)testOversizedRecordIsNotSplit
+{
+  LogFileWriter * writer = [[LogFileWriter alloc] initWithDirectoryPath:self.directoryPath maxFileSize:4];
+  NSError * error = nil;
+  XCTAssertTrue([writer openWithError:&error], @"%@", error);
+  XCTAssertTrue([writer writeData:[self data:@"123456"] error:&error], @"%@", error);
+
+  XCTAssertEqualObjects([NSData dataWithContentsOfFile:writer.currentFilePath], [self data:@"123456"]);
+  XCTAssertFalse([NSFileManager.defaultManager fileExistsAtPath:writer.rotatedFilePath]);
+}
+
+- (void)testMoveFailureStopsTheWriterWithoutTruncatingTheCurrentFile
+{
+  MoveFailingFileManager * fileManager = [[MoveFailingFileManager alloc] init];
+  LogFileWriter * writer = [[LogFileWriter alloc] initWithDirectoryPath:self.directoryPath
+                                                            maxFileSize:4
+                                                            fileManager:fileManager];
+  NSError * error = nil;
+  XCTAssertTrue([writer openWithError:&error], @"%@", error);
+  XCTAssertTrue([writer writeData:[self data:@"1234"] error:&error], @"%@", error);
+
+  fileManager.failMove = YES;
+  XCTAssertFalse([writer writeData:[self data:@"5"] error:&error]);
+  XCTAssertNotNil(error);
+  XCTAssertFalse(writer.isOpen);
+  XCTAssertEqualObjects([NSData dataWithContentsOfFile:writer.currentFilePath], [self data:@"1234"]);
+  XCTAssertFalse([fileManager fileExistsAtPath:writer.rotatedFilePath]);
+}
+
+- (void)testSnapshotIsChronologicalAndRequiresTheCurrentFile
+{
+  LogFileWriter * writer = [[LogFileWriter alloc] initWithDirectoryPath:self.directoryPath maxFileSize:4];
+  NSError * error = nil;
+  XCTAssertTrue([writer openWithError:&error], @"%@", error);
+  XCTAssertTrue([writer writeData:[self data:@"1234"] error:&error], @"%@", error);
+  XCTAssertTrue([writer writeData:[self data:@"5"] error:&error], @"%@", error);
+
+  NSString * snapshotPath = [self.directoryPath stringByAppendingPathComponent:@"snapshot"];
+  XCTAssertTrue([NSFileManager.defaultManager createDirectoryAtPath:snapshotPath
+                                        withIntermediateDirectories:NO
+                                                         attributes:nil
+                                                              error:&error],
+                @"%@", error);
+  NSArray<NSString *> * copies = [writer copyLogFilesToDirectory:snapshotPath error:&error];
+  XCTAssertEqual(copies.count, 2);
+  XCTAssertEqualObjects(copies.firstObject.lastPathComponent, writer.rotatedFilePath.lastPathComponent);
+  XCTAssertEqualObjects(copies.lastObject.lastPathComponent, writer.currentFilePath.lastPathComponent);
+  XCTAssertEqualObjects([NSData dataWithContentsOfFile:copies.firstObject], [self data:@"1234"]);
+  XCTAssertEqualObjects([NSData dataWithContentsOfFile:copies.lastObject], [self data:@"5"]);
+
+  XCTAssertTrue([NSFileManager.defaultManager removeItemAtPath:writer.currentFilePath error:&error], @"%@", error);
+  NSString * secondSnapshotPath = [self.directoryPath stringByAppendingPathComponent:@"second-snapshot"];
+  XCTAssertTrue([NSFileManager.defaultManager createDirectoryAtPath:secondSnapshotPath
+                                        withIntermediateDirectories:NO
+                                                         attributes:nil
+                                                              error:&error],
+                @"%@", error);
+  XCTAssertNil([writer copyLogFilesToDirectory:secondSnapshotPath error:&error]);
+  XCTAssertNotNil(error);
+}
+
+- (NSData *)data:(NSString *)string
+{
+  return [string dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+@end

--- a/iphone/Maps/Tests/Core/LoggerTests.swift
+++ b/iphone/Maps/Tests/Core/LoggerTests.swift
@@ -21,16 +21,22 @@ final class LoggerTests: XCTestCase {
 
     var completedOnMainThread = true
     var archiveData: Data?
+    var archiveError: Error?
     let exported = expectation(description: "The log archive is created")
-    Logger.getLogArchive { data in
+    Logger.getLogArchive { data, error in
       completedOnMainThread = Thread.isMainThread
       archiveData = data
+      archiveError = error
       exported.fulfill()
     }
     wait(for: [exported], timeout: 30)
 
     XCTAssertFalse(completedOnMainThread, "Reading and zipping the log must not run on the main thread")
+    XCTAssertNil(archiveError)
     XCTAssertGreaterThan(archiveData?.count ?? 0, 0)
+    let names = archiveData.map(archiveEntryNames) ?? []
+    XCTAssertTrue(names.contains("log.txt"))
+    XCTAssertTrue(names.contains("system-log.txt"))
   }
 
   func testArchiveIsRebuiltFromTheSystemLogWhenFileLoggingIsOff() {
@@ -38,14 +44,18 @@ final class LoggerTests: XCTestCase {
     LOG(.info, "A record that has to reach the system log report")
 
     var archiveData: Data?
+    var archiveError: Error?
     let exported = expectation(description: "The system log archive is created")
-    Logger.getLogArchive { data in
+    Logger.getLogArchive { data, error in
       archiveData = data
+      archiveError = error
       exported.fulfill()
     }
     wait(for: [exported], timeout: 30)
 
+    XCTAssertNil(archiveError)
     XCTAssertGreaterThan(archiveData?.count ?? 0, 0)
+    XCTAssertEqual(archiveData.map(archiveEntryNames), ["system-log.txt"])
   }
 
   func testEnablingCreatesTheLogAndDisablingRemovesIt() {
@@ -76,5 +86,42 @@ final class LoggerTests: XCTestCase {
     let drained = expectation(description: "The pending writes are drained")
     Logger.flush { drained.fulfill() }
     wait(for: [drained], timeout: 30)
+  }
+
+  /// Reads file names from ZIP central-directory records. The archive payload stays compressed.
+  private func archiveEntryNames(_ data: Data) -> Set<String> {
+    let bytes = [UInt8](data)
+    let centralDirectorySignature: UInt32 = 0x0201_4B50
+    var names = Set<String>()
+    var offset = 0
+    while offset + 46 <= bytes.count {
+      if uint32(bytes, at: offset) != centralDirectorySignature {
+        offset += 1
+        continue
+      }
+
+      let nameLength = uint16(bytes, at: offset + 28)
+      let extraLength = uint16(bytes, at: offset + 30)
+      let commentLength = uint16(bytes, at: offset + 32)
+      let nameStart = offset + 46
+      let nameEnd = nameStart + nameLength
+      guard nameEnd <= bytes.count else { break }
+      if let name = String(bytes: bytes[nameStart ..< nameEnd], encoding: .utf8) {
+        names.insert(name)
+      }
+      offset = nameEnd + extraLength + commentLength
+    }
+    return names
+  }
+
+  private func uint16(_ bytes: [UInt8], at offset: Int) -> Int {
+    Int(bytes[offset]) | Int(bytes[offset + 1]) << 8
+  }
+
+  private func uint32(_ bytes: [UInt8], at offset: Int) -> UInt32 {
+    UInt32(bytes[offset]) |
+      UInt32(bytes[offset + 1]) << 8 |
+      UInt32(bytes[offset + 2]) << 16 |
+      UInt32(bytes[offset + 3]) << 24
   }
 }

--- a/iphone/Maps/Tests/Core/LoggerTests.swift
+++ b/iphone/Maps/Tests/Core/LoggerTests.swift
@@ -1,0 +1,80 @@
+@testable import Organic_Maps__Debug_
+import XCTest
+
+final class LoggerTests: XCTestCase {
+  private var wasFileLoggingEnabled = false
+
+  override func setUp() {
+    super.setUp()
+    wasFileLoggingEnabled = Logger.fileLoggingEnabled
+  }
+
+  override func tearDown() {
+    Logger.fileLoggingEnabled = wasFileLoggingEnabled
+    super.tearDown()
+  }
+
+  func testExportedArchiveIsCreatedOffTheMainThread() {
+    Logger.fileLoggingEnabled = true
+    XCTAssertTrue(Logger.fileLoggingEnabled)
+    LOG(.info, "A record that has to reach the exported archive")
+
+    var completedOnMainThread = true
+    var archiveData: Data?
+    let exported = expectation(description: "The log archive is created")
+    Logger.getLogArchive { data in
+      completedOnMainThread = Thread.isMainThread
+      archiveData = data
+      exported.fulfill()
+    }
+    wait(for: [exported], timeout: 30)
+
+    XCTAssertFalse(completedOnMainThread, "Reading and zipping the log must not run on the main thread")
+    XCTAssertGreaterThan(archiveData?.count ?? 0, 0)
+  }
+
+  func testArchiveIsRebuiltFromTheSystemLogWhenFileLoggingIsOff() {
+    Logger.fileLoggingEnabled = false
+    LOG(.info, "A record that has to reach the system log report")
+
+    var archiveData: Data?
+    let exported = expectation(description: "The system log archive is created")
+    Logger.getLogArchive { data in
+      archiveData = data
+      exported.fulfill()
+    }
+    wait(for: [exported], timeout: 30)
+
+    XCTAssertGreaterThan(archiveData?.count ?? 0, 0)
+  }
+
+  func testEnablingCreatesTheLogAndDisablingRemovesIt() {
+    Logger.fileLoggingEnabled = true
+    LOG(.info, "A record that has to reach the log file")
+    drainPendingWrites()
+    XCTAssertGreaterThan(Logger.getLogFileSize(), 0)
+
+    // Disabling runs synchronously on the same serial queue, so it also drains the asynchronous write.
+    Logger.fileLoggingEnabled = false
+
+    XCTAssertFalse(Logger.fileLoggingEnabled)
+    XCTAssertEqual(Logger.getLogFileSize(), 0, "Disabling logging must remove every log file")
+  }
+
+  func testNoDiagnosticLogIsLeftInDocuments() throws {
+    Logger.fileLoggingEnabled = true
+    LOG(.info, "A record that has to reach the log file")
+
+    // Documents is exposed to the user through the Files app and is included in backups.
+    let documents = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: documents.appendingPathComponent("log.txt").path))
+  }
+
+  /// Ordinary records are written asynchronously. A completion enqueued on the same serial queue
+  /// waits for every write that was submitted before it.
+  private func drainPendingWrites() {
+    let drained = expectation(description: "The pending writes are drained")
+    Logger.flush { drained.fulfill() }
+    wait(for: [drained], timeout: 30)
+  }
+}

--- a/iphone/Maps/UI/MailComposer/MailComposer.swift
+++ b/iphone/Maps/UI/MailComposer/MailComposer.swift
@@ -5,12 +5,9 @@ final class MailComposer: NSObject {
 
   override private init() {}
 
-  /// Composes an email with the provided subject, body and attachment file for the given recipients.
-  static func sendEmail(subject: String? = nil, body: String? = nil, toRecipients recipients: [String], attachmentFileURL: URL? = nil) {
-    sendEmailWith(subject: subject ?? "",
-                  body: body ?? "",
-                  toRecipients: recipients,
-                  attachmentFileURL: attachmentFileURL)
+  /// Composes an email with the provided subject and body for the given recipients.
+  static func sendEmail(subject: String? = nil, body: String? = nil, toRecipients recipients: [String]) {
+    sendEmailWith(subject: subject ?? "", body: body ?? "", toRecipients: recipients)
   }
 
   /// Composes an email with the additional app information and the log file attachment for the developers.
@@ -30,26 +27,30 @@ final class MailComposer: NSObject {
                     Locale.preferredLanguages.joined(separator: ", "))
     }
     UIApplication.shared.showLoadingOverlay {
-      let logFileURL = Logger.getLogFileURL()
-      UIApplication.shared.hideLoadingOverlay {
-        sendEmailWith(subject: subject(),
-                      body: body(),
-                      toRecipients: [SocialMedia.organicMapsEmail.link],
-                      attachmentFileURL: logFileURL)
+      // Archive creation and temporary-file cleanup finish on a background queue.
+      Logger.getLogArchive { archiveData in
+        DispatchQueue.main.async {
+          UIApplication.shared.hideLoadingOverlay {
+            sendEmailWith(subject: subject(),
+                          body: body(),
+                          toRecipients: [SocialMedia.organicMapsEmail.link],
+                          attachment: archiveData)
+          }
+        }
       }
     }
   }
 
-  private static func sendEmailWith(subject: String, body: String, toRecipients recipients: [String], attachmentFileURL: URL? = nil) {
-    // If the attachment file path is provided, the default mail composer should be used.
-    if let attachmentFileURL {
-      if MWMMailViewController.canSendMail(), let attachmentData = try? Data(contentsOf: attachmentFileURL) {
+  private static func sendEmailWith(subject: String, body: String, toRecipients recipients: [String], attachment: Data? = nil) {
+    // If the attachment is provided, the default mail composer should be used.
+    if let attachment {
+      if MWMMailViewController.canSendMail() {
         let mailViewController = MWMMailViewController()
         mailViewController.mailComposeDelegate = mailComposer
         mailViewController.setSubject(subject)
         mailViewController.setMessageBody(body, isHTML: false)
         mailViewController.setToRecipients(recipients)
-        mailViewController.addAttachmentData(attachmentData, mimeType: "application/zip", fileName: attachmentFileURL.lastPathComponent)
+        mailViewController.addAttachmentData(attachment, mimeType: "application/zip", fileName: "log.zip")
         topViewController.present(mailViewController, animated: true, completion: nil)
       } else {
         showMailComposingAlert(recipients: recipients)

--- a/iphone/Maps/UI/MailComposer/MailComposer.swift
+++ b/iphone/Maps/UI/MailComposer/MailComposer.swift
@@ -28,9 +28,21 @@ final class MailComposer: NSObject {
     }
     UIApplication.shared.showLoadingOverlay {
       // Archive creation and temporary-file cleanup finish on a background queue.
-      Logger.getLogArchive { archiveData in
+      Logger.getLogArchive { archiveData, error in
         DispatchQueue.main.async {
           UIApplication.shared.hideLoadingOverlay {
+            if let error {
+              showLogArchiveError(error)
+              return
+            }
+            guard let archiveData else {
+              assertionFailure("Logger completed without archive data or an error")
+              let error = NSError(domain: "app.organicmaps.Logger",
+                                  code: 0,
+                                  userInfo: [NSLocalizedDescriptionKey: "The diagnostic archive is unavailable."])
+              showLogArchiveError(error)
+              return
+            }
             sendEmailWith(subject: subject(),
                           body: body(),
                           toRecipients: [SocialMedia.organicMapsEmail.link],
@@ -39,6 +51,14 @@ final class MailComposer: NSObject {
         }
       }
     }
+  }
+
+  private static func showLogArchiveError(_ error: Error) {
+    let alert = UIAlertController(title: L("dialog_routing_system_error"),
+                                  message: error.localizedDescription,
+                                  preferredStyle: .alert)
+    alert.addAction(UIAlertAction(title: L("ok"), style: .default))
+    topViewController.present(alert, animated: true)
   }
 
   private static func sendEmailWith(subject: String, body: String, toRecipients recipients: [String], attachment: Data? = nil) {

--- a/iphone/Maps/UI/PlacePage/PlacePageManager/MWMPlacePageManager.mm
+++ b/iphone/Maps/UI/PlacePage/PlacePageManager/MWMPlacePageManager.mm
@@ -373,7 +373,7 @@ using namespace storage;
 
 - (void)openEmail:(PlacePageData *)data
 {
-  [MailComposer sendEmailWithSubject:nil body:nil toRecipients:@[data.infoData.email] attachmentFileURL:nil];
+  [MailComposer sendEmailWithSubject:nil body:nil toRecipients:@[data.infoData.email]];
 }
 
 #pragma mark - AvailableArea / PlacePageArea

--- a/iphone/Maps/UI/Settings/Root/RootSettingsInteractor.swift
+++ b/iphone/Maps/UI/Settings/Root/RootSettingsInteractor.swift
@@ -3,10 +3,14 @@ final class RootSettingsInteractor {
 
   private let settings: Settings.Type
   private var iCloudSynchronizationState: SynchronizationManagerState?
+  private var fileLoggingStateObserver: NSObjectProtocol?
   private var isObserving = false
 
   deinit {
     iCloudSynchronizaionManager.shared.removeObserver(self)
+    if let fileLoggingStateObserver {
+      NotificationCenter.default.removeObserver(fileLoggingStateObserver)
+    }
   }
 
   init(settings: Settings.Type = Settings.self) {
@@ -51,7 +55,9 @@ final class RootSettingsInteractor {
     }
 
     setSetting(setting, enabled: enabled)
-    updateSettings()
+    // Force the reconfiguration: a setter that fails or normalizes the value leaves the view model
+    // unchanged, and the switch would keep the position the user just moved it to.
+    updateSettings(reconfiguredItems: [setting])
   }
 
   func confirmICloudSynchronization() {
@@ -103,6 +109,13 @@ final class RootSettingsInteractor {
     iCloudSynchronizaionManager.shared.addObserver(self) { [weak self] state in
       self?.iCloudSynchronizationState = state
       self?.updateSettings()
+    }
+    fileLoggingStateObserver = NotificationCenter.default.addObserver(
+      forName: Logger.fileLoggingStateDidChangeNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      self?.updateSettings(reconfiguredItems: [.logging])
     }
   }
 

--- a/iphone/Maps/UI/Settings/Root/RootSettingsInteractor.swift
+++ b/iphone/Maps/UI/Settings/Root/RootSettingsInteractor.swift
@@ -54,10 +54,13 @@ final class RootSettingsInteractor {
       return
     }
 
-    setSetting(setting, enabled: enabled)
+    let error = setSetting(setting, enabled: enabled)
     // Force the reconfiguration: a setter that fails or normalizes the value leaves the view model
     // unchanged, and the switch would keep the position the user just moved it to.
     updateSettings(reconfiguredItems: [setting])
+    if let error {
+      presenter?.presentFileLoggingError(error)
+    }
   }
 
   func confirmICloudSynchronization() {
@@ -114,7 +117,10 @@ final class RootSettingsInteractor {
       forName: Logger.fileLoggingStateDidChangeNotification,
       object: nil,
       queue: .main
-    ) { [weak self] _ in
+    ) { [weak self] notification in
+      if let error = notification.object as? NSError {
+        self?.presenter?.presentFileLoggingError(error)
+      }
       self?.updateSettings(reconfiguredItems: [.logging])
     }
   }
@@ -153,7 +159,8 @@ final class RootSettingsInteractor {
     !settings.isPowerManagementMaximum()
   }
 
-  private func setSetting(_ setting: RootSettings, enabled: Bool) {
+  @discardableResult
+  private func setSetting(_ setting: RootSettings, enabled: Bool) -> Error? {
     switch setting {
     case .zoomButtons:
       settings.setZoomButtonsEnabled(enabled)
@@ -170,7 +177,7 @@ final class RootSettingsInteractor {
     case .iCloud:
       settings.setICLoudSynchronizationEnabled(enabled)
     case .logging:
-      settings.setFileLoggingEnabled(enabled)
+      return settings.setFileLoggingEnabled(enabled)
     case .perspectiveView:
       settings.setPerspectiveViewEnabled(enabled)
     case .autoZoom:
@@ -191,6 +198,7 @@ final class RootSettingsInteractor {
          .routingOptions:
       break
     }
+    return nil
   }
 
   private func canBackupBookmarks() -> Bool {

--- a/iphone/Maps/UI/Settings/Root/RootSettingsPresenter.swift
+++ b/iphone/Maps/UI/Settings/Root/RootSettingsPresenter.swift
@@ -74,6 +74,14 @@ final class RootSettingsPresenter {
     viewController?.display(alert)
   }
 
+  func presentFileLoggingError(_ error: Error) {
+    let alert = UIAlertController(title: L("dialog_routing_system_error"),
+                                  message: error.localizedDescription,
+                                  preferredStyle: .alert)
+    alert.addAction(UIAlertAction(title: L("ok"), style: .default))
+    viewController?.display(alert)
+  }
+
   func presentHighlight(_ setting: RootSettings) {
     viewController?.displayHighlight(setting)
   }

--- a/libs/base/base_tests/string_utils_test.cpp
+++ b/libs/base/base_tests/string_utils_test.cpp
@@ -1498,4 +1498,43 @@ UNIT_TEST(ToLower_ToUpper)
   static_assert(strings::AsciiToLower('[') == '[' && strings::AsciiToUpper('{') == '{');
 }
 
+UNIT_TEST(TruncateUtf8)
+{
+  TEST_EQUAL(strings::TruncateUtf8("abc", 5), "abc", ());
+  TEST_EQUAL(strings::TruncateUtf8("abc", 3), "abc", ());
+  TEST_EQUAL(strings::TruncateUtf8("abc", 2), "ab", ());
+  TEST_EQUAL(strings::TruncateUtf8("abc", 0), "", ());
+  TEST_EQUAL(strings::TruncateUtf8("", 5), "", ());
+
+  // "аб" is two 2-byte code points, "€" is 3-byte and the emoji is 4-byte.
+  std::string const two = "аб";
+  TEST_EQUAL(strings::TruncateUtf8(two, 3), "а", ());
+  TEST_EQUAL(strings::TruncateUtf8(two, 2), "а", ());
+  TEST_EQUAL(strings::TruncateUtf8(two, 1), "", ());
+
+  std::string const mixed = "a€b";
+  TEST_EQUAL(strings::TruncateUtf8(mixed, 4), "a€", ());
+  TEST_EQUAL(strings::TruncateUtf8(mixed, 3), "a", ());
+
+  std::string const emoji = "a🌍";
+  TEST_EQUAL(strings::TruncateUtf8(emoji, 4), "a", ());
+  TEST_EQUAL(strings::TruncateUtf8(emoji, 1), "a", ());
+
+  // Never longer than the limit, and never splits a code point.
+  for (auto const & s : {two, mixed, emoji, std::string("abc")})
+  {
+    for (size_t maxBytes = 0; maxBytes <= s.size() + 1; ++maxBytes)
+    {
+      auto const truncated = strings::TruncateUtf8(s, maxBytes);
+      TEST_LESS_OR_EQUAL(truncated.size(), maxBytes, (s, maxBytes));
+      TEST_EQUAL(std::string(truncated), s.substr(0, truncated.size()), ());
+      TEST_EQUAL(strings::ToUtf8(strings::MakeUniString(truncated)), truncated, (s, maxBytes));
+    }
+  }
+
+  // Malformed input is cut deterministically, at most 3 bytes before the limit.
+  std::string const malformed("a\x80\x80\x80\x80\x80", 6);
+  TEST_EQUAL(strings::TruncateUtf8(malformed, 5).size(), 2, ());
+}
+
 }  // namespace string_utils_test

--- a/libs/base/string_utils.cpp
+++ b/libs/base/string_utils.cpp
@@ -176,6 +176,22 @@ size_t Utf8Length(std::string_view const s)
   return utf8::unchecked::distance(s.begin(), s.end());
 }
 
+std::string_view TruncateUtf8(std::string_view s, size_t maxBytes)
+{
+  if (s.size() <= maxBytes)
+    return s;
+
+  // s[end] is the first excluded byte. While it is a continuation byte (10xxxxxx), the cut is
+  // inside a code point. A code point is at most 4 bytes long, so at most 3 steps back are needed
+  // and the loop terminates on malformed input too.
+  size_t end = maxBytes;
+  size_t const limit = end > 3 ? end - 3 : 0;
+  while (end > limit && (static_cast<unsigned char>(s[end]) & 0xC0) == 0x80)
+    --end;
+
+  return s.substr(0, end);
+}
+
 void AsciiToLower(std::string & s)
 {
   std::transform(s.begin(), s.end(), s.begin(), [](char c) { return AsciiToLower(c); });

--- a/libs/base/string_utils.hpp
+++ b/libs/base/string_utils.hpp
@@ -108,6 +108,11 @@ size_t CountNormLowerSymbols(UniString const & s, UniString const & lowStr);
 
 size_t Utf8Length(std::string_view const s);
 
+/// @return The longest prefix of |s| that is not longer than |maxBytes| and does not split a UTF-8
+/// code point. Returns an empty view if even the first code point does not fit. Malformed input is
+/// truncated at most 3 bytes earlier than |maxBytes|, never later.
+std::string_view TruncateUtf8(std::string_view s, size_t maxBytes);
+
 constexpr char AsciiToLower(char c) noexcept
 {
   return c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c;


### PR DESCRIPTION
Stacked on #13230.

Makes detailed iOS diagnostics inexpensive and reliable:
- bypasses the file queue while file logging is disabled and keeps only error-or-higher writes synchronous
- maps native levels to unified-log severity and enables debug records with the file-logging setting
- bounds oversized UTF-8 records and rotates two 16 MiB retained files outside Documents/backups
- exports every available retained file together with `system-log.txt` in one archive, accepts a recoverable rotated-only snapshot, and reports concrete failures
- keeps archive work off the main thread and surfaces logging/export failures in Settings and bug-report email

Testing:
- 11 focused logger/writer tests, also run as part of the 16-test stacked arm64 iOS 18.6 suite
- `base_tests --filter=Logging_ThreadIds|TruncateUtf8`
- `assembleGoogleDebug -Parm64`

Related to #9872 and #10041; this PR improves diagnostics but does not claim to fix those sync bugs.