### PR TITLE
[routing] Don't compute an alternative route that won't be shown

### DIFF
--- a/libs/routing/async_router.cpp
+++ b/libs/routing/async_router.cpp
@@ -157,7 +157,7 @@ void AsyncRouter::SetRouter(std::unique_ptr<IRouter> && router, std::unique_ptr<
 }
 
 void AsyncRouter::CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & direction, bool adjustToPrevRoute,
-                                 ReadyCallbackOwnership const & readyCallback,
+                                 bool needAlternatives, ReadyCallbackOwnership const & readyCallback,
                                  NeedMoreMapsCallback const & needMoreMapsCallback,
                                  RemoveRouteCallback const & removeRouteCallback,
                                  ProgressCallback const & progressCallback, uint32_t timeoutSec)
@@ -167,6 +167,7 @@ void AsyncRouter::CalculateRoute(Checkpoints const & checkpoints, m2::PointD con
   m_checkpoints = checkpoints;
   m_startDirection = direction;
   m_adjustToPrevRoute = adjustToPrevRoute;
+  m_needAlternatives = needAlternatives;
 
   ResetDelegate();
 
@@ -272,6 +273,7 @@ void AsyncRouter::CalculateRoute()
   std::shared_ptr<RouterDelegateProxy> delegateProxy;
   m2::PointD startDirection;
   bool adjustToPrevRoute = false;
+  bool needAlternatives = true;
   std::shared_ptr<AbsentRegionsFinder> absentRegionsFinder;
   std::shared_ptr<IRouter> router;
   uint64_t routeId = 0;
@@ -299,6 +301,7 @@ void AsyncRouter::CalculateRoute()
     routerName = router->GetName();
     router->SetGuides(std::move(m_guides));
     m_guides.clear();
+    needAlternatives = m_needAlternatives;
   }
 
   auto result = std::make_shared<RoutesResult>(router->GetName(), routeId);
@@ -318,8 +321,8 @@ void AsyncRouter::CalculateRoute()
 
     if (code == RouterResultCode::NoError)
     {
-      code =
-          router->CalculateRoute(checkpoints, startDirection, adjustToPrevRoute, delegateProxy->GetDelegate(), *result);
+      code = router->CalculateRoute(checkpoints, startDirection, adjustToPrevRoute, needAlternatives,
+                                    delegateProxy->GetDelegate(), *result);
     }
 
     router->SetGuides({});

--- a/libs/routing/async_router.hpp
+++ b/libs/routing/async_router.hpp
@@ -37,13 +37,15 @@ public:
   /// @param checkpoints start, finish and intermadiate points
   /// @param direction start direction for routers with high cost of the turnarounds
   /// @param adjustToPrevRoute adjust route to the previous one if possible
+  /// @param needAlternatives compute alternative routes; false while navigating, they aren't drawn
   /// @param readyCallback function to return routing result
   /// @param progressCallback function to update the router progress
   /// @param timeoutSec timeout to cancel routing. 0 is infinity.
   // @TODO(bykoianko) Gather |readyCallback|, |needMoreMapsCallback| and |removeRouteCallback|
   // to one delegate. No need to add |progressCallback| to the delegate.
   void CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & direction, bool adjustToPrevRoute,
-                      ReadyCallbackOwnership const & readyCallback, NeedMoreMapsCallback const & needMoreMapsCallback,
+                      bool needAlternatives, ReadyCallbackOwnership const & readyCallback,
+                      NeedMoreMapsCallback const & needMoreMapsCallback,
                       RemoveRouteCallback const & removeRouteCallback, ProgressCallback const & progressCallback,
                       uint32_t timeoutSec = RouterDelegate::kNoTimeout);
 
@@ -112,6 +114,7 @@ private:
 
   m2::PointD m_startDirection = m2::PointD::Zero();
   bool m_adjustToPrevRoute = false;
+  bool m_needAlternatives = true;
   std::shared_ptr<RouterDelegateProxy> m_delegateProxy;
   std::shared_ptr<AbsentRegionsFinder> m_absentRegionsFinder;
   std::shared_ptr<IRouter> m_router;

