### PR TITLE
[coding] Parse validated HTTP origins

### DIFF
--- a/libs/coding/coding_tests/url_tests.cpp
+++ b/libs/coding/coding_tests/url_tests.cpp
@@ -6,7 +6,9 @@
 
 #include <queue>
 #include <string>
+#include <string_view>
 #include <utility>
+#include <vector>
 
 namespace url_tests
 {
@@ -210,6 +212,299 @@ UNIT_TEST(UrlApi_Smoke)
 
   TEST(url.GetLastParam(), ());
   TEST(url.GetParamValue("m"), ());
+}
+
+struct OriginTestCase
+{
+  string_view m_url;
+  string_view m_origin;  // Empty means "no origin".
+};
+
+// Returns an empty string when there is no origin, to keep the tables below readable.
+string ParsedOrigin(string_view url, bool allowProtocolRelative = false)
+{
+  return ParseHttpOrigin(url, allowProtocolRelative).value_or(string());
+}
+
+void TestOrigins(vector<OriginTestCase> const & cases, bool allowProtocolRelative = false)
+{
+  for (auto const & c : cases)
+    TEST_EQUAL(ParsedOrigin(c.m_url, allowProtocolRelative), c.m_origin, (c.m_url));
+}
+
+UNIT_TEST(HttpOrigin_Valid)
+{
+  TestOrigins({
+      {"https://example.com", "https://example.com"},
+      {"http://example.com", "http://example.com"},
+      {"https://example.com/", "https://example.com"},
+      {"https://example.com/path/to/x", "https://example.com"},
+      {"https://example.com?q=1", "https://example.com"},
+      {"https://example.com#frag", "https://example.com"},
+      {"https://example.com/path?q=1#frag", "https://example.com"},
+      // Scheme and host are case insensitive and get lowercased.
+      {"HTTPS://EXAMPLE.COM/X", "https://example.com"},
+      {"HtTpS://ExAmPlE.cOm", "https://example.com"},
+      {"HTTP://Example.COM", "http://example.com"},
+      // Ports.
+      {"https://example.com:8443/x", "https://example.com:8443"},
+      {"https://example.com:1", "https://example.com:1"},
+      {"https://example.com:65535", "https://example.com:65535"},
+      {"https://example.com:443", "https://example.com"},    // Default for https.
+      {"http://example.com:80", "http://example.com"},       // Default for http.
+      {"http://example.com:443", "http://example.com:443"},  // Not a default for http.
+      {"https://example.com:80", "https://example.com:80"},  // Not a default for https.
+      // Hosts.
+      {"https://localhost/x", "https://localhost"},
+      {"https://a.b.c.d.example.co.uk", "https://a.b.c.d.example.co.uk"},
+      {"https://my-cdn.example.com", "https://my-cdn.example.com"},
+      {"https://xn--80ak6aa92e.com/x", "https://xn--80ak6aa92e.com"},  // Punycode is plain ASCII.
+      {"https://123.example.com/x", "https://123.example.com"},
+      // Only canonical dotted-decimal IPv4 is accepted.
+      {"https://0.0.0.0", "https://0.0.0.0"},
+      {"https://192.168.0.1:8080/x", "https://192.168.0.1:8080"},
+      {"https://255.255.255.255", "https://255.255.255.255"},
+      // The authority ends at the first delimiter, so the host here is evil.com, like in a browser.
+      {"https://evil.com/@example.com", "https://evil.com"},
+      {"https://evil.com?@example.com", "https://evil.com"},
+      {"https://evil.com#@example.com", "https://evil.com"},
+  });
+}
+
+UNIT_TEST(HttpOrigin_Rejected)
+{
+  TestOrigins({
+      {"", ""},
+      {"example.com", ""},
+      {"//example.com", ""},  // Protocol relative is not allowed here.
+      // Only http(s) with exactly "://".
+      {"ftp://example.com", ""},
+      {"file:///x", ""},
+      {"javascript:https://example.com", ""},
+      {"data:text/html,https://example.com", ""},
+      {"about:blank", ""},
+      {"xhttps://example.com", ""},  // The scheme starts at the beginning of the url.
+      {"shttp://example.com", ""},
+      {" https://example.com", ""},
+      {"https//example.com", ""},
+      {"https ://example.com", ""},
+      // Browsers strip tabs and newlines before parsing, we fail closed instead.
+      {"htt\tps://example.com", ""},
+      {"https\n://example.com", ""},
+      // Truncated urls must not be read past their end.
+      {"h", ""},
+      {"http", ""},
+      {"https", ""},
+      {"http:", ""},
+      {"https:/", ""},
+      {"/", ""},
+      {"//", ""},
+      // Browsers read a host out of all of these, we fail closed instead of guessing.
+      {"https:example.com", ""},
+      {"https:/example.com", ""},
+      {"HTTPS:/example.com", ""},
+      {"https:///x", ""},
+      {"https://///example.com", ""},
+      {"https://", ""},
+      {"http://", ""},
+      {"https://:443", ""},
+      {"https://:443/x", ""},
+      {"https://?q", ""},
+      {"https:\\\\example.com", ""},
+      // Credentials.
+      {"https://user:pw@example.com", ""},
+      {"https://user@example.com", ""},
+      {"https://user@example.com@evil.com", ""},
+      {"https://example.com@evil.com/x", ""},
+      // Backslashes, which some browsers treat as slashes.
+      {"https://example.com\\path", ""},
+      {"https://example.com\\@evil.com", ""},
+      // Percent escapes.
+      {"https://ex%61mple.com", ""},
+      {"https://example.com%2f@evil.com", ""},
+      // Whitespace, control and non-ASCII bytes.
+      {"https://exa mple.com", ""},
+      {"https:// example.com", ""},
+      {"https://example.com ", ""},
+      {"https://exa\tmple.com", ""},
+      {"https://exa\nmple.com", ""},
+      {"https://exa\rmple.com", ""},
+      {"https://exa\0mple.com"sv, ""},  // A NUL byte.
+      {"https://example.com\x01", ""},
+      {"https://example.com\x7f", ""},
+      {"https://\xd0\xbf\xd1\x80\xd0\xb8\xd0\xbc\xd0\xb5\xd1\x80.\xd1\x80\xd1\x84", ""},  // "пример.рф".
+      // Ports.
+      {"https://example.com:", ""},
+      {"https://example.com:/x", ""},
+      {"https://example.com:abc", ""},
+      {"https://example.com:80x", ""},
+      {"https://example.com:8443:80", ""},
+      {"https://example.com:84:80", ""},  // Short enough to reach the digit loop.
+      {"https://example.com: 80", ""},
+      {"https://example.com:+80", ""},
+      {"https://example.com:-80", ""},
+      {"https://example.com:0", ""},
+      {"https://example.com:00000", ""},
+      {"https://example.com:0443", ""},  // A padded port is not a port.
+      {"https://example.com:08443", ""},
+      {"https://example.com:000080", ""},
+      {"https://example.com:65536", ""},
+      {"https://example.com:99999", ""},
+      {"https://example.com:123456", ""},  // More than 5 digits.
+      // Hosts.
+      {"https://.example.com", ""},
+      {"https://example..com", ""},
+      {"https://example.com.", ""},
+      {"https://.", ""},
+      {"https://..", ""},
+      {"https://exa_mple.com", ""},  // Underscore is not a DNS char.
+      {"https://exa*mple.com", ""},
+      {"https://exa!mple.com", ""},
+      {"https://example.com]", ""},
+      {"https://exa[mple.com", ""},
+      // Numeric hosts a browser would reinterpret as IPv4, and malformed IPv4.
+      {"https://127.1", ""},
+      {"https://0177.0.0.1", ""},
+      {"https://0x7f.1", ""},
+      {"https://0x7f000001", ""},
+      {"https://017700000001", ""},
+      {"https://2130706433", ""},
+      {"https://192.168.000.001", ""},
+      {"https://1.2.3.999", ""},
+      {"https://1.2.3.256", ""},
+      {"https://1.2.3", ""},
+      {"https://1.2.3.4.5", ""},
+      {"https://foo.123", ""},
+      {"https://1.2.3.0x10", ""},
+      {"https://09", ""},
+      {"https://0x", ""},
+      // IPv6 is outside the strict safe subset, valid or not.
+      {"https://[::1]", ""},
+      {"https://[0:0:0:0:0:0:0:1]", ""},
+      {"https://[::ffff:192.0.2.1]", ""},
+      {"https://[::::]", ""},
+      {"https://[::1", ""},
+      {"https://[fe80::1%25eth0]", ""},
+  });
+}
+
+UNIT_TEST(HttpOrigin_ProtocolRelative)
+{
+  TestOrigins(
+      {
+          {"//example.com", "https://example.com"},
+          {"//example.com/x?y#z", "https://example.com"},
+          {"//example.com:8443/x", "https://example.com:8443"},
+          {"//EXAMPLE.com:443", "https://example.com"},
+          // Absolute urls are parsed exactly as with the flag disabled.
+          {"http://example.com:80/x", "http://example.com"},
+          {"https://example.com/x", "https://example.com"},
+          // Invalid authorities are still rejected.
+          {"//", ""},
+          {"///x", ""},
+          {"/example.com", ""},
+          {"//user@example.com", ""},
+          {"//exa mple.com", ""},
+          {"//example.com:0", ""},
+          {"//https://example.com", ""},
+          {"\\\\example.com", ""},  // Backslashes are not slashes for us.
+          {"//example.com\\evil.com", ""},
+          {"// example.com", ""},
+          {"//example.com:65536", ""},
+          {"//127.1/x", ""},
+          {"//[::1]:8443", ""},
+      },
+      true /* allowProtocolRelative */);
+
+  // The same inputs without the flag.
+  TestOrigins({
+      {"//example.com", ""},
+      {"//example.com:8443/x", ""},
+      {"http://example.com:80/x", "http://example.com"},
+      {"https://example.com/x", "https://example.com"},
+  });
+}
+
+UNIT_TEST(HttpOrigin_HostSizeLimits)
+{
+  string const label63(63, 'a');
+  string const host253 = label63 + '.' + label63 + '.' + label63 + '.' + string(61, 'b');
+  TEST_EQUAL(host253.size(), size_t(253), ());
+
+  TEST_EQUAL(ParsedOrigin("https://" + host253), "https://" + host253, ());
+  TEST_EQUAL(ParsedOrigin("https://" + host253 + ":8443/x"), "https://" + host253 + ":8443", ());
+  TEST_EQUAL(ParsedOrigin("https://" + host253 + "/x"), "https://" + host253, ());
+  TEST_EQUAL(ParsedOrigin("https://b" + host253), "", ());  // 254 chars.
+  TEST_EQUAL(ParsedOrigin("https://b" + host253 + "/x"), "", ());
+
+  // The longest possible authority is host + ':' + 5 port digits, one byte more is rejected
+  // without looking at the rest of the url.
+  TEST_EQUAL(ParsedOrigin("https://" + host253 + ":65535"), "https://" + host253 + ":65535", ());
+  TEST_EQUAL(ParsedOrigin("https://" + host253 + ":65535/x"), "https://" + host253 + ":65535", ());
+  TEST_EQUAL(ParsedOrigin("https://" + host253 + "?q"), "https://" + host253, ());
+  TEST_EQUAL(ParsedOrigin("https://" + host253 + "#f"), "https://" + host253, ());
+  TEST_EQUAL(ParsedOrigin("https://" + string(254, 'a') + ":65535"), "", ());
+  TEST_EQUAL(ParsedOrigin("https://" + string(1024, 'a')), "", ());  // No delimiter at all.
+  TEST_EQUAL(ParsedOrigin("https://" + string(1024, 'a') + "/x"), "", ());
+
+  TEST_EQUAL(ParsedOrigin("https://" + label63 + ".com"), "https://" + label63 + ".com", ());
+  TEST_EQUAL(ParsedOrigin("https://a" + label63 + ".com"), "", ());  // 64 chars in a label.
+}
+
+UNIT_TEST(HttpOrigin_Normalization)
+{
+  auto const origin = ParseHttpOrigin("HTTPS://Example.COM:8443/path?q#f");
+  TEST(origin.has_value(), ());
+  TEST_EQUAL(*origin, "https://example.com:8443", ());
+
+  auto const defaultPort = ParseHttpOrigin("https://example.com:443/x");
+  TEST(defaultPort.has_value(), ());
+  TEST_EQUAL(*defaultPort, "https://example.com", ());
+
+  // A normalized origin round trips unchanged.
+  for (auto const * url : {"https://example.com/x", "http://example.com:80", "https://example.com:80",
+                           "https://example.com:8443?q", "https://192.168.0.1/x"})
+  {
+    auto const parsed = ParseHttpOrigin(url);
+    TEST(parsed.has_value(), (url));
+    TEST_EQUAL(ParseHttpOrigin(*parsed), parsed, (url));
+  }
+}
+
+UNIT_TEST(HttpOrigin_QueryIsNotScanned)
+{
+  // Every byte here would make the parser fail if it ever looked past the authority.
+  string const poison = "@%\\ \t\x7f\xd0\xbf";
+  size_t const kTailSize = 1024 * 1024;
+
+  string url = "https://example.com/path?";
+  url.reserve(url.size() + kTailSize + poison.size());
+  while (url.size() < kTailSize)
+    url += poison;
+
+  TEST_EQUAL(ParsedOrigin(url), "https://example.com", ());
+  TEST_EQUAL(ParsedOrigin("https://example.com:8443#" + string(kTailSize, '\\')), "https://example.com:8443", ());
+  TEST_EQUAL(ParsedOrigin("https://example.com?" + string(kTailSize, ' ')), "https://example.com", ());
+
+  // Without any delimiter the authority is simply too long, which is also decided without
+  // scanning the tail.
+  TEST_EQUAL(ParsedOrigin("https://example.com" + string(kTailSize, 'a')), "", ());
+}
+
+// The lenient url::Url parser is intentionally left as is, ParseHttpOrigin() is a separate,
+// strict entry point.
+UNIT_TEST(HttpOrigin_UrlClassIsUnchanged)
+{
+  Url const withCredentials("https://user:pw@example.com/x");
+  TEST_EQUAL(withCredentials.GetScheme(), "https", ());
+  TEST_EQUAL(withCredentials.GetHost(), "user:pw@example.com", ());
+  TEST_EQUAL(withCredentials.GetPath(), "x", ());
+  TEST(!ParseHttpOrigin("https://user:pw@example.com/x"), ());
+
+  Url const nonAscii = Url::FromString("\xd0\xbf\xd1\x80\xd0\xb8\xd0\xbc\xd0\xb5\xd1\x80.\xd1\x80\xd1\x84/x");
+  TEST_EQUAL(nonAscii.GetScheme(), "https", ());
+  TEST_EQUAL(nonAscii.GetHost(), "\xd0\xbf\xd1\x80\xd0\xb8\xd0\xbc\xd0\xb5\xd1\x80.\xd1\x80\xd1\x84", ());
+  TEST(!ParseHttpOrigin("https://" + nonAscii.GetHostAndPath()), ());
 }
 
 }  // namespace url_tests

