### PR TITLE
[search] Find "Sankt" places by "St." queries

### DIFF
--- a/libs/search/locality_scorer.cpp
+++ b/libs/search/locality_scorer.cpp
@@ -62,6 +62,29 @@ private:
   std::vector<std::pair<LevenshteinDFA, uint64_t>> const & m_tokensToDf;
   std::vector<std::pair<PrefixDFA, uint64_t>> const & m_prefixToDf;
 };
+
+// Returns |token| as the query spells it: the query token whose synonym is |token|, or |token|.
+// QueryVec::Similarity compares tokens for equality, so a name token that the query spells as a
+// synonym ("Sankt Wendel" for "st wendel") must take the query spelling to count as matched.
+UniString GetQuerySpelling(QueryParams const & params, UniString const & token)
+{
+  size_t const numTokens = params.GetNumTokens();
+
+  // A name token spelled literally by the query keeps its spelling, otherwise it would be re-spelled
+  // as another query token's synonym ("saint" -> "st" for the "saint petersburg st" street query).
+  for (size_t i = 0; i < numTokens; ++i)
+    if (params.GetToken(i).GetOriginal() == token)
+      return token;
+
+  for (size_t i = 0; i < numTokens; ++i)
+  {
+    auto const & queryToken = params.GetToken(i);
+    if (queryToken.AnyOfSynonyms([&token](UniString const & s) { return s == token; }))
+      return queryToken.GetOriginal();
+  }
+
+  return token;
+}
 }  // namespace
 
 // Used as a default (minimun) number of candidates for futher processing (read FeatureType).
@@ -338,7 +361,7 @@ void LocalityScorer::GetDocVecs(uint32_t localityId, std::vector<DocVec> & dvs) 
     ForEachNormalizedToken(name, [&](strings::UniString const & token)
     {
       if (!IsStopWord(token))
-        builder.Add(token);
+        builder.Add(GetQuerySpelling(m_params, token));
     });
     dvs.emplace_back(std::move(builder));
   }

--- a/libs/search/query_params.cpp
+++ b/libs/search/query_params.cpp
@@ -26,6 +26,8 @@ std::map<std::string, std::vector<std::string>> const kSynonyms = {
     /// @todo Should not duplicate Street synonyms defined in StreetsSynonymsHolder (avoid useless double queries).
     /// Remove "street" and "avenue" here, but should update GetNameScore.
     {"st", {"saint", "sankt", "street"}},
+    {"saint", {"sankt", "st"}},
+    {"sankt", {"saint", "st"}},
     {"dr", {"doctor"}},
 
     // widely used in LATAM, like "Ntra Sra Asuncion Zelaya"

--- a/libs/search/query_params.cpp
+++ b/libs/search/query_params.cpp
@@ -25,7 +25,7 @@ std::map<std::string, std::vector<std::string>> const kSynonyms = {
 
     /// @todo Should not duplicate Street synonyms defined in StreetsSynonymsHolder (avoid useless double queries).
     /// Remove "street" and "avenue" here, but should update GetNameScore.
-    {"st", {"saint", "street"}},
+    {"st", {"saint", "sankt", "street"}},
     {"dr", {"doctor"}},
 
     // widely used in LATAM, like "Ntra Sra Asuncion Zelaya"

--- a/libs/search/search_integration_tests/processor_test.cpp
+++ b/libs/search/search_integration_tests/processor_test.cpp
@@ -1982,6 +1982,20 @@ UNIT_CLASS_TEST(ProcessorTest, CountrySynonymsTest)
   }
 }
 
+// "St." is a common abbreviation of the German "Sankt" (St. Wendel, St. Gallen, St. Pölten).
+UNIT_CLASS_TEST(ProcessorTest, SanktSynonymTest)
+{
+  TestCity sanktWendel({0, 0}, "Sankt Wendel", "de", 100 /* rank */);
+
+  auto const worldId = BuildWorld([&](TestMwmBuilder & builder) { builder.Add(sanktWendel); });
+
+  SetViewport(m2::RectD(-1.0, -1.0, 1.0, 1.0));
+  Rules const rules = {ExactMatch(worldId, sanktWendel)};
+  TEST(ResultsMatch("sankt wendel ", rules), ());
+  TEST(ResultsMatch("st wendel ", rules), ());
+  TEST(ResultsMatch("St. Wendel", rules), ());
+}
+
 UNIT_CLASS_TEST(ProcessorTest, SynonymsTest)
 {
   TestStreet streetEn({{0.5, -0.5}, {0.0, 0.0}, {-0.5, 0.5}}, "Southwest street", "en");

--- a/libs/search/search_integration_tests/processor_test.cpp
+++ b/libs/search/search_integration_tests/processor_test.cpp
@@ -1982,18 +1982,33 @@ UNIT_CLASS_TEST(ProcessorTest, CountrySynonymsTest)
   }
 }
 