--- a/libs/routing/index_router.cpp
+++ b/libs/routing/index_router.cpp
@@ -420,8 +420,8 @@ void IndexRouter::SetGuides(GuidesTracks && guides)
 }
 
 RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                             bool adjustToPrevRoute, RouterDelegate const & delegate,
-                                             RoutesResult & result)
+                                             bool adjustToPrevRoute, bool needAlternatives,
+                                             RouterDelegate const & delegate, RoutesResult & result)
 {
   auto const & startPoint = checkpoints.GetStart();
   auto const & finalPoint = checkpoints.GetFinish();
@@ -463,8 +463,8 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
       // transit gets a less-walking / fewer-transfers alternative (e.g. a direct bus instead of
       // subway + walk).
       double const altMaxDistanceM = m_vehicleType == VehicleType::Car ? 300'000.0 : 100'000.0;
-      if ((code == RouterResultCode::NoError || code == RouterResultCode::HasWarnings) && !delegate.IsCancelled() &&
-          mercator::DistanceOnEarth(startPoint, finalPoint) <= altMaxDistanceM)
+      if (needAlternatives && (code == RouterResultCode::NoError || code == RouterResultCode::HasWarnings) &&
+          !delegate.IsCancelled() && mercator::DistanceOnEarth(startPoint, finalPoint) <= altMaxDistanceM)
       {
         // Save the Normal route's adjust-cache; the alternative computation would overwrite it.
         auto savedLastRoute = std::move(m_lastRoute);

--- a/libs/routing/index_router.hpp
+++ b/libs/routing/index_router.hpp
@@ -81,7 +81,7 @@ public:
 
   void SetGuides(GuidesTracks && guides) override;
   RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                  bool adjustToPrevRoute, RouterDelegate const & delegate,
+                                  bool adjustToPrevRoute, bool needAlternatives, RouterDelegate const & delegate,
                                   RoutesResult & result) override;
 
   bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,

--- a/libs/routing/router.hpp
+++ b/libs/routing/router.hpp
@@ -64,13 +64,15 @@ public:
   /// @param checkpoints start, finish and intermediate points
   /// @param startDirection start direction for routers with high cost of the turnarounds
   /// @param adjust adjust route to the previous one if possible
+  /// @param needAlternatives compute alternative routes besides the main one
   /// @param delegate callback functions and cancellation flag
   /// @param result populated with one or more alternative routes (as RouteBase) when successful;
   ///               callers consume the active alternative via result.GetActive()
   /// @return ResultCode error code or NoError if at least one route was produced
   /// @see Cancellable
   virtual RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                          bool adjust, RouterDelegate const & delegate, RoutesResult & result) = 0;
+                                          bool adjust, bool needAlternatives, RouterDelegate const & delegate,
+                                          RoutesResult & result) = 0;
 
   virtual bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
                                            EdgeProj & proj) = 0;

--- a/libs/routing/routes_builder/routes_builder.cpp
+++ b/libs/routing/routes_builder/routes_builder.cpp
@@ -297,7 +297,7 @@ RoutesBuilder::Result RoutesBuilder::Processor::operator()(Params const & params
     m_delegate->SetTimeout(params.m_timeoutSeconds);
     base::Timer timer;
     resultCode = m_router->CalculateRoute(params.m_checkpoints, m2::PointD::Zero(), false /* adjustToPrevRoute */,
-                                          *m_delegate, routesResult);
+                                          true /* needAlternatives */, *m_delegate, routesResult);
 
     if (resultCode != RouterResultCode::NoError)
       break;

