### PR TITLE
[ios] Update bookmarks tables insets and separators

### DIFF
--- a/iphone/Maps/Core/Theme/Renderers/UITableViewRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/UITableViewRenderer.swift
@@ -1,5 +1,7 @@
 extension UITableView {
   @objc override func applyTheme() {
+    // Separators use UIKit's automatic leading inset and reach the cell's trailing edge app-wide.
+    separatorInset = UIEdgeInsets(top: 0, left: UITableView.automaticDimension, bottom: 0, right: 0)
     if styleName.isEmpty {
       setStyle(.tableView)
     }

--- a/iphone/Maps/Extensions/Views/UITableViewCell+SeparatorInset.swift
+++ b/iphone/Maps/Extensions/Views/UITableViewCell+SeparatorInset.swift
@@ -1,0 +1,17 @@
+extension UITableViewCell {
+  /// Starts the separator at the view's leading edge. Measuring its laid-out geometry includes the
+  /// safe area inset applied to `contentView`; UIKit mirrors `separatorInset` for RTL layouts, while
+  /// separators end at the cell's trailing edge throughout the app.
+  @objc(alignSeparatorWithView:)
+  func alignSeparator(with view: UIView) {
+    contentView.layoutIfNeeded()
+    let frame = convert(view.bounds, from: view)
+    let leading = effectiveUserInterfaceLayoutDirection == .rightToLeft
+      ? bounds.maxX - frame.maxX
+      : frame.minX
+    let inset = UIEdgeInsets(top: 0, left: leading, bottom: 0, right: 0)
+    // Avoid invalidating the cell's layout when called from layoutSubviews().
+    guard separatorInset != inset else { return }
+    separatorInset = inset
+  }
+}

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -114,7 +114,7 @@
 		F0A0B0012FF2ABCD00FA103D /* BookmarksListCellConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A0B0002FF2ABCD00FA103D /* BookmarksListCellConfiguration.swift */; };
 		ED82C4FD2F90180300FA103D /* BookmarksListCellStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C2A82F90180300FA103D /* BookmarksListCellStrategy.swift */; };
 		ED82C4FE2F90180300FA103D /* BookmarksListSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C2A92F90180300FA103D /* BookmarksListSectionHeader.swift */; };
-		ED82C4FF2F90180300FA103D /* SubgroupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C2AB2F90180300FA103D /* SubgroupCell.swift */; };
+		ED82C4FF2F90180300FA103D /* BookmarksListSubgroupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C2AB2F90180300FA103D /* BookmarksListSubgroupCell.swift */; };
 		ED82C5002F90180300FA103D /* BookmarksListBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C2AE2F90180300FA103D /* BookmarksListBuilder.swift */; };
 		ED82C5012F90180300FA103D /* BookmarksListInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C2AF2F90180300FA103D /* BookmarksListInfoViewController.swift */; };
 		ED82C5022F90180300FA103D /* BookmarksListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C2B12F90180300FA103D /* BookmarksListInteractor.swift */; };
@@ -381,7 +381,7 @@
 		ED82C61C2F90180300FA103D /* DefaultTranslationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C4ED2F90180300FA103D /* DefaultTranslationController.swift */; };
 		ED82C61D2F90180300FA103D /* MWMAutoupdateController.xib in Resources */ = {isa = PBXBuildFile; fileRef = ED82C2992F90180300FA103D /* MWMAutoupdateController.xib */; };
 		ED82C61F2F90180300FA103D /* BookmarksListSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = ED82C2AA2F90180300FA103D /* BookmarksListSectionHeader.xib */; };
-		ED82C6202F90180300FA103D /* SubgroupCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = ED82C2AC2F90180300FA103D /* SubgroupCell.xib */; };
+		ED82C6202F90180300FA103D /* BookmarksListSubgroupCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = ED82C2AC2F90180300FA103D /* BookmarksListSubgroupCell.xib */; };
 		ED82C6212F90180300FA103D /* BookmarksListInfoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = ED82C2B02F90180300FA103D /* BookmarksListInfoViewController.xib */; };
 		ED82C6222F90180300FA103D /* BookmarksListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = ED82C2B62F90180300FA103D /* BookmarksListViewController.xib */; };
 		ED82C6242F90180300FA103D /* BMCViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = ED82C2BC2F90180300FA103D /* BMCViewController.xib */; };
