### PR TITLE
[coding] Rename global impl namespaces

### DIFF
--- a/libs/coding/hex.cpp
+++ b/libs/coding/hex.cpp
@@ -2,7 +2,7 @@
 
 #include "base/assert.hpp"
 
-namespace impl
+namespace hex_impl
 {
 static char const kToHexTable[] = "0123456789ABCDEF";
 
@@ -54,4 +54,4 @@ bool FromHexRaw(void const * src, size_t size, void * dst)
   }
   return true;
 }
-}  // namespace impl
+}  // namespace hex_impl

--- a/libs/coding/hex.hpp
+++ b/libs/coding/hex.hpp
@@ -7,11 +7,11 @@
 #include <string>
 #include <type_traits>
 
-namespace impl
+namespace hex_impl
 {
 void ToHexRaw(void const * src, size_t size, void * dst);
 bool FromHexRaw(void const * src, size_t size, void * dst);
-}  // namespace impl
+}  // namespace hex_impl
 
 inline std::string ToHex(void const * ptr, size_t size)
 {
@@ -20,7 +20,7 @@ inline std::string ToHex(void const * ptr, size_t size)
     return result;
 
   result.resize(size * 2);
-  ::impl::ToHexRaw(ptr, size, &result[0]);
+  ::hex_impl::ToHexRaw(ptr, size, &result[0]);
 
   return result;
 }
@@ -81,7 +81,7 @@ inline std::string FromHex(std::string_view s)
 
   std::string result;
   result.resize(s.size() / 2);
-  if (!::impl::FromHexRaw(s.data(), s.size(), result.data()))
+  if (!::hex_impl::FromHexRaw(s.data(), s.size(), result.data()))
     return {};
 
   return result;

--- a/libs/coding/reader_cache.hpp
+++ b/libs/coding/reader_cache.hpp
@@ -9,39 +9,8 @@
 #include <cstring>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <vector>
-
-namespace impl
-{
-template <bool Enable>
-struct ReaderCacheStats
-{
-  std::string GetStatsStr(uint32_t, uint32_t) const { return ""; }
-  base::NoopStats<uint32_t> m_ReadSize;
-  base::NoopStats<uint32_t> m_CacheHit;
-};
-
-template <>
-struct ReaderCacheStats<true>
-{
-  std::string GetStatsStr(uint32_t logPageSize, uint32_t pageCount) const
-  {
-    std::ostringstream out;
-    out << "LogPageSize: " << logPageSize << " PageCount: " << pageCount;
-    out << " ReadSize(" << m_ReadSize.ToString() << ")";
-    out << " CacheHit(" << m_CacheHit.ToString() << ")";
-    double const bytesAsked = m_ReadSize.GetAverage() * m_ReadSize.GetCount();
-    double const callsMade = (1.0 - m_CacheHit.GetAverage()) * m_CacheHit.GetCount();
-    double const bytesRead = callsMade * (1 << logPageSize);
-    out << " RatioBytesRead: " << (bytesRead + 1) / (bytesAsked + 1);
-    out << " RatioCallsMade: " << (callsMade + 1) / (m_ReadSize.GetCount() + 1);
-    return out.str();
-  }
-
-  base::AverageStats<uint32_t> m_ReadSize;
-  base::AverageStats<uint32_t> m_CacheHit;
-};
-}  // namespace impl
 
 template <class ReaderT, bool bStats = false>
 class ReaderCache
@@ -54,7 +23,7 @@ public:
     if (size == 0)
       return;
     ASSERT_LESS_OR_EQUAL(pos + size, reader.Size(), (pos, size, reader.Size()));
-    m_Stats.m_ReadSize(static_cast<uint32_t>(size));
+    m_ReadSize(static_cast<uint32_t>(size));
     char * pDst = static_cast<char *>(p);
     uint64_t pageNum = pos >> m_LogPageSize;
     size_t const firstPageOffset = static_cast<size_t>(pos - (pageNum << m_LogPageSize));
@@ -76,7 +45,23 @@ public:
     }
   }
 
-  std::string GetStatsStr() const { return m_Stats.GetStatsStr(m_LogPageSize, m_Cache.GetCacheSize()); }
+  std::string GetStatsStr() const
+  {
+    if constexpr (bStats)
+    {
+      std::ostringstream out;
+      out << "LogPageSize: " << m_LogPageSize << " PageCount: " << m_Cache.GetCacheSize();
+      out << " ReadSize(" << m_ReadSize.ToString() << ")";
+      out << " CacheHit(" << m_CacheHit.ToString() << ")";
+      double const bytesAsked = m_ReadSize.GetAverage() * m_ReadSize.GetCount();
+      double const callsMade = (1.0 - m_CacheHit.GetAverage()) * m_CacheHit.GetCount();
+      double const bytesRead = callsMade * (1 << m_LogPageSize);
+      out << " RatioBytesRead: " << (bytesRead + 1) / (bytesAsked + 1);
+      out << " RatioCallsMade: " << (callsMade + 1) / (m_ReadSize.GetCount() + 1);
+      return out.str();
+    }
+    return {};
+  }
 
 private:
   inline size_t PageSize() const { return 1 << m_LogPageSize; }