--- a/libs/coding/url.cpp
+++ b/libs/coding/url.cpp
@@ -1,8 +1,12 @@
 #include "coding/url.hpp"
-#include <string_view>
+
 #include "coding/hex.hpp"
 
 #include "base/assert.hpp"
+#include "base/string_utils.hpp"
+
+#include <cstdint>
+#include <string_view>
 
 namespace url
 {
@@ -153,6 +157,171 @@ std::string UrlDecode(std::string_view encodedUrl)
   }
 
   return result;
+}
+
+namespace
+{
+// An origin is ASCII-only by design, see ParseHttpOrigin().
+size_t constexpr kMaxHostSize = 253;
+size_t constexpr kMaxLabelSize = 63;
+size_t constexpr kMaxPortDigits = 5;
+
+// Lowercase conventional DNS name or IPv4 literal: [a-z0-9.-] with non-empty labels.
+bool IsValidDnsHost(std::string_view host)
+{
+  if (host.empty() || host.size() > kMaxHostSize)
+    return false;
+
+  size_t labelSize = 0;
+  for (char const c : host)
+  {
+    if (c == '.')
+    {
+      if (labelSize == 0)  // Leading or double dot.
+        return false;
+      labelSize = 0;
+      continue;
+    }
+
+    if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-'))
+      return false;
+    if (++labelSize > kMaxLabelSize)
+      return false;
+  }
+
+  return labelSize != 0;  // Trailing dot.
+}
+
+bool IsDecimal(std::string_view s)
+{
+  if (s.empty())
+    return false;
+  for (char const c : s)
+    if (c < '0' || c > '9')
+      return false;
+  return true;
+}
+
+// The browser URL parser treats a host whose last label is a number as IPv4, including legacy
+// one-part, octal and hexadecimal spellings. Such a host must either be canonical IPv4 or fail.
+bool EndsInIPv4Number(std::string_view host)
+{
+  size_t const dot = host.rfind('.');
+  std::string_view const last = host.substr(dot == std::string_view::npos ? 0 : dot + 1);
+  if (IsDecimal(last))
+    return true;
+  if (!last.starts_with("0x"))
+    return false;
+  for (char const c : last.substr(2))
+    if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
+      return false;
+  return true;
+}
+
+bool IsCanonicalIPv4(std::string_view host)
+{
+  size_t pos = 0;
+  for (size_t part = 0; part < 4; ++part)
+  {
+    size_t const end = host.find('.', pos);
+    if ((part < 3) != (end != std::string_view::npos))
+      return false;
+
+    std::string_view const digits = host.substr(pos, end - pos);
+    if (!IsDecimal(digits) || digits.size() > 3 || (digits.size() > 1 && digits.front() == '0'))
+      return false;
+
+    uint32_t value = 0;
+    for (char const c : digits)
+      value = value * 10 + static_cast<uint32_t>(c - '0');
+    if (value > 255)
+      return false;
+
+    if (part < 3)
+      pos = end + 1;
+  }
+  return true;
+}
+}  // namespace
+
+std::optional<std::string> ParseHttpOrigin(std::string_view url, bool allowProtocolRelative)
+{
+  std::string_view scheme;
+  size_t authorityPos;
+  if (strings::EqualAsciiNoCase(url.substr(0, 8), "https://"))
+  {
+    scheme = "https";
+    authorityPos = 8;
+  }
+  else if (strings::EqualAsciiNoCase(url.substr(0, 7), "http://"))
+  {
+    scheme = "http";
+    authorityPos = 7;
+  }
+  else if (allowProtocolRelative && url.starts_with("//"))
+  {
+    scheme = "https";
+    authorityPos = 2;
+  }
+  else
+    return {};
+
+  // The authority ends at the path/query/fragment delimiter and is never longer than
+  // host + ':' + port, so the rest of the url (e.g. a huge query) is not scanned at all.
+  size_t constexpr kMaxAuthoritySize = kMaxHostSize + 1 + kMaxPortDigits;
+  std::string_view authority = url.substr(authorityPos, kMaxAuthoritySize + 1);
+  authority = authority.substr(0, authority.find_first_of("/?#"));
+  if (authority.size() > kMaxAuthoritySize)
+    return {};
+
+  // IPv6 needs full parsing and canonical serialization to represent a browser origin correctly.
+  // It is outside this deliberately small safe subset.
+  if (authority.starts_with('['))
+    return {};
+
+  // Split the authority into the host and the optional port. Every byte ends up either in the host,
+  // restricted to [a-z0-9.-] by IsValidDnsHost(), or in the port digits, so credentials,
+  // backslashes, percent-escapes, whitespace, control and non-ASCII bytes are all rejected below.
+  size_t const colon = authority.find(':');
+  std::string_view host = authority;
+  uint32_t port = 0;
+  if (colon != std::string_view::npos)
+  {
+    host = authority.substr(0, colon);
+
+    // Ports are never padded in practice, and rejecting a leading zero makes kMaxPortDigits exact.
+    std::string_view const portDigits = authority.substr(colon + 1);
+    if (portDigits.empty() || portDigits.size() > kMaxPortDigits || portDigits.front() == '0')
+      return {};
+
+    uint32_t value = 0;
+    for (char const c : portDigits)
+    {
+      if (c < '0' || c > '9')
+        return {};
+      value = value * 10 + static_cast<uint32_t>(c - '0');
+    }
+
+    if (value > 0xFFFF)
+      return {};
+
+    // A default port is not a part of the origin.
+    if (!((scheme == "http" && value == 80) || (scheme == "https" && value == 443)))
+      port = value;
+  }
+
+  std::string origin;
+  origin.reserve(scheme.size() + 3 + host.size() + (port == 0 ? 0 : 6));
+  origin.append(scheme).append("://").append(host);
+  strings::AsciiToLower(origin);
+
+  std::string_view const normalizedHost(origin.data() + scheme.size() + 3, host.size());
+  if (!IsValidDnsHost(normalizedHost) || (EndsInIPv4Number(normalizedHost) && !IsCanonicalIPv4(normalizedHost)))
+    return {};
+
+  if (port != 0)
+    origin.append(1, ':').append(std::to_string(port));
+  return origin;
 }
 
 }  // namespace url

