### PR TITLE
[ios] Hide individual tracks

### DIFF
--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -41711,7 +41711,7 @@ zh-Hant = 更改顏色
 
 [hide_track]
 comment = Text for the hiding track.
-tags = android-app
+tags = android-app,apple-maps
 en = Hide track
 af = Versteek roete
 ar = إخفاء المسار
@@ -41758,7 +41758,7 @@ zh-Hant = 隱藏軌跡
 
 [show_track]
 comment = Text for the showing track.
-tags = android-app
+tags = android-app,apple-maps
 en = Show track
 af = Wys roete
 ar = عرض المسار

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
@@ -91,6 +91,7 @@ NS_SWIFT_NAME(BookmarksManager)
 - (BOOL)isCategoryVisible:(MWMMarkGroupID)groupId;
 - (void)setCategory:(MWMMarkGroupID)groupId isVisible:(BOOL)isVisible;
 - (void)setUserCategoriesVisible:(BOOL)isVisible;
+- (void)setTrack:(MWMTrackID)trackId isVisible:(BOOL)isVisible;
 - (void)deleteCategory:(MWMMarkGroupID)groupId;
 - (BOOL)checkCategoryName:(NSString *)name;
 - (BOOL)hasCategory:(MWMMarkGroupID)groupId;

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -368,6 +368,11 @@ static void DeleteTemporaryBookmarksFile(std::string const & filePath)
   self.bm.SetAllCategoriesVisibility(isVisible);
 }
 
+- (void)setTrack:(MWMTrackID)trackId isVisible:(BOOL)isVisible
+{
+  GetFramework().SetTrackVisibility(trackId, isVisible);
+}
+
 - (void)deleteCategory:(MWMMarkGroupID)groupId
 {
   self.bm.GetEditSession().DeleteBmCategory(groupId, false /* move to the Trash */);

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMTrack.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMTrack.h
@@ -11,6 +11,7 @@ NS_SWIFT_NAME(Track)
 @property(nonatomic, readonly) NSString * trackName;
 @property(nonatomic, readonly) NSInteger trackLengthMeters;
 @property(nonatomic, readonly) UIColor * trackColor;
+@property(nonatomic, readonly, getter=isVisible) BOOL visible;
 
 @end
 

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMTrack.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMTrack.mm
@@ -16,6 +16,7 @@
     _trackLengthMeters = track->GetLengthMeters();
     auto const color = track->GetColor(0);
     _trackColor = [UIColor colorWithRed:color.GetRedF() green:color.GetGreenF() blue:color.GetBlueF() alpha:1.f];
+    _visible = track->IsVisible();
   }
   return self;
 }

--- a/iphone/Maps/LocalizedStrings/af.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/af.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Verander kleur";
 
+/* Text for the hiding track. */
+"hide_track" = "Versteek roete";
+
+/* Text for the showing track. */
+"show_track" = "Wys roete";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Kaart";
 

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "غير اللون";
 
+/* Text for the hiding track. */
+"hide_track" = "إخفاء المسار";
+
+/* Text for the showing track. */
+"show_track" = "عرض المسار";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "الخريطة";
 

--- a/iphone/Maps/LocalizedStrings/ast.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ast.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Change Color";
 
+/* Text for the hiding track. */
+"hide_track" = "Hide track";
+
+/* Text for the showing track. */
+"show_track" = "Show track";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mapa";
 

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Rəng dəyişdirin";
 
+/* Text for the hiding track. */
+"hide_track" = "İzi gizlədin";
+
+/* Text for the showing track. */
+"show_track" = "İzi göstər";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Xəritə";
 

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Змяніць колер";
 
+/* Text for the hiding track. */
+"hide_track" = "Схаваць трэк";
+
+/* Text for the showing track. */
+"show_track" = "Паказаць трэк";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Карта";
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Промяна на цвета";
 
+/* Text for the hiding track. */
+"hide_track" = "Скриване на маршрут";
+
+/* Text for the showing track. */
+"show_track" = "Показване на маршрут";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Карта";
 

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Canvia de color";
 
+/* Text for the hiding track. */
+"hide_track" = "Amaga el recorregut";
+
+/* Text for the showing track. */
+"show_track" = "Mostra el recorregut";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mapa";
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Změna barvy";
 
+/* Text for the hiding track. */
+"hide_track" = "Skrýt stopu";
+
+/* Text for the showing track. */
+"show_track" = "Zobrazit stopu";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mapa";
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Skift farve";
 
+/* Text for the hiding track. */
+"hide_track" = "Skjul spor";
+
+/* Text for the showing track. */
+"show_track" = "Vis spor";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Kort";
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Farbe ändern";
 
+/* Text for the hiding track. */
+"hide_track" = "Track ausblenden";
+
+/* Text for the showing track. */
+"show_track" = "Track anzeigen";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Karte";
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Αλλαγή χρώματος";
 
