### PR TITLE
[routing] Don't use the router from the gui thread while it is calculating

### DIFF
--- a/libs/routing/async_router.cpp
+++ b/libs/routing/async_router.cpp
@@ -4,6 +4,7 @@
 
 #include "base/logging.hpp"
 #include "base/macros.hpp"
+#include "base/scope_guard.hpp"
 #include "base/timer.hpp"
 
 #include <functional>
@@ -75,7 +76,13 @@ void AsyncRouter::RouterDelegateProxy::Cancel()
 bool AsyncRouter::FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
                                               EdgeProj & proj)
 {
-  /// @todo No need to put a lock_guard at first glance. May be wrong ..
+  lock_guard ul(m_guard);
+  // IndexRouter::FindClosestProjectionToRoad reads the road graph caches that CalculateRoute fills
+  // and clears on the routing thread, so refuse rather than read them from under it. The caller
+  // only snaps the position marker to a road, and it is off route anyway while a rebuild runs.
+  if (!m_router || m_isCalculating)
+    return false;
+
   return m_router->FindClosestProjectionToRoad(point, direction, radius, proj);
 }
 
@@ -154,6 +161,7 @@ void AsyncRouter::SetRouter(std::unique_ptr<IRouter> && router, std::unique_ptr<
 
   m_router = std::move(router);
   m_absentRegionsFinder = std::move(finder);
+  m_cachedRoutesId = 0;
 }
 
 void AsyncRouter::CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & direction, bool adjustToPrevRoute,
@@ -189,16 +197,22 @@ void AsyncRouter::ClearState()
   lock_guard ul(m_guard);
 
   m_clearState = true;
+  m_cachedRoutesId = 0;
   m_threadCondVar.notify_one();
 
   ResetDelegate();
 }
 
-void AsyncRouter::SwapAltRouteToActive()
+bool AsyncRouter::SwapAltRouteToActive(uint64_t routesId)
 {
   lock_guard ul(m_guard);
-  if (m_router)
-    m_router->SwapAltRouteToActive();
+  // m_guard doesn't cover IRouter::CalculateRoute, which runs unlocked on the routing thread and
+  // writes the very state the swap exchanges.
+  if (!m_router || m_isCalculating || routesId == 0 || routesId != m_cachedRoutesId)
+    return false;
+
+  m_router->SwapAltRouteToActive();
+  return true;
 }
 
 // static
@@ -294,6 +308,7 @@ void AsyncRouter::CalculateRoute()
     checkpoints = m_checkpoints;
     startDirection = m_startDirection;
     adjustToPrevRoute = m_adjustToPrevRoute;
+    needAlternatives = m_needAlternatives;
     delegateProxy = m_delegateProxy;
     router = m_router;
     absentRegionsFinder = m_absentRegionsFinder;
@@ -301,7 +316,7 @@ void AsyncRouter::CalculateRoute()
     routerName = router->GetName();
     router->SetGuides(std::move(m_guides));
     m_guides.clear();
-    needAlternatives = m_needAlternatives;
+    m_isCalculating = true;
   }
 
   auto result = std::make_shared<RoutesResult>(router->GetName(), routeId);
