### PR TITLE
[tools] Upgrade clang-format to 23

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -63,7 +63,7 @@ AllowShortFunctionsOnASingleLine: Empty
 
 ---
 Language: ObjC
-# clang-format 20-22 parse a block literal with an angle-bracketed return type, e.g.
+# clang-format 20-23 parse a block literal with an angle-bracketed return type, e.g.
 # ^NSDictionary<NSString *, NSString *> *(...) in libs/platform/http_uploader_apple.mm,
 # as a function definition, so RemoveSemicolon deletes the ; that terminates it.
 RemoveSemicolon: false

--- a/.github/workflows/code-style-check.yaml
+++ b/.github/workflows/code-style-check.yaml
@@ -23,19 +23,18 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Install clang-format
-        run: |
-          sudo apt purge -y clang-format-18  # Remove default old version of clang-format
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main' | sudo tee /etc/apt/sources.list.d/llvm-toolchain-noble-22.list
-          sudo apt-get update
-          sudo apt-get install -y clang-format-22
-          sudo update-alternatives --force --install /usr/bin/clang-format clang-format /usr/bin/clang-format-22 10
-          sudo update-alternatives --force --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-22 10
-          clang-format --version
-
       - name: Checkout sources
         uses: actions/checkout@v6
+
+      # The versioned binary is enough: clang-format.sh resolves clang-format-$CLANG_FORMAT_VERSION
+      # by name and verifies its version, so the unversioned one in the image is never used.
+      - name: Install clang-format
+        run: |
+          source tools/hooks/format-config.bash
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-$CLANG_FORMAT_VERSION main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-noble-$CLANG_FORMAT_VERSION.list
+          sudo apt-get update
+          sudo apt-get install -y "clang-format-$CLANG_FORMAT_VERSION"
 
       - name: Run clang-format
         run: tools/unix/clang-format.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ The C++ core is accessed from platforms via bridging layers:
 - `using` instead of `typedef`
 - Compile-time constants: `kCamelCase` and `constexpr`
 - Comments should be brief, explaining only reasoning that is not obvious from the code itself
-- Auto-format: `clang-format -i file.cpp` (v22+), or `tools/unix/clang-format.sh` for the whole tree
+- Auto-format: `clang-format -i file.cpp` (v23), or `tools/unix/clang-format.sh` for the whole tree
 - Swift: format with `swiftformat iphone/` or `swiftformat <file>` (config in `iphone/.swiftformat`)
 - Kotlin: format with `tools/unix/ktlint_format.sh` (config in `android/.editorconfig`)
 - Style checks gate CI (clang-format, swiftformat, ktlint, and detekt static analysis) -- run them before pushing

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
@@ -81,11 +81,9 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
       });
 
   private final ActivityResultLauncher<Intent> startBookmarkSettingsForResult =
-      registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
-                                activityResult
-                                -> {
-                                    // not handled at the moment
-                                });
+      registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), activityResult -> {
+        // not handled at the moment
+      });
 
   @Override
   @LayoutRes

--- a/android/app/src/main/java/app/organicmaps/editor/MultilanguageAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/editor/MultilanguageAdapter.java
@@ -116,15 +116,13 @@ public class MultilanguageAdapter extends RecyclerView.Adapter<MultilanguageAdap
         }
       });
 
-      itemView.findViewById(R.id.delete)
-          .setOnClickListener(v
-                              -> {
-                                  // TODO(mgsergio): Implement item deletion.
-                                  // int position = getAdapterPosition();
-                                  // mHostFragment.removeLocalizedName(position + 1);
-                                  // mNames.remove(position);
-                                  // notifyItemRemoved(position);
-                              });
+      itemView.findViewById(R.id.delete).setOnClickListener(v -> {
+        // TODO(mgsergio): Implement item deletion.
+        // int position = getAdapterPosition();
+        // mHostFragment.removeLocalizedName(position + 1);
+        // mNames.remove(position);
+        // notifyItemRemoved(position);
+      });
     }
   }
 }

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageStateListener.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageStateListener.java
@@ -1,4 +1,5 @@
 package app.organicmaps.widget.placepage;
 
 public interface PlacePageStateListener