--- a/libs/coding/url.hpp
+++ b/libs/coding/url.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -48,6 +50,20 @@ private:
   std::string m_scheme, m_host, m_path;
   std::vector<Param> m_params;
 };
+
+// Strict origin-only parser for untrusted urls, e.g. resource references in imported bookmark
+// html descriptions. Parsing stops at the end of the authority, so path/query/fragment are never
+// scanned and the work is bounded by the maximum authority length.
+// Credentials, backslashes, percent-escapes, whitespace, control and non-ASCII bytes are rejected.
+// Non-canonical IPv4 spellings that a browser would reinterpret are rejected too. IPv6 is outside
+// this deliberately small safe subset. DNS names are restricted to conventional ASCII labels. The
+// caller gets no origin for valid browser URLs outside the subset, never a wrong origin.
+// Returns a normalized "http(s)://host[:port]" string. Default ports (80 for http, 443 for https)
+// are omitted.
+// allowProtocolRelative additionally accepts "//host/path" as an https origin. A browser would
+// resolve such a url against the scheme of the embedding document, which is unknown here, so https
+// is assumed as the safe choice.
+std::optional<std::string> ParseHttpOrigin(std::string_view url, bool allowProtocolRelative = false);
 
 // Joins URL, appends/removes slashes if needed.
 std::string Join(std::string const & lhs, std::string const & rhs);


### PR DESCRIPTION
Strict origin-only parser for untrusted urls, e.g. resource references in imported bookmark HTML descriptions. It stops at the end of the authority, so a huge query is never scanned, and rejects anything a browser could reinterpret: credentials, backslashes, percent-escapes, whitespace, control and non-ASCII bytes, bad ports. Existing url::Url semantics are unchanged.

Part 1 in the upcoming WebView improvements.