+/* Text for the hiding track. */
+"hide_track" = "Απόκρυψη διαδρομής";
+
+/* Text for the showing track. */
+"show_track" = "Εμφάνιση διαδρομής";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Χάρτης";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Change Color";
 
+/* Text for the hiding track. */
+"hide_track" = "Hide track";
+
+/* Text for the showing track. */
+"show_track" = "Show track";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Map";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Change Color";
 
+/* Text for the hiding track. */
+"hide_track" = "Hide track";
+
+/* Text for the showing track. */
+"show_track" = "Show track";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Map";
 

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Cambiar color";
 
+/* Text for the hiding track. */
+"hide_track" = "Ocultar trayecto";
+
+/* Text for the showing track. */
+"show_track" = "Mostrar trayecto";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mapa";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Cambiar color";
 
+/* Text for the hiding track. */
+"hide_track" = "Ocultar trayecto";
+
+/* Text for the showing track. */
+"show_track" = "Mostrar trayecto";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mapa";
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Muuda värvi";
 
+/* Text for the hiding track. */
+"hide_track" = "Peida rada";
+
+/* Text for the showing track. */
+"show_track" = "Näita rada";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Kaart";
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Kolorea aldatu";
 
+/* Text for the hiding track. */
+"hide_track" = "Ezkutatu arrastoa";
+
+/* Text for the showing track. */
+"show_track" = "Erakutsi arrastoa";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mapa";
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "تغییر رنگ";
 
+/* Text for the hiding track. */
+"hide_track" = "مخفی کردن مسیر";
+
+/* Text for the showing track. */
+"show_track" = "نمایش مسیر";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "نقشه";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Vaihda väri";
 
+/* Text for the hiding track. */
+"hide_track" = "Piilota reitti";
+
+/* Text for the showing track. */
+"show_track" = "Näytä reitti";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Kartta";
 

--- a/iphone/Maps/LocalizedStrings/fr-CA.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr-CA.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Change de couleur";
 
+/* Text for the hiding track. */
+"hide_track" = "Cacher le tracé";
+
+/* Text for the showing track. */
+"show_track" = "Afficher le tracé";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Carte";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Change de couleur";
 
+/* Text for the hiding track. */
+"hide_track" = "Cacher le tracé";
+
+/* Text for the showing track. */
+"show_track" = "Afficher le tracé";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Carte";
 

--- a/iphone/Maps/LocalizedStrings/gl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/gl.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Cambiar cor";
 
+/* Text for the hiding track. */
+"hide_track" = "Hide track";
+
+/* Text for the showing track. */
+"show_track" = "Show track";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mapa";
 

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "שנה צבע";
 
+/* Text for the hiding track. */
+"hide_track" = "הסתר מסלול";
+
+/* Text for the showing track. */
+"show_track" = "הצג מסלול";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "מפה";
 

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "रंग बदलना";
 
+/* Text for the hiding track. */
+"hide_track" = "मार्ग छिपाएँ";
+
+/* Text for the showing track. */
+"show_track" = "मार्ग दिखाएँ";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "नक्शा";
 

--- a/iphone/Maps/LocalizedStrings/hr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hr.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Promijeni boju";
 
+/* Text for the hiding track. */
+"hide_track" = "Hide track";
+
+/* Text for the showing track. */
+"show_track" = "Show track";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Karta";
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Szín módosítása";
 
+/* Text for the hiding track. */
+"hide_track" = "Nyomvonal elrejtése";
+
+/* Text for the showing track. */
+"show_track" = "Nyomvonal megjelenítése";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Térkép";
 

--- a/iphone/Maps/LocalizedStrings/hy.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hy.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Փոխել գույնը";
 
+/* Text for the hiding track. */
+"hide_track" = "Hide track";
+
+/* Text for the showing track. */
+"show_track" = "Show track";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Քարտեզ";
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Mengubah warna";
 
+/* Text for the hiding track. */
+"hide_track" = "Sembunyikan jalur";
+
+/* Text for the showing track. */
+"show_track" = "Tampilkan jalur";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Peta";
 

--- a/iphone/Maps/LocalizedStrings/is.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/is.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Breyta lit";
 
+/* Text for the hiding track. */
+"hide_track" = "Hide track";
+
+/* Text for the showing track. */
+"show_track" = "Show track";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Landakort";
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Cambia colore";
 
+/* Text for the hiding track. */
+"hide_track" = "Nascondi traccia";
+
+/* Text for the showing track. */
+"show_track" = "Mostra traccia";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mappa";
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "色を変える";
 
+/* Text for the hiding track. */
+"hide_track" = "ルートを非表示";
+
+/* Text for the showing track. */
+"show_track" = "ルートを表示";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "地図";
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "색상 변경";
 
+/* Text for the hiding track. */
+"hide_track" = "경로 숨기기";
+
+/* Text for the showing track. */
+"show_track" = "경로 표시";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "지도";
 

--- a/iphone/Maps/LocalizedStrings/lo.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/lo.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "ປ່ຽນສີ";
 
