### PR TITLE
[tests] Fix building and running unit tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,39 +1,10 @@
-# Every text file is checked out with LF line endings, tests compare fixtures byte for byte.
+# Text files are checked out with LF by default because tests compare fixtures byte for byte.
 * text=auto eol=lf
 
-# Explicitly declare text files we want to always be normalized and converted 
-# to native line endings on checkout.
-*.c    text
-*.h    text
-*.cpp  text
-*.hpp  text
-*.cxx  text
-*.cc   text
-*.java text
-*.mm   text
-
-# Declare files that will always have LF line endings on checkout.
-*.txt    text eol=lf
-*.html   text eol=lf
-*.xml    text eol=lf
-*.csv    text eol=lf
-*.svg    text eol=lf
-*.py     text eol=lf
-*.sh     text eol=lf
-*.lst    text eol=lf
-*.mapcss text eol=lf
-*.test   text eol=lf
-*.skn    text eol=lf
-*.meta   text eol=lf
-*.gitattributes text eol=lf
-*.gitignore text eol=lf
-
-# Declare files that will always have CRLF line endings on checkout.
-*.dsp    text eol=crlf
-*.dsw    text eol=crlf
+# Windows batch files are checked out with CRLF line endings.
 *.bat    text eol=crlf
 
-# Binary files which doesn't need any normalization
+# Binary files are not normalized.
 *.bin     binary
 *.bz2     binary
 *.kmz     binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Set default behaviour, in case users don't have core.autocrlf set.
-* text=auto
+# Every text file is checked out with LF line endings, tests compare fixtures byte for byte.
+* text=auto eol=lf
 
 # Explicitly declare text files we want to always be normalized and converted 
 # to native line endings on checkout.
@@ -31,6 +31,7 @@
 # Declare files that will always have CRLF line endings on checkout.
 *.dsp    text eol=crlf
 *.dsw    text eol=crlf
+*.bat    text eol=crlf
 
 # Binary files which doesn't need any normalization
 *.bin     binary

--- a/generator/generator_tests/descriptions_section_builder_tests.cpp
+++ b/generator/generator_tests/descriptions_section_builder_tests.cpp
@@ -78,19 +78,13 @@ public:
 
   void MakePath() const
   {
-    std::string trueAnswer = "/wikiDir/en.wikipedia.org/wiki/Helsinki_Olympic_Stadium";
-    {
-      std::string const wikiDir = "/wikiDir/";
-      std::string const wikiUrl = "http://en.wikipedia.org/wiki/Helsinki_Olympic_Stadium/";
-      auto const answer = DescriptionsCollector::MakePathForWikipedia(wikiDir, wikiUrl);
-      TEST_EQUAL(trueAnswer, answer, ());
-    }
-    {
-      std::string const wikiDir = "/wikiDir";
-      std::string const wikiUrl = "https://en.wikipedia.org/wiki/Helsinki_Olympic_Stadium";
-      auto const answer = DescriptionsCollector::MakePathForWikipedia(wikiDir, wikiUrl);
-      TEST_EQUAL(trueAnswer, answer, ());
-    }
+    // Only the scheme and trailing slash stripping is under test; the directory is joined with the
+    // native separator.
+    std::string const page = "en.wikipedia.org/wiki/Helsinki_Olympic_Stadium";
+    TEST_EQUAL(DescriptionsCollector::MakePathForWikipedia("/wikiDir/", "http://" + page + "/"),
+               base::JoinPath("/wikiDir/", page), ());
+    TEST_EQUAL(DescriptionsCollector::MakePathForWikipedia("/wikiDir", "https://" + page),
+               base::JoinPath("/wikiDir", page), ());
   }
 
   void FindPageAndFill() const

