### PR TITLE
[routing] Keep the chosen route variant across rebuilds

### DIFF
--- a/libs/routing/index_router.cpp
+++ b/libs/routing/index_router.cpp
@@ -83,6 +83,14 @@ bool IsAlternativeEtaAcceptable(VehicleType vehicleType, double activeEtaSec, do
   return vehicleType == VehicleType::Transit || alternativeEtaSec <= kMaxAltEtaRatio * activeEtaSec;
 }
 
+// The route to follow is built with one strategy and its alternative with the other one. More
+// alternatives would need a list of strategies here and an adjust-cache per route in IndexRouter.
+EdgeEstimator::Strategy OtherStrategy(EdgeEstimator::Strategy strategy)
+{
+  return strategy == EdgeEstimator::Strategy::Normal ? EdgeEstimator::Strategy::DistanceBiased
+                                                     : EdgeEstimator::Strategy::Normal;
+}
+
 // If user left the route within this range(meters), adjust the route. Else full rebuild.
 double constexpr kAdjustRangeM = 5000.0;
 // Full rebuild if distance(meters) is less.
@@ -368,12 +376,19 @@ void IndexRouter::ClearState()
   m_lastFakeEdges.reset();
   m_lastAltRoute.reset();
   m_lastAltFakeEdges.reset();
+  // A new route starts from the default variant again.
+  m_activeStrategy = EdgeEstimator::Strategy::Normal;
 }
 
 void IndexRouter::SwapAltRouteToActive()
 {
   std::swap(m_lastRoute, m_lastAltRoute);
   std::swap(m_lastFakeEdges, m_lastAltFakeEdges);
+  // Keep rebuilding the variant the user follows instead of the fastest one (issue #13205). Transit
+  // keeps the default weights: its alternative also scales the walking weights that
+  // TransitWorldGraph::CheckLength budgets, so a rebuild with them could find no route at all.
+  if (m_vehicleType != VehicleType::Transit)
+    m_activeStrategy = OtherStrategy(m_activeStrategy);
 }
 
 bool IndexRouter::FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