-// "St." is a common abbreviation of the German "Sankt" (St. Wendel, St. Gallen, St. Pölten).
+// "St." is a common abbreviation of the German "Sankt", and OSM stores both spellings
+// (Sankt Wendel, but St. Gallen and St. Pölten).
 UNIT_CLASS_TEST(ProcessorTest, SanktSynonymTest)
 {
   TestCity sanktWendel({0, 0}, "Sankt Wendel", "de", 100 /* rank */);
+  TestCity stGallen({0.5, 0.5}, "St. Gallen", "de", 100 /* rank */);
 
-  auto const worldId = BuildWorld([&](TestMwmBuilder & builder) { builder.Add(sanktWendel); });
+  auto const worldId = BuildWorld([&](TestMwmBuilder & builder)
+  {
+    builder.Add(sanktWendel);
+    builder.Add(stGallen);
+  });
 
   SetViewport(m2::RectD(-1.0, -1.0, 1.0, 1.0));
-  Rules const rules = {ExactMatch(worldId, sanktWendel)};
-  TEST(ResultsMatch("sankt wendel ", rules), ());
-  TEST(ResultsMatch("st wendel ", rules), ());
-  TEST(ResultsMatch("St. Wendel", rules), ());
+  {
+    Rules const rules = {ExactMatch(worldId, sanktWendel)};
+    TEST(ResultsMatch("sankt wendel ", rules), ());
+    TEST(ResultsMatch("st wendel ", rules), ());
+    TEST(ResultsMatch("saint wendel ", rules), ());
+    TEST(ResultsMatch("St. Wendel", rules), ());
+  }
+  {
+    Rules const rules = {ExactMatch(worldId, stGallen)};
+    TEST(ResultsMatch("st gallen ", rules), ());
+    TEST(ResultsMatch("sankt gallen ", rules), ());
+    TEST(ResultsMatch("saint gallen ", rules), ());
+  }
 }
 
 UNIT_CLASS_TEST(ProcessorTest, SynonymsTest)

--- a/libs/search/search_tests/locality_scorer_test.cpp
+++ b/libs/search/search_tests/locality_scorer_test.cpp
@@ -278,6 +278,31 @@ UNIT_CLASS_TEST(LocalityScorerTest, Similarity)
   TEST_EQUAL(GetTopLocalities(1 /* limit */), Ids({ID_SAN_CARLOS_APOQUINDO}), ());
 }
 
+// Query synonyms ("st" -> "saint", see QueryParams) must count as matched tokens, otherwise the
+// one-token range "petersburg" outscores the full range and the locality is never matched as a whole.
+UNIT_CLASS_TEST(LocalityScorerTest, Synonyms)
+{
+  enum
+  {
+    ID_SAINT_PETERSBURG
+  };
+
+  AddLocality("Saint Petersburg", ID_SAINT_PETERSBURG);
+
+  InitParams("st petersburg", false /* lastTokenIsPrefix */);
+  auto const localities = GetLocalities(1 /* limit */);
+  TEST_EQUAL(localities.size(), 1, ());
+  TEST_EQUAL(localities[0].GetFeatureIndex(), ID_SAINT_PETERSBURG, ());
+  TEST_EQUAL(localities[0].m_tokenRange, TokenRange(0, 2), ());
+
+  // "Saint" is spelled literally by the query, so it must not be re-spelled as a synonym of the
+  // trailing "st" (a street), or the city would be matched at [1, 3) instead.
+  InitParams("saint petersburg st", false /* lastTokenIsPrefix */);
+  auto const withStreet = GetLocalities(1 /* limit */);
+  TEST_EQUAL(withStreet.size(), 1, ());
+  TEST_EQUAL(withStreet[0].m_tokenRange, TokenRange(0, 2), ());
+}
+
 UNIT_CLASS_TEST(LocalityScorerTest, DistanceToPivot)
 {
   enum


### PR DESCRIPTION
Query "St. Wendel" now finds the town "Sankt Wendel".

- `st` expands to `sankt` in query synonyms.
- Locality scoring honours query synonyms. The cosine similarity compared tokens literally, so a city matched through a synonym lost its full token range to the one-token range and was never matched as a whole. The same happened to "st petersburg" for "Saint Petersburg".

Fixes #13242

Tested: new `LocalityScorerTest.Synonyms` (fails without the scoring fix) and `ProcessorTest.SanktSynonymTest`; all `search_tests` and `search_integration_tests` pass.