--- a/libs/base/base_tests/cancellable_tests.cpp
+++ b/libs/base/base_tests/cancellable_tests.cpp
@@ -48,8 +48,7 @@ UNIT_TEST(Cancellable_Smoke)
 UNIT_TEST(Cancellable_Deadline)
 {
   Cancellable cancellable;
-  chrono::steady_clock::duration kTimeout = chrono::milliseconds(20);
-  cancellable.SetDeadline(chrono::steady_clock::now() + kTimeout);
+  constexpr auto kTimeout = chrono::milliseconds(20);
 
   promise<void> syncPromise;
   auto syncFuture = syncPromise.get_future();
@@ -58,6 +57,8 @@ UNIT_TEST(Cancellable_Deadline)
 
   auto const fn = [&]
   {
+    // Set the deadline once the thread runs, otherwise a slow thread start leaves too few iterations.
+    cancellable.SetDeadline(chrono::steady_clock::now() + kTimeout);
     while (true)
     {
       if (cancellable.IsCancelled())

--- a/libs/base/base_tests/cancellable_tests.cpp
+++ b/libs/base/base_tests/cancellable_tests.cpp
@@ -48,35 +48,14 @@ UNIT_TEST(Cancellable_Smoke)
 UNIT_TEST(Cancellable_Deadline)
 {
   Cancellable cancellable;
-  constexpr auto kTimeout = chrono::milliseconds(20);
+  auto const now = chrono::steady_clock::now();
+  cancellable.SetDeadline(now + chrono::hours(1));
+  TEST(!cancellable.IsCancelled(), ());
+  TEST_EQUAL(cancellable.CancellationStatus(), Cancellable::Status::Active, ());
 
-  promise<void> syncPromise;
-  auto syncFuture = syncPromise.get_future();
-
-  double x = 0.123;
-
-  auto const fn = [&]
-  {
-    // Set the deadline once the thread runs, otherwise a slow thread start leaves too few iterations.
-    cancellable.SetDeadline(chrono::steady_clock::now() + kTimeout);
-    while (true)
-    {
-      if (cancellable.IsCancelled())
-        break;
-
-      x = cos(x);
-    }
-
-    syncPromise.set_value();
-  };
-
-  threads::SimpleThread thread(fn);
-  syncFuture.wait();
-  thread.join();
-
+  cancellable.SetDeadline(now - chrono::hours(1));
   TEST(cancellable.IsCancelled(), ());
   TEST_EQUAL(cancellable.CancellationStatus(), Cancellable::Status::DeadlineExceeded, ());
-  TEST(AlmostEqualAbs(x, 0.739, 1e-3), ());
 
   cancellable.Cancel();
   TEST(cancellable.IsCancelled(), ());

--- a/libs/indexer/indexer_tests/mwm_set_test.cpp
+++ b/libs/indexer/indexer_tests/mwm_set_test.cpp
@@ -39,15 +39,16 @@ void TestFilesPresence(MwmsInfo const & mwmsInfo, initializer_list<string> const
 
 UNIT_TEST(MwmSetSmokeTest)
 {
-  TestMwmSet mwmSet;
-  MwmsInfo mwmsInfo;
-
   ScopedMwm mwm0("0.mwm");
   ScopedMwm mwm1("1.mwm");
   ScopedMwm mwm2("2.mwm");
   ScopedMwm mwm3("3.mwm");
   ScopedMwm mwm4("4.mwm");
   ScopedMwm mwm5("5.mwm");
+
+  // Destroyed before the files: Windows cannot delete maps that are still open.
+  TestMwmSet mwmSet;
+  MwmsInfo mwmsInfo;
 
   UNUSED_VALUE(mwmSet.Register(LocalCountryFile::MakeForTesting("0")));
   UNUSED_VALUE(mwmSet.Register(LocalCountryFile::MakeForTesting("1")));

--- a/libs/map/map_tests/bookmarks_test.cpp
+++ b/libs/map/map_tests/bookmarks_test.cpp
@@ -813,7 +813,7 @@ UNIT_TEST(Bookmarks_IllegalFileName)
 UNIT_TEST(Bookmarks_UniqueFileName)
 {
   string const BASE = "SomeUniqueFileName";
-  string const FILEBASE = "./" + BASE;
+  string const FILEBASE = base::JoinPath(".", BASE);
   string const FILENAME = FILEBASE + string{kKmlExtension};
 
   {
@@ -2321,8 +2321,8 @@ UNIT_CLASS_TEST(Runner, Bookmarks_RecentlyDeleted)
   BookmarkManager::KMLDataCollection kmlDataCollection;
   kmlDataCollection.emplace_back(filePath, LoadKmlData(MemReader(kmlString, std::strlen(kmlString)), FileType::Kml));
 
-  FileWriter w(filePath);
-  w.Write(kmlDataCollection.data(), kmlDataCollection.size());
+  // Closed before the manager moves the file, Windows refuses to move open files.
+  FileWriter(filePath).Write(kmlString, std::strlen(kmlString));
 
   TEST(kmlDataCollection.back().second, ());
   bmManager.CreateCategories(std::move(kmlDataCollection));

--- a/libs/map/map_tests/editor_notes_tests.cpp
+++ b/libs/map/map_tests/editor_notes_tests.cpp
@@ -74,6 +74,8 @@ UNIT_CLASS_TEST(VisualParamsFixture, EditorNotes_UseSelectionPointNotFeatureCent
   // Looser tolerance: the note round-trips through XML.
   TEST_ALMOST_EQUAL_ABS(notes.GetNotesForTests().front().m_point, mercator::ToLatLon(tapPoint), 1e-4, ());
 
+  // Windows cannot delete the map while it is still registered, i.e. open.
+  frm.DeregisterAllMaps();
   platform::CountryIndexes::DeleteFromDisk(country);
   country.DeleteFromDisk(MapFileType::Map);
 }
@@ -119,6 +121,8 @@ UNIT_CLASS_TEST(VisualParamsFixture, EditorNotes_UseSelectionPointForExplicitFea
   TEST_EQUAL(notes.GetNotesForTests().size(), 1, ());
   TEST_ALMOST_EQUAL_ABS(notes.GetNotesForTests().front().m_point, mercator::ToLatLon(tapPoint), 1e-4, ());
 
+  // Windows cannot delete the map while it is still registered, i.e. open.
+  frm.DeregisterAllMaps();
   platform::CountryIndexes::DeleteFromDisk(country);
   country.DeleteFromDisk(MapFileType::Map);
 }

--- a/libs/platform/platform.cpp
+++ b/libs/platform/platform.cpp
@@ -6,9 +6,10 @@
 #include "base/file_name_utils.hpp"
 #include "base/logging.hpp"
 #include "base/random.hpp"
-#include "base/string_utils.hpp"
 
 #include <algorithm>
+#include <filesystem>
+#include <system_error>
 #include <thread>
 
 #include "private.h"
@@ -303,28 +304,13 @@ bool Platform::MkDirRecursively(std::string const & dirName)
 {
   CHECK(!dirName.empty(), ());
 
-  std::string::value_type const sep[] = {base::GetNativeSeparator(), 0};
-  std::string path = dirName.starts_with(sep[0]) ? sep : ".";
-  for (auto const & t : strings::Tokenize(dirName, sep))
-  {
-    path = base::JoinPath(path, std::string{t});
-    if (!IsFileExistsByFullPath(path))
-    {
-      switch (MkDir(path))
-      {
-      case ERR_OK: break;
-      case ERR_FILE_ALREADY_EXISTS:
-      {
-        if (!IsDirectory(path))
-          return false;
-        break;
-      }
-      default: return false;
-      }
-    }
-  }
-
-  return true;
+  // create_directories handles both separator kinds and Windows drive roots, and tolerates directories
+  // created concurrently by other processes.
+  std::error_code ec;
+  std::filesystem::create_directories(dirName, ec);
+  if (ec)
+    LOG(LWARNING, ("Can't create directory", dirName, ec.message()));
+  return !ec;
 }
 
 unsigned Platform::CpuCores()

--- a/libs/platform/platform_qt.cpp
+++ b/libs/platform/platform_qt.cpp
@@ -58,7 +58,7 @@ Platform::EError Platform::MkDir(std::string const & dirName)
     return Platform::ERR_OK;
   // mkdir failed: most commonly because the directory already exists. QDir::mkdir() doesn't
   // expose errno, so re-check to map this benign case to ERR_FILE_ALREADY_EXISTS (which
-  // MkDirRecursively/MkDirChecked tolerate) instead of a misleading ERR_UNKNOWN.
+  // MkDirChecked tolerates) instead of a misleading ERR_UNKNOWN.
   if (QDir().exists(dirName.c_str()))
     return Platform::ERR_FILE_ALREADY_EXISTS;
   LOG(LWARNING, ("Can't create directory:", dirName));

--- a/libs/platform/platform_tests/downloader_utils_tests.cpp
+++ b/libs/platform/platform_tests/downloader_utils_tests.cpp
@@ -40,7 +40,7 @@ UNIT_TEST(Downloader_GetFilePathByUrl)
   }
 
   TEST_EQUAL(downloader::GetFilePathByUrl("/maps/220314/Belarus_Brest Region.mwm"),
-             base::JoinPath(GetPlatform().WritableDir(), "220314/Belarus_Brest Region.mwm.ready"), ());
+             base::JoinPath(GetPlatform().WritableDir(), "220314", "Belarus_Brest Region.mwm.ready"), ());
 }
 
 UNIT_TEST(Downloader_IsUrlSupported)

--- a/libs/platform/platform_tests/http_client_test.cpp
+++ b/libs/platform/platform_tests/http_client_test.cpp
@@ -23,11 +23,12 @@ namespace http_client_test
 using namespace platform;
 using std::string;
 
-// Reads through a temporary: Windows cannot delete a file that is still open.
-string ReadFile(string const & path)
+// Reads through a temporary before deleting because Windows cannot delete an open file.
+string ReadAndDeleteFile(string const & path)
 {
   string data;
   FileReader(path).ReadAsString(data);
+  TEST(base::DeleteFileX(path), (path));
   return data;
 }
 
@@ -454,12 +455,8 @@ UNIT_TEST(HttpClient_ReceivedFile_Success)
     // When writing to file, m_serverResponse should be empty.
     TEST(result.m_serverResponse.empty(), ());
   }
-  // Verify file contents.
-  {
-    auto const data = ReadFile(filePath);
-    TEST_EQUAL(data, "Test1", ());
-  }
-  base::DeleteFileX(filePath);
+  auto const data = ReadAndDeleteFile(filePath);
+  TEST_EQUAL(data, "Test1", ());
 }
 
 UNIT_TEST(HttpClient_ReceivedFile_InvalidPath)
@@ -500,13 +497,10 @@ UNIT_TEST(HttpClient_ReceivedFile_WithProgress)
     TEST_EQUAL(result.m_errorCode, 200, ());
     TEST(result.m_serverResponse.empty(), ());
   }
-  {
-    auto const data = ReadFile(filePath);
-    TEST_EQUAL(data.size(), expectedBody.size(), ());
-    TEST_EQUAL(data, expectedBody, ());
-  }
+  auto const data = ReadAndDeleteFile(filePath);
+  TEST_EQUAL(data.size(), expectedBody.size(), ());
+  TEST_EQUAL(data, expectedBody, ());
   TEST(progressCalled.load(std::memory_order_acquire), ());
-  base::DeleteFileX(filePath);
 }
 
 UNIT_TEST(HttpClient_ReceivedFile_WithProgress_InvalidPath)
@@ -1034,11 +1028,8 @@ UNIT_TEST(HttpClient_RangeRequest_WithReceivedFile)
     TEST_EQUAL(result.m_errorCode, 206, ());
     TEST(result.m_serverResponse.empty(), ());
   }