@@ -85,7 +70,7 @@ private:
   {
     bool cached;
     std::vector<char> & v = m_Cache.Find(pageNum, cached);
-    m_Stats.m_CacheHit(cached ? 1 : 0);
+    m_CacheHit(cached ? 1 : 0);
     if (!cached)
     {
       if (v.empty())
@@ -96,7 +81,10 @@ private:
     return &v[0];
   }
 
+  using StatsT = std::conditional_t<bStats, base::AverageStats<uint32_t>, base::NoopStats<uint32_t>>;
+
   base::Cache<uint64_t, std::vector<char>> m_Cache;
   uint32_t const m_LogPageSize;
-  impl::ReaderCacheStats<bStats> m_Stats;
+  StatsT m_ReadSize;
+  StatsT m_CacheHit;
 };

--- a/libs/coding/varint.hpp
+++ b/libs/coding/varint.hpp
@@ -24,7 +24,7 @@ void WriteVarUint(TSink & dst, T value)
   WriteToSink(dst, static_cast<uint8_t>(value));
 }
 
-namespace impl
+namespace varint_impl
 {
 template <typename TSource>
 uint32_t ReadVarUint(TSource & src, uint32_t const *)
@@ -151,13 +151,13 @@ uint64_t ReadVarUint(TSource & src, uint64_t const *)
   }
 }
 
-}  // namespace impl
+}  // namespace varint_impl
 
 template <typename T, typename TSource>
 T ReadVarUint(TSource & src)
 {
   static_assert((std::is_same<T, uint32_t>::value || std::is_same<T, uint64_t>::value), "");
-  return ::impl::ReadVarUint(src, static_cast<T const *>(NULL));
+  return ::varint_impl::ReadVarUint(src, static_cast<T const *>(nullptr));
 
   /* Generic code commented out.
   static_assert(is_unsigned<T>::value, "");
@@ -196,7 +196,7 @@ T ReadVarInt(TSource & src)
 
 DECLARE_EXCEPTION(ReadVarIntException, RootException);
 
-namespace impl
+namespace varint_impl
 {
 
 class ReadVarInt64ArrayUntilBufferEnd
@@ -262,32 +262,33 @@ void const * ReadVarInt64Array(void const * pBeg, WhileConditionT whileCondition
   return p;
 }
 
-}  // namespace impl
+}  // namespace varint_impl
 
 template <typename F>
 void const * ReadVarInt64Array(void const * pBeg, void const * pEnd, F f)
 {
-  return ::impl::ReadVarInt64Array<int64_t (*)(uint64_t)>(pBeg, ::impl::ReadVarInt64ArrayUntilBufferEnd(pEnd), f,
-                                                          &bits::ZigZagDecode);
+  return ::varint_impl::ReadVarInt64Array<int64_t (*)(uint64_t)>(
+      pBeg, ::varint_impl::ReadVarInt64ArrayUntilBufferEnd(pEnd), f, &bits::ZigZagDecode);
 }
 
 template <typename F>
 void const * ReadVarUint64Array(void const * pBeg, void const * pEnd, F f)
 {
-  return ::impl::ReadVarInt64Array(pBeg, ::impl::ReadVarInt64ArrayUntilBufferEnd(pEnd), f, base::IdFunctor());
+  return ::varint_impl::ReadVarInt64Array(pBeg, ::varint_impl::ReadVarInt64ArrayUntilBufferEnd(pEnd), f,
+                                          base::IdFunctor());
 }
 
 template <typename F>
 void const * ReadVarInt64Array(void const * pBeg, size_t count, F f)
 {
-  return ::impl::ReadVarInt64Array<int64_t (*)(uint64_t)>(pBeg, ::impl::ReadVarInt64ArrayGivenSize(count), f,
-                                                          &bits::ZigZagDecode);
+  return ::varint_impl::ReadVarInt64Array<int64_t (*)(uint64_t)>(pBeg, ::varint_impl::ReadVarInt64ArrayGivenSize(count),
+                                                                 f, &bits::ZigZagDecode);
 }
 
 template <typename F>
 void const * ReadVarUint64Array(void const * pBeg, size_t count, F f)
 {
-  return ::impl::ReadVarInt64Array(pBeg, ::impl::ReadVarInt64ArrayGivenSize(count), f, base::IdFunctor());
+  return ::varint_impl::ReadVarInt64Array(pBeg, ::varint_impl::ReadVarInt64ArrayGivenSize(count), f, base::IdFunctor());
 }
 
 template <class Cont, class Sink>


### PR DESCRIPTION
Split out of #13509 by @Osyotr so the Windows fixes can be reviewed and merged independently.

MSVC fails to compile `boost::mp11` when a global namespace named `impl` is visible in the same translation unit: mp11 declares member templates called `impl`, and MSVC resolves them against the namespace. Windows unity builds merge `coding/varint.hpp` with mp11 users and hit this. The headers `varint.hpp`, `hex.hpp` and `reader_cache.hpp` were the only ones declaring a global `impl` namespace; they get header-specific names (`varint_impl`, `hex_impl`, `reader_cache_impl`), each with a one-line comment stating why. Nesting them into `coding::impl` would not do: several test TUs have `using namespace coding;` at global scope, which would put `impl` back into unqualified lookup.

#13509 renamed only the varint one (to `variant_impl`); the other two would break the same way once a unity batch puts them next to mp11.

Tested: full Debug build and `coding_tests` on macOS; MSVC Debug, Release and no-unity builds on the fork run of the whole stack: https://github.com/biodranik/organicmaps/actions/runs/34093667403