--- a/libs/routing/routing_benchmarks/helpers.cpp
+++ b/libs/routing/routing_benchmarks/helpers.cpp
@@ -154,7 +154,7 @@ void TestRouter(routing::IRouter & router, m2::PointD const & startPos, m2::Poin
   routing::RoutesResult res(router.GetName(), 0 /* routes id */);
   auto const resultCode =
       router.CalculateRoute(routing::Checkpoints(startPos, finalPos), m2::PointD::Zero() /* startDirection */,
-                            false /* adjust */, delegate, res);
+                            false /* adjust */, true /* needAlternatives */, delegate, res);
   double const elapsedSec = timer.ElapsedSeconds();
   TEST_EQUAL(routing::RouterResultCode::NoError, resultCode, ());
   TEST(res.IsValid(), ());

--- a/libs/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/libs/routing/routing_integration_tests/routing_test_tools.cpp
@@ -152,8 +152,9 @@ TRouteResult CalculateRoute(IRouterComponents const & routerComponents, m2::Poin
 {
   RouterDelegate delegate;
   RoutesResult res("mapsme", 0 /* routes id */);
-  RouterResultCode result = routerComponents.GetRouter().CalculateRoute(
-      Checkpoints(startPoint, finalPoint), startDirection, false /* adjust */, delegate, res);
+  RouterResultCode result =
+      routerComponents.GetRouter().CalculateRoute(Checkpoints(startPoint, finalPoint), startDirection,
+                                                  false /* adjust */, true /* needAlternatives */, delegate, res);
   routerComponents.GetRouter().SetGuides({});
   return TRouteResult(PromoteActive(res), result);
 }
@@ -164,8 +165,9 @@ TRouteResult CalculateRoute(IRouterComponents const & routerComponents, Checkpoi
   RouterDelegate delegate;
   RoutesResult res("mapsme", 0 /* routes id */);
   routerComponents.GetRouter().SetGuides(std::move(guides));
-  RouterResultCode result = routerComponents.GetRouter().CalculateRoute(
-      checkpoints, m2::PointD::Zero() /* startDirection */, false /* adjust */, delegate, res);
+  RouterResultCode result =
+      routerComponents.GetRouter().CalculateRoute(checkpoints, m2::PointD::Zero() /* startDirection */,
+                                                  false /* adjust */, true /* needAlternatives */, delegate, res);
   routerComponents.GetRouter().SetGuides({});
   return TRouteResult(PromoteActive(res), result);
 }
@@ -174,8 +176,9 @@ TRoutesResult CalculateRoutes(IRouterComponents const & routerComponents, Checkp
 {
   RouterDelegate delegate;
   RoutesResult res("mapsme", 0 /* routes id */);
-  RouterResultCode const result = routerComponents.GetRouter().CalculateRoute(
-      checkpoints, m2::PointD::Zero() /* startDirection */, false /* adjust */, delegate, res);
+  RouterResultCode const result =
+      routerComponents.GetRouter().CalculateRoute(checkpoints, m2::PointD::Zero() /* startDirection */,
+                                                  false /* adjust */, true /* needAlternatives */, delegate, res);
   routerComponents.GetRouter().SetGuides({});
 
   vector<shared_ptr<Route>> routes;

--- a/libs/routing/routing_session.cpp
+++ b/libs/routing/routing_session.cpp
@@ -91,8 +91,10 @@ void RoutingSession::RebuildRoute(m2::PointD const & startPoint, ReadyCallback c
   checkpoints.SetPointFrom(startPoint);
   // Use old-style callback construction, because lambda constructs buggy function on Android
   // (callback param isn't captured by value).
-  m_router->CalculateRoute(checkpoints, direction, adjustToPrevRoute, DoReadyCallback(*this, readyCallback),
-                           needMoreMapsCallback, removeRouteCallback, m_progressCallback, timeoutSec);
+  // RoutingManager::InsertRoute draws alternatives only outside navigation, don't pay for them.
+  m_router->CalculateRoute(checkpoints, direction, adjustToPrevRoute, !m_isFollowing /* needAlternatives */,
+                           DoReadyCallback(*this, readyCallback), needMoreMapsCallback, removeRouteCallback,
+                           m_progressCallback, timeoutSec);
 }
 
 m2::PointD RoutingSession::GetStartPoint() const

--- a/libs/routing/routing_tests/async_router_test.cpp
+++ b/libs/routing/routing_tests/async_router_test.cpp
@@ -27,7 +27,7 @@ public:
   string GetName() const override { return "Dummy"; }
   void SetGuides(GuidesTracks && /* guides */) override {}
   RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                  bool adjustToPrevRoute, RouterDelegate const & delegate,
+                                  bool adjustToPrevRoute, bool needAlternatives, RouterDelegate const & delegate,
                                   RoutesResult & result) override
   {
     Route route;

--- a/libs/routing/routing_tests/routing_session_test.cpp
+++ b/libs/routing/routing_tests/routing_session_test.cpp
@@ -62,7 +62,7 @@ public:
   void SetGuides(GuidesTracks && /* guides */) override {}
 
   RouterResultCode CalculateRoute(Checkpoints const & /* checkpoints */, m2::PointD const & /* startDirection */,
-                                  bool /* adjust */, RouterDelegate const & /* delegate */,
+                                  bool /* adjust */, bool /* needAlternatives */, RouterDelegate const & /* delegate */,
                                   RoutesResult & result) override
   {
     ++m_buildCount;
@@ -75,6 +75,24 @@ public:
   {
     return false;
   }
+};
+
+// Router recording whether the session asked for alternative routes.
+class AlternativesFlagRouter : public DummyRouter
+{
+public:
+  AlternativesFlagRouter(size_t & buildCounter, vector<bool> & flags) : DummyRouter(buildCounter), m_flags(flags) {}
+
+  RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection, bool adjust,
+                                  bool needAlternatives, RouterDelegate const & delegate,
+                                  RoutesResult & result) override
+  {
+    m_flags.push_back(needAlternatives);
+    return DummyRouter::CalculateRoute(checkpoints, startDirection, adjust, needAlternatives, delegate, result);
+  }
+
+private:
+  vector<bool> & m_flags;
 };
 
 // Router which every next call of CalculateRoute() method return different return codes.
@@ -92,7 +110,7 @@ public:
   void SetGuides(GuidesTracks && /* guides */) override {}
 
   RouterResultCode CalculateRoute(Checkpoints const & /* checkpoints */, m2::PointD const & /* startDirection */,
-                                  bool /* adjust */, RouterDelegate const & /* delegate */,
+                                  bool /* adjust */, bool /* needAlternatives */, RouterDelegate const & /* delegate */,
                                   RoutesResult & result) override
   {
     TEST_LESS(m_returnCodesIdx, m_returnCodes.size(), ());
@@ -608,5 +626,37 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingError)
     vector<double> const latitudes = {0.003, 0.0035, 0.004};
     TestMovingByUpdatingLat(sessionStateTest, latitudes, info, *m_session);
   }
+}
+
+// Alternatives are drawn only outside navigation (RoutingManager::InsertRoute), so a rebuild in
+// follow mode must not pay for computing them.
+UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestAlternativesSkippedWhileFollowing)
+{
+  size_t counter = 0;
+  vector<bool> flags;
+
+  TimedSignal builtSignal;
+  GetPlatform().RunTask(Platform::Thread::Gui, [&builtSignal, &counter, &flags, this]()
+  {
+    InitRoutingSession();
+    m_session->SetRouter(make_unique<AlternativesFlagRouter>(counter, flags), nullptr);
+    m_session->SetRoutingCallbacks([&builtSignal](RoutesResult const &, RouterResultCode) {
+      builtSignal.Signal();
+    }, nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */);
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), RouterDelegate::kNoTimeout);
+  });
+  TEST(builtSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
+  TEST_EQUAL(flags, vector<bool>({true}), ("The initial build computes alternatives."));
+
+  TimedSignal rebuiltSignal;
+  GetPlatform().RunTask(Platform::Thread::Gui, [&rebuiltSignal, this]()
+  {
+    TEST(m_session->EnableFollowMode(), ());
+    m_session->RebuildRoute(kTestRoute.front(), [&rebuiltSignal](RoutesResult const &, RouterResultCode)
+    { rebuiltSignal.Signal(); }, nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */,
+                            RouterDelegate::kNoTimeout, SessionState::RouteRebuilding, true /* adjustToPrevRoute */);
+  });
+  TEST(rebuiltSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not rebuilt."));
+  TEST_EQUAL(flags, vector<bool>({true, false}), ("A rebuild while navigating skips alternatives."));
 }
 }  // namespace routing_session_test