-  {
-    auto const data = ReadFile(filePath);
-    TEST_EQUAL(static_cast<int64_t>(data.size()), 100, ());
-  }
-  base::DeleteFileX(filePath);
+  auto const data = ReadAndDeleteFile(filePath);
+  TEST_EQUAL(static_cast<int64_t>(data.size()), 100, ());
 }
 
 // =====================================================================
@@ -1090,11 +1081,8 @@ UNIT_TEST(HttpClient_Post_BodyData_ResponseToFile)
     // Response went to file — m_serverResponse must NOT contain stale request body.
     TEST(result.m_serverResponse.empty(), (result.m_serverResponse));
   }
-  {
-    auto const data = ReadFile(filePath);
-    TEST_EQUAL(data, body, ());
-  }
-  base::DeleteFileX(filePath);
+  auto const data = ReadAndDeleteFile(filePath);
+  TEST_EQUAL(data, body, ());
 }
 
 // =====================================================================
@@ -1167,7 +1155,7 @@ UNIT_TEST(HttpClient_Segment_Success_NonZeroOffset)
   TEST_EQUAL(result.m_errorCode, 206, ());
   TEST(result.m_serverResponse.empty(), ("segment mode must leave m_serverResponse empty"));
 
-  auto const data = ReadFile(path);
+  auto const data = ReadAndDeleteFile(path);
   TEST_EQUAL(static_cast<int64_t>(data.size()), kSegmentTestTotalSize, ());
   for (int64_t i = 0; i < kSegmentTestTotalSize; ++i)
   {
@@ -1175,7 +1163,6 @@ UNIT_TEST(HttpClient_Segment_Success_NonZeroOffset)
     uint8_t const expected = (i >= offset && i < offset + bytes) ? ExpectedSegmentByte(i) : 0xAB;
     TEST_EQUAL(got, expected, ("byte at", i));
   }