@@ -312,6 +327,21 @@ void AsyncRouter::CalculateRoute()
 
   try
   {
+    // Publish the cache generation together with the idle state. Until the gui accepts this result,
+    // its older routesId prevents a stale tap from swapping the new result's adjustment caches.
+    // A calculation without a route keeps the generation: the gui still shows the previous result
+    // with its alternatives, and routers store adjustment caches only together with a new route.
+    SCOPE_GUARD(routerIdle, [&]
+    {
+      lock_guard ul(m_guard);
+      if (result->IsValid())
+      {
+        bool const isCurrentResult = m_router == router && m_delegateProxy == delegateProxy && !m_clearState;
+        m_cachedRoutesId = isCurrentResult && code == RouterResultCode::NoError ? routeId : 0;
+      }
+      m_isCalculating = false;
+    });
+
     LOG(LINFO, ("Calculating the route of direct length", checkpoints.GetSummaryLengthBetweenPointsMeters(),
                 "m. checkpoints:", checkpoints, "startDirection:", startDirection, "router name:", router->GetName()));
 

--- a/libs/routing/async_router.hpp
+++ b/libs/routing/async_router.hpp
@@ -53,7 +53,9 @@ public:
   /// Interrupt routing and clear buffers
   void ClearState();
   /// Forward to the underlying IRouter. See IRouter::SwapAltRouteToActive.
-  void SwapAltRouteToActive();
+  /// @return false if there is no router, a calculation is running, or |routesId| does not identify
+  ///         the result whose adjustment state is currently cached by the router.
+  bool SwapAltRouteToActive(uint64_t routesId);
 
   bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
                                    EdgeProj & proj);
@@ -115,6 +117,11 @@ private:
   m2::PointD m_startDirection = m2::PointD::Zero();
   bool m_adjustToPrevRoute = false;
   bool m_needAlternatives = true;
+  /// True while the routing thread has exclusive ownership of the router for a calculation request.
+  bool m_isCalculating = false;
+  /// Id of the valid result represented by the router's adjustment caches, or 0 when they cannot
+  /// safely be associated with a delivered result. A calculation without a route keeps it.
+  uint64_t m_cachedRoutesId = 0;
   std::shared_ptr<RouterDelegateProxy> m_delegateProxy;
   std::shared_ptr<AbsentRegionsFinder> m_absentRegionsFinder;
   std::shared_ptr<IRouter> m_router;

--- a/libs/routing/routing_session.cpp
+++ b/libs/routing/routing_session.cpp
@@ -576,6 +576,11 @@ bool RoutingSession::SwapActiveAlternative(size_t idx)
   if (!m_lastResult || idx >= m_lastResult->m_routes.size() || idx == m_lastResult->m_activeIdx)
     return false;
 
+  // Ask the router first so its adjustment caches and the session switch atomically from the same
+  // route generation.
+  if (!m_router->SwapAltRouteToActive(m_lastResult->m_routesId))
+    return false;
+
   m_lastResult->m_activeIdx = idx;
   // Promote the newly-active RouteBase to a followed Route, preserving the session's routing settings.
   auto route = std::make_shared<Route>(m_lastResult->GetActive());
@@ -594,8 +599,6 @@ bool RoutingSession::SwapActiveAlternative(size_t idx)
 
   m_speedCameraManager.Reset();
   m_speedCameraManager.SetRoute(m_route);
-  if (m_router)
-    m_router->SwapAltRouteToActive();
   return true;
 }
 

--- a/libs/routing/routing_session.hpp
+++ b/libs/routing/routing_session.hpp
@@ -151,8 +151,9 @@ public:
   void AssignRouteForTesting(Route && route, RouterResultCode e);
 
   /// \brief Swap the currently active route to alternative |idx| inside m_lastResult.
-  /// Used when the user taps an alternative ETA balloon. Returns false if the index is out of range
-  /// or already active. The follow state (m_route) is rebuilt from the newly-promoted RouteBase.
+  /// Used when the user taps an alternative ETA balloon. Returns false if the index is out of range,
+  /// already active, or the router refuses the swap (it is calculating, or the result is stale).
+  /// The follow state (m_route) is rebuilt from the newly-promoted RouteBase.
   bool SwapActiveAlternative(size_t idx);
 
   bool IsSpeedCamLimitExceeded() const { return m_speedCameraManager.IsSpeedLimitExceeded(); }

--- a/libs/routing/routing_tests/async_router_test.cpp
+++ b/libs/routing/routing_tests/async_router_test.cpp
@@ -1,10 +1,17 @@
 #include "testing/testing.hpp"
 
+#include "routing/async_router.hpp"
 #include "routing/route.hpp"
 #include "routing/router.hpp"
 #include "routing/routing_callbacks.hpp"
 
