### PR TITLE
[drape] Use dp::Framebuffer in the shape test fixture

### DIFF
--- a/libs/drape_frontend/drape_frontend_tests/shape_test_fixture.cpp
+++ b/libs/drape_frontend/drape_frontend_tests/shape_test_fixture.cpp
@@ -39,8 +39,7 @@ void ShapeTestFixture::Render(char const * title, uint32_t width, uint32_t heigh
 {
   RunTestInOpenGLOffscreenEnvironment(title, [&]()
   {
-    if (!Init(width, height))
-      return;
+    Init(width, height);
 
     createShapes(*this);
 
@@ -67,18 +66,12 @@ void ShapeTestFixture::ReleaseGLResources()
   m_texMng.reset();
   m_progMng.reset();
 
-  if (m_fbo != 0)
-  {
-    glDeleteFramebuffers(1, &m_fbo);
-    glDeleteRenderbuffers(1, &m_colorRbo);
-    glDeleteRenderbuffers(1, &m_depthRbo);
-    m_fbo = 0;
-  }
+  m_framebuffer.reset();
 
   m_context.reset();
 }
 
-bool ShapeTestFixture::Init(uint32_t width, uint32_t height)
+void ShapeTestFixture::Init(uint32_t width, uint32_t height)
 {
   m_width = width;
   m_height = height;
@@ -92,25 +85,11 @@ bool ShapeTestFixture::Init(uint32_t width, uint32_t height)
   m_context = std::move(ctx);
   auto const contextRef = make_ref(m_context);
 
-  // Create FBO for offscreen rendering.
-  glGenFramebuffers(1, &m_fbo);
-  glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
-
-  glGenRenderbuffers(1, &m_colorRbo);
-  glBindRenderbuffer(GL_RENDERBUFFER, m_colorRbo);
-  glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, width, height);
-  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorRbo);
-
-  glGenRenderbuffers(1, &m_depthRbo);
-  glBindRenderbuffer(GL_RENDERBUFFER, m_depthRbo);
-  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
-  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthRbo);
-
-  if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
-  {
-    LOG(LWARNING, ("FBO incomplete, skipping visual test"));
-    return false;
-  }
+  // Offscreen render target: the same RGBA8 color plus depth framebuffer FrontendRenderer draws into.
+  m_framebuffer =
+      make_unique_dp<dp::Framebuffer>(dp::TextureFormat::RGBA8, true /* depthEnabled */, false /* stencilEnabled */);
+  m_framebuffer->SetSize(contextRef, width, height);
+  CHECK(m_framebuffer->IsSupported(), ("RGBA8 + depth FBO is incomplete"));
 
   m_context->SetViewport(0, 0, width, height);
   m_context->SetDepthTestEnabled(true);
@@ -146,8 +125,6 @@ bool ShapeTestFixture::Init(uint32_t width, uint32_t height)
   m_batcher = std::make_unique<dp::Batcher>(kBatchSize, kBatchSize);
   m_batcher->StartSession([this](dp::RenderState const & state, drape_ptr<dp::RenderBucket> && bucket)
   { m_buckets.push_back({state, std::move(bucket)}); });
-
-  return true;
 }
 
 void ShapeTestFixture::AddShape(drape_ptr<MapShape> && shape)
@@ -169,7 +146,7 @@ void ShapeTestFixture::Render()
 {
   auto const contextRef = make_ref(m_context);
 
-  glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+  m_framebuffer->Bind();
   m_context->SetClearColor(dp::Color::White());
   m_context->Clear(dp::ClearBits::ColorBit | dp::ClearBits::DepthBit, 0);
 

--- a/libs/drape_frontend/drape_frontend_tests/shape_test_fixture.hpp
+++ b/libs/drape_frontend/drape_frontend_tests/shape_test_fixture.hpp
@@ -3,6 +3,7 @@
 #include "drape_frontend/map_shape.hpp"
 
 #include "drape/batcher.hpp"
+#include "drape/framebuffer.hpp"
 #include "drape/render_bucket.hpp"
 #include "drape/render_state.hpp"
 #include "drape/texture_manager.hpp"
@@ -45,7 +46,7 @@ public:
   QImage const & GetLastImage() const { return m_lastImage; }
 
 private:
-  bool Init(uint32_t width, uint32_t height);
+  void Init(uint32_t width, uint32_t height);
   void Flush();
   void Render();
   void ReleaseGLResources();
@@ -58,9 +59,7 @@ private:
 
   uint32_t m_width = 0;
   uint32_t m_height = 0;
-  uint32_t m_fbo = 0;
-  uint32_t m_colorRbo = 0;
-  uint32_t m_depthRbo = 0;
+  drape_ptr<dp::Framebuffer> m_framebuffer;
 
   std::unique_ptr<dp::GraphicsContext> m_context;
   std::unique_ptr<dp::TextureManager> m_texMng;


### PR DESCRIPTION
Split out of #13509 by @Osyotr so the Windows fixes can be reviewed and merged independently; reworked after review.

`opengl32` on Windows exposes only the OpenGL 1.1 entry points, so the framebuffer and renderbuffer functions that `ShapeTestFixture` called directly did not link there. Instead of adding test-only renderbuffer wrappers to `GLFunctions` (the first version of this PR), the fixture now uses `dp::Framebuffer`, which builds the same RGBA8 color plus depth target through the existing `GLFunctions` wrappers and is what `FrontendRenderer` draws into. The framebuffer is also released on the "unsupported" path instead of leaking it. Net deletion, no new drape API.

Tested: `drape_tests`, `drape_frontend_tests` and `shaders_tests` with `QT_QPA_PLATFORM=offscreen` on macOS; MSVC builds and the offscreen suites on the Windows CI leg of #13516 (fork run of the whole stack: https://github.com/biodranik/organicmaps/actions/runs/34093667403).