@@ -435,6 +450,12 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
   {
     SCOPE_GUARD(featureRoadGraphClear, [this] { ClearRouteCalculationState(); });
 
+    // Both the adjustment and the full build below keep the strategy of the route the user follows.
+    // Guides edges are priced at max speed (see SetGuidesGraphParams), above the DistanceBiased cap,
+    // so the tighter heuristic is only valid without them. They are not attached to the graph yet,
+    // hence IsActive() and not IsAttached().
+    m_estimator->SetStrategy(m_activeStrategy, !m_guides.IsActive() /* tightHeuristicAllowed */);
+
     bool doCalculate = true;
     if (adjustToPrevRoute && m_lastRoute && m_lastFakeEdges && finalPoint == m_lastRoute->GetFinish())
     {
@@ -442,6 +463,8 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
       double const distanceToFinish = mercator::DistanceOnEarth(startPoint, finalPoint);
       if (distanceToRoute <= kAdjustRangeM && distanceToFinish >= kMinDistanceToFinishM)
       {
+        // AdjustLengthChecker limits routing weight, not ETA. DistanceBiased weights cover less
+        // distance on fast roads within that budget, so adjustments can need a full rebuild sooner.
         code = AdjustRoute(checkpoints, startDirection, delegate, route);
         if (code != RouterResultCode::RouteNotFound)
           doCalculate = false;
@@ -456,27 +479,27 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
     {
       code = DoCalculateRoute(checkpoints, startDirection, delegate, route);
 
-      // Compute an alternative alongside the Normal route. Only on a full (non-adjust) build and only
+      // Compute an alternative alongside the active route. Only on a full (non-adjust) build and only
       // within a reasonable distance budget — the alternative search costs about 0.5-1x of the
       // normal one (measured; the tight DistanceBiased heuristic keeps it cheap, see
-      // EdgeEstimator::CalcHeuristic). Non-transit profiles get a distance-biased alternative;
+      // EdgeEstimator::CalcHeuristic). Non-transit profiles get the route of the other strategy;
       // transit gets a less-walking / fewer-transfers alternative (e.g. a direct bus instead of
       // subway + walk).
       double const altMaxDistanceM = m_vehicleType == VehicleType::Car ? 300'000.0 : 100'000.0;
       if (needAlternatives && (code == RouterResultCode::NoError || code == RouterResultCode::HasWarnings) &&
           !delegate.IsCancelled() && mercator::DistanceOnEarth(startPoint, finalPoint) <= altMaxDistanceM)
       {
-        // Save the Normal route's adjust-cache; the alternative computation would overwrite it.
+        // Save the active route's adjust-cache; the alternative computation would overwrite it.
         auto savedLastRoute = std::move(m_lastRoute);
         auto savedLastFakeEdges = std::move(m_lastFakeEdges);
-        SCOPE_GUARD(restoreNormal, [&]
+        SCOPE_GUARD(restoreActive, [&]
         {
           m_estimator->SetStrategy(EdgeEstimator::Strategy::Normal);
           m_estimator->SetTransitAltFactors(1.0, 1.0);
           // Save the alternative route's adjust-cache.
           m_lastAltRoute = std::move(m_lastRoute);
           m_lastAltFakeEdges = std::move(m_lastFakeEdges);
-          // Restore the Normal cache.
+          // Restore the active one.
           m_lastRoute = std::move(savedLastRoute);
           m_lastFakeEdges = std::move(savedLastFakeEdges);
         });
@@ -490,8 +513,7 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
         {
           // Guides edges are priced at max speed (see SetGuidesGraphParams call below), above the
           // DistanceBiased cap, so the tighter heuristic is only valid without attached guides.
-          m_estimator->SetStrategy(EdgeEstimator::Strategy::DistanceBiased,
-                                   !m_guides.IsAttached() /* tightHeuristicAllowed */);
+          m_estimator->SetStrategy(OtherStrategy(m_activeStrategy), !m_guides.IsAttached() /* tightHeuristicAllowed */);
         }
         altCode = DoCalculateRoute(checkpoints, startDirection, delegate, altRoute);
       }

--- a/libs/routing/index_router.hpp
+++ b/libs/routing/index_router.hpp
@@ -306,6 +306,9 @@ private:
   /// A major refactoring is needed, but IndexRouer becomes stateless (is a plus).
   std::unique_ptr<SegmentedRoute> m_lastAltRoute;
   std::unique_ptr<FakeEdgesContainer> m_lastAltFakeEdges;
+  // Strategy of the route variant the user follows, flipped by SwapAltRouteToActive and reset by
+  // ClearState. Adjustments and full rebuilds use it, see issue #13205.
+  EdgeEstimator::Strategy m_activeStrategy = EdgeEstimator::Strategy::Normal;
 
   // If a ckeckpoint is near to the guide track we need to build route through this track.
   GuidesConnections m_guides;

--- a/libs/routing/router.hpp
+++ b/libs/routing/router.hpp
@@ -78,8 +78,8 @@ public:
                                            EdgeProj & proj) = 0;
 
   /// Swap the saved last-route state with the alternative's saved state. Called when the user
-  /// picks an alternative variant so a subsequent AdjustRoute (off-route rebuild) adjusts to
-  /// the selected route rather than the original primary. Default: no-op.
+  /// picks an alternative variant so subsequent adjustments and full rebuilds (off-route rebuilds)
+  /// keep the selected variant rather than the original primary. Default: no-op.
   virtual void SwapAltRouteToActive() {}
 };
 

--- a/libs/routing/routing_integration_tests/route_test.cpp
+++ b/libs/routing/routing_integration_tests/route_test.cpp
@@ -11,6 +11,7 @@
 
 #include "geometry/mercator.hpp"
 
+#include "base/scope_guard.hpp"
 #include "base/stl_helpers.hpp"
 
 #include <algorithm>
@@ -1045,6 +1046,83 @@ UNIT_TEST(India_Bangalore_ShortRoute)
 {
   CalculateRouteAndTestRouteLength(GetVehicleComponents(VehicleType::Car), FromLatLon(12.963008, 77.648966), {0., 0.},
                                    FromLatLon(12.9600501, 77.6451721), 1997.79);
+}
+
+// The variant the user picked must survive a rebuild: after switching to the shorter alternative,
+// recalculating the route (as happens after every off-route deviation) has to keep the
+// distance-biased weights instead of silently returning the fastest route again.
+// https://github.com/organicmaps/organicmaps/issues/13205
+UNIT_TEST(Germany_FrankfurtDarmstadt_KeepAlternativeAfterRebuild)
+{
+  auto & components = GetVehicleComponents(VehicleType::Car);
+  // Frankfurt -> Darmstadt: A5 motorway (fastest) vs the shorter B3 (about 1.4 km less).
+  Checkpoints const checkpoints(FromLatLon(50.1109, 8.6821), FromLatLon(49.8728, 8.6512));
+
+  // The router keeps the chosen variant until the next route is built; don't leak it into the
+  // tests that share these components.
+  SCOPE_GUARD(clearRouter, [&components] { components.GetRouter().ClearState(); });
+
+  auto const initial = CalculateRoutes(components, checkpoints);
+  TEST_EQUAL(initial.second, RouterResultCode::NoError, ());
+  TEST_EQUAL(initial.first.size(), 2, ());
+
+  double const fastestM = initial.first[0]->GetTotalDistanceMeters();
+  double const shortestM = initial.first[1]->GetTotalDistanceMeters();
+  TEST_LESS(shortestM, fastestM, ());
+
+  // The user switches to the shorter alternative, then the route is rebuilt.
+  components.GetRouter().SwapAltRouteToActive();
+
+  auto const rebuilt = CalculateRoutes(components, checkpoints);
+  TEST_EQUAL(rebuilt.second, RouterResultCode::NoError, ());
+  TEST_EQUAL(rebuilt.first.size(), 2, ());
+  TEST_ALMOST_EQUAL_ABS(rebuilt.first[0]->GetTotalDistanceMeters(), shortestM, 1.0, ());
+  TEST_ALMOST_EQUAL_ABS(rebuilt.first[1]->GetTotalDistanceMeters(), fastestM, 1.0, ());
+
+  // Switching back to the fastest one is remembered just the same.
+  components.GetRouter().SwapAltRouteToActive();
+
+  auto const restored = CalculateRoutes(components, checkpoints);
+  TEST_EQUAL(restored.second, RouterResultCode::NoError, ());
+  TEST_EQUAL(restored.first.size(), 2, ());
+  TEST_ALMOST_EQUAL_ABS(restored.first[0]->GetTotalDistanceMeters(), fastestM, 1.0, ());
+
+  // A new journey resets the choice, including when the distance-biased route was active.
+  components.GetRouter().SwapAltRouteToActive();
+  components.GetRouter().ClearState();
+  auto const newJourney = CalculateRoutes(components, checkpoints);
+  TEST_EQUAL(newJourney.second, RouterResultCode::NoError, ());
+  TEST_EQUAL(newJourney.first.size(), 2, ());
+  TEST_ALMOST_EQUAL_ABS(newJourney.first[0]->GetTotalDistanceMeters(), fastestM, 1.0, ());
+
+  // Move along the selected route far enough to exercise its cached suffix during adjustment.
+  auto const & selected = *newJourney.first[1];
+  auto const & segments = selected.GetRouteSegments();
+  auto const startIt = std::find_if(segments.begin(), segments.end(), [](RouteSegment const & segment)
+  { return segment.GetDistFromBeginningMeters() >= 2000.0; });
+  TEST(startIt != segments.end(), ());
+  Checkpoints const advanced(startIt->GetJunction().GetPoint(), checkpoints.GetFinish());
+  components.GetRouter().SwapAltRouteToActive();
+
+  RouterDelegate delegate;
+  RoutesResult adjusted;
+  TEST_EQUAL(components.GetRouter().CalculateRoute(advanced, {} /* startDirection */, true /* adjust */,
+                                                   true /* needAlternatives */, delegate, adjusted),
+             RouterResultCode::NoError, ());
+  TEST_EQUAL(adjusted.m_routes.size(), 1, ());
+  TEST_LESS(Route(adjusted.GetActive()).GetTotalDistanceMeters(), shortestM, ());
+
+  // An adjustment publishes only the active route, but must retain its strategy for a later
+  // full rebuild. Compare that rebuild with a fresh fastest-first calculation at the same start.
+  auto const afterAdjust = CalculateRoutes(components, advanced);
+  TEST_EQUAL(afterAdjust.second, RouterResultCode::NoError, ());
+  components.GetRouter().ClearState();
+  auto const reference = CalculateRoutes(components, advanced);
+  TEST_EQUAL(reference.second, RouterResultCode::NoError, ());
+  TEST_EQUAL(reference.first.size(), 2, ());
+  TEST_EQUAL(afterAdjust.first.size(), 2, ());
+  TEST_ALMOST_EQUAL_ABS(afterAdjust.first[0]->GetTotalDistanceMeters(), reference.first[1]->GetTotalDistanceMeters(),
+                        1.0, ());
 }
 
 }  // namespace route_test

--- a/libs/routing/routing_tests/routing_session_test.cpp
+++ b/libs/routing/routing_tests/routing_session_test.cpp
@@ -29,6 +29,7 @@ using chrono::seconds;
 using chrono::steady_clock;
 
 vector<m2::PointD> kTestRoute = {{0., 1.}, {0., 1.}, {0., 3.}, {0., 4.}};
+vector<m2::PointD> const kTestAltRoute = {{0., 1.}, {0., 1.}, {1., 3.}, {0., 4.}};
 vector<Segment> const kTestSegments = {{0, 0, 0, true}, {0, 0, 1, true}, {0, 0, 2, true}};
 vector<turns::TurnItem> const kTestTurnsReachOnly = {turns::TurnItem(1, turns::CarDirection::None),
                                                      turns::TurnItem(2, turns::CarDirection::None),
@@ -93,6 +94,43 @@ public:
 
 private:
   vector<bool> & m_flags;
+};
+
+// Router returning two route variants and counting the "user picked the other one" notifications.
+class AltRoutesRouter : public IRouter
+{
+public:
+  explicit AltRoutesRouter(size_t & swapCount) : m_swapCount(swapCount) {}
+
+  string GetName() const override { return "alt routes"; }
+  void ClearState() override {}
+  void SetGuides(GuidesTracks && /* guides */) override {}
+  void SwapAltRouteToActive() override { ++m_swapCount; }
+
+  RouterResultCode CalculateRoute(Checkpoints const & /* checkpoints */, m2::PointD const & /* startDirection */,
+                                  bool /* adjust */, bool /* needAlternatives */, RouterDelegate const & /* delegate */,
+                                  RoutesResult & result) override
+  {
+    Route active;
+    active.SetGeometry(kTestRoute.begin(), kTestRoute.end());
+    FillSubroutesInfo(active);
+    result.MakeFrom(GetName(), std::move(active));
+
+    Route alt;
+    alt.SetGeometry(kTestAltRoute.begin(), kTestAltRoute.end());
+    FillSubroutesInfo(alt);
+    result.m_routes.emplace_back(std::move(static_cast<RouteBase &>(alt)));
+    return RouterResultCode::NoError;
+  }
+
+  bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
+                                   EdgeProj & proj) override
+  {
+    return false;
+  }
+
+private:
+  size_t & m_swapCount;
 };
 
 // Router which every next call of CalculateRoute() method return different return codes.
@@ -658,5 +696,43 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestAlternativesSkippedWhi
   });
   TEST(rebuiltSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not rebuilt."));
   TEST_EQUAL(flags, vector<bool>({true, false}), ("A rebuild while navigating skips alternatives."));
+}
+
+// Picking an alternative route must reach the router: IndexRouter remembers the chosen variant
+// there and keeps its weights on the next rebuild.
+// https://github.com/organicmaps/organicmaps/issues/13205
+UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestSwapActiveAlternative)
+{
+  TimedSignal builtSignal;
+  size_t swapCount = 0;
+
+  GetPlatform().RunTask(Platform::Thread::Gui, [&builtSignal, &swapCount, this]()
+  {
+    InitRoutingSession();
+    m_session->SetRouter(make_unique<AltRoutesRouter>(swapCount), nullptr);
+    m_session->SetRoutingCallbacks([&builtSignal](RoutesResult const &, RouterResultCode) {
+      builtSignal.Signal();
+    }, nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */);
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), RouterDelegate::kNoTimeout);
+  });
+  TEST(builtSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
+
+  TimedSignal swappedSignal;
+  GetPlatform().RunTask(Platform::Thread::Gui, [&swappedSignal, &swapCount, this]()
+  {
+    TEST(m_session->SwapActiveAlternative(1), ());
+    TEST_EQUAL(swapCount, 1, ());
+
+    // Picking the route which is already active changes nothing.
+    TEST(!m_session->SwapActiveAlternative(1), ());
+    TEST_EQUAL(swapCount, 1, ());
+
+    // Switching back is forwarded just the same.
+    TEST(m_session->SwapActiveAlternative(0), ());
+    TEST_EQUAL(swapCount, 2, ());
+
+    swappedSignal.Signal();
+  });
+  TEST(swappedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Alternative was not swapped."));
 }
 }  // namespace routing_session_test