+/* Text for the hiding track. */
+"hide_track" = "Hide track";
+
+/* Text for the showing track. */
+"show_track" = "Show track";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "ແຜນທີ່";
 

--- a/iphone/Maps/LocalizedStrings/lt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/lt.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Keisti spalvą";
 
+/* Text for the hiding track. */
+"hide_track" = "Paslėpti trasą";
+
+/* Text for the showing track. */
+"show_track" = "Rodyti trasą";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Žemėlapis";
 

--- a/iphone/Maps/LocalizedStrings/lv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/lv.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Mainīt krāsu";
 
+/* Text for the hiding track. */
+"hide_track" = "Paslēpt pēdojumu";
+
+/* Text for the showing track. */
+"show_track" = "Rādīt pēdojumu";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Karte";
 

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "रंग बदला";
 
+/* Text for the hiding track. */
+"hide_track" = "मार्ग लपवा";
+
+/* Text for the showing track. */
+"show_track" = "मार्ग दाखवा";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "नकाशा";
 

--- a/iphone/Maps/LocalizedStrings/mt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mt.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Biddel il-kulur";
 
+/* Text for the hiding track. */
+"hide_track" = "Hide track";
+
+/* Text for the showing track. */
+"show_track" = "Show track";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mappa";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Endre farge";
 
+/* Text for the hiding track. */
+"hide_track" = "Skjul ruten";
+
+/* Text for the showing track. */
+"show_track" = "Vis ruten";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Kart";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Verander kleur";
 
+/* Text for the hiding track. */
+"hide_track" = "Route verbergen";
+
+/* Text for the showing track. */
+"show_track" = "Route tonen";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Kaart";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Zmień kolor";
 
+/* Text for the hiding track. */
+"hide_track" = "Ukryj trasę";
+
+/* Text for the showing track. */
+"show_track" = "Pokaż trasę";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mapa";
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Mudança de cor";
 
+/* Text for the hiding track. */
+"hide_track" = "Ocultar trilha";
+
+/* Text for the showing track. */
+"show_track" = "Mostrar trilha";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mapa";
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Alterar cor";
 
+/* Text for the hiding track. */
+"hide_track" = "Ocultar trajeto";
+
+/* Text for the showing track. */
+"show_track" = "Mostrar trajeto";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mapa";
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Schimbă culoarea";
 
+/* Text for the hiding track. */
+"hide_track" = "Ascundeți traseul";
+
+/* Text for the showing track. */
+"show_track" = "Afișează traseul";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Hartă";
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Изменить цвет";
 
+/* Text for the hiding track. */
+"hide_track" = "Скрыть трек";
+
+/* Text for the showing track. */
+"show_track" = "Показать трек";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Карта";
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Zmena farby";
 
+/* Text for the hiding track. */
+"hide_track" = "Skryť trasu";
+
+/* Text for the showing track. */
+"show_track" = "Zobraziť trasu";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Mapa";
 

--- a/iphone/Maps/LocalizedStrings/sl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sl.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Spremeni barvo";
 
+/* Text for the hiding track. */
+"hide_track" = "Hide track";
+
+/* Text for the showing track. */
+"show_track" = "Show track";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Zemljevid";
 

--- a/iphone/Maps/LocalizedStrings/sq.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sq.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Ndrysho Ngjyrën";
 
+/* Text for the hiding track. */
+"hide_track" = "Hide track";
+
+/* Text for the showing track. */
+"show_track" = "Show track";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Harta";
 

--- a/iphone/Maps/LocalizedStrings/sr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sr.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Промени боју";
 
+/* Text for the hiding track. */
+"hide_track" = "Hide track";
+
+/* Text for the showing track. */
+"show_track" = "Show track";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Мапа";
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Ändra färg";
 
+/* Text for the hiding track. */
+"hide_track" = "Dölj spår";
+
+/* Text for the showing track. */
+"show_track" = "Visa spår";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Karta";
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Badilisha rangi";
 
+/* Text for the hiding track. */
+"hide_track" = "Ficha njia";
+
+/* Text for the showing track. */
+"show_track" = "Onyesha njia";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Ramani";
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "เปลี่ยนสี";
 
+/* Text for the hiding track. */
+"hide_track" = "ซ่อนเส้นทาง";
+
+/* Text for the showing track. */
+"show_track" = "แสดงเส้นทาง";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "แผนที่";
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Renk Değiştir";
 
+/* Text for the hiding track. */
+"hide_track" = "İzi gizle";
+
+/* Text for the showing track. */
+"show_track" = "İzi göster";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Harita";
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Змінити колір";
 
+/* Text for the hiding track. */
+"hide_track" = "Приховати трек";
+
+/* Text for the showing track. */
+"show_track" = "Показати трек";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Мапа";
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "Thay đổi màu sắc";
 