@@ -592,6 +592,7 @@
 		ED82C8022F90186900FA103D /* UINavigationItem+StyleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C7D12F90186900FA103D /* UINavigationItem+StyleStyle.swift */; };
 		ED82C8032F90186900FA103D /* UINib+Init.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C7D22F90186900FA103D /* UINib+Init.swift */; };
 		ED82C8042F90186900FA103D /* UITableView+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C7D32F90186900FA103D /* UITableView+Cells.swift */; };
+		0F13484A0000000000000002 /* UITableViewCell+SeparatorInset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F13484A0000000000000001 /* UITableViewCell+SeparatorInset.swift */; };
 		ED82C8052F90186900FA103D /* UITableView+Updates.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED82C7D42F90186900FA103D /* UITableView+Updates.swift */; };
 		ED82C8062F90186900FA103D /* UITextField+RuntimeAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = ED82C7D62F90186900FA103D /* UITextField+RuntimeAttributes.m */; };
 		ED82C8072F90186900FA103D /* UITextView+RuntimeAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = ED82C7D82F90186900FA103D /* UITextView+RuntimeAttributes.m */; };
@@ -975,8 +976,8 @@
 		ED82C2A82F90180300FA103D /* BookmarksListCellStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksListCellStrategy.swift; sourceTree = "<group>"; };
 		ED82C2A92F90180300FA103D /* BookmarksListSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksListSectionHeader.swift; sourceTree = "<group>"; };
 		ED82C2AA2F90180300FA103D /* BookmarksListSectionHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BookmarksListSectionHeader.xib; sourceTree = "<group>"; };
-		ED82C2AB2F90180300FA103D /* SubgroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubgroupCell.swift; sourceTree = "<group>"; };
-		ED82C2AC2F90180300FA103D /* SubgroupCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SubgroupCell.xib; sourceTree = "<group>"; };
+		ED82C2AB2F90180300FA103D /* BookmarksListSubgroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksListSubgroupCell.swift; sourceTree = "<group>"; };
+		ED82C2AC2F90180300FA103D /* BookmarksListSubgroupCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BookmarksListSubgroupCell.xib; sourceTree = "<group>"; };
 		ED82C2AE2F90180300FA103D /* BookmarksListBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksListBuilder.swift; sourceTree = "<group>"; };
 		ED82C2AF2F90180300FA103D /* BookmarksListInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksListInfoViewController.swift; sourceTree = "<group>"; };
 		ED82C2B02F90180300FA103D /* BookmarksListInfoViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BookmarksListInfoViewController.xib; sourceTree = "<group>"; };
@@ -1621,6 +1622,7 @@
 		ED82C7D12F90186900FA103D /* UINavigationItem+StyleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+StyleStyle.swift"; sourceTree = "<group>"; };
 		ED82C7D22F90186900FA103D /* UINib+Init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINib+Init.swift"; sourceTree = "<group>"; };
 		ED82C7D32F90186900FA103D /* UITableView+Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Cells.swift"; sourceTree = "<group>"; };
+		0F13484A0000000000000001 /* UITableViewCell+SeparatorInset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+SeparatorInset.swift"; sourceTree = "<group>"; };
 		ED82C7D42F90186900FA103D /* UITableView+Updates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Updates.swift"; sourceTree = "<group>"; };
 		ED82C7D52F90186900FA103D /* UITextField+RuntimeAttributes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UITextField+RuntimeAttributes.h"; sourceTree = "<group>"; };
 		ED82C7D62F90186900FA103D /* UITextField+RuntimeAttributes.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UITextField+RuntimeAttributes.m"; sourceTree = "<group>"; };
@@ -2247,8 +2249,8 @@
 				ED82C2A82F90180300FA103D /* BookmarksListCellStrategy.swift */,
 				ED82C2A92F90180300FA103D /* BookmarksListSectionHeader.swift */,
 				ED82C2AA2F90180300FA103D /* BookmarksListSectionHeader.xib */,