### PR DESCRIPTION
Picking the shorter alternative route was forgotten on the next recalculation: after any off-route deviation the fastest route came back, so the user had to stop and re-pick it.

`SwapAltRouteToActive()` swapped only the adjust caches, while `CalculateRoute()` always built the active route with `Strategy::Normal`.

## What changed

* `IndexRouter` remembers the strategy of the route the user follows (`m_activeStrategy`, flipped by `SwapAltRouteToActive()`, reset to `Normal` by `ClearState()`).
* The active route is built **and adjusted** with that strategy; the other variant is computed as the alternative, so the fastest route stays one tap away.
* Route adjustment now uses the same weights as the route it adjusts, instead of trading distance for time on a route the user picked for distance.

## Scope

* The choice lives as long as the route does. Building a new route, or adding an intermediate point, starts from the fastest variant again — the alternatives are drawn right there, so the user can re-pick.
* Transit keeps the default weights. Its alternative also scales the walking weights that `TransitWorldGraph::CheckLength` budgets, so remembering them for the active route could prune the whole search and answer a rebuild with `TransitRouteNotFoundTooLongPedestrian` instead of a route.
* Cleanups from earlier revisions of this PR are in #13557. The race between an alternative swap and a running calculation is #13518.

## Testing

`routing_tests` pass. Measured on real maps (`Germany_Hesse_Regierungsbezirk Darmstadt`, `Switzerland_Lake Geneva region`), car, after switching to the shorter route and deviating 1 km off it:

| case | before | after |
|---|---|---|
| Frankfurt→Darmstadt | active 30880 m / 1611 s (fastest) | active 29969 m / 1880 s (shortest) |
| Montreux→Nyon | active 68872 m / 2636 s | active 57781 m / 3611 s |
| Frankfurt→Darmstadt, on-route adjust | 28880 m / 1740 s | 28842 m / 1779 s |

Tests added:

* `routing_integration_tests/route_test.cpp::Germany_FrankfurtDarmstadt_KeepAlternativeAfterRebuild` — a rebuild after the swap returns the chosen variant as active, a new route resets the choice, and an adjustment keeps it. Fails without the fix: 33422.7 m instead of 32051.3 m.
* `routing_tests/routing_session_test.cpp::TestSwapActiveAlternative` — the session forwards the choice to the router (runs in CI, unlike the integration suite).

Fixes: #13205