### PR TITLE
[ios][icloud] Log bounded, actionable sync diagnostics

### DIFF
--- a/iphone/Maps/Core/iCloud/CloudDirectoryMonitor.swift
+++ b/iphone/Maps/Core/iCloud/CloudDirectoryMonitor.swift
@@ -163,7 +163,7 @@ private extension iCloudDocumentsMonitor {
     do {
       let currentContents = try Self.getCurrentContents(notification)
       LOG(.info, "Cloud contents (\(currentContents.count))")
-      currentContents.forEach { LOG(.debug, $0.shortDebugDescription) }
+      currentContents.forEach { LOG(.debug, $0.synchronizationDebugDescription) }
       delegate?.didFinishGathering(currentContents)
     } catch {
       delegate?.didReceiveCloudMonitorError(error)
@@ -177,20 +177,20 @@ private extension iCloudDocumentsMonitor {
     LOG(.debug, "Query did update")
     do {
       let changedContents = try Self.getChangedContents(notification)
-      /* The metadataQuery can send the same changes multiple times with only uploading/downloading process updates.
-       This unnecessary updated should be skipped. */
+      // NSMetadataQuery may repeat the same batch. Skip exact duplicates, but keep download
+      // progress and state changes because the resolver acts on them.
       if changedContents != previouslyChangedContents {
-        previouslyChangedContents = changedContents
         let currentContents = try Self.getCurrentContents(notification)
+        previouslyChangedContents = changedContents
         // The inventory is the bulk of the log and repeats itself on every update, so it stays at
         // the debug level. The changed items are a handful per update and are what a sync bug is
         // read from, so they are kept in a default report. One record each: a single record is
         // truncated by the system log at about 1 KB.
         LOG(.info, "Cloud contents (\(currentContents.count)), added \(changedContents.added.count), updated \(changedContents.updated.count), removed \(changedContents.removed.count)")
-        currentContents.forEach { LOG(.debug, $0.shortDebugDescription) }
-        changedContents.added.forEach { LOG(.info, "Added: \($0.shortDebugDescription)") }
-        changedContents.updated.forEach { LOG(.info, "Updated: \($0.shortDebugDescription)") }
-        changedContents.removed.forEach { LOG(.info, "Removed: \($0.shortDebugDescription)") }
+        currentContents.forEach { LOG(.debug, $0.synchronizationDebugDescription) }
+        changedContents.added.forEach { LOG(.info, "Added: \($0.synchronizationDebugDescription)") }
+        changedContents.updated.forEach { LOG(.info, "Updated: \($0.synchronizationDebugDescription)") }
+        changedContents.removed.forEach { LOG(.info, "Removed: \($0.synchronizationDebugDescription)") }
         delegate?.didUpdate(currentContents, changedContents)
       }
     } catch {

--- a/iphone/Maps/Core/iCloud/CloudDirectoryMonitor.swift
+++ b/iphone/Maps/Core/iCloud/CloudDirectoryMonitor.swift
@@ -162,8 +162,8 @@ private extension iCloudDocumentsMonitor {
     LOG(.debug, "Query did finish gathering")
     do {
       let currentContents = try Self.getCurrentContents(notification)
-      LOG(.info, "Cloud contents (\(currentContents.count)):")
-      currentContents.forEach { LOG(.info, $0.shortDebugDescription) }
+      LOG(.info, "Cloud contents (\(currentContents.count))")
+      currentContents.forEach { LOG(.debug, $0.shortDebugDescription) }
       delegate?.didFinishGathering(currentContents)
     } catch {
       delegate?.didReceiveCloudMonitorError(error)
@@ -182,11 +182,15 @@ private extension iCloudDocumentsMonitor {
       if changedContents != previouslyChangedContents {
         previouslyChangedContents = changedContents
         let currentContents = try Self.getCurrentContents(notification)
-        LOG(.info, "Cloud contents (\(currentContents.count)):")
-        currentContents.forEach { LOG(.info, $0.shortDebugDescription) }
-        LOG(.info, "Added to the cloud content (\(changedContents.added.count)): \n\(changedContents.added.shortDebugDescription)")
-        LOG(.info, "Updated in the cloud content (\(changedContents.updated.count)): \n\(changedContents.updated.shortDebugDescription)")
-        LOG(.info, "Removed from the cloud content (\(changedContents.removed.count)): \n\(changedContents.removed.shortDebugDescription)")
+        // The inventory is the bulk of the log and repeats itself on every update, so it stays at
+        // the debug level. The changed items are a handful per update and are what a sync bug is
+        // read from, so they are kept in a default report. One record each: a single record is
+        // truncated by the system log at about 1 KB.
+        LOG(.info, "Cloud contents (\(currentContents.count)), added \(changedContents.added.count), updated \(changedContents.updated.count), removed \(changedContents.removed.count)")
+        currentContents.forEach { LOG(.debug, $0.shortDebugDescription) }
+        changedContents.added.forEach { LOG(.info, "Added: \($0.shortDebugDescription)") }
+        changedContents.updated.forEach { LOG(.info, "Updated: \($0.shortDebugDescription)") }
+        changedContents.removed.forEach { LOG(.info, "Removed: \($0.shortDebugDescription)") }
         delegate?.didUpdate(currentContents, changedContents)
       }
     } catch {

--- a/iphone/Maps/Core/iCloud/LocalDirectoryMonitor.swift
+++ b/iphone/Maps/Core/iCloud/LocalDirectoryMonitor.swift
@@ -160,19 +160,20 @@ final class FileSystemDispatchSourceMonitor: LocalDirectoryMonitor {
   private func didFinishGathering(_ currentContents: LocalContents) {
     didFinishGatheringIsCalled = true
     contents = currentContents
-    LOG(.info, "Local contents (\(currentContents.count)):")
-    currentContents.forEach { LOG(.info, $0.shortDebugDescription) }
+    LOG(.info, "Local contents (\(currentContents.count))")
+    currentContents.forEach { LOG(.debug, $0.shortDebugDescription) }
     delegate?.didFinishGathering(currentContents)
   }
 
   private func didUpdate(_ currentContents: LocalContents) {
     let changedContents = Self.getChangedContents(oldContents: contents, newContents: currentContents)
     contents = currentContents
-    LOG(.info, "Local contents (\(currentContents.count)):")
-    currentContents.forEach { LOG(.info, $0.shortDebugDescription) }
-    LOG(.info, "Added to the local content (\(changedContents.added.count)): \n\(changedContents.added.shortDebugDescription)")
-    LOG(.info, "Updated in the local content (\(changedContents.updated.count)): \n\(changedContents.updated.shortDebugDescription)")
-    LOG(.info, "Removed from the local content (\(changedContents.removed.count)): \n\(changedContents.removed.shortDebugDescription)")
+    LOG(.info, "Local contents (\(currentContents.count)), added \(changedContents.added.count), updated \(changedContents.updated.count), removed \(changedContents.removed.count)")
+    currentContents.forEach { LOG(.debug, $0.shortDebugDescription) }
+    // See iCloudDocumentsMonitor.queryDidUpdate for why only the inventory is a debug record.
+    changedContents.added.forEach { LOG(.info, "Added: \($0.shortDebugDescription)") }
+    changedContents.updated.forEach { LOG(.info, "Updated: \($0.shortDebugDescription)") }
+    changedContents.removed.forEach { LOG(.info, "Removed: \($0.shortDebugDescription)") }
     delegate?.didUpdate(currentContents, changedContents)
   }
 

--- a/iphone/Maps/Core/iCloud/MetadataItem.swift
+++ b/iphone/Maps/Core/iCloud/MetadataItem.swift
@@ -39,77 +39,77 @@ extension LocalMetadataItem {
 }
 
 extension CloudMetadataItem {
-  private static let required: [(key: String, isValid: (Any) -> Bool)] = [
-    (NSMetadataItemFSNameKey, { $0 is String }),
-    (NSMetadataItemURLKey, { $0 is URL }),
-    (NSMetadataUbiquitousItemDownloadingStatusKey, { $0 is String }),
-    (NSMetadataUbiquitousItemPercentDownloadedKey, { $0 is NSNumber }),
-    (NSMetadataItemFSContentChangeDateKey, { $0 is Date }),
-    (NSMetadataUbiquitousItemHasUnresolvedConflictsKey, { $0 is Bool }),
+  static let requiredAttributes = [
+    NSMetadataItemFSNameKey,
+    NSMetadataItemURLKey,
+    NSMetadataUbiquitousItemDownloadingStatusKey,
+    NSMetadataUbiquitousItemPercentDownloadedKey,
+    NSMetadataItemFSContentChangeDateKey,
+    NSMetadataUbiquitousItemHasUnresolvedConflictsKey,
   ]
 
-  private static let requiredAttributes: [String] = required.map(\.key)
+  private static let metadataAttributes = requiredAttributes + [
+    NSMetadataUbiquitousItemDownloadingErrorKey,
+    NSMetadataUbiquitousItemUploadingErrorKey,
+  ]
 
-  /// Names of the required attributes that are missing or have an unexpected type.
-  static func invalidAttributes(in values: [String: Any]) -> [String] {
-    required.compactMap { key, isValid in
-      guard let value = values[key] else { return "\(key) (missing)" }
-      return isValid(value) ? nil : "\(key) (\(type(of: value)))"
+  /// Builds the item, or reports the attributes whose absence or type made it fail.
+  static func make(from values: [String: Any]) -> (item: CloudMetadataItem?, invalid: [String]) {
+    var invalid = [String]()
+    func value<T>(_ key: String, as _: T.Type = T.self) -> T? {
+      guard let rawValue = values[key] else {
+        invalid.append("\(key) (missing)")
+        return nil
+      }
+      guard let value = rawValue as? T else {
+        invalid.append("\(key) (\(type(of: rawValue)))")
+        return nil
+      }
+      return value
     }
+
+    // Parse every attribute before checking the result so one record names every bad value.
+    let fileName: String? = value(NSMetadataItemFSNameKey)
+    let fileUrl: URL? = value(NSMetadataItemURLKey)
+    let downloadStatus: String? = value(NSMetadataUbiquitousItemDownloadingStatusKey)
+    let percentDownloaded: NSNumber? = value(NSMetadataUbiquitousItemPercentDownloadedKey)
+    let modificationDate: Date? = value(NSMetadataItemFSContentChangeDateKey)
+    let hasUnresolvedConflicts: Bool? = value(NSMetadataUbiquitousItemHasUnresolvedConflictsKey)
+    guard let fileName,
+          let fileUrl,
+          let downloadStatus,
+          let percentDownloaded,
+          let modificationDate,
+          let hasUnresolvedConflicts
+    else {
+      return (nil, invalid)
+    }
+
+    let item = CloudMetadataItem(fileName: fileName,
+                                 fileUrl: fileUrl.standardizedFileURL,
+                                 isDownloaded: downloadStatus == NSMetadataUbiquitousItemDownloadingStatusCurrent,
+                                 percentDownloaded: percentDownloaded,
+                                 lastModificationDate: modificationDate.roundedTime,
+                                 downloadingError: values[NSMetadataUbiquitousItemDownloadingErrorKey] as? NSError,
+                                 uploadingError: values[NSMetadataUbiquitousItemUploadingErrorKey] as? NSError,
+                                 hasUnresolvedConflicts: hasUnresolvedConflicts)
+    return (item, invalid)
   }
 
   init(metadataItem: NSMetadataItem) throws {
-    let values = metadataItem.values(forAttributes: Self.requiredAttributes) ?? [:]
-    guard let fileName = values[NSMetadataItemFSNameKey] as? String,
-          let fileUrl = values[NSMetadataItemURLKey] as? URL,
-          let downloadStatus = values[NSMetadataUbiquitousItemDownloadingStatusKey] as? String,
-          let percentDownloaded = values[NSMetadataUbiquitousItemPercentDownloadedKey] as? NSNumber,
-          let lastModificationDate = (values[NSMetadataItemFSContentChangeDateKey] as? Date)?.roundedTime,
-          let hasUnresolvedConflicts = values[NSMetadataUbiquitousItemHasUnresolvedConflictsKey] as? Bool
-    else {
+    let values = metadataItem.values(forAttributes: Self.metadataAttributes) ?? [:]
+    let (item, invalid) = Self.make(from: values)
+    guard let item else {
       // The joined names stay well inside the per-record limit of the system log.
-      let invalid = Self.invalidAttributes(in: values).joined(separator: ", ")
-      LOG(.error, "Failed to initialize CloudMetadataItem. Invalid attributes: \(invalid)")
-      for attribute in metadataItem.attributes {
-        LOG(.debug, "\(attribute): \(String(describing: metadataItem.value(forAttribute: attribute)))")
+      assert(!invalid.isEmpty)
+      LOG(.error, "Failed to initialize CloudMetadataItem. Invalid attributes: \(invalid.joined(separator: ", "))")
+      let allValues = metadataItem.values(forAttributes: metadataItem.attributes) ?? [:]
+      for (attribute, value) in allValues {
+        LOG(.debug, "\(attribute): \(value)")
       }
       throw SynchronizationError.failedToCreateMetadataItem
     }
-    self.fileName = fileName
-    self.fileUrl = fileUrl.standardizedFileURL
-    isDownloaded = downloadStatus == NSMetadataUbiquitousItemDownloadingStatusCurrent
-    self.percentDownloaded = percentDownloaded
-    self.lastModificationDate = lastModificationDate
-    self.hasUnresolvedConflicts = hasUnresolvedConflicts
-    downloadingError = metadataItem.value(forAttribute: NSMetadataUbiquitousItemDownloadingErrorKey) as? NSError
-    uploadingError = metadataItem.value(forAttribute: NSMetadataUbiquitousItemUploadingErrorKey) as? NSError
-  }
-
-  init(fileUrl: URL) throws {
-    let resources = try fileUrl.resourceValues(forKeys: [.nameKey,
-                                                         .contentModificationDateKey,
-                                                         .ubiquitousItemDownloadingStatusKey,
-                                                         .ubiquitousItemHasUnresolvedConflictsKey,
-                                                         .ubiquitousItemDownloadingErrorKey,
-                                                         .ubiquitousItemUploadingErrorKey])
-    guard let downloadStatus = resources.ubiquitousItemDownloadingStatus,
-          // Not used.
-          // let percentDownloaded = resources.ubiquitousItemDownloadingStatus,
-          let lastModificationDate = resources.contentModificationDate?.roundedTime,
-          let hasUnresolvedConflicts = resources.ubiquitousItemHasUnresolvedConflicts
-    else {
-      LOG(.error, "Failed to initialize CloudMetadataItem from \(fileUrl) resources: \(resources.allValues)")
-      throw SynchronizationError.failedToCreateMetadataItem
-    }
-    fileName = fileUrl.lastPathComponent
-    self.fileUrl = fileUrl.standardizedFileURL
-    let isDownloaded = downloadStatus.rawValue == NSMetadataUbiquitousItemDownloadingStatusCurrent
-    self.isDownloaded = isDownloaded
-    percentDownloaded = isDownloaded ? 0.0 : 100.0
-    self.lastModificationDate = lastModificationDate
-    self.hasUnresolvedConflicts = hasUnresolvedConflicts
-    downloadingError = resources.ubiquitousItemDownloadingError
-    uploadingError = resources.ubiquitousItemUploadingError
+    self = item
   }
 
   func relatedLocalItemUrl(to localContainer: URL) -> URL {
@@ -120,6 +120,16 @@ extension CloudMetadataItem {
 extension MetadataItem {
   var shortDebugDescription: String {
     "fileName: \(fileName), lastModified: \(lastModificationDate)"
+  }
+}
+
+extension CloudMetadataItem {
+  var synchronizationDebugDescription: String {
+    "lastModified: \(lastModificationDate), url: \(fileUrl.path), downloaded: \(isDownloaded), percentDownloaded: \(percentDownloaded), unresolvedConflicts: \(hasUnresolvedConflicts), downloadingError: \(Self.errorCode(downloadingError)), uploadingError: \(Self.errorCode(uploadingError))"
+  }
+
+  private static func errorCode(_ error: NSError?) -> String {
+    error.map { "\($0.domain)#\($0.code)" } ?? "none"
   }
 }
 

--- a/iphone/Maps/Core/iCloud/MetadataItem.swift
+++ b/iphone/Maps/Core/iCloud/MetadataItem.swift
@@ -39,16 +39,40 @@ extension LocalMetadataItem {
 }
 
 extension CloudMetadataItem {
+  private static let required: [(key: String, isValid: (Any) -> Bool)] = [
+    (NSMetadataItemFSNameKey, { $0 is String }),
+    (NSMetadataItemURLKey, { $0 is URL }),
+    (NSMetadataUbiquitousItemDownloadingStatusKey, { $0 is String }),
+    (NSMetadataUbiquitousItemPercentDownloadedKey, { $0 is NSNumber }),
+    (NSMetadataItemFSContentChangeDateKey, { $0 is Date }),
+    (NSMetadataUbiquitousItemHasUnresolvedConflictsKey, { $0 is Bool }),
+  ]
+
+  private static let requiredAttributes: [String] = required.map(\.key)
+
+  /// Names of the required attributes that are missing or have an unexpected type.
+  static func invalidAttributes(in values: [String: Any]) -> [String] {
+    required.compactMap { key, isValid in
+      guard let value = values[key] else { return "\(key) (missing)" }
+      return isValid(value) ? nil : "\(key) (\(type(of: value)))"
+    }
+  }
+
   init(metadataItem: NSMetadataItem) throws {
-    guard let fileName = metadataItem.value(forAttribute: NSMetadataItemFSNameKey) as? String,
-          let fileUrl = metadataItem.value(forAttribute: NSMetadataItemURLKey) as? URL,
-          let downloadStatus = metadataItem.value(forAttribute: NSMetadataUbiquitousItemDownloadingStatusKey) as? String,
-          let percentDownloaded = metadataItem.value(forAttribute: NSMetadataUbiquitousItemPercentDownloadedKey) as? NSNumber,
-          let lastModificationDate = (metadataItem.value(forAttribute: NSMetadataItemFSContentChangeDateKey) as? Date)?.roundedTime,
-          let hasUnresolvedConflicts = metadataItem.value(forAttribute: NSMetadataUbiquitousItemHasUnresolvedConflictsKey) as? Bool
+    let values = metadataItem.values(forAttributes: Self.requiredAttributes) ?? [:]
+    guard let fileName = values[NSMetadataItemFSNameKey] as? String,
+          let fileUrl = values[NSMetadataItemURLKey] as? URL,
+          let downloadStatus = values[NSMetadataUbiquitousItemDownloadingStatusKey] as? String,
+          let percentDownloaded = values[NSMetadataUbiquitousItemPercentDownloadedKey] as? NSNumber,
+          let lastModificationDate = (values[NSMetadataItemFSContentChangeDateKey] as? Date)?.roundedTime,
+          let hasUnresolvedConflicts = values[NSMetadataUbiquitousItemHasUnresolvedConflictsKey] as? Bool
     else {
-      let allAttributes = metadataItem.values(forAttributes: metadataItem.attributes)
-      LOG(.error, "Failed to initialize CloudMetadataItem from NSMetadataItem: \(allAttributes.debugDescription)")
+      // The joined names stay well inside the per-record limit of the system log.
+      let invalid = Self.invalidAttributes(in: values).joined(separator: ", ")
+      LOG(.error, "Failed to initialize CloudMetadataItem. Invalid attributes: \(invalid)")
+      for attribute in metadataItem.attributes {
+        LOG(.debug, "\(attribute): \(String(describing: metadataItem.value(forAttribute: attribute)))")
+      }
       throw SynchronizationError.failedToCreateMetadataItem
     }
     self.fileName = fileName
@@ -112,10 +136,6 @@ extension Array where Element: MetadataItem {
 
   func firstByName(_ item: any MetadataItem) -> Element? {
     first(where: { $0.fileName == item.fileName })
-  }
-
-  var shortDebugDescription: String {
-    map(\.shortDebugDescription).joined(separator: "\n")
   }
 }
 

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -635,6 +635,7 @@
 		EDF838C22C00B9D6007E4E67 /* MetadataItemStubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF838B42C00B9C7007E4E67 /* MetadataItemStubs.swift */; };
 		AB10ADAD2026072600000004 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB10ADAD2026072600000003 /* LoggerTests.swift */; };
 		AB10ADAD2026081200000021 /* LogFileWriterTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = AB10ADAD2026081200000020 /* LogFileWriterTests.mm */; };
+		AB10ADAD2026072600000002 /* CloudMetadataItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB10ADAD2026072600000001 /* CloudMetadataItemTests.swift */; };
 		EDF838C32C00B9D6007E4E67 /* UbiquitousDirectoryMonitorDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF838B12C00B9C7007E4E67 /* UbiquitousDirectoryMonitorDelegateMock.swift */; };
 		EDF838C42C00B9D6007E4E67 /* FileManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF838B32C00B9C7007E4E67 /* FileManagerMock.swift */; };
 		F623DA6C1C9C2731006A3436 /* opening_hours_how_to_edit.html in Resources */ = {isa = PBXBuildFile; fileRef = F623DA6A1C9C2731006A3436 /* opening_hours_how_to_edit.html */; };
@@ -1723,6 +1724,7 @@
 		EDF838B42C00B9C7007E4E67 /* MetadataItemStubs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetadataItemStubs.swift; sourceTree = "<group>"; };
 		AB10ADAD2026072600000003 /* LoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		AB10ADAD2026081200000020 /* LogFileWriterTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LogFileWriterTests.mm; sourceTree = "<group>"; };
+		AB10ADAD2026072600000001 /* CloudMetadataItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudMetadataItemTests.swift; sourceTree = "<group>"; };
 		EE026F0511D6AC0D00645242 /* classificator.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = classificator.txt; path = ../../data/classificator.txt; sourceTree = SOURCE_ROOT; };
 		F623DA6A1C9C2731006A3436 /* opening_hours_how_to_edit.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = opening_hours_how_to_edit.html; path = ../../data/opening_hours_how_to_edit.html; sourceTree = "<group>"; };
 		F6C3A1B121AC22810060EEC8 /* Alert 5.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Alert 5.m4a"; sourceTree = "<group>"; };
@@ -4114,6 +4116,7 @@
 				EDF838AF2C00B9C7007E4E67 /* SynchronizationStateManagerTests.swift */,
 				EDF838B02C00B9C7007E4E67 /* iCloudDirectoryMonitorTests */,
 				EDF838B42C00B9C7007E4E67 /* MetadataItemStubs.swift */,
+				AB10ADAD2026072600000001 /* CloudMetadataItemTests.swift */,
 			);
 			path = iCloudTests;
 			sourceTree = "<group>";
@@ -5019,6 +5022,7 @@
 				EDF838C22C00B9D6007E4E67 /* MetadataItemStubs.swift in Sources */,
 				AB10ADAD2026081200000021 /* LogFileWriterTests.mm in Sources */,
 				AB10ADAD2026072600000004 /* LoggerTests.swift in Sources */,
+				AB10ADAD2026072600000002 /* CloudMetadataItemTests.swift in Sources */,
 				EDC4E3612C5E2576009286A2 /* RecentlyDeletedCategoriesViewModelTests.swift in Sources */,
 				4B4153B52BF9695500EE4B02 /* MWMTextToSpeechTests.mm in Sources */,
 				EDF838C42C00B9D6007E4E67 /* FileManagerMock.swift in Sources */,

--- a/iphone/Maps/Tests/Core/iCloudTests/CloudMetadataItemTests.swift
+++ b/iphone/Maps/Tests/Core/iCloudTests/CloudMetadataItemTests.swift
@@ -1,0 +1,40 @@
+@testable import Organic_Maps__Debug_
+import XCTest
+
+final class CloudMetadataItemTests: XCTestCase {
+  private let validValues: [String: Any] = [
+    NSMetadataItemFSNameKey: "Bookmarks.kml",
+    NSMetadataItemURLKey: URL(fileURLWithPath: "/tmp/Bookmarks.kml"),
+    NSMetadataUbiquitousItemDownloadingStatusKey: NSMetadataUbiquitousItemDownloadingStatusCurrent,
+    NSMetadataUbiquitousItemPercentDownloadedKey: NSNumber(value: 100),
+    NSMetadataItemFSContentChangeDateKey: Date(),
+    NSMetadataUbiquitousItemHasUnresolvedConflictsKey: false,
+  ]
+
+  func testValidValuesHaveNoInvalidAttributes() {
+    XCTAssertEqual(CloudMetadataItem.invalidAttributes(in: validValues), [])
+  }
+
+  func testMissingAttributeIsReported() {
+    var values = validValues
+    values.removeValue(forKey: NSMetadataItemURLKey)
+    XCTAssertEqual(CloudMetadataItem.invalidAttributes(in: values), ["\(NSMetadataItemURLKey) (missing)"])
+  }
+
+  func testAttributeOfUnexpectedTypeIsReported() {
+    var values = validValues
+    // The system reports the URL as a plain string instead of a URL.
+    values[NSMetadataItemURLKey] = "/tmp/Bookmarks.kml"
+    let invalid = CloudMetadataItem.invalidAttributes(in: values)
+    XCTAssertEqual(invalid.count, 1)
+    XCTAssertTrue(invalid[0].contains(NSMetadataItemURLKey))
+  }
+
+  func testEveryMissingAttributeIsReported() {
+    let invalid = CloudMetadataItem.invalidAttributes(in: [:])
+    XCTAssertEqual(invalid.count, validValues.count)
+    for key in validValues.keys {
+      XCTAssertTrue(invalid.contains("\(key) (missing)"))
+    }
+  }
+}

--- a/iphone/Maps/Tests/Core/iCloudTests/CloudMetadataItemTests.swift
+++ b/iphone/Maps/Tests/Core/iCloudTests/CloudMetadataItemTests.swift
@@ -2,39 +2,75 @@
 import XCTest
 
 final class CloudMetadataItemTests: XCTestCase {
+  private let downloadingError = NSError(domain: "download", code: 7)
+  private let uploadingError = NSError(domain: "upload", code: 8)
   private let validValues: [String: Any] = [
-    NSMetadataItemFSNameKey: "Bookmarks.kml",
-    NSMetadataItemURLKey: URL(fileURLWithPath: "/tmp/Bookmarks.kml"),
-    NSMetadataUbiquitousItemDownloadingStatusKey: NSMetadataUbiquitousItemDownloadingStatusCurrent,
+    NSMetadataItemFSNameKey: NSString(string: "Bookmarks.kml"),
+    NSMetadataItemURLKey: NSURL(fileURLWithPath: "/tmp/Folder/../Bookmarks.kml"),
+    NSMetadataUbiquitousItemDownloadingStatusKey: NSString(string: NSMetadataUbiquitousItemDownloadingStatusCurrent),
     NSMetadataUbiquitousItemPercentDownloadedKey: NSNumber(value: 100),
-    NSMetadataItemFSContentChangeDateKey: Date(),
-    NSMetadataUbiquitousItemHasUnresolvedConflictsKey: false,
+    NSMetadataItemFSContentChangeDateKey: NSDate(timeIntervalSince1970: 123.75),
+    NSMetadataUbiquitousItemHasUnresolvedConflictsKey: NSNumber(value: false),
+    NSMetadataUbiquitousItemDownloadingErrorKey: NSError(domain: "download", code: 7),
+    NSMetadataUbiquitousItemUploadingErrorKey: NSError(domain: "upload", code: 8),
   ]
 
-  func testValidValuesHaveNoInvalidAttributes() {
-    XCTAssertEqual(CloudMetadataItem.invalidAttributes(in: validValues), [])
+  func testBridgedValuesAreMappedToTheItem() throws {
+    let result = CloudMetadataItem.make(from: validValues)
+    let item = try XCTUnwrap(result.item)
+    XCTAssertEqual(item.fileName, "Bookmarks.kml")
+    XCTAssertEqual(item.fileUrl, URL(fileURLWithPath: "/tmp/Bookmarks.kml"))
+    XCTAssertTrue(item.isDownloaded)
+    XCTAssertEqual(item.percentDownloaded, 100)
+    XCTAssertEqual(item.lastModificationDate, 123)
+    XCTAssertEqual(item.downloadingError?.domain, downloadingError.domain)
+    XCTAssertEqual(item.downloadingError?.code, downloadingError.code)
+    XCTAssertEqual(item.uploadingError?.domain, uploadingError.domain)
+    XCTAssertEqual(item.uploadingError?.code, uploadingError.code)
+    XCTAssertFalse(item.hasUnresolvedConflicts)
+    XCTAssertEqual(result.invalid, [])
   }
 
   func testMissingAttributeIsReported() {
     var values = validValues
     values.removeValue(forKey: NSMetadataItemURLKey)
-    XCTAssertEqual(CloudMetadataItem.invalidAttributes(in: values), ["\(NSMetadataItemURLKey) (missing)"])
+    XCTAssertEqual(CloudMetadataItem.make(from: values).invalid,
+                   ["\(NSMetadataItemURLKey) (missing)"])
   }
 
   func testAttributeOfUnexpectedTypeIsReported() {
     var values = validValues
     // The system reports the URL as a plain string instead of a URL.
     values[NSMetadataItemURLKey] = "/tmp/Bookmarks.kml"
-    let invalid = CloudMetadataItem.invalidAttributes(in: values)
+    let invalid = CloudMetadataItem.make(from: values).invalid
     XCTAssertEqual(invalid.count, 1)
     XCTAssertTrue(invalid[0].contains(NSMetadataItemURLKey))
   }
 
   func testEveryMissingAttributeIsReported() {
-    let invalid = CloudMetadataItem.invalidAttributes(in: [:])
-    XCTAssertEqual(invalid.count, validValues.count)
-    for key in validValues.keys {
+    let invalid = CloudMetadataItem.make(from: [:]).invalid
+    XCTAssertEqual(invalid.count, CloudMetadataItem.requiredAttributes.count)
+    for key in CloudMetadataItem.requiredAttributes {
       XCTAssertTrue(invalid.contains("\(key) (missing)"))
     }
+  }
+
+  func testSynchronizationDescriptionContainsDecisionState() {
+    let item = CloudMetadataItem(fileName: "Bookmarks.kml",
+                                 fileUrl: URL(fileURLWithPath: "/tmp/.Trash/Bookmarks.kml"),
+                                 isDownloaded: false,
+                                 percentDownloaded: 42,
+                                 lastModificationDate: 10,
+                                 downloadingError: NSError(domain: "download", code: 7),
+                                 uploadingError: nil,
+                                 hasUnresolvedConflicts: true)
+
+    let description = item.synchronizationDebugDescription
+    XCTAssertTrue(description.contains("/tmp/.Trash/Bookmarks.kml"))
+    XCTAssertTrue(description.contains("downloaded: false"))
+    XCTAssertTrue(description.contains("percentDownloaded: 42"))
+    XCTAssertTrue(description.contains("unresolvedConflicts: true"))
+    XCTAssertTrue(description.contains("downloadingError: download#7"))
+    XCTAssertFalse(description.contains("fileName:"))
   }
 }


### PR DESCRIPTION
Stacked on #13445, which is stacked on #13230.

Makes iCloud synchronization reports bounded and actionable:
- derives the metadata fetch from the required-key list and uses one mapping path for validation, item construction, URL/date/status conversion, and optional errors
- keeps inventory details at debug while logging changed items with the full path, download state/progress, conflicts, and compact error codes without repeating the file name
- suppresses only exact duplicate update batches
- removes an unused URL initializer whose progress values were reversed

Testing:
- 5 `CloudMetadataItemTests` covering bridged production values and the complete mapping, also run as part of the 16-test stacked arm64 iOS 18.6 suite
- `assembleGoogleDebug -Parm64` for the complete stack

Related to #9872 and #10041; this PR improves diagnostics but does not claim to fix those sync bugs.