-				ED82C2AB2F90180300FA103D /* SubgroupCell.swift */,
-				ED82C2AC2F90180300FA103D /* SubgroupCell.xib */,
+				ED82C2AB2F90180300FA103D /* BookmarksListSubgroupCell.swift */,
+				ED82C2AC2F90180300FA103D /* BookmarksListSubgroupCell.xib */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -3987,6 +3989,7 @@
 				ED82C7D12F90186900FA103D /* UINavigationItem+StyleStyle.swift */,
 				ED82C7D22F90186900FA103D /* UINib+Init.swift */,
 				ED82C7D32F90186900FA103D /* UITableView+Cells.swift */,
+				0F13484A0000000000000001 /* UITableViewCell+SeparatorInset.swift */,
 				ED82C7D42F90186900FA103D /* UITableView+Updates.swift */,
 				ED82C7D52F90186900FA103D /* UITextField+RuntimeAttributes.h */,
 				ED82C7D62F90186900FA103D /* UITextField+RuntimeAttributes.m */,
@@ -4379,7 +4382,7 @@
 				DB05F1CE1BF340DE002C974C /* drules_vehicle.bin in Resources */,
 				ED82C61D2F90180300FA103D /* MWMAutoupdateController.xib in Resources */,
 				ED82C61F2F90180300FA103D /* BookmarksListSectionHeader.xib in Resources */,
-				ED82C6202F90180300FA103D /* SubgroupCell.xib in Resources */,
+				ED82C6202F90180300FA103D /* BookmarksListSubgroupCell.xib in Resources */,
 				ED82C6212F90180300FA103D /* BookmarksListInfoViewController.xib in Resources */,
 				ED82C6222F90180300FA103D /* BookmarksListViewController.xib in Resources */,
 				ED82C6242F90180300FA103D /* BMCViewController.xib in Resources */,
@@ -4514,7 +4517,7 @@
 				F0A0B0012FF2ABCD00FA103D /* BookmarksListCellConfiguration.swift in Sources */,
 				ED82C4FD2F90180300FA103D /* BookmarksListCellStrategy.swift in Sources */,
 				ED82C4FE2F90180300FA103D /* BookmarksListSectionHeader.swift in Sources */,
-				ED82C4FF2F90180300FA103D /* SubgroupCell.swift in Sources */,
+				ED82C4FF2F90180300FA103D /* BookmarksListSubgroupCell.swift in Sources */,
 				ED82C5002F90180300FA103D /* BookmarksListBuilder.swift in Sources */,
 				ED82C5012F90180300FA103D /* BookmarksListInfoViewController.swift in Sources */,
 				ED82C5022F90180300FA103D /* BookmarksListInteractor.swift in Sources */,
@@ -4921,6 +4924,7 @@
 				ED82C8022F90186900FA103D /* UINavigationItem+StyleStyle.swift in Sources */,
 				ED82C8032F90186900FA103D /* UINib+Init.swift in Sources */,
 				ED82C8042F90186900FA103D /* UITableView+Cells.swift in Sources */,
+				0F13484A0000000000000002 /* UITableViewCell+SeparatorInset.swift in Sources */,
 				ED82C8052F90186900FA103D /* UITableView+Updates.swift in Sources */,
 				ED82C8202F90186900FA103D /* MWMKeyboard.m in Sources */,
 				ED82C8212F90186900FA103D /* Common.swift in Sources */,

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/BookmarksListInfoViewController.xib
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/BookmarksListInfoViewController.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="25084" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="25084" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="25061"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -112,15 +113,16 @@
                                 </button>
                             </subviews>
                             <constraints>