-  base::DeleteFileX(path);
 }
 
 UNIT_TEST(HttpClient_Segment_Success_OpenEndedRange)
@@ -1195,10 +1182,9 @@ UNIT_TEST(HttpClient_Segment_Success_OpenEndedRange)
   TEST(result.m_success, ("errorCode:", result.m_errorCode));
   TEST_EQUAL(result.m_errorCode, 206, ());
 
-  auto const data = ReadFile(path);
+  auto const data = ReadAndDeleteFile(path);
   for (int64_t i = offset; i < kSegmentTestTotalSize; ++i)
     TEST_EQUAL(static_cast<uint8_t>(data[i]), ExpectedSegmentByte(i), ("byte at", i));
-  base::DeleteFileX(path);
 }
 
 UNIT_TEST(HttpClient_Segment_WrongExpectedTotal)
@@ -1217,10 +1203,9 @@ UNIT_TEST(HttpClient_Segment_WrongExpectedTotal)
   TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
 
   // File must be unchanged (sentinel bytes preserved).
-  auto const data = ReadFile(path);
+  auto const data = ReadAndDeleteFile(path);
   for (size_t i = 0; i < data.size(); ++i)
     TEST_EQUAL(static_cast<uint8_t>(data[i]), 0xEF, ("byte at", i));
-  base::DeleteFileX(path);
 }
 
 UNIT_TEST(HttpClient_Segment_IgnoredRange_Returns200)
@@ -1238,10 +1223,9 @@ UNIT_TEST(HttpClient_Segment_IgnoredRange_Returns200)
   TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
 
   // File untouched.
-  auto const data = ReadFile(path);
+  auto const data = ReadAndDeleteFile(path);
   for (size_t i = 0; i < data.size(); ++i)
     TEST_EQUAL(static_cast<uint8_t>(data[i]), 0x11, ("byte at", i));
-  base::DeleteFileX(path);
 }
 
 UNIT_TEST(HttpClient_Segment_MissingContentRange)
@@ -1257,10 +1241,9 @@ UNIT_TEST(HttpClient_Segment_MissingContentRange)
   TEST(!result.m_success, ());
   TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
 
-  auto const data = ReadFile(path);
+  auto const data = ReadAndDeleteFile(path);
   for (size_t i = 0; i < data.size(); ++i)
     TEST_EQUAL(static_cast<uint8_t>(data[i]), 0x22, ("byte at", i));
-  base::DeleteFileX(path);
 }
 
 UNIT_TEST(HttpClient_Segment_ShortBody)
@@ -1314,10 +1297,9 @@ UNIT_TEST(HttpClient_Segment_UnknownTotal_Rejected)
   TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
 
   // File untouched — no bytes written before validation failure.
-  auto const data = ReadFile(path);
+  auto const data = ReadAndDeleteFile(path);
   for (size_t i = 0; i < data.size(); ++i)
     TEST_EQUAL(static_cast<uint8_t>(data[i]), 0x66, ("byte at", i));
-  base::DeleteFileX(path);
 }
 
 UNIT_TEST(HttpClient_Segment_404_PreservesHttpCode)
@@ -1366,9 +1348,8 @@ UNIT_TEST(HttpClient_Segment_NoSegment_ExistingBehaviorUnchanged)
   TEST_EQUAL(result.m_errorCode, 200, ());
   TEST(result.m_serverResponse.empty(), ());
 
-  auto const data = ReadFile(path);
+  auto const data = ReadAndDeleteFile(path);
   TEST_EQUAL(data, "Test1", ());
-  base::DeleteFileX(path);
 }
 
 }  // namespace http_client_test

--- a/libs/platform/platform_tests/http_client_test.cpp
+++ b/libs/platform/platform_tests/http_client_test.cpp
@@ -23,6 +23,14 @@ namespace http_client_test
 using namespace platform;
 using std::string;
 
+// Reads through a temporary: Windows cannot delete a file that is still open.
+string ReadFile(string const & path)
+{
+  string data;
+  FileReader(path).ReadAsString(data);
+  return data;
+}
+
 char constexpr kTestUrl1[] = "http://localhost:24568/unit_tests/1.txt";
 char constexpr kTestUrl404[] = "http://localhost:24568/unit_tests/notexisting_unittest";
 char constexpr kTestUrlBigFile[] = "http://localhost:24568/unit_tests/47kb.file";
@@ -448,9 +456,7 @@ UNIT_TEST(HttpClient_ReceivedFile_Success)
   }
   // Verify file contents.
   {
-    FileReader reader(filePath);
-    string data;
-    reader.ReadAsString(data);
+    auto const data = ReadFile(filePath);
     TEST_EQUAL(data, "Test1", ());
   }
   base::DeleteFileX(filePath);
@@ -495,9 +501,7 @@ UNIT_TEST(HttpClient_ReceivedFile_WithProgress)
     TEST(result.m_serverResponse.empty(), ());
   }
   {
-    FileReader reader(filePath);
-    string data;
-    reader.ReadAsString(data);
+    auto const data = ReadFile(filePath);
     TEST_EQUAL(data.size(), expectedBody.size(), ());
     TEST_EQUAL(data, expectedBody, ());
   }