--- a/libs/routing/ruler_router.cpp
+++ b/libs/routing/ruler_router.cpp
@@ -37,8 +37,8 @@ namespace routing
 
  */
 RouterResultCode RulerRouter::CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                             bool adjustToPrevRoute, RouterDelegate const & delegate,
-                                             RoutesResult & result)
+                                             bool adjustToPrevRoute, bool /* needAlternatives */,
+                                             RouterDelegate const & delegate, RoutesResult & result)
 {
   auto const & points = checkpoints.GetPoints();
   size_t const count = points.size();

--- a/libs/routing/ruler_router.hpp
+++ b/libs/routing/ruler_router.hpp
@@ -13,7 +13,7 @@ class RulerRouter : public IRouter
   void SetGuides(GuidesTracks && guides) override {}
 
   RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                  bool adjustToPrevRoute, RouterDelegate const & delegate,
+                                  bool adjustToPrevRoute, bool needAlternatives, RouterDelegate const & delegate,
                                   RoutesResult & result) override;
   bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
                                    EdgeProj & proj) override;


### PR DESCRIPTION
`RoutingManager::InsertRoute` draws alternatives and their ETA balloons only outside navigation (`if (!isFollowing)`), but `IndexRouter::CalculateRoute` computed one on every full rebuild regardless. So every reroute while driving pays for a second search and discards it — at the moment the driver is waiting for guidance.