-{}
+{
+}

--- a/android/libs/car/src/main/java/app/organicmaps/car/screens/CategoriesScreen.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/screens/CategoriesScreen.java
@@ -26,7 +26,8 @@ import java.util.List;
 public class CategoriesScreen extends BaseMapScreen
 {
   private record CategoryData(@StringRes int nameResId, @DrawableRes int iconResId)
-  {}
+  {
+  }
 
   private static final List<CategoryData> CATEGORIES =
       Arrays.asList(new CategoryData(R.string.category_fuel, R.drawable.ic_category_fuel),

--- a/android/libs/car/src/main/java/app/organicmaps/car/screens/settings/DrivingOptionsScreen.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/screens/settings/DrivingOptionsScreen.java
@@ -27,7 +27,8 @@ public class DrivingOptionsScreen extends BaseMapScreen
   public static final Object DRIVING_OPTIONS_RESULT_CHANGED = 0x1;
 
   private record DrivingOption(RoadType roadType, @StringRes int text)
-  {}
+  {
+  }
 
   private final DrivingOption[] mDrivingOptions = {new DrivingOption(RoadType.Toll, R.string.avoid_tolls),
                                                    new DrivingOption(RoadType.Dirty, R.string.avoid_unpaved),

--- a/android/libs/car/src/main/java/app/organicmaps/car/util/UserActionRequired.java
+++ b/android/libs/car/src/main/java/app/organicmaps/car/util/UserActionRequired.java
@@ -3,4 +3,5 @@ package app.organicmaps.car.util;
 /// Marker interface for screens that require user action to proceed.
 /// These screens can't be dropped from AA's screen stack.
 public interface UserActionRequired
-{}
+{
+}

--- a/android/sdk/src/main/java/app/organicmaps/sdk/widget/placepage/PlacePageData.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/widget/placepage/PlacePageData.java
@@ -6,4 +6,5 @@ import androidx.annotation.Keep;
 // Used by JNI.
 @Keep
 @SuppressWarnings("unused")
-public interface PlacePageData extends Parcelable {}
+public interface PlacePageData extends Parcelable {
+}

--- a/android/sdk/wear/core/src/main/java/app/organicmaps/sdk/wear/WearBridge.java
+++ b/android/sdk/wear/core/src/main/java/app/organicmaps/sdk/wear/WearBridge.java
@@ -14,7 +14,8 @@ import app.organicmaps.wear.protocol.WearNavigationState;
 public final class WearBridge
 {
   @NonNull
-  private static final WearNavigationPublisher NO_OP = state -> {};
+  private static final WearNavigationPublisher NO_OP = state ->
+  {};
 
   @NonNull
   private static volatile WearNavigationPublisher sPublisher = NO_OP;

--- a/docs/CODE_STYLE_GUIDE.md
+++ b/docs/CODE_STYLE_GUIDE.md
@@ -4,7 +4,7 @@ Read the code, and follow the existing style as much as possible.
 
 ## ClangFormat
 
-For C++, Java and Objective C/C++ code we use [clang-format](http://clang.llvm.org/docs/ClangFormat.html) of version 22 or later.
+For C++, Java and Objective C/C++ code we use [clang-format](http://clang.llvm.org/docs/ClangFormat.html) version 23.
 
 ### Installation
 
@@ -13,21 +13,29 @@ For C++, Java and Objective C/C++ code we use [clang-format](http://clang.llvm.o
 - Ubuntu 24:
    ```bash
    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-   echo 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main' | sudo tee /etc/apt/sources.list.d/ llvm-toolchain-noble-22.list
+   echo 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-23 main' | sudo tee /etc/apt/sources.list.d/llvm-toolchain-noble-23.list
    sudo apt-get update
-   sudo apt-get install -y clang-format-22  # Run it as clang-format-22
+   sudo apt-get install -y clang-format-23  # Run it as clang-format-23
    ```
+- Any OS, pinned to an exact version: `pip install clang-format==23.1.0`
 
-Make sure that clang-format is in your PATH.
+Make sure that clang-format 23.x is in your PATH. The formatting scripts reject other major versions to prevent
+formatting differences between local development and CI. Homebrew and MSYS2 track the current LLVM release, so
+use the pinned `pip` package (or `brew install llvm@23`, binary in `$(brew --prefix llvm@23)/bin`) once they
+move ahead of 23.
 
 ### Usage
 
 - Configuration is in `.clang-format`
 - Set up a `git commit` hook (see below) for automatic formatting of changed files
-- To manually format a file run `clang-format -i file` (`clang-format-22` for Ubuntu)
+- To manually format a file run `clang-format -i file` (`clang-format-23` for Ubuntu)
 - To format all files in the repository run `tools/unix/clang-format.sh`
 - To format changes added to commit run `git clang-format`
 - To format already committed changes run `git clang-format HEAD~1`
+
+`git clang-format` runs whichever `clang-format` is first in PATH and does not check its version, unlike
+`tools/unix/clang-format.sh` and the commit hook. Pass `--binary clang-format-23` if you have several versions
+installed.
 
 ### ClangFormat in Android Studio
 

--- a/iphone/CoreApi/CoreApi/Common/MWMTypes.h
+++ b/iphone/CoreApi/CoreApi/Common/MWMTypes.h
@@ -8,9 +8,15 @@ typedef void (^MWMURLBlock)(NSURL *);
 typedef BOOL (^MWMCheckStringBlock)(NSString *);
 typedef void (^MWMBoolBlock)(BOOL);
 
-typedef NS_ENUM(NSUInteger, MWMDayTime) { MWMDayTimeDay, MWMDayTimeNight } NS_SWIFT_NAME(DayTime);
+typedef NS_ENUM(NSUInteger, MWMDayTime) {
+  MWMDayTimeDay,
+  MWMDayTimeNight
+} NS_SWIFT_NAME(DayTime);
 
-typedef NS_ENUM(NSUInteger, MWMUnits) { MWMUnitsMetric, MWMUnitsImperial } NS_SWIFT_NAME(Units);
+typedef NS_ENUM(NSUInteger, MWMUnits) {
+  MWMUnitsMetric,
+  MWMUnitsImperial
+} NS_SWIFT_NAME(Units);
 
 typedef NS_ENUM(NSUInteger, MWMPlacement) {
   MWMPlacementNone,

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.h
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.h
@@ -8,7 +8,10 @@
 @class TrackInfo;
 @class ElevationProfileData;
 
-typedef NS_ENUM(NSUInteger, MWMZoomMode) { MWMZoomModeIn = 0, MWMZoomModeOut };
+typedef NS_ENUM(NSUInteger, MWMZoomMode) {
+  MWMZoomModeIn = 0,
+  MWMZoomModeOut
+};
 
 typedef NS_ENUM(NSInteger, ProductsPopupCloseReason) {
   ProductsPopupCloseReasonClose,

--- a/iphone/Maps/Core/Routing/MWMRouter.h
+++ b/iphone/Maps/Core/Routing/MWMRouter.h
@@ -3,7 +3,12 @@
 
 @class RouteElevationPreviewData;
 
-typedef NS_ENUM(NSInteger, MWMRoadType) { MWMRoadTypeToll, MWMRoadTypeDirty, MWMRoadTypeFerry, MWMRoadTypeMotorway };
+typedef NS_ENUM(NSInteger, MWMRoadType) {
+  MWMRoadTypeToll,
+  MWMRoadTypeDirty,
+  MWMRoadTypeFerry,
+  MWMRoadTypeMotorway
+};
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/iphone/Maps/Core/Routing/MWMRouterRecommendation.h
+++ b/iphone/Maps/Core/Routing/MWMRouterRecommendation.h
@@ -1,1 +1,3 @@
-typedef NS_ENUM(NSUInteger, MWMRouterRecommendation) { MWMRouterRecommendationRebuildAfterPointsLoading };
+typedef NS_ENUM(NSUInteger, MWMRouterRecommendation) {
+  MWMRouterRecommendationRebuildAfterPointsLoading
+};

--- a/iphone/Maps/Core/Search/MWMSearch.h
+++ b/iphone/Maps/Core/Search/MWMSearch.h
@@ -11,7 +11,11 @@ typedef NS_ENUM(NSUInteger, SearchTextSource) {
   SearchTextSourceDeeplink
 };
 
-typedef NS_ENUM(NSUInteger, SearchMode) { SearchModeEverywhere, SearchModeViewport, SearchModeEverywhereAndViewport };
+typedef NS_ENUM(NSUInteger, SearchMode) {
+  SearchModeEverywhere,
+  SearchModeViewport,
+  SearchModeEverywhereAndViewport
+};
 
 @class SearchResult;
 @class SearchQuery;

--- a/iphone/Maps/Core/Search/SearchItemType.h
+++ b/iphone/Maps/Core/Search/SearchItemType.h
@@ -1,1 +1,4 @@
-typedef NS_ENUM(NSInteger, SearchItemType) { SearchItemTypeRegular, SearchItemTypeSuggestion };
+typedef NS_ENUM(NSInteger, SearchItemType) {
+  SearchItemTypeRegular,
+  SearchItemTypeSuggestion
+};

--- a/iphone/Maps/Core/Theme/Core/Style.swift
+++ b/iphone/Maps/Core/Theme/Core/Style.swift
@@ -72,7 +72,7 @@ class Style: ExpressibleByDictionaryLiteral {
   func append(_ styles: [Style]) {
     for style in styles {
       params.merge(style.params) { a, _ -> Style.Value in
-        return a
+        a
       }
     }
   }

--- a/iphone/Maps/Core/Theme/Core/StyleManager.swift
+++ b/iphone/Maps/Core/Theme/Core/StyleManager.swift
@@ -70,7 +70,7 @@
 
   @objc func removeListener(_ themeListener: ThemeListener) {
     listeners.removeAll { container -> Bool in
-      return container.value === themeListener
+      container.value === themeListener
     }
   }
 }

--- a/iphone/Maps/UI/Downloader/MWMMapDownloaderMode.h
+++ b/iphone/Maps/UI/Downloader/MWMMapDownloaderMode.h
@@ -1,1 +1,4 @@
-typedef NS_ENUM(NSUInteger, MWMMapDownloaderMode) { MWMMapDownloaderModeDownloaded, MWMMapDownloaderModeAvailable };
+typedef NS_ENUM(NSUInteger, MWMMapDownloaderMode) {
+  MWMMapDownloaderModeDownloaded,
+  MWMMapDownloaderModeAvailable
+};

--- a/iphone/Maps/UI/Help/AboutController/AboutController.swift
+++ b/iphone/Maps/UI/Help/AboutController/AboutController.swift
@@ -256,7 +256,7 @@ private extension AboutController {
   func buildInfoTableViewData() -> [AboutInfoTableViewCellModel] {
     let infoContent: [AboutInfo] = [.faq, .reportMapDataProblem, .reportABug, .news, .volunteer, .rateTheApp]
     return infoContent.map { [weak self] aboutInfo in
-      return AboutInfoTableViewCellModel(title: aboutInfo.title, image: aboutInfo.image, didTapHandler: {
+      AboutInfoTableViewCellModel(title: aboutInfo.title, image: aboutInfo.image, didTapHandler: {
         switch aboutInfo {
         case .faq:
           self?.navigationController?.pushViewController(FaqController(), animated: true)
@@ -276,7 +276,7 @@ private extension AboutController {
   func buildSocialMediaCollectionViewData() -> [SocialMediaCollectionViewCellModel] {
     let socialMediaContent = SocialMedia.allCases
     return socialMediaContent.map { [weak self] socialMedia in
-      return SocialMediaCollectionViewCellModel(image: socialMedia.image, didTapHandler: {
+      SocialMediaCollectionViewCellModel(image: socialMedia.image, didTapHandler: {
         switch socialMedia {
         case .telegram: fallthrough
         case .github: fallthrough

--- a/iphone/Maps/UI/Map/MapViewController.mm
+++ b/iphone/Maps/UI/Map/MapViewController.mm
@@ -33,7 +33,11 @@ extern NSString * const kMap2GoogleLoginSegue = @"Map2GoogleLogin";
 static CGFloat kPlacePageCompactWidth = 350;
 static CGFloat kPlacePageLeadingOffset = IPAD ? 20 : 0;
 
-typedef NS_ENUM(NSUInteger, UserTouchesAction) { UserTouchesActionNone, UserTouchesActionDrag, UserTouchesActionScale };
+typedef NS_ENUM(NSUInteger, UserTouchesAction) {
+  UserTouchesActionNone,
+  UserTouchesActionDrag,
+  UserTouchesActionScale
+};
 
 namespace
 {

--- a/libs/drape_frontend/gps_track_renderer.cpp
+++ b/libs/drape_frontend/gps_track_renderer.cpp
@@ -28,11 +28,13 @@ int const kMinVisibleZoomLevel = 5;
 uint32_t const kAveragePointsCount = 512;
 
 // Radius of circles depending on zoom levels.
+// clang-format off
 std::array<float, 20> const kRadiusInPixel = {
     // 1   2     3     4     5     6     7     8     9     10
     0.8f, 0.8f, 1.5f, 2.5f, 2.5f, 2.5f, 2.5f, 2.5f, 2.5f, 2.5f,
     // 11   12    13    14    15    16    17    18    19     20
     2.5f, 2.5f, 2.5f, 2.5f, 3.0f, 4.0f, 4.5f, 4.5f, 5.0f, 5.5f};
+// clang-format on
 
 double const kHumanSpeed = 2.6;  // meters per second
 double const kCarSpeed = 6.2;    // meters per second

--- a/libs/drape_frontend/route_shape.cpp
+++ b/libs/drape_frontend/route_shape.cpp
@@ -21,6 +21,7 @@
 
 namespace df
 {
+// clang-format off
 std::array<float, 20> const kRouteHalfWidthInPixelCar = {
     // 1   2     3     4     5     6     7     8     9     10
     1.0f, 1.2f, 1.5f, 1.5f, 1.7f, 2.0f, 2.0f, 2.3f, 2.5f, 2.7f,
@@ -38,6 +39,7 @@ std::array<float, 20> const kRouteHalfWidthInPixelOthers = {
     1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.1f, 1.2f, 1.3f,
     // 11   12    13    14    15   16    17    18    19     20
     1.5f, 1.7f, 2.3f, 2.7f, 3.5, 4.5f, 5.0f, 7.0f, 11.0f, 13.0f};
+// clang-format on
 
 namespace rs
 {

--- a/libs/drape_frontend/rule_drawer.cpp
+++ b/libs/drape_frontend/rule_drawer.cpp
@@ -36,9 +36,11 @@ namespace
 {
 // The first zoom level in kAverageSegmentsCount.
 int constexpr kFirstZoomInAverageSegments = 10;
+// clang-format off
 std::array<size_t, 10> const kAverageSegmentsCount = {
     // 10  11    12     13    14    15    16    17    18   19
     10000, 5000, 10000, 5000, 2500, 5000, 2000, 1000, 500, 500};
+// clang-format on
 
 double constexpr kMetersPerLevel = 3.0;
 

--- a/libs/drape_frontend/selection_shape.cpp
+++ b/libs/drape_frontend/selection_shape.cpp
@@ -16,11 +16,13 @@ namespace df
 {
 namespace
 {
+// clang-format off
 std::array<float, 20> const kHalfLineWidthInPixel = {
     // 1   2     3     4     5     6     7     8     9     10
     1.0f, 1.2f, 1.5f, 1.5f, 1.7f, 2.0f, 2.0f, 2.3f, 2.5f, 2.7f,
     // 11   12    13    14    15   16    17    18    19     20
     3.0f, 3.5f, 4.5f, 5.5f, 7.0, 9.0f, 10.0f, 14.0f, 22.0f, 27.0f};
+// clang-format on
 }  // namespace
 
 SelectionShape::SelectionShape(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::TextureManager> mng)

--- a/libs/drape_frontend/traffic_renderer.cpp
+++ b/libs/drape_frontend/traffic_renderer.cpp
@@ -29,6 +29,7 @@ int constexpr kOutlineMinZoomLevel = 14;
 
 float const kTrafficArrowAspect = 128.0f / 8.0f;
 
+// clang-format off
 std::array<float, 20> const kLeftWidthInPixel = {
     // 1   2     3     4     5     6     7     8     9    10
     0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f,
@@ -58,6 +59,7 @@ std::array<float, 20> const kTwoWayOffsetInPixel = {
     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
     // 11  12    13    14    15     16   17    18    19    20
     0.0f, 0.5f, 0.5f, 0.75f, 1.7f, 2.5f, 2.5f, 2.5f, 2.5f, 2.5f};
+// clang-format on
 
 std::array<int, 3> const kLineDrawerRoadClass1 = {12, 13, 14};
 

--- a/libs/kml/visitors.hpp
+++ b/libs/kml/visitors.hpp
@@ -35,10 +35,7 @@ class CollectorVisitor
     static int Test(...);
 
   public:
-    enum
-    {
-      value = sizeof(Test<RealT>(0)) == sizeof(char)
-    };
+    static constexpr bool value = sizeof(Test<RealT>(0)) == sizeof(char);
   };
 
   // All types which will be visited to collect.
@@ -48,17 +45,15 @@ class CollectorVisitor
     using RealT = std::remove_cvref_t<T>;
 
   public:
-    enum
-    {
-      value = std::is_same<RealT, BookmarkData>::value || std::is_same<RealT, TrackData>::value ||
-              std::is_same<RealT, CategoryData>::value || std::is_same<RealT, FileData>::value ||
-              std::is_same<RealT, BookmarkDataV3>::value || std::is_same<RealT, TrackDataV3>::value ||
-              std::is_same<RealT, CategoryDataV3>::value || std::is_same<RealT, FileDataV3>::value ||
-              std::is_same<RealT, BookmarkDataV6>::value || std::is_same<RealT, TrackDataV6>::value ||
-              std::is_same<RealT, CategoryDataV6>::value || std::is_same<RealT, FileDataV6>::value ||
-              std::is_same<RealT, BookmarkDataV7>::value || std::is_same<RealT, TrackDataV7>::value ||
-              std::is_same<RealT, CategoryDataV7>::value || std::is_same<RealT, FileDataV7>::value
-    };
+    static constexpr bool value =
+        std::is_same<RealT, BookmarkData>::value || std::is_same<RealT, TrackData>::value ||
+        std::is_same<RealT, CategoryData>::value || std::is_same<RealT, FileData>::value ||
+        std::is_same<RealT, BookmarkDataV3>::value || std::is_same<RealT, TrackDataV3>::value ||
+        std::is_same<RealT, CategoryDataV3>::value || std::is_same<RealT, FileDataV3>::value ||
+        std::is_same<RealT, BookmarkDataV6>::value || std::is_same<RealT, TrackDataV6>::value ||
+        std::is_same<RealT, CategoryDataV6>::value || std::is_same<RealT, FileDataV6>::value ||
+        std::is_same<RealT, BookmarkDataV7>::value || std::is_same<RealT, TrackDataV7>::value ||
+        std::is_same<RealT, CategoryDataV7>::value || std::is_same<RealT, FileDataV7>::value;
   };
 
 public:

--- a/libs/routing_common/bicycle_model.cpp
+++ b/libs/routing_common/bicycle_model.cpp
@@ -92,7 +92,8 @@ VehicleModel::LimitsInitList const kDefaultOptions = {
     {HighwayType::HighwayPlatform, true},
     {HighwayType::HighwayFootway, true},
     {HighwayType::ManMadePier, true},
-    {HighwayType::RouteFerry, true}};
+    {HighwayType::RouteFerry, true},
+};
 
 // Same as defaults except trunk and trunk_link are not allowed
 VehicleModel::LimitsInitList NoTrunk()

--- a/libs/routing_common/car_model.cpp
+++ b/libs/routing_common/car_model.cpp
@@ -77,7 +77,8 @@ VehicleModel::SurfaceInitList const kCarSurface = {
     {{"psurface", "paved_good"}, {1.0, 1.0}},
     {{"psurface", "paved_bad"}, {0.6, 0.7}},
     {{"psurface", "unpaved_good"}, {0.4, 0.7}},
-    {{"psurface", "unpaved_bad"}, {0.2, 0.3}}};
+    {{"psurface", "unpaved_bad"}, {0.2, 0.3}},
+};
 }  // namespace car_model
 
 namespace routing

--- a/libs/routing_common/pedestrian_model.cpp
+++ b/libs/routing_common/pedestrian_model.cpp
@@ -88,7 +88,8 @@ VehicleModel::LimitsInitList const kDefaultOptions = {
     {HighwayType::HighwayPlatform, true},
     {HighwayType::HighwayFootway, true},
     {HighwayType::ManMadePier, true},
-    {HighwayType::RouteFerry, true}};
+    {HighwayType::RouteFerry, true},
+};
 
 // Same as defaults except bridleway and cycleway are allowed.
 VehicleModel::LimitsInitList AllAllowed()

--- a/tools/hooks/format-config.bash
+++ b/tools/hooks/format-config.bash
@@ -30,15 +30,23 @@ resolve_ktlint() {
   return 1
 }
 
-# Resolve a clang-format binary, preferring a versioned one.
+# Major version of clang-format used by CI. Different majors reformat the same
+# code differently, so local and CI runs must agree. Also read by the workflow.
+CLANG_FORMAT_VERSION=23
+
+# Resolve the clang-format binary matching CLANG_FORMAT_VERSION, preferring a versioned name.
 resolve_clang_format() {
-  local binary
-  for binary in clang-format clang-format-22; do
-    if command -v "$binary" >/dev/null 2>&1; then
+  local binary version found=
+  for binary in "clang-format-$CLANG_FORMAT_VERSION" clang-format; do
+    command -v "$binary" >/dev/null 2>&1 || continue
+    version=$("$binary" --version)
+    if [[ "$version" == *"version $CLANG_FORMAT_VERSION."* ]]; then
       echo "$binary"
       return 0
     fi
+    found="${found:-$version}"
   done
-  echo "Error: clang-format not found." >&2
+  echo "Error: clang-format $CLANG_FORMAT_VERSION.x is required, found: ${found:-none}." >&2
+  echo "See docs/CODE_STYLE_GUIDE.md for installation instructions." >&2
   return 1
 }


### PR DESCRIPTION
Pins clang-format 23 in CI, in the pre-commit hook and in the setup docs, and rejects other major versions locally so that local and CI runs cannot disagree on formatting.

Two commits: the tooling change plus the hand-written fixes for what 23 changes, then the mechanical `tools/unix/clang-format.sh` output.

23 changes three behaviours that damage hand-laid code. These are fixed at the cause rather than absorbed into the reformat:

- A comment as the first element of a braced list no longer forces a break after the brace. The `drape_frontend` zoom tables are grids whose legends label columns, so they are guarded with `clang-format off`; the `routing_common` tables only need a trailing comma, matching `kDefaultSpeeds` beside them. No `.clang-format` option restores the old layout — `BreakAfterOpenBracketBracedList` is the only one that comes close, and it reflows 184 unrelated files while still missing `rule_drawer.cpp` (its hoisted line fits in 120 columns, so the option never fires).
- An unnamed `enum` body is parsed as an expression list, so `<` in `std::is_same<T, X>::value` is read as a comparison and mangles `kml::CollectorVisitor`. Both helpers there now use `static constexpr bool`.
- ObjC block literals with an angle-bracketed return type are still misparsed, so `RemoveSemicolon: false` stays; only its version range is updated.

Refs #3661

Tested:
- `tools/unix/clang-format.sh` with 23.1.0 is a fixed point over the whole tree
- the reformat commit, regenerated from a clean first commit, reproduces byte for byte
- the version gate rejects 22.1.8 and accepts 23.1.0, in both the script and the pre-commit hook
- `kml`, `routing_common` and `drape_frontend` build; `kml_tests` and `routing_common_tests` pass