+/* Text for the hiding track. */
+"hide_track" = "Ẩn tuyến đường";
+
+/* Text for the showing track. */
+"show_track" = "Hiển thị tuyến đường";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "Bản đồ";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "更改颜色";
 
+/* Text for the hiding track. */
+"hide_track" = "隐藏轨迹";
+
+/* Text for the showing track. */
+"show_track" = "显示轨迹";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "地图";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -1074,6 +1074,12 @@
 /* Text for the editing the Track's color button. */
 "change_color" = "更改顏色";
 
+/* Text for the hiding track. */
+"hide_track" = "隱藏軌跡";
+
+/* Text for the showing track. */
+"show_track" = "顯示軌跡";
+
 /* Main screen title "Map" displayed in the navigation back button's menu. */
 "map" = "地圖";
 

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/BookmarksListInteractor.swift
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/BookmarksListInteractor.swift
@@ -83,6 +83,10 @@ extension BookmarksListInteractor: IBookmarksListInteractor {
     bookmarksManager.setCategory(groupId, isVisible: visible)
   }
 
+  func setTrack(_ trackId: MWMTrackID, visible: Bool) {
+    bookmarksManager.setTrack(trackId, isVisible: visible)
+  }
+
   func sort(_ sortingType: BookmarksListSortingType,
             location: CLLocation?,
             completion: @escaping ([BookmarksSection]) -> Void) {

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/BookmarksListInterfaces.swift
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/BookmarksListInterfaces.swift
@@ -34,7 +34,7 @@ protocol IBookmarksSectionViewModel: IBookmarksListSectionViewModel {
 }
 
 protocol ITracksSectionViewModel: IBookmarksListSectionViewModel {
-  var tracks: [IBookmarksListItemViewModel] { get }
+  var tracks: [ITrackViewModel] { get }
 }
 
 protocol ISubgroupsSectionViewModel: IBookmarksListSectionViewModel {
@@ -48,6 +48,11 @@ protocol IBookmarksListItemViewModel {
   var subtitle: String { get }
   var image: UIImage { get }
   var colorDidTapAction: ((_ anchor: UIView?) -> Void)? { get }
+}
+
+protocol ITrackViewModel: IBookmarksListItemViewModel {
+  var isVisible: Bool { get }
+  var visibilityDidTapAction: () -> Void { get }
 }
 
 protocol ISubgroupViewModel {
@@ -114,6 +119,7 @@ protocol IBookmarksListInteractor {
   func viewBookmarkOnMap(_ bookmarkId: MWMMarkID)
   func viewTrackOnMap(_ trackId: MWMTrackID)
   func setGroup(_ groupId: MWMMarkGroupID, visible: Bool)
+  func setTrack(_ trackId: MWMTrackID, visible: Bool)
   func sort(_ sortingType: BookmarksListSortingType,
             location: CLLocation?,
             completion: @escaping ([BookmarksSection]) -> Void)

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/BookmarksListPresenter.swift
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/BookmarksListPresenter.swift
@@ -51,14 +51,7 @@ final class BookmarksListPresenter {
 
   private func setDefaultSections() {
     var sections: [IBookmarksListSectionViewModel] = []
-    let tracks = bookmarkGroup.tracks.map { track in
-      TrackViewModel(track, formattedDistance: formatDistance(Double(track.trackLengthMeters)), colorDidTap: { anchor in
-        self.view?.showColorPicker(anchor: anchor, currentColor: track.trackColor) { color in
-          self.interactor.setColor(color, for: [.track(track.trackId)])
-          self.reload()
-        }
-      })
-    }
+    let tracks = bookmarkGroup.tracks.map { makeTrackViewModel($0) }
     if !tracks.isEmpty {
       sections.append(TracksSectionViewModel(tracks: tracks))
     }
@@ -98,6 +91,20 @@ final class BookmarksListPresenter {
         }
       })
     }
+  }
+
+  private func makeTrackViewModel(_ track: Track) -> TrackViewModel {
+    TrackViewModel(track,
+                   formattedDistance: formatDistance(Double(track.trackLengthMeters)),
+                   colorDidTap: { [weak self] anchor in
+                     self?.view?.showColorPicker(anchor: anchor, currentColor: track.trackColor) { color in
+                       self?.interactor.setColor(color, for: [.track(track.trackId)])
+                       self?.reload()
+                     }
+                   },
+                   visibilityDidTap: { [weak self] in
+                     self?.toggleTrackVisibility(trackId: track.trackId, isVisible: track.isVisible)
+                   })
   }
 
   private func formatDistance(_ distance: Double) -> String {
@@ -190,6 +197,11 @@ final class BookmarksListPresenter {
     router.viewOnMap(bookmarkGroup)
   }
 
+  private func toggleTrackVisibility(trackId: MWMTrackID, isVisible: Bool) {
+    interactor.setTrack(trackId, visible: !isVisible)
+    reload()
+  }
+
   private func sort(_ sortingType: BookmarksListSortingType) {
     let location = LocationManager.lastLocation()
     // A by-distance sort without a position yields no sections, and the interactor drops that result, so the
@@ -199,24 +211,20 @@ final class BookmarksListPresenter {
       return
     }
 
+    // The core keeps the completion alive and calls it after the screen is gone, so a dead
+    // presenter must bail out instead of falling through to fatalError() below.
     interactor.sort(sortingType, location: location) { [weak self] sortedSections in
+      guard let self else { return }
       let sections = sortedSections.map { bookmarksSection -> IBookmarksListSectionViewModel in
-        if let bookmarks = bookmarksSection.bookmarks, let self = self {
+        if let bookmarks = bookmarksSection.bookmarks {
           return BookmarksSectionViewModel(title: bookmarksSection.sectionName, bookmarks: self.mapBookmarks(bookmarks))
         }
-        if let tracks = bookmarksSection.tracks, let self = self {
-          return TracksSectionViewModel(tracks: tracks.map { track in
-            TrackViewModel(track, formattedDistance: self.formatDistance(Double(track.trackLengthMeters)), colorDidTap: { anchor in
-              self.view?.showColorPicker(anchor: anchor, currentColor: track.trackColor) { color in
-                self.interactor.setColor(color, for: [.track(track.trackId)])
-                self.reload()
-              }
-            })
-          })
+        if let tracks = bookmarksSection.tracks {
+          return TracksSectionViewModel(tracks: tracks.map { self.makeTrackViewModel($0) })
         }
         fatalError()
       }
-      self?.view?.setSections(sections)
+      self.view?.setSections(sections)
     }
   }
 }
@@ -450,25 +458,32 @@ private struct BookmarkViewModel: IBookmarksListItemViewModel {
   }
 }
 
-private struct TrackViewModel: IBookmarksListItemViewModel {
+private struct TrackViewModel: ITrackViewModel {
   let trackId: MWMTrackID
   let name: String
   let subtitle: String
+  let isVisible: Bool
   var itemId: BookmarksListItemId { .track(trackId) }
   var image: UIImage {
     circleImageForColor(trackColor, frameSize: 22)
   }
 
   var colorDidTapAction: ((_ anchor: UIView?) -> Void)?
+  let visibilityDidTapAction: () -> Void
 
   private let trackColor: UIColor
 
-  init(_ track: Track, formattedDistance: String, colorDidTap: ((_ anchor: UIView?) -> Void)?) {
+  init(_ track: Track,
+       formattedDistance: String,
+       colorDidTap: ((_ anchor: UIView?) -> Void)?,
+       visibilityDidTap: @escaping () -> Void) {
     trackId = track.trackId
     name = track.trackName
     subtitle = "\(L("length")) \(formattedDistance)"
+    isVisible = track.isVisible
     trackColor = track.trackColor
     colorDidTapAction = colorDidTap
+    visibilityDidTapAction = visibilityDidTap
   }
 }
 
@@ -499,7 +514,7 @@ private struct BookmarksSectionViewModel: IBookmarksSectionViewModel {
 }
 
 private struct TracksSectionViewModel: ITracksSectionViewModel {
-  let tracks: [IBookmarksListItemViewModel]
+  let tracks: [ITrackViewModel]
 }
 
 private struct SubgroupsSectionViewModel: ISubgroupsSectionViewModel {

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListCell.swift
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListCell.swift
@@ -1,5 +1,5 @@
-/// A list cell with a fixed layout: an optional leading icon button, a title/subtitle block and a
-/// trailing icon button.
+/// A list cell with a fixed layout: an optional leading icon button, a title/subtitle block and up
+/// to two trailing icon buttons.
 ///
 /// `UITableViewCell`'s built-in layout is deliberately not used. Its system accessories
 /// (`accessoryType = .detailButton`) resize with the content size category while custom icons do
@@ -12,6 +12,10 @@ final class BookmarksListCell: MWMTableViewCell {
   private enum Constants {
     static let leadingButtonWidth: CGFloat = 52
     static let trailingButtonWidth: CGFloat = 52
+    static let innerTrailingButtonWidth: CGFloat = 36
+    /// The inner slot is narrower than the 44pt minimum touch target, so it claims the difference
+    /// from the side that faces the labels.
+    static let innerTrailingButtonTouchInset: CGFloat = 8
     static let minimumHeight: CGFloat = 48
     static let verticalInset: CGFloat = 12
     static let horizontalInset: CGFloat = 16
@@ -25,6 +29,7 @@ final class BookmarksListCell: MWMTableViewCell {
   private let labelsStackView = UIStackView()
   private let titleLabel = UILabel()
   private let subtitleLabel = UILabel()
+  private let innerTrailingButton = IconButton(frame: .zero)
   private let trailingButton = IconButton(frame: .zero)
 
   private var isShowingEditControl = false
@@ -48,7 +53,7 @@ final class BookmarksListCell: MWMTableViewCell {
     subtitleLabel.text = configuration.subtitle
     subtitleLabel.isHidden = configuration.subtitle?.isEmpty ?? true
     applyLeadingItem(configuration.leadingItem)
-    apply(configuration.trailingButton, to: trailingButton)
+    applyTrailingButtons(configuration.trailingButtons)
     updateEditingState()
   }
 
@@ -96,9 +101,13 @@ final class BookmarksListCell: MWMTableViewCell {
     contentStackView.isLayoutMarginsRelativeArrangement = true
     contentStackView.addArrangedSubview(leadingButton)
     contentStackView.addArrangedSubview(labelsContainerView)
+    contentStackView.addArrangedSubview(innerTrailingButton)
     contentStackView.addArrangedSubview(trailingButton)
-    // The leading button's width already includes the padding around its icon.
+    // The leading button's width already includes the padding around its icon, and the two trailing
+    // buttons form a single column.
     contentStackView.setCustomSpacing(0, after: leadingButton)
+    contentStackView.setCustomSpacing(0, after: innerTrailingButton)
+    innerTrailingButton.touchInset = Constants.innerTrailingButtonTouchInset
     contentView.addSubview(contentStackView)
     contentView.shouldGroupAccessibilityChildren = true
 
@@ -129,6 +138,7 @@ final class BookmarksListCell: MWMTableViewCell {
                                               constant: -Constants.verticalInset),
 
       leadingButton.widthAnchor.constraint(equalToConstant: Constants.leadingButtonWidth),
+      innerTrailingButton.widthAnchor.constraint(equalToConstant: Constants.innerTrailingButtonWidth),
       trailingButton.widthAnchor.constraint(equalToConstant: Constants.trailingButtonWidth),
     ])
   }
@@ -147,6 +157,20 @@ final class BookmarksListCell: MWMTableViewCell {
     }
   }
 
+  private func applyTrailingButtons(_ buttons: Configuration.TrailingButtons) {
+    switch buttons {
+    case .none:
+      apply(nil, to: innerTrailingButton)
+      apply(nil, to: trailingButton)
+    case .one(let button):
+      apply(nil, to: innerTrailingButton)
+      apply(button, to: trailingButton)
+    case .two(let inner, let edge):
+      apply(inner, to: innerTrailingButton)
+      apply(edge, to: trailingButton)
+    }
+  }
+
   private func apply(_ configuration: Configuration.TrailingButton?, to button: IconButton) {
     button.setImage(configuration?.image, for: .normal)
     button.tintColor = configuration?.tintColor
@@ -155,10 +179,11 @@ final class BookmarksListCell: MWMTableViewCell {
   }
 
   private func updateEditingState() {
-    // Multiple selection is the only state that removes the button: a visible control that does
+    // Multiple selection is the only state that removes the buttons: a visible control that does
     // nothing is still announced by VoiceOver. Swipe actions are deliberately excluded — UIKit turns
-    // `isEditing` on for them too, and dropping the button there would re-wrap the labels mid-swipe,
+    // `isEditing` on for them too, and dropping the buttons there would re-wrap the labels mid-swipe,
     // while a system accessory keeps the row's layout untouched.
+    innerTrailingButton.isHidden = isShowingEditControl || innerTrailingButton.action == nil
     trailingButton.isHidden = isShowingEditControl || trailingButton.action == nil
     leadingButton.isUserInteractionEnabled = !isEditing && leadingButton.action != nil
     updateInsets()
@@ -180,6 +205,10 @@ final class BookmarksListCell: MWMTableViewCell {
 private final class IconButton: UIButton {
   var action: ((UIView) -> Void)?
 
+  /// Extra touch area on both sides. The neighbouring button is later in `subviews` and therefore
+  /// wins the overlap, so the button only really gains the side that faces the labels.
+  var touchInset: CGFloat = 0
+
   override init(frame: CGRect) {
     super.init(frame: frame)
     addTarget(self, action: #selector(onTap), for: .touchUpInside)
@@ -188,6 +217,10 @@ private final class IconButton: UIButton {
   @available(*, unavailable)
   required init?(coder _: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+
+  override func point(inside point: CGPoint, with _: UIEvent?) -> Bool {
+    bounds.insetBy(dx: -touchInset, dy: 0).contains(point)
   }
 
   @objc private func onTap() {

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListCellConfiguration.swift
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListCellConfiguration.swift
@@ -12,10 +12,17 @@ extension BookmarksListCell {
       let action: (UIView) -> Void
     }
 
+    enum TrailingButtons {
+      case none
+      /// A single button always takes the slot at the cell's trailing edge.
+      case one(TrailingButton)
+      case two(inner: TrailingButton, edge: TrailingButton)
+    }
+
     let title: String
     let subtitle: String?
     let leadingItem: LeadingItem
-    let trailingButton: TrailingButton?
+    let trailingButtons: TrailingButtons
   }
 }
 
@@ -24,6 +31,13 @@ extension BookmarksListCell.Configuration.TrailingButton {
   /// with another button nor keep its size when the content size category grows.
   static func info(action: @escaping (UIView) -> Void) -> Self {
     .init(image: .icInfo, tintColor: .linkBlue, accessibilityLabel: L("edit"), action: action)
+  }
+
+  static func visibility(isVisible: Bool, action: @escaping (UIView) -> Void) -> Self {
+    .init(image: isVisible ? .icEyeOn : .icEyeOff,
+          tintColor: isVisible ? .linkBlue : .blackHintText,
+          accessibilityLabel: L(isVisible ? "hide_track" : "show_track"),
+          action: action)
   }
 
   static func more(action: @escaping (UIView) -> Void) -> Self {
@@ -36,7 +50,7 @@ extension BookmarksListCell.Configuration {
     BookmarksListCell.Configuration(title: "",
                                     subtitle: nil,
                                     leadingItem: .none,
-                                    trailingButton: nil)
+                                    trailingButtons: .none)
   }
 
   static func bookmark(_ item: IBookmarksListItemViewModel, infoAction: @escaping (UIView) -> Void) -> Self {
@@ -45,7 +59,20 @@ extension BookmarksListCell.Configuration {
                                     leadingItem: .image(item.image,
                                                         tintColor: nil,
                                                         action: item.colorDidTapAction),
-                                    trailingButton: .info(action: infoAction))
+                                    trailingButtons: .one(.info(action: infoAction)))
+  }
+
+  static func track(_ item: ITrackViewModel, infoAction: @escaping (UIView) -> Void) -> Self {
+    BookmarksListCell.Configuration(title: item.name,
+                                    subtitle: item.subtitle,
+                                    leadingItem: .image(item.image,
+                                                        tintColor: nil,
+                                                        action: item.colorDidTapAction),
+                                    trailingButtons: .two(
+                                      inner: .visibility(isVisible: item.isVisible,
+                                                         action: { _ in item.visibilityDidTapAction() }),
+                                      edge: .info(action: infoAction)
+                                    ))
   }
 
   static func category(_ category: BookmarkGroup,
@@ -56,7 +83,7 @@ extension BookmarksListCell.Configuration {
                                     leadingItem: .image(category.isVisible ? UIImage.icEyeOn : UIImage.icEyeOff,
                                                         tintColor: category.isVisible ? .linkBlue : .blackHintText,
                                                         action: leadingAction),
-                                    trailingButton: .more(action: accessoryAction))
+                                    trailingButtons: .one(.more(action: accessoryAction)))
   }
 
   static func action(_ action: BMCAction) -> Self {
@@ -65,6 +92,6 @@ extension BookmarksListCell.Configuration {
                                     leadingItem: .image(action.image,
                                                         tintColor: .linkBlue,
                                                         action: nil),
-                                    trailingButton: nil)
+                                    trailingButtons: .none)
   }
 }

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListCellStrategy.swift
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListCellStrategy.swift
@@ -31,7 +31,7 @@ final class BookmarksListCellStrategy {
     case let tracksSection as ITracksSectionViewModel:
       let track = tracksSection.tracks[indexPath.row]
       let cell = tableView.dequeueReusableCell(cell: BookmarksListCell.self, indexPath: indexPath)
-      cell.configure(.bookmark(track, infoAction: { [weak self, weak cell] _ in
+      cell.configure(.track(track, infoAction: { [weak self, weak cell] _ in
         guard let cell else { return }
         self?.cellEditHandler?(cell)
       }))

--- a/iphone/Maps/UI/EditBookmark/EditTrackViewController.swift
+++ b/iphone/Maps/UI/EditBookmark/EditTrackViewController.swift
@@ -10,6 +10,7 @@ final class EditTrackViewController: MWMTableViewController {
 
   private enum InfoSectionRows: Int {
     case title
+    case visibility
     case color
     // case lineWidth // TODO: possible new section & ability - edit track line width
     case bookmarkGroup
@@ -26,6 +27,7 @@ final class EditTrackViewController: MWMTableViewController {
   private var trackGroupTitle: String?
   private var trackGroupId = FrameworkHelper.invalidCategoryId()
   private var trackColor: UIColor
+  private var trackVisibility: Bool
 
   private let bookmarksManager = BookmarksManager.shared()
   private var isDeleting = false
@@ -38,6 +40,7 @@ final class EditTrackViewController: MWMTableViewController {
     initialTrackTitle = track.trackName
     trackTitle = initialTrackTitle
     trackColor = track.trackColor
+    trackVisibility = track.isVisible
     trackDescription = bookmarksManager.description(forTrackId: trackId)
 
     let category = bookmarksManager.category(forTrackId: trackId)
@@ -74,6 +77,7 @@ final class EditTrackViewController: MWMTableViewController {
     title = L("track_title")
 
     tableView.register(cell: SettingsTextFieldCell.self)
+    tableView.register(cell: SettingsTableViewSwitchCell.self)
     tableView.registerNib(cell: MWMButtonCell.self)
     tableView.registerNib(cell: MWMNoteCell.self)
 
@@ -120,6 +124,10 @@ final class EditTrackViewController: MWMTableViewController {
         cell.accessoryType = .disclosureIndicator
         cell.textLabel?.text = L("change_color")
         cell.imageView?.image = circleImageForColor(trackColor, frameSize: 28, diameter: 22)
+        return cell
+      case .visibility:
+        let cell = tableView.dequeueReusableCell(cell: SettingsTableViewSwitchCell.self, indexPath: indexPath)
+        cell.config(delegate: self, title: L("show_track"), isOn: trackVisibility)
         return cell
       case .bookmarkGroup:
         let cell = tableView.dequeueDefaultCell(for: indexPath)
@@ -202,12 +210,13 @@ final class EditTrackViewController: MWMTableViewController {
     }
     let currentDescription = bookmarksManager.description(forTrackId: trackId)
     let descriptionToSave = trackDescription ?? currentDescription
-    let changesSaved = trackGroupId != trackGroup.categoryId ||
+    let metadataChanged = trackGroupId != trackGroup.categoryId ||
       !trackColor.isEqual(track.trackColor) ||
       titleToSave != track.trackName ||
       descriptionToSave != currentDescription
+    let visibilityChanged = trackVisibility != track.isVisible
 
-    if changesSaved {
+    if metadataChanged {
       bookmarksManager.updateTrack(trackId,
                                    setGroupId: trackGroupId,
                                    color: trackColor,
@@ -215,8 +224,11 @@ final class EditTrackViewController: MWMTableViewController {
                                    description: descriptionToSave)
       initialTrackTitle = titleToSave
     }
+    if visibilityChanged {
+      bookmarksManager.setTrack(trackId, isVisible: trackVisibility)
+    }
 
-    editingCompleted(changesSaved)
+    editingCompleted(metadataChanged || visibilityChanged)
   }
 
   private func updateColor(_ color: UIColor) {
@@ -251,6 +263,12 @@ extension EditTrackViewController: SettingsTextFieldCellDelegate {
 
   func textFieldCell(_: SettingsTextFieldCell, didEndEditingText title: String) {
     trackTitle = title
+  }
+}
+
+extension EditTrackViewController: SettingsTableViewSwitchCellDelegate {
+  func switchCell(_: SettingsTableViewSwitchCell, didChangeValue value: Bool) {
+    trackVisibility = value
   }
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on top of #13468 — that PR is the base branch here, so please review and merge it first. The diff below shows only the commits on top of it.

## What

Brings the iOS app up to parity with Android for hiding and showing individual tracks in a bookmark list.

- **Track rows** get an eye button that toggles the track's visibility right from the list. Hidden tracks are not rendered and are skipped by tap detection; the state is persisted to KML by the core.
- **Track editor** gets a "Show track" switch. Like the other fields on that screen it is staged and applied in `saveChanges()`, which the editor runs when it disappears.
- **Opening a track** from the list unhides it — no iOS code needed, `Framework::ShowTrack` already calls `SetTrackVisibility(trackId, true)`.

The core, the KML format and the Android UI landed in #12021; this is the iOS part of #5503.

## Commits

1. `[strings] Regenerated` — `hide_track` / `show_track` already existed in `strings.txt` but were only tagged `android-app`, so they were never generated for iOS.
2. `[ios] Hide individual tracks from the bookmarks list` — `MWMTrack.isVisible` and `MWMBookmarksManager.setTrack(_:visible:)` (routed through `Framework::SetTrackVisibility`, which uses an `EditSession`), plus the view model, the presenter and the eye button in the row.
3. `[ios] Add a visibility switch to the track editor` — the staged switch. It also fixes the ordering in `saveChanges()`: visibility is applied before the completion handler runs, not after.

## Notes

- The cell's inner trailing slot lives here rather than in #13468: the 36pt button, its 8pt touch-area inset (the slot is under the 44pt minimum, so it claims the difference from the side facing the labels) and the `TrailingButtons` enum all arrive with the eye/info pair that exercises them. #13468 keeps a single trailing slot.
- Category visibility still takes precedence over track visibility, same as on Android: a track inside a hidden category is not shown even if its own eye is on.
- Hidden tracks stay in place in the list rather than moving to a separate section — matching Android; a "Hidden tracks" subsection was discussed in #12021 as possible future work.

## Test

Built and run on the iOS simulator: toggling from the list and from the editor, opening a hidden track, sorting, multi-select mode, and light/dark themes.


<img width="590" height="1278" alt="IMG_2074" src="https://github.com/user-attachments/assets/24f19267-a126-40f0-bbab-3c445c41e894" />
<img width="590" height="1278" alt="IMG_2073" src="https://github.com/user-attachments/assets/6f1724cb-3840-4a11-8bb7-1c5799f86010" />