+#include "routing/routing_tests/tools.hpp"
+
+#include "base/scope_guard.hpp"
+
+#include <chrono>
 #include <condition_variable>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -131,4 +138,188 @@ struct DummyRoutingCallbacks
 //  TEST_EQUAL(resultCallback.m_absent.size(), 1, ());
 //  TEST(resultCallback.m_absent[0].empty(), ());
 //}
+// Straight route through the checkpoints, enough for a valid RoutesResult.
+Route MakeValidRoute(Checkpoints const & checkpoints)
+{
+  auto const & points = checkpoints.GetPoints();
+  Route route;
+  route.SetGeometry(points.cbegin(), points.cend());
+  vector<RouteSegment> segments;
+  RouteSegmentsFrom({}, points, {}, {}, segments);
+  route.SetRouteSegments(std::move(segments));
+  route.SetSubroutes(vector<Route::SubrouteAttrs>{Route::SubrouteAttrs(
+      geometry::PointWithAltitude(points.front(), geometry::kDefaultAltitudeMeters),
+      geometry::PointWithAltitude(points.back(), geometry::kDefaultAltitudeMeters), 0, points.size() - 1)});
+  return route;
+}
+
+// Parks inside CalculateRoute until the test releases it and records direct router calls.
+class BlockingRouter : public IRouter
+{
+public:
+  string GetName() const override { return "blocking"; }
+  void ClearState() override {}
+  void SetGuides(GuidesTracks && /* guides */) override {}
+  void SwapAltRouteToActive() override { ++m_swaps; }
+
+  RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & /* startDirection */,
+                                  bool /* adjustToPrevRoute */, bool /* needAlternatives */,
+                                  RouterDelegate const & /* delegate */, RoutesResult & result) override
+  {
+    Notify(m_started);
+    {
+      unique_lock l(m_mutex);
+      m_cv.wait(l, [this] { return m_release; });
+    }
+
+    result.MakeFrom(GetName(), MakeValidRoute(checkpoints));
+    return RouterResultCode::NoError;
+  }
+
+  bool FindClosestProjectionToRoad(m2::PointD const & /* point */, m2::PointD const & /* direction */,
+                                   double /* radius */, EdgeProj & /* proj */) override
+  {
+    ++m_projections;
+    return false;
+  }
+
+  bool WaitStarted(std::chrono::seconds timeout)
+  {
+    unique_lock l(m_mutex);
+    return m_cv.wait_for(l, timeout, [this] { return m_started; });
+  }
+
+  void Release() { Notify(m_release); }
+
+  size_t m_swaps = 0;
+  size_t m_projections = 0;
+
+private:
+  void Notify(bool & flag)
+  {
+    {
+      lock_guard l(m_mutex);
+      flag = true;
+    }
+    m_cv.notify_all();
+  }
+
+  mutex m_mutex;
+  condition_variable m_cv;
+  bool m_started = false;
+  bool m_release = false;
+};
+
+// IRouter::CalculateRoute runs without m_guard and mutates state also used by the synchronous
+// gui-thread entry points, so AsyncRouter must reject those calls until the result is ready.
+UNIT_CLASS_TEST(AsyncGuiThreadTest, RouterCallsWhileCalculating)
+{
+  auto router = make_unique<BlockingRouter>();
+  auto * blocking = router.get();
+
+  // The gui thread outlives the test body, so the ready callback must not capture a local by
+  // reference: a TEST throwing above would leave it pointing at a destroyed promise.
+  auto readyPromise = make_shared<promise<uint64_t>>();
+  auto readyFuture = readyPromise->get_future();
+
+  AsyncRouter async(nullptr /* pointCheckCallback */);
+  async.SetRouter(std::move(router), nullptr /* absentRegionsFinder */);
+  async.CalculateRoute(Checkpoints({1, 2} /* start */, {5, 6} /* finish */), {3, 4} /* direction */,
+                       false /* adjustToPrevRoute */,
+                       true /* needAlternatives */, [readyPromise](shared_ptr<RoutesResult> result, RouterResultCode) {
+    readyPromise->set_value(result->m_routesId);
+  }, nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */, nullptr /* progressCallback */);
+
+  // ~AsyncRouter joins the routing thread, so the router must be let go even if a TEST throws.
+  SCOPE_GUARD(releaseRouter, [blocking] { blocking->Release(); });
+  TEST(blocking->WaitStarted(std::chrono::seconds(30)), ("Route calculation did not start."));
+
+  EdgeProj proj;
+  m2::PointD const point(1.0, 2.0);
+  m2::PointD const direction(0.0, 1.0);
+
+  TEST(!async.SwapAltRouteToActive(1), ("The swap must not touch a calculating router."));
+  TEST_EQUAL(blocking->m_swaps, 0, ());
+  TEST(!async.FindClosestProjectionToRoad(point, direction, 50.0 /* radius */, proj),
+       ("The projection lookup must not touch a calculating router."));
+  TEST_EQUAL(blocking->m_projections, 0, ());
+
+  blocking->Release();
+  TEST(readyFuture.wait_for(std::chrono::seconds(30)) == future_status::ready, ("Route was not built."));
+  auto const routesId = readyFuture.get();
+
+  TEST(!async.SwapAltRouteToActive(routesId + 1), ("A stale result must not swap the router caches."));
+  TEST_EQUAL(blocking->m_swaps, 0, ());
+  TEST(async.SwapAltRouteToActive(routesId), ("The ready result must swap."));
+  TEST_EQUAL(blocking->m_swaps, 1, ());
+  // The mock finds nothing, the point is that the call reaches it now.
+  async.FindClosestProjectionToRoad(point, direction, 50.0 /* radius */, proj);
+  TEST_EQUAL(blocking->m_projections, 1, ("An idle router must answer the projection lookup."));
+}
+
+// Builds the first route, fails every later calculation and records alternative swaps.
+class FailingRebuildRouter : public IRouter
+{
+public:
+  string GetName() const override { return "failing rebuild"; }
+  void ClearState() override {}
+  void SetGuides(GuidesTracks && /* guides */) override {}
+  void SwapAltRouteToActive() override { ++m_swaps; }
+
+  RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & /* startDirection */,
+                                  bool /* adjustToPrevRoute */, bool /* needAlternatives */,
+                                  RouterDelegate const & /* delegate */, RoutesResult & result) override
+  {
+    if (m_calculations++ > 0)
+      return RouterResultCode::RouteNotFound;
+
+    result.MakeFrom(GetName(), MakeValidRoute(checkpoints));
+    return RouterResultCode::NoError;
+  }
+
+  bool FindClosestProjectionToRoad(m2::PointD const & /* point */, m2::PointD const & /* direction */,
+                                   double /* radius */, EdgeProj & /* proj */) override
+  {
+    return false;
+  }
+
+  size_t m_swaps = 0;
+
+private:
+  size_t m_calculations = 0;
+};
+
+// A failed rebuild leaves the previous result and its alternatives on screen (RoutingManager rebuilds
+// without a remove callback), so the alternatives of that result must stay selectable.
+UNIT_CLASS_TEST(AsyncGuiThreadTest, SwapAfterFailedCalculation)
+{
+  auto router = make_unique<FailingRebuildRouter>();
+  auto * failing = router.get();
+
+  AsyncRouter async(nullptr /* pointCheckCallback */);
+  async.SetRouter(std::move(router), nullptr /* absentRegionsFinder */);
+
+  // Promises are shared with the callbacks: the gui thread outlives the test body.
+  auto readyPromise = make_shared<promise<uint64_t>>();
+  auto readyFuture = readyPromise->get_future();
+  async.CalculateRoute(Checkpoints({1, 2} /* start */, {5, 6} /* finish */), {3, 4} /* direction */,
+                       false /* adjustToPrevRoute */,
+                       true /* needAlternatives */, [readyPromise](shared_ptr<RoutesResult> result, RouterResultCode) {
+    readyPromise->set_value(result->m_routesId);
+  }, nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */, nullptr /* progressCallback */);
+  TEST(readyFuture.wait_for(std::chrono::seconds(30)) == future_status::ready, ("Route was not built."));
+  auto const routesId = readyFuture.get();
+
+  // The remove callback only tells the test that the rebuild is over.
+  auto failedPromise = make_shared<promise<void>>();
+  auto failedFuture = failedPromise->get_future();
+  async.CalculateRoute(Checkpoints({1, 2} /* start */, {5, 6} /* finish */), {3, 4} /* direction */,
+                       true /* adjustToPrevRoute */, true /* needAlternatives */, nullptr /* readyCallback */,
+                       nullptr /* needMoreMapsCallback */, [failedPromise](RouterResultCode)
+  { failedPromise->set_value(); }, nullptr /* progressCallback */);
+  TEST(failedFuture.wait_for(std::chrono::seconds(30)) == future_status::ready, ("Rebuild did not finish."));
+
+  TEST(async.SwapAltRouteToActive(routesId), ("The failed rebuild left this result on screen."));
+  TEST_EQUAL(failing->m_swaps, 1, ());
+}
 }  //  namespace async_router_test