-                                <constraint firstAttribute="trailing" secondItem="226-gO-8GN" secondAttribute="trailing" constant="20" id="Bc0-zj-luu"/>
+                                <constraint firstItem="hDR-sA-fe1" firstAttribute="trailing" secondItem="226-gO-8GN" secondAttribute="trailing" constant="20" id="Bc0-zj-luu"/>
                                 <constraint firstItem="ixf-Ba-3Fe" firstAttribute="leading" secondItem="TFR-Qj-pUF" secondAttribute="trailing" constant="8" id="9jE-YY-ZE7"/>
                                 <constraint firstItem="ixf-Ba-3Fe" firstAttribute="top" secondItem="TFR-Qj-pUF" secondAttribute="top" id="aPt-h4-3s1"/>
                                 <constraint firstItem="ixf-Ba-3Fe" firstAttribute="bottom" secondItem="TFR-Qj-pUF" secondAttribute="bottom" id="Uc4-1t-Kb8"/>
-                                <constraint firstAttribute="trailing" secondItem="ixf-Ba-3Fe" secondAttribute="trailing" id="Z5s-ln-YsX"/>
-                                <constraint firstItem="226-gO-8GN" firstAttribute="leading" secondItem="jGS-bD-wyb" secondAttribute="leading" constant="20" id="CBz-2b-FdW"/>
+                                <constraint firstItem="hDR-sA-fe1" firstAttribute="trailing" secondItem="ixf-Ba-3Fe" secondAttribute="trailing" id="Z5s-ln-YsX"/>
+                                <constraint firstItem="226-gO-8GN" firstAttribute="leading" secondItem="hDR-sA-fe1" secondAttribute="leading" constant="20" id="CBz-2b-FdW"/>
                                 <constraint firstAttribute="bottom" secondItem="226-gO-8GN" secondAttribute="bottom" id="eCj-gO-9cQ"/>
                                 <constraint firstItem="226-gO-8GN" firstAttribute="top" secondItem="jGS-bD-wyb" secondAttribute="top" id="wIb-n9-mts"/>
                             </constraints>
+                            <viewLayoutGuide key="safeArea" id="hDR-sA-fe1"/>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p5d-oU-wVm">
                             <rect key="frame" x="0.0" y="339" width="375" height="1"/>

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/BookmarksListViewController.xib
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/BookmarksListViewController.xib
@@ -25,7 +25,6 @@
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="60" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="fva-qQ-WqU">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
-                    <inset key="separatorInset" minX="52" minY="0.0" maxX="0.0" maxY="0.0"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="TableView:PressBackground"/>
                     </userDefinedRuntimeAttributes>
@@ -60,11 +59,11 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="cD8-kh-Gmp" secondAttribute="bottom" id="FgV-RT-cCW"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="cD8-kh-Gmp" secondAttribute="trailing" id="LZs-Au-R4I"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="fva-qQ-WqU" secondAttribute="trailing" id="OsX-Pn-Js4"/>
-                <constraint firstItem="fva-qQ-WqU" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="d61-I4-Ku3"/>
+                <constraint firstAttribute="trailing" secondItem="cD8-kh-Gmp" secondAttribute="trailing" id="LZs-Au-R4I"/>
+                <constraint firstAttribute="trailing" secondItem="fva-qQ-WqU" secondAttribute="trailing" id="OsX-Pn-Js4"/>
+                <constraint firstItem="fva-qQ-WqU" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="d61-I4-Ku3"/>
                 <constraint firstAttribute="bottom" secondItem="fva-qQ-WqU" secondAttribute="bottom" id="i6G-0W-mED"/>