Reroutes during navigation are full rebuilds more often than it looks: `AdjustRoute` is only attempted when `distanceToRoute <= 5 km && distanceToFinish >= 10 km`, so **every reroute within 10 km of the destination** takes the full path, and the adjust can also fail and fall through (a 1 km lateral deviation already does).

## Measured

Same binary, alternative computation disabled for the second column (`Germany_Hesse_Regierungsbezirk Darmstadt`, car, debug build — read the ratio, not the absolute times):

| route | length | with alt | without | overhead |
|---|---|---|---|---|
| Frankfurt Hbf → Zoo | 4.2 km | 2.936 s | 1.612 s | +82 % |
| Darmstadt → Eberstadt | 7.4 km | 2.495 s | 1.300 s | +92 % |
| Offenbach → Frankfurt Hbf | 11.4 km | 2.908 s | 1.720 s | +69 % |
| Frankfurt → Darmstadt | 33.4 km | 4.569 s | 2.443 s | +87 % |

## What changed

`needAlternatives` joins `adjust` as a `CalculateRoute` argument, so it is request-scoped by construction and the router keeps no new state. `RoutingSession::RebuildRoute` passes `!m_isFollowing`; every other caller (tests, benchmarks, `routes_builder`) passes `true`.

Nothing else consumes the alternative: `RoutesResult::m_routes` is read only by `RoutingManager` (drawing) and by the ROUTE_ALT mark tap / `TryTapOnAlternativeRoute`, both unreachable while following. The predicate is also stable across a request — `EnableFollowMode`/`DisableFollowMode` only act in `RouteNotStarted`/`OnRoute`, so following can neither start nor stop while a build is in flight. The alternative's adjust-cache is still dropped on the skipped path, since `altCode` stays `RouteNotFound`.

## Testing

`routing_tests` plus the rest of the default `ctest` suite are green. New `routing_session_test.cpp::TestAlternativesSkippedWhileFollowing` drives the real session and `AsyncRouter` and asserts the flag arrives as `true` for the initial build and `false` for a rebuild in follow mode; verified to fail (`[2: 1 1 ]`) when the session passes a constant `true`.