### PR TITLE
[routing] Continue multi-route search after queue exhaustion

### DIFF
--- a/libs/routing/base/astar_algorithm.hpp
+++ b/libs/routing/base/astar_algorithm.hpp
@@ -179,7 +179,8 @@ public:
   template <typename P>
   Result FindPath(P & params, RoutingResult<Vertex, Weight> & result) const;
 
-  /// Fetch routes until \a emitter returns false.
+  /// Fetch routes until \a emitter returns true or the search is exhausted.
+  /// The same route may be emitted more than once, the emitter is expected to filter duplicates.
   template <class P, class Emitter>
   Result FindPathBidirectionalEx(P & params, Emitter && emitter) const;
 
@@ -534,6 +535,7 @@ typename AStarAlgorithm<Vertex, Edge, Weight>::Result AStarAlgorithm<Vertex, Edg
   auto & backwardParents = backward.GetParents();
 
   bool foundAnyPath = false;
+  bool foundAnyPathEver = false;
   Weight bestPathReducedLength = kZeroDistance;
   Weight bestPathRealLength = kZeroDistance;
 
@@ -550,31 +552,32 @@ typename AStarAlgorithm<Vertex, Edge, Weight>::Result AStarAlgorithm<Vertex, Edg
   BidirectionalStepContext * cur = &forward;
   BidirectionalStepContext * nxt = &backward;
 
-  auto const EmitResult = [cur, nxt, &bestPathRealLength, &emitter]()
+  auto const EmitResult = [&forward, &backward, &bestPathRealLength, &emitter]()
   {
     // No problem if length check fails, but we still emit the result.
     // Happens with "transit" route because of length, haven't seen with regular car route.
     // ASSERT(params.m_checkLengthCallback(bestPathRealLength), ());
 
     RoutingResult<Vertex, Weight> result;
-    ReconstructPathBidirectional(cur->bestVertex, nxt->bestVertex, cur->parent, nxt->parent, result.m_path);
+    ReconstructPathBidirectional(forward.bestVertex, backward.bestVertex, forward.parent, backward.parent,
+                                 result.m_path);
     result.m_distance = bestPathRealLength;
-    if (!cur->forward)
-      reverse(result.m_path.begin(), result.m_path.end());
-
     return emitter(std::move(result));
   };
 
   typename Graph::EdgeListT adj;
 
-  // It is not necessary to check emptiness for both queues here
-  // because if we have not found a path by the time one of the
-  // queues is exhausted, we never will.
+  // Before the first result, exhausting either queue proves that there is no path. If the emitter requests more
+  // results, the remaining wave may still find alternatives by meeting vertices already visited by the exhausted
+  // wave, so continue until both queues are empty.
   uint32_t steps = 0;
   PeriodicPollCancellable periodicCancellable(params.m_cancellable);
 
-  while (!cur->queue.empty() && !nxt->queue.empty())
+  while (!forward.queue.empty() || !backward.queue.empty())
   {
+    if (!foundAnyPathEver && (forward.queue.empty() || backward.queue.empty()))
+      break;
+
     ++steps;
 
     if (periodicCancellable.IsCancelled())
@@ -583,11 +586,11 @@ typename AStarAlgorithm<Vertex, Edge, Weight>::Result AStarAlgorithm<Vertex, Edg
     if (steps % kQueueSwitchPeriod == 0)
       std::swap(cur, nxt);
 
+    if (cur->queue.empty())
+      std::swap(cur, nxt);
+
     if (foundAnyPath)
     {
-      auto const curTop = cur->TopDistance();
-      auto const nxtTop = nxt->TopDistance();
-
       // The intuition behind this is that we cannot obtain a path shorter
       // than the left side of the inequality because that is how any path we find
       // will look like (see comment for curPathReducedLength below).
@@ -599,7 +602,8 @@ typename AStarAlgorithm<Vertex, Edge, Weight>::Result AStarAlgorithm<Vertex, Edg
       // several top states in a priority queue may have equal reduced path lengths and
       // different real path lengths.
 
-      if (curTop + nxtTop >= bestPathReducedLength - epsilon)
+      // With no opposite frontier, emit immediately so that later, possibly longer candidates can be considered.
+      if (nxt->queue.empty() || cur->TopDistance() + nxt->TopDistance() >= bestPathReducedLength - epsilon)
       {
         if (EmitResult())
           return Result::OK;
@@ -666,7 +670,7 @@ typename AStarAlgorithm<Vertex, Edge, Weight>::Result AStarAlgorithm<Vertex, Edg
           bestPathRealLength += cur->pS - pV;
           bestPathRealLength += nxt->pS - nxt->ConsistentHeuristic(stateW.vertex);
 
-          foundAnyPath = true;
+          foundAnyPath = foundAnyPathEver = true;
           cur->bestVertex = stateV.vertex;
           nxt->bestVertex = stateW.vertex;
         }
@@ -678,12 +682,9 @@ typename AStarAlgorithm<Vertex, Edge, Weight>::Result AStarAlgorithm<Vertex, Edg
   }
 
   if (foundAnyPath)
-  {
     (void)EmitResult();
-    return Result::OK;
-  }
 
-  return Result::NoPath;
+  return foundAnyPathEver ? Result::OK : Result::NoPath;
 }
 
 template <typename Vertex, typename Edge, typename Weight>

--- a/libs/routing/routing_integration_tests/route_test.cpp
+++ b/libs/routing/routing_integration_tests/route_test.cpp
@@ -11,7 +11,13 @@
 
 #include "geometry/mercator.hpp"
 
+#include "base/stl_helpers.hpp"
+
+#include <algorithm>
 #include <limits>
+#include <set>
+#include <string>
+#include <vector>
 
 namespace route_test
 {
@@ -159,6 +165,36 @@ UNIT_TEST(GermanyToTallinCrossMwmRoute)
 {
   CalculateRouteAndTestRouteLength(GetVehicleComponents(VehicleType::Car), FromLatLon(48.397416, 16.515289), {0.0, 0.0},
                                    FromLatLon(59.437214, 24.745355), 1650000.);
+}
+
+// https://github.com/organicmaps/organicmaps/issues/13346
+UNIT_TEST(Canada_Lethbridge_Inuvik_NoBacktrack)
+{
+  std::set<std::string> const mwmNames = {
+      "Canada_Alberta_Edmonton",
+      "Canada_Alberta_North",
+      "Canada_Alberta_South",
+      "Canada_British Columbia_Central",
+      "Canada_British Columbia_Far_North",
+      "Canada_British Columbia_North",
+      "Canada_British Columbia_Northeast",
+      "Canada_Northwest Territories_North",
+      "Canada_Yukon_North",
+      "Canada_Yukon_Whitehorse",
+  };
+
+  // Keep the complete dataset on disk and register only the maps needed for this route in a dedicated router.
+  std::vector<LocalCountryFile> localFiles;
+  GetAllLocalFiles(localFiles);
+  base::EraseIf(localFiles,
+                [&mwmNames](LocalCountryFile const & file) { return !mwmNames.contains(file.GetCountryName()); });
+  TEST_EQUAL(localFiles.size(), mwmNames.size(), (mwmNames));
+  std::sort(localFiles.begin(), localFiles.end(), [](LocalCountryFile const & lhs, LocalCountryFile const & rhs)
+  { return lhs.GetCountryName() < rhs.GetCountryName(); });
+
+  VehicleRouterComponents components(localFiles, VehicleType::Car);
+  CalculateRouteAndTestRouteLength(components, FromLatLon(49.6956, -112.8451), {0., 0.}, FromLatLon(68.3607, -133.7230),
+                                   3'717'609, 0.05);
 }
 
 UNIT_TEST(Russia_Moscow_Leningradskiy39RepublicOfSouthAfricaCapeTownCenterRouteTest)

--- a/libs/routing/routing_tests/astar_algorithm_test.cpp
+++ b/libs/routing/routing_tests/astar_algorithm_test.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <map>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -50,6 +51,42 @@ UNIT_TEST(AStarAlgorithm_Sample)
   vector<unsigned> const expectedRoute = {0, 1, 2, 3, 4};
 
   TestAStar(graph, expectedRoute, 23);
+}
+
+UNIT_TEST(AStarAlgorithm_BidirectionalMultipleRoutesAfterQueueExhaustion)
+{
+  UndirectedGraph graph;
+
+  // The forward wave exhausts this small graph before the periodic direction switch. The backward wave must still
+  // run after the first route is emitted to discover the second route.
+  graph.AddEdge(0, 1, 1);
+  graph.AddEdge(1, 4, 1);
+  graph.AddEdge(0, 2, 1);
+  graph.AddEdge(2, 3, 1);
+  graph.AddEdge(3, 4, 1);
+
+  Algorithm algo;
+  Algorithm::ParamsForTests<> params(graph, 0u /* startVertex */, 4u /* finishVertex */);
+
+  set<vector<unsigned>> routes;
+  auto const result = algo.FindPathBidirectionalEx(params, [&routes](RoutingResult<unsigned, double> && route)
+  {
+    // Different meeting points may reconstruct the same route.
+    routes.insert(std::move(route.m_path));
+    return routes.size() == 2;
+  });
+
+  TEST_EQUAL(result, Algorithm::Result::OK, ());
+  TEST_EQUAL(routes, (set<vector<unsigned>>{{0, 1, 4}, {0, 2, 3, 4}}), ());
+
+  routes.clear();
+  auto const exhaustiveResult = algo.FindPathBidirectionalEx(params, [&routes](RoutingResult<unsigned, double> && route)
+  {
+    routes.insert(std::move(route.m_path));
+    return false;
+  });
+  TEST_EQUAL(exhaustiveResult, Algorithm::Result::OK, ());
+  TEST_EQUAL(routes, (set<vector<unsigned>>{{0, 1, 4}, {0, 2, 3, 4}}), ());
 }
 
 UNIT_TEST(AStarAlgorithm_CheckLength)


### PR DESCRIPTION
Continue the surviving A* wave when the emitter asks for more routes. It can still meet vertices visited by the exhausted wave.

Fixes: #13346

Validation:

- Regression test fails on the original implementation and passes with the fix.
- Complete routing_tests suite passes.
- Lethbridge–Inuvik with only the ten required July 2026 maps:
    - 3,717.609 km
    - 50.024 hours
    - 27,299 polyline points
    - Zero repeated points