-                <constraint firstItem="cD8-kh-Gmp" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="jVJ-nY-UBF"/>
+                <constraint firstItem="cD8-kh-Gmp" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="jVJ-nY-UBF"/>
                 <constraint firstItem="fva-qQ-WqU" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="yZs-bO-F39"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListCell.swift
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListCell.swift
@@ -60,6 +60,11 @@ final class BookmarksListCell: MWMTableViewCell {
     updateEditingState()
   }
 
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    alignSeparator(with: labelsContainerView)
+  }
+
   override func willTransition(to state: UITableViewCell.StateMask) {
     super.willTransition(to: state)
     isShowingEditControl = state.contains(.showingEditControl)
@@ -166,8 +171,6 @@ final class BookmarksListCell: MWMTableViewCell {
       bottom: 0,
       trailing: trailingButton.isHidden ? Constants.horizontalInset : 0
     )
-    let separatorLeftInset = leadingButton.isHidden ? Constants.horizontalInset : Constants.leadingButtonWidth
-    separatorInset = UIEdgeInsets(top: 0, left: separatorLeftInset, bottom: 0, right: 0)
   }
 }
 

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListCellStrategy.swift
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListCellStrategy.swift
@@ -1,10 +1,4 @@
 final class BookmarksListCellStrategy {
-  private enum CellId {
-    static let listItem = "BookmarksListCell"
-    static let subgroup = "SubgroupCell"
-    static let sectionHeader = "SectionHeader"
-  }
-
   typealias CheckHandlerClosure = (IBookmarksListSectionViewModel, Int, Bool) -> Void
   var cellCheckHandler: CheckHandlerClosure?
 
@@ -18,9 +12,8 @@ final class BookmarksListCellStrategy {
 
   func registerCells(_ tableView: UITableView) {
     tableView.register(cell: BookmarksListCell.self)
-    tableView.register(UINib(nibName: "SubgroupCell", bundle: nil), forCellReuseIdentifier: CellId.subgroup)
-    tableView.register(UINib(nibName: "BookmarksListSectionHeader", bundle: nil),
-                       forHeaderFooterViewReuseIdentifier: CellId.sectionHeader)
+    tableView.registerNib(cell: BookmarksListSubgroupCell.self)
+    tableView.registerNibForHeaderFooterView(BookmarksListSectionHeader.self)
   }
 
   func tableCell(_ tableView: UITableView,
@@ -29,7 +22,7 @@ final class BookmarksListCellStrategy {
     switch viewModel {
     case let bookmarksSection as IBookmarksSectionViewModel:
       let bookmark = bookmarksSection.bookmarks[indexPath.row]
-      let cell = tableView.dequeueReusableCell(withIdentifier: CellId.listItem, for: indexPath) as! BookmarksListCell
+      let cell = tableView.dequeueReusableCell(cell: BookmarksListCell.self, indexPath: indexPath)
       cell.configure(.bookmark(bookmark, infoAction: { [weak self, weak cell] _ in
         guard let cell else { return }
         self?.cellEditHandler?(cell)
@@ -37,7 +30,7 @@ final class BookmarksListCellStrategy {
       return cell
     case let tracksSection as ITracksSectionViewModel:
       let track = tracksSection.tracks[indexPath.row]
-      let cell = tableView.dequeueReusableCell(withIdentifier: CellId.listItem, for: indexPath) as! BookmarksListCell
+      let cell = tableView.dequeueReusableCell(cell: BookmarksListCell.self, indexPath: indexPath)
       cell.configure(.bookmark(track, infoAction: { [weak self, weak cell] _ in
         guard let cell else { return }
         self?.cellEditHandler?(cell)
@@ -45,7 +38,7 @@ final class BookmarksListCellStrategy {
       return cell
     case let subgroupsSection as ISubgroupsSectionViewModel:
       let subgroup = subgroupsSection.subgroups[indexPath.row]
-      let cell = tableView.dequeueReusableCell(withIdentifier: CellId.subgroup, for: indexPath) as! SubgroupCell
+      let cell = tableView.dequeueReusableCell(cell: BookmarksListSubgroupCell.self, indexPath: indexPath)
       cell.config(subgroup)
       cell.checkHandler = { [weak self] checked in
         self?.cellCheckHandler?(viewModel, indexPath.row, checked)
@@ -58,8 +51,7 @@ final class BookmarksListCellStrategy {
 
   func headerView(_ tableView: UITableView,
                   for viewModel: IBookmarksListSectionViewModel) -> UITableViewHeaderFooterView {
-    let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: CellId.sectionHeader)
-      as! BookmarksListSectionHeader
+    let headerView = tableView.dequeueReusableHeaderFooterView(BookmarksListSectionHeader.self)
     headerView.config(viewModel)
     headerView.visibilityHandler = { [weak self] in
       self?.cellVisibilityHandler?(viewModel)

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListSectionHeader.xib
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListSectionHeader.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -41,10 +42,11 @@
             </subviews>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="xCm-Dh-8mT" secondAttribute="bottom" id="3MG-Ep-gMo"/>
-                <constraint firstItem="xCm-Dh-8mT" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="9XD-d8-7vk"/>
-                <constraint firstAttribute="trailing" secondItem="xCm-Dh-8mT" secondAttribute="trailing" constant="16" id="OGF-TS-kyi"/>
+                <constraint firstItem="xCm-Dh-8mT" firstAttribute="leading" secondItem="sHd-sA-fe2" secondAttribute="leading" constant="16" id="9XD-d8-7vk"/>
+                <constraint firstItem="sHd-sA-fe2" firstAttribute="trailing" secondItem="xCm-Dh-8mT" secondAttribute="trailing" constant="16" id="OGF-TS-kyi"/>
                 <constraint firstItem="xCm-Dh-8mT" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="12" id="OLp-AI-xo9"/>
             </constraints>
+            <viewLayoutGuide key="safeArea" id="sHd-sA-fe2"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="titleLabel" destination="yNv-Yr-Hkr" id="2D1-wr-wFj"/>

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListSubgroupCell.swift
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListSubgroupCell.swift
@@ -1,10 +1,15 @@
-final class SubgroupCell: UITableViewCell {
+final class BookmarksListSubgroupCell: UITableViewCell {
   @IBOutlet private var subgroupTitleLabel: UILabel!
   @IBOutlet private var subgroupSubtitleLabel: UILabel!
   @IBOutlet private var subgroupVisibleMark: Checkmark!
 
   typealias CheckHandlerClosure = (Bool) -> Void
   var checkHandler: CheckHandlerClosure?
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    alignSeparator(with: subgroupTitleLabel)
+  }
 
   func config(_ subgroup: ISubgroupViewModel) {
     subgroupTitleLabel.text = subgroup.subgroupName

--- a/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListSubgroupCell.xib
+++ b/iphone/Maps/UI/Bookmarks/BookmarksList/Cells/BookmarksListSubgroupCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="64" id="KGk-i7-Jjw" customClass="SubgroupCell" customModule="Organic_Maps" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="64" id="KGk-i7-Jjw" customClass="BookmarksListSubgroupCell" customModule="Organic_Maps" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">

--- a/iphone/Maps/UI/Bookmarks/Categories/BMCView/BMCViewController.xib
+++ b/iphone/Maps/UI/Bookmarks/Categories/BMCView/BMCViewController.xib
@@ -35,8 +35,8 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="2ia-hi-UhQ" secondAttribute="bottom" id="3LS-kF-koO"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="2ia-hi-UhQ" secondAttribute="trailing" id="Xvt-xX-QwP"/>
-                <constraint firstItem="2ia-hi-UhQ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="fEc-XL-6gs"/>
+                <constraint firstAttribute="trailing" secondItem="2ia-hi-UhQ" secondAttribute="trailing" id="Xvt-xX-QwP"/>
+                <constraint firstItem="2ia-hi-UhQ" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="fEc-XL-6gs"/>
                 <constraint firstItem="2ia-hi-UhQ" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="zOH-o1-384"/>
             </constraints>
             <point key="canvasLocation" x="10" y="54"/>

--- a/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderLargeCountryTableViewCell.xib
+++ b/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderLargeCountryTableViewCell.xib
@@ -78,7 +78,6 @@
                     <constraint firstItem="3NQ-tT-U9b" firstAttribute="centerY" secondItem="rFT-0r-5zy" secondAttribute="centerY" id="zd3-Ex-VJY"/>
                 </constraints>
             </tableViewCellContentView>
-            <inset key="separatorInset" minX="60" minY="0.0" maxX="0.0" maxY="0.0"/>
             <userDefinedRuntimeAttributes>
                 <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
             </userDefinedRuntimeAttributes>

--- a/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderPlaceTableViewCell.xib
+++ b/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderPlaceTableViewCell.xib
@@ -70,7 +70,6 @@
                     <constraint firstItem="rqh-iy-Sx9" firstAttribute="leading" secondItem="fev-4l-MY3" secondAttribute="trailing" constant="4" id="rqB-DG-k9N"/>
                 </constraints>
             </tableViewCellContentView>
-            <inset key="separatorInset" minX="60" minY="0.0" maxX="0.0" maxY="0.0"/>
             <userDefinedRuntimeAttributes>
                 <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
             </userDefinedRuntimeAttributes>

--- a/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderSubplaceTableViewCell.xib
+++ b/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderSubplaceTableViewCell.xib
@@ -82,7 +82,6 @@
                     <constraint firstItem="rqh-iy-Sx9" firstAttribute="centerY" secondItem="mRF-11-OKU" secondAttribute="centerY" id="qZa-yl-a6W"/>
                 </constraints>
             </tableViewCellContentView>
-            <inset key="separatorInset" minX="60" minY="0.0" maxX="0.0" maxY="0.0"/>
             <userDefinedRuntimeAttributes>
                 <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
             </userDefinedRuntimeAttributes>

--- a/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderTableViewCell.m
+++ b/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderTableViewCell.m
@@ -29,6 +29,12 @@
   [self addGestureRecognizer:lpGR];
 }
 
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  [self alignSeparatorWithView:self.title];
+}
+
 - (void)prepareForReuse
 {
   [super prepareForReuse];

--- a/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderTableViewCell.xib
+++ b/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderTableViewCell.xib
@@ -54,7 +54,6 @@
                     <constraint firstItem="rTN-aw-5k7" firstAttribute="centerY" secondItem="hYr-eg-wbg" secondAttribute="centerY" id="tND-fx-OhO"/>
                 </constraints>
             </tableViewCellContentView>
-            <inset key="separatorInset" minX="60" minY="0.0" maxX="0.0" maxY="0.0"/>
             <userDefinedRuntimeAttributes>
                 <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
             </userDefinedRuntimeAttributes>


### PR DESCRIPTION
## What

Make the bookmarks list and categories tables behave like system tables on notched devices:

- Table rows and the bookmarks toolbar extend to the screen edges.
- Cell content, table headers, section headers, and toolbar items remain inside the safe area.
- Bookmark separators derive their leading inset from the laid-out label position, including safe-area and RTL adjustments.

## Separator policy

All themed native table views now keep UIKit's automatic leading separator inset and use a zero trailing inset. Custom cells set only their leading inset and share the same zero-trailing helper.

The map downloader cells also derive the leading inset from their title position, so their separators stay aligned after the safe area moves the content in landscape.

Review follow-ups also move the reusable cell helpers to `Extensions/Views`, lay out nested content before measuring it, and make the bookmarks toolbar background full-width.

## Test

- Built the `OMaps` Debug scheme for iPhone 17 / iOS 26.4 Simulator.
- Ran SwiftFormat lint for the changed Swift files.
- Validated the changed XIB files with `xmllint` and the Xcode project with `plutil`.
- Checked portrait and landscape layouts on a notched iPhone: backgrounds remain edge-to-edge, content stays inside the safe area, and separators start under the labels and reach the trailing edge.

AI assistance was used for review and implementation.

## Before / After

<img width="338" height="735" alt="image" src="https://github.com/user-attachments/assets/a889808f-5bb4-402e-8e60-441e41feec8e" /> <img width="366" height="793" alt="image" src="https://github.com/user-attachments/assets/a30387e5-076c-4e4a-ad3f-1655fbda9252" />

<img width="673" height="400" alt="image" src="https://github.com/user-attachments/assets/55057b9e-f2fb-4036-a6c6-6ed28c87a2af" />
<img width="731" height="429" alt="image" src="https://github.com/user-attachments/assets/1d162f53-3187-46a3-9b1f-85f8831bbb23" />

<img width="338" height="735" alt="image" src="https://github.com/user-attachments/assets/a7cab5e0-d661-4185-a122-b68b0a489aef" />
<img width="366" height="793" alt="image" src="https://github.com/user-attachments/assets/2583f2d8-2674-4a11-a5d1-4dcbca34beb7" />

<img width="673" height="400" alt="image" src="https://github.com/user-attachments/assets/b886c094-1c88-4abc-881d-3440b3d9cd65" />
<img width="731" height="429" alt="image" src="https://github.com/user-attachments/assets/c9f68b47-46f5-417b-9093-3a905473faf8" />