@@ -1031,9 +1035,7 @@ UNIT_TEST(HttpClient_RangeRequest_WithReceivedFile)
     TEST(result.m_serverResponse.empty(), ());
   }
   {
-    FileReader reader(filePath);
-    string data;
-    reader.ReadAsString(data);
+    auto const data = ReadFile(filePath);
     TEST_EQUAL(static_cast<int64_t>(data.size()), 100, ());
   }
   base::DeleteFileX(filePath);
@@ -1089,9 +1091,7 @@ UNIT_TEST(HttpClient_Post_BodyData_ResponseToFile)
     TEST(result.m_serverResponse.empty(), (result.m_serverResponse));
   }
   {
-    FileReader reader(filePath);
-    string data;
-    reader.ReadAsString(data);
+    auto const data = ReadFile(filePath);
     TEST_EQUAL(data, body, ());
   }
   base::DeleteFileX(filePath);
@@ -1167,9 +1167,7 @@ UNIT_TEST(HttpClient_Segment_Success_NonZeroOffset)
   TEST_EQUAL(result.m_errorCode, 206, ());
   TEST(result.m_serverResponse.empty(), ("segment mode must leave m_serverResponse empty"));
 
-  FileReader reader(path);
-  string data;
-  reader.ReadAsString(data);
+  auto const data = ReadFile(path);
   TEST_EQUAL(static_cast<int64_t>(data.size()), kSegmentTestTotalSize, ());
   for (int64_t i = 0; i < kSegmentTestTotalSize; ++i)
   {
@@ -1197,9 +1195,7 @@ UNIT_TEST(HttpClient_Segment_Success_OpenEndedRange)
   TEST(result.m_success, ("errorCode:", result.m_errorCode));
   TEST_EQUAL(result.m_errorCode, 206, ());
 
-  FileReader reader(path);
-  string data;
-  reader.ReadAsString(data);
+  auto const data = ReadFile(path);
   for (int64_t i = offset; i < kSegmentTestTotalSize; ++i)
     TEST_EQUAL(static_cast<uint8_t>(data[i]), ExpectedSegmentByte(i), ("byte at", i));
   base::DeleteFileX(path);
@@ -1221,9 +1217,7 @@ UNIT_TEST(HttpClient_Segment_WrongExpectedTotal)
   TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
 
   // File must be unchanged (sentinel bytes preserved).
-  FileReader reader(path);
-  string data;
-  reader.ReadAsString(data);
+  auto const data = ReadFile(path);
   for (size_t i = 0; i < data.size(); ++i)
     TEST_EQUAL(static_cast<uint8_t>(data[i]), 0xEF, ("byte at", i));
   base::DeleteFileX(path);
@@ -1244,9 +1238,7 @@ UNIT_TEST(HttpClient_Segment_IgnoredRange_Returns200)
   TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
 
   // File untouched.
-  FileReader reader(path);
-  string data;
-  reader.ReadAsString(data);
+  auto const data = ReadFile(path);
   for (size_t i = 0; i < data.size(); ++i)
     TEST_EQUAL(static_cast<uint8_t>(data[i]), 0x11, ("byte at", i));
   base::DeleteFileX(path);
@@ -1265,9 +1257,7 @@ UNIT_TEST(HttpClient_Segment_MissingContentRange)
   TEST(!result.m_success, ());
   TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
 
-  FileReader reader(path);
-  string data;
-  reader.ReadAsString(data);
+  auto const data = ReadFile(path);
   for (size_t i = 0; i < data.size(); ++i)
     TEST_EQUAL(static_cast<uint8_t>(data[i]), 0x22, ("byte at", i));
   base::DeleteFileX(path);
@@ -1324,9 +1314,7 @@ UNIT_TEST(HttpClient_Segment_UnknownTotal_Rejected)
   TEST_EQUAL(result.m_errorCode, HttpClient::kInconsistentFileSize, ());
 
   // File untouched — no bytes written before validation failure.
-  FileReader reader(path);
-  string data;
-  reader.ReadAsString(data);
+  auto const data = ReadFile(path);
   for (size_t i = 0; i < data.size(); ++i)
     TEST_EQUAL(static_cast<uint8_t>(data[i]), 0x66, ("byte at", i));
   base::DeleteFileX(path);
@@ -1378,9 +1366,7 @@ UNIT_TEST(HttpClient_Segment_NoSegment_ExistingBehaviorUnchanged)
   TEST_EQUAL(result.m_errorCode, 200, ());
   TEST(result.m_serverResponse.empty(), ());
 
-  FileReader reader(path);
-  string data;
-  reader.ReadAsString(data);
+  auto const data = ReadFile(path);
   TEST_EQUAL(data, "Test1", ());
   base::DeleteFileX(path);
 }

--- a/libs/platform/platform_tests/local_country_file_tests.cpp
+++ b/libs/platform/platform_tests/local_country_file_tests.cpp
@@ -59,7 +59,7 @@ UNIT_TEST(LocalCountryFile_Smoke)
   CountryFile countryFile("TestCountry", 1 /* size */, "hash");
   LocalCountryFile localFile("/test-dir", countryFile, 150309);
 
-  TEST_EQUAL("/test-dir/TestCountry" DATA_FILE_EXTENSION, localFile.GetPath(MapFileType::Map), ());
+  TEST_EQUAL(base::JoinPath("/test-dir", "TestCountry" DATA_FILE_EXTENSION), localFile.GetPath(MapFileType::Map), ());
 
   // Not synced with disk yet.
   TEST(!localFile.HasFiles(), ());

