### PR TITLE
[ios] Remove unused expanded state from route planning screen

### DIFF
--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardModalPresentationStepStrategy.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardModalPresentationStepStrategy.swift
@@ -1,5 +1,4 @@
 enum NavigationDashboardModalPresentationStep: Int, CaseIterable, ModalPresentationStep {
-  case expanded
   case regular
   case halfScreen
   case compact
@@ -44,7 +43,7 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
   }
 
   var steps: [Step] {
-    var availableSteps: [Step] = [.expanded, .regular]
+    var availableSteps: [Step] = [.regular]
     if shouldShowHalfScreenStep {
       availableSteps.append(.halfScreen)
     }
@@ -58,11 +57,7 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
 
   func upperTo(_ step: Step) -> Step {
     switch step {
-    case .expanded:
-      return .expanded
-    case .regular:
-      return .expanded
-    case .halfScreen:
+    case .regular, .halfScreen:
       return .regular
     case .compact:
       return shouldShowHalfScreenStep ? .halfScreen : .regular
@@ -75,8 +70,6 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
 
   func lowerTo(_ step: Step) -> Step {
     switch step {
-    case .expanded:
-      return .regular
     case .regular:
       return shouldShowHalfScreenStep ? .halfScreen : .compact
     case .halfScreen:
@@ -115,8 +108,6 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
       frame.size.width = Constants.iPadWidth
       frame.origin.x = Constants.iPadLeadingOffset
       switch step {
-      case .expanded:
-        frame.origin.y = safeAreaInsets.top + Constants.topInset
       case .regular:
         if regularHeight != 0 {
           frame.origin.y = max(containerSize.height - regularHeight, safeAreaInsets.top + Constants.topInset)
@@ -149,8 +140,6 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
       let isPortraitOrientation = traitCollection.verticalSizeClass == .regular
       if isPortraitOrientation {
         switch step {
-        case .expanded:
-          frame.origin.y = safeAreaInsets.top + Constants.topInset
         case .regular:
           if regularHeight != 0 {
             frame.origin.y = max(containerSize.height - regularHeight, safeAreaInsets.top + Constants.topInset)
@@ -180,7 +169,7 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
         frame.size.width = Constants.iPadWidth
         frame.origin.x = safeAreaInsets.left
         switch step {
-        case .expanded, .regular, .halfScreen:
+        case .regular, .halfScreen:
           frame.origin.y = Constants.topInset
         case .compact:
           frame.origin.y = containerSize.height - (compactHeight != 0 ? compactHeight : Constants.compactHeightOffset)

--- a/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardModalPresentationStepStrategy.swift
+++ b/iphone/Maps/UI/NavigationDashboard/Views/NavigationDashboardModalPresentationStepStrategy.swift
@@ -170,7 +170,9 @@ final class NavigationDashboardModalPresentationStepStrategy: ModalPresentationS
         frame.origin.x = safeAreaInsets.left
         switch step {
         case .regular, .halfScreen:
-          frame.origin.y = Constants.topInset
+          frame.origin.y = regularHeight != 0
+            ? max(containerSize.height - regularHeight, Constants.topInset)
+            : Constants.topInset
         case .compact:
           frame.origin.y = containerSize.height - (compactHeight != 0 ? compactHeight : Constants.compactHeightOffset)
         case .estimates:

--- a/iphone/Maps/UI/ReusableComponents/ModalPresentation/ModalPresentationStepStrategy.swift
+++ b/iphone/Maps/UI/ReusableComponents/ModalPresentation/ModalPresentationStepStrategy.swift
@@ -1,6 +1,7 @@
 protocol ModalPresentationStepStrategy<Step>: Equatable {
-  associatedtype Step: CaseIterable & Equatable
+  associatedtype Step: ModalPresentationStep & CaseIterable
 
+  /// Steps ordered from the topmost available position to hidden.
   var steps: [Step] { get }
 
   func upperTo(_ step: Step) -> Step

--- a/iphone/Maps/UI/ReusableComponents/ModalPresentation/ModalPresentationStepsController.swift
+++ b/iphone/Maps/UI/ReusableComponents/ModalPresentation/ModalPresentationStepsController.swift
@@ -1,5 +1,4 @@
 protocol ModalPresentationStep: Equatable {
-  static var expanded: Self { get }
   static var hidden: Self { get }
 }
 
@@ -21,14 +20,15 @@ final class ModalPresentationStepsController<Step: ModalPresentationStep> {
   private weak var presentedView: UIView?
   private weak var containerViewController: UIViewController?
   private var currentStep: Step
-  private(set) var maxAvailableFrame: CGRect = .zero
 
   var stepStrategy: any ModalPresentationStepStrategy<Step>
   var didUpdateHandler: ((StepUpdate) -> Void)?
   var hiddenFrame: CGRect { frame(for: .hidden) }
+  var maxAvailableFrame: CGRect { frame(for: topStep) }
 
   private var initialTranslationY: CGFloat = .zero
   private var isPanning: Bool = false
+  private var topStep: Step { stepStrategy.steps.first ?? .hidden }
 
   init(presentedView: UIView,
        containerViewController: UIViewController,
@@ -57,14 +57,13 @@ final class ModalPresentationStepsController<Step: ModalPresentationStep> {
   }
 
   func handlePan(_ gesture: UIPanGestureRecognizer) {
-    guard let presentedView, let containerViewController else { return }
+    guard let presentedView, containerViewController != nil else { return }
     let translation = gesture.translation(in: presentedView)
     let velocity = gesture.velocity(in: presentedView)
     var currentFrame = presentedView.frame
 
     switch gesture.state {
     case .began:
-      maxAvailableFrame = stepStrategy.frame(.expanded, for: presentedView, in: containerViewController)
       initialTranslationY = presentedView.frame.origin.y
       isPanning = true
     case .changed:
@@ -77,7 +76,7 @@ final class ModalPresentationStepsController<Step: ModalPresentationStep> {
       if velocity.y > Constants.fastSwipeDownVelocity {
         nextStep = .hidden
       } else if velocity.y < -Constants.fastSwipeUpVelocity {
-        nextStep = .expanded
+        nextStep = topStep
       } else if abs(translation.y) > Constants.maxRecognizedTranslation {
         nextStep = nearestStep(for: currentFrame.origin.y)
       } else if velocity.y > Constants.slowSwipeVelocity && translation.y > Constants.minRecognizedTranslation {

--- a/iphone/Maps/UI/ReusableComponents/ModalPresentation/ModalPresentationStepsController.swift
+++ b/iphone/Maps/UI/ReusableComponents/ModalPresentation/ModalPresentationStepsController.swift
@@ -98,6 +98,10 @@ final class ModalPresentationStepsController<Step: ModalPresentationStep> {
 
       let animation: PresentationStepChangeAnimation = abs(velocity.y) > Constants.slowSwipeVelocity ? .slideAndBounce : .slide
       setStep(nextStep, animation: animation)
+    case .cancelled:
+      setStep(currentStep, animation: .slide)
+    case .failed:
+      isPanning = false
     default:
       break
     }


### PR DESCRIPTION
With only a few route points, the route planning screen could be manually dragged into an expanded fullscreen state, leaving a large empty area.

This removes the unused expanded state from the navigation dashboard and uses the dynamic regular height as its top position. The sheet still grows up to the safe-area limit when many route points require more space. Search-on-map expanded presentation remains unchanged.

<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-09-04 at 12 44 07" src="https://github.com/user-attachments/assets/a7d2655d-3e7d-4573-8d2d-8ed5bdbe6060" />

<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-09-04 at 12 40 46" src="https://github.com/user-attachments/assets/9a1f0248-fda1-44e8-9d72-9cf742d68ffd" />

<img width="673" height="400" alt="image" src="https://github.com/user-attachments/assets/0c67716b-5cab-4f76-9069-c4653bbb1975" />

Tested: 
- manual route planning screen check on iPhone 17 simulator; 
- Manual testing on the iPhone 15 Pro device; 
- swiftformat on changed Swift files; xcrun swiftc -parse for modal presentation strategies/controller; git diff --check for changed PR files.

LLM tools were used to help implement and review this change.