### PR DESCRIPTION
`AsyncRouter` releases `m_guard` before calling `IRouter::CalculateRoute`, so the lock protects the router pointer but not mutable router state. Two synchronous gui-thread calls could therefore overlap route calculation:

- `SwapAltRouteToActive()` exchanged `IndexRouter`'s active/alternative adjustment caches while calculation rewrote them.
- `FindClosestProjectionToRoad()` read road-graph and vehicle-model caches while calculation filled or cleared them. A direct stress repro on master aborted in `FeaturesRoadGraphBase::ExtractRoadInfo` in 3 of 5 runs; Release has no bound check at that write.

## What changed

`AsyncRouter` marks the underlying router exclusively owned for the whole calculation request. Alternative swaps and road projections are refused while it is owned; the check and synchronous call stay under `m_guard`, so calculation cannot start between them.

Alternative swaps also carry the displayed `routesId`. When a calculation produces a route, `AsyncRouter` publishes its cache generation together with the idle state, or invalidates it if the request was replaced or cleared meanwhile. A stale gui result therefore cannot swap caches belonging to a newer result during the worker-to-gui callback window.

A calculation that produces no route keeps the generation. The gui still shows the previous result with its alternatives (`RoutingManager` rebuilds without a remove callback), and routers store adjustment caches only together with a new route, so those alternatives stay selectable after a failed rebuild.

`RoutingSession::SwapActiveAlternative()` asks the router first and changes its active route only after the router accepts the same generation, so the two layers cannot be left half-switched.

A refused road projection leaves that location update unsnapped. Making `FeaturesRoadGraphBase` independently thread-safe would require holding its cache lock while parsing geometry and would still leave other router state shared.

## Alternative architecture

#13520 removes previous-route adjustment caches from `IndexRouter` entirely. Each returned route owns an immutable adjustment context, and `RoutingSession` passes the selected route's context into the next rebuild. It is a broader API refactor, but removes alternative cache swapping and generation bookkeeping by construction. The two PRs are independent alternatives for review.

## Testing

- `routing_tests` (Debug); `async_router_test` repeated 100 times.
- `RouterCallsWhileCalculating` parks a valid mock result inside `CalculateRoute`, checks that both synchronous calls are refused while the router is owned, that a wrong result generation is refused afterward, and that normal calls work once the matching result is ready.
- `SwapAfterFailedCalculation` builds a route, fails the rebuild and checks that the displayed result can still swap. It fails if a failed calculation drops the generation.