--- a/libs/platform/platform_tests/platform_test.cpp
+++ b/libs/platform/platform_tests/platform_test.cpp
@@ -270,11 +270,11 @@ UNIT_TEST(MkDirRecursively)
   CHECK(Platform::RmDirRecursively(workPath), ());
 }
 
-// Regression guard for a TOCTOU race in directory creation (now inside create_directories): when
-// several threads (mimicking the parallel ctest binaries that all create ~/.config/OMaps on a fresh
-// runner) create the same not-yet-existing directory at once, every MkDirRecursively call must
-// succeed instead of one failing because a peer won the create. The race window is tiny, so hammer
-// it across many iterations with fresh, deep paths.
+// Regression guard for the TOCTOU race in directory creation: when several threads (mimicking the
+// parallel ctest binaries that all create ~/.config/OMaps on a fresh runner) create the same
+// not-yet-existing directory at once, every MkDirRecursively call must succeed instead of one
+// failing because a peer won the create. The race window is tiny, so hammer it across many
+// iterations with fresh, deep paths.
 UNIT_TEST(MkDirRecursively_Concurrent)
 {
   auto const workPath = base::JoinPath(GetPlatform().WritableDir(), "MkDirRecursivelyConcurrent");

--- a/libs/platform/platform_tests/platform_test.cpp
+++ b/libs/platform/platform_tests/platform_test.cpp
@@ -270,11 +270,11 @@ UNIT_TEST(MkDirRecursively)
   CHECK(Platform::RmDirRecursively(workPath), ());
 }
 
-// Regression guard for a TOCTOU race in Platform::MkDir: when several threads (mimicking the
-// parallel ctest binaries that all create ~/.config/OMaps on a fresh runner) create the same
-// not-yet-existing directory at once, every MkDirRecursively call must succeed instead of one
-// failing because a peer won the create. The race window is tiny, so hammer it across many
-// iterations with fresh, deep paths.
+// Regression guard for a TOCTOU race in directory creation (now inside create_directories): when
+// several threads (mimicking the parallel ctest binaries that all create ~/.config/OMaps on a fresh
+// runner) create the same not-yet-existing directory at once, every MkDirRecursively call must
+// succeed instead of one failing because a peer won the create. The race window is tiny, so hammer
+// it across many iterations with fresh, deep paths.
 UNIT_TEST(MkDirRecursively_Concurrent)
 {
   auto const workPath = base::JoinPath(GetPlatform().WritableDir(), "MkDirRecursivelyConcurrent");

--- a/libs/search/search_integration_tests/generate_tests.cpp
+++ b/libs/search/search_integration_tests/generate_tests.cpp
@@ -67,26 +67,29 @@ UNIT_CLASS_TEST(GenerateTest, GenerateDeprecatedTypes)
     MakeFeature(builder, {{"leisure", "playground"}, {"sport", "tennis"}}, {1.0, 1.0});
   }
 
-  FrozenDataSource dataSource;
-  TEST_EQUAL(dataSource.Register(file).second, MwmSet::RegResult::Success, ());
-
-  // New types.
-  base::StringIL arr[] = {{"leisure", "dog_park"}, {"leisure", "playground"}, {"sport", "tennis"}};
-
-  Classificator const & cl = classif();
-  set<uint32_t> types;
-  for (auto const & s : arr)
-    types.insert(cl.GetTypeByPath(s));
-
-  int count = 0;
-  auto const fn = [&](FeatureType & ft)
+  // Close the map before deleting it, Windows refuses to delete files that are still open.
   {
-    ++count;
-    ft.ForEachType([&](uint32_t t) { TEST(types.count(t) > 0, (cl.GetReadableObjectName(t))); });
-  };
-  dataSource.ForEachInScale(fn, scales::GetUpperScale());
+    FrozenDataSource dataSource;
+    TEST_EQUAL(dataSource.Register(file).second, MwmSet::RegResult::Success, ());
 
-  TEST_EQUAL(count, 2, ());
+    // New types.
+    base::StringIL arr[] = {{"leisure", "dog_park"}, {"leisure", "playground"}, {"sport", "tennis"}};
+
+    Classificator const & cl = classif();
+    set<uint32_t> types;
+    for (auto const & s : arr)
+      types.insert(cl.GetTypeByPath(s));
+
+    int count = 0;
+    auto const fn = [&](FeatureType & ft)
+    {
+      ++count;
+      ft.ForEachType([&](uint32_t t) { TEST(types.count(t) > 0, (cl.GetReadableObjectName(t))); });
+    };
+    dataSource.ForEachInScale(fn, scales::GetUpperScale());
+
+    TEST_EQUAL(count, 2, ());
+  }
 
   file.DeleteFromDisk(MapFileType::Map);
 }

--- a/libs/shaders/shaders_tests/CMakeLists.txt
+++ b/libs/shaders/shaders_tests/CMakeLists.txt
@@ -3,9 +3,13 @@ project(shaders_tests)
 set(SRC
   gl_shaders_desktop_compile_tests.cpp
   gl_program_params_tests.cpp
-  # Mobile compilation test takes much more time than others, so it should be the last.
-  gl_shaders_mobile_compile_test.cpp
 )
+
+# The mobile compilation test runs the compilers bundled in tools/shaders_compiler, which exist for
+# Linux and macOS only. It takes much more time than the other tests, so it should be the last.
+if (PLATFORM_LINUX OR PLATFORM_MAC)
+  list(APPEND SRC gl_shaders_mobile_compile_test.cpp)
+endif()
 
 omim_add_test(${PROJECT_NAME} ${SRC})
 

--- a/libs/shaders/shaders_tests/CMakeLists.txt
+++ b/libs/shaders/shaders_tests/CMakeLists.txt
@@ -5,21 +5,23 @@ set(SRC
   gl_program_params_tests.cpp
 )
 
+omim_add_test(${PROJECT_NAME} ${SRC})
+
 # The mobile compilation test runs the compilers bundled in tools/shaders_compiler, which exist for
 # Linux and macOS only. It takes much more time than the other tests, so it should be the last.
 if (PLATFORM_LINUX OR PLATFORM_MAC)
-  list(APPEND SRC gl_shaders_mobile_compile_test.cpp)
+  target_sources(${PROJECT_NAME}
+    PRIVATE
+      gl_shaders_mobile_compile_test.cpp
+  )
+
+  # The compilers are only executed, never written to, so run them from the source tree regardless
+  # of the test's working directory.
+  target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+      OMIM_SHADERS_COMPILERS_DIR="${OMIM_ROOT}/tools/shaders_compiler"
+  )
 endif()
-
-omim_add_test(${PROJECT_NAME} ${SRC})
-
-# External GLSL compilers used by gl_shaders_mobile_compile_test. They are only executed, never
-# written to, so the test runs them right from the source tree, no matter which directory it is
-# started from.
-target_compile_definitions(${PROJECT_NAME}
-  PRIVATE
-    OMIM_SHADERS_COMPILERS_DIR="${OMIM_ROOT}/tools/shaders_compiler"
-)
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE

--- a/libs/storage/storage_tests/fake_map_files_downloader.cpp
+++ b/libs/storage/storage_tests/fake_map_files_downloader.cpp
@@ -124,6 +124,9 @@ void FakeMapFilesDownloader::OnFileDownloaded(QueuedCountry const & queuedCountr
   auto const country = queuedCountry;
   m_queue.PopFront();
 
+  // Close the file before the storage renames it, Windows refuses to rename open files.
+  m_writer.reset();
+
   m_taskRunner.PostTask([country, status]() { country.OnDownloadFinished(status); });
 
   if (!m_queue.IsEmpty())

--- a/libs/testing/testingmain.cpp
+++ b/libs/testing/testingmain.cpp
@@ -25,6 +25,14 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
+#ifdef OMIM_OS_WINDOWS
+#include "std/windows.hpp"
+
+#include <crtdbg.h>
+#include <cstdio>
+#include <cstdlib>
+#endif
+
 #ifndef OMIM_UNIT_TEST_DISABLE_PLATFORM_INIT
 #include "platform/platform.hpp"
 #endif
@@ -170,6 +178,27 @@ int main(int argc, char * argv[])
 #else
   UNUSED_VALUE(argc);
   UNUSED_VALUE(argv);
+#endif
+
+#ifdef OMIM_OS_WINDOWS
+  // Report crashes and CRT assertions on stderr and abort instead of blocking on a dialog box,
+  // otherwise a failing test hangs unattended runs until the ctest timeout.
+  if (!IsDebuggerPresent())
+  {
+    SetErrorMode(GetErrorMode() | SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    _set_error_mode(_OUT_TO_STDERR);
+    _set_abort_behavior(_WRITE_ABORT_MSG, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+    // Debug CRT assertions and errors fail fast: the default report modes either show a dialog or return
+    // and let the test continue on corrupted state.
+    _CrtSetReportHook([](int reportType, char * message, int * /* returnValue */) -> int
+    {
+      if (reportType == _CRT_WARN)
+        return FALSE;  // Default processing, e.g. for leak reports.
+      std::fputs(message, stderr);
+      std::fflush(stderr);
+      std::_Exit(EXIT_FAILURE);  // Not abort(): its own report would re-enter this hook.
+    });
+  }
 #endif
 
   base::ScopedLogLevelChanger const infoLogLevel(LINFO);

--- a/libs/testing/testingmain.cpp
+++ b/libs/testing/testingmain.cpp
@@ -181,8 +181,8 @@ int main(int argc, char * argv[])
 #endif
 
 #ifdef OMIM_OS_WINDOWS
-  // Report crashes and CRT assertions on stderr and abort instead of blocking on a dialog box,
-  // otherwise a failing test hangs unattended runs until the ctest timeout.
+  // Suppress Windows crash dialogs, route abort and Debug CRT reports to stderr, and terminate
+  // failed tests instead of hanging unattended runs until the ctest timeout.
   if (!IsDebuggerPresent())
   {
     SetErrorMode(GetErrorMode() | SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);

--- a/libs/timezone/timezone_tests/conversion_tests.cpp
+++ b/libs/timezone/timezone_tests/conversion_tests.cpp
@@ -3,24 +3,18 @@
 
 #include "timezone/serdes.hpp"
 
+#include "base/timegm.hpp"
+
 using namespace om::tz;
 
 namespace
 {
-constexpr TimeZone kZeroTz{.generation_year_offset = 0, .base_offset = 64, .dst_delta = 0, .transitions = {}};
+// Not constexpr: MSVC's debug std::vector allocates its checked-iterator proxy during constant evaluation.
+TimeZone const kZeroTz{.generation_year_offset = 0, .base_offset = 64, .dst_delta = 0, .transitions = {}};
 
 time_t CreateTime(int const year, int const month, int const day, int const hour, int const minute, int const second)
 {
-  std::tm tm_time{};
-  tm_time.tm_year = year - 1900;  // tm_year is years since 1900
-  tm_time.tm_mon = month - 1;     // tm_mon is 0-based
-  tm_time.tm_mday = day;
-  tm_time.tm_hour = hour;
-  tm_time.tm_min = minute;
-  tm_time.tm_sec = second;
-  tm_time.tm_isdst = -1;
-
-  return timegm(&tm_time);
+  return base::TimeGM(year, month, day, hour, minute, second);
 }
 
 std::string TimeToString(time_t const t)
@@ -43,7 +37,7 @@ TEST(TimeZoneConvert, ShoudNotChangeTimeWhenEqualTimeZones)
 
 TEST(TimeZoneConvert, ShoudAdd1Hour)
 {
-  constexpr TimeZone dstTz{.generation_year_offset = 0, .base_offset = 68, .dst_delta = 0, .transitions = {}};
+  TimeZone const dstTz{.generation_year_offset = 0, .base_offset = 68, .dst_delta = 0, .transitions = {}};
 
   {
     time_t const srcTime = CreateTime(2026, 12, 13, 21, 18, 16);
@@ -63,7 +57,7 @@ TEST(TimeZoneConvert, ShoudAdd1Hour)
 
 TEST(TimeZoneConvert, ShoudDecrease1Hour)
 {
-  constexpr TimeZone srcTz{.generation_year_offset = 0, .base_offset = 68, .dst_delta = 0, .transitions = {}};
+  TimeZone const srcTz{.generation_year_offset = 0, .base_offset = 68, .dst_delta = 0, .transitions = {}};
 
   {
     time_t const srcTime = CreateTime(2026, 12, 13, 22, 18, 16);
@@ -133,10 +127,10 @@ TEST(TimeZoneConvert, ShouldApplyDst)
 TEST(TimeZoneConvert, CrossTimeZoneWithOffsets)
 {
   // Source timezone: -2:30 (minutes = -150), no DST
-  constexpr TimeZone srcTz{.generation_year_offset = 0,
-                           .base_offset = 54,  // -2:30 hours
-                           .dst_delta = 0,
-                           .transitions = {}};
+  TimeZone const srcTz{.generation_year_offset = 0,
+                       .base_offset = 54,  // -2:30 hours
+                       .dst_delta = 0,
+                       .transitions = {}};
 
   // Destination timezone: +8:00, DST +60 minutes
   TimeZone const dstTz{.generation_year_offset = 0,

--- a/libs/timezone/timezone_tests/serdes_tests.cpp
+++ b/libs/timezone/timezone_tests/serdes_tests.cpp
@@ -11,7 +11,7 @@ using namespace om::tz;
 
 TEST(TimeZoneSerDes, EmptyTimeZone)
 {
-  constexpr TimeZone tz{.generation_year_offset = 0, .base_offset = 0, .dst_delta = 0, .transitions = {}};
+  TimeZone const tz{.generation_year_offset = 0, .base_offset = 0, .dst_delta = 0, .transitions = {}};
 
   auto const result = Serialize(tz);
   EXPECT_TRUE(result.has_value());


### PR DESCRIPTION
Split out of #13509 by @Osyotr, with the test-runner part taken from his earlier #10255, so the Windows fixes can be reviewed and merged independently.

- `Platform::MkDirRecursively` split the path on the native separator only and rooted anything else at `.`, so the `--writable_path=D:/.../test_writable/<test>` that ctest passes became `.\D:/...` and every unit test binary aborted at startup on Windows (31 of 36 in the #13509 run). `std::filesystem::create_directories` handles both separator kinds, drive roots and concurrent creation, and the reason of a failure is logged; `platform_tests` cover the existing semantics.
- `timezone_tests` used `timegm()`, which MSVC does not provide; `base::TimeGM` is the portable equivalent. Their `constexpr TimeZone` objects become `const` (commented): `TimeZone` holds a `std::vector`, and MSVC's debug `std::vector` allocates its iterator-checking proxy even in constant evaluation.
- `shaders_tests`: the mobile shader compilers in `tools/shaders_compiler` exist for Linux and macOS only, so that test is built only there instead of leaving the compiler paths undefined elsewhere (#13509 wrapped the tests in `#if !defined(OMIM_OS_WINDOWS)`).
- `testingmain`: on Windows suppress crash dialogs, route abort and Debug CRT reports to stderr, and exit with a failure (a report hook for `_CRT_ASSERT`/`_CRT_ERROR`; `_Exit` rather than `abort()`, whose own report re-enters the hook) instead of blocking on dialog boxes, which hang unattended runs until the ctest timeout; the abort message itself is kept. This fail-fast immediately exposed two `isdigit()`-on-UTF-8 sites in `libs/search`, fixed in #13514.
- `generate_tests`: close the test map before deleting it, Windows refuses to delete open files.
- `.gitattributes`: the runner's Git has `core.autocrlf=true` (system config), so GPX, KML, OSM and JSON fixtures were checked out with CRLF and text comparisons failed. Every text file is now checked out with LF by default (`* text=auto eol=lf`) instead of one rule per fixture extension; batch files keep CRLF. No tracked text file contains CRLF, so nothing renormalizes on the next commit.
- `storage_tests`, `http_client_test` (one `ReadFile()` helper for all sites), `bookmarks_test`, `mwm_set_test`, `editor_notes_tests`: close, destroy or deregister files and maps before the code under test renames or deletes them; Windows refuses both on open files and the logged error aborts Debug test binaries. `downloader_utils_tests`, `local_country_file_tests`, `bookmarks_test`, `descriptions_section_builder_tests`: build expected paths with the native separator.
- `cancellable_tests`: set the deadline from the worker thread, a slow thread start on a loaded runner left too few iterations to converge (flaked on Windows Debug).

Tested: `platform_tests`, `timezone_tests`, `base_tests`, `search_integration_tests` (generate_tests.cpp), `map_tests`, `indexer_tests` and the offscreen `shaders_tests` on macOS. With the whole stack applied, the Windows leg passes all 36 unit test suites and the 3 offscreen rendering suites in Debug and Release on the fork: https://github.com/biodranik/organicmaps/actions/runs/34093667403