### PR TITLE
[routing] Keep adjustment state with route results

### DIFF
--- a/libs/routing/CMakeLists.txt
+++ b/libs/routing/CMakeLists.txt
@@ -130,6 +130,7 @@ set(SRC
   road_point.hpp
   route.cpp
   route.hpp
+  route_adjustment_context.hpp
   route_point.hpp
   route_weight.cpp
   route_weight.hpp

--- a/libs/routing/async_router.cpp
+++ b/libs/routing/async_router.cpp
@@ -4,6 +4,7 @@
 
 #include "base/logging.hpp"
 #include "base/macros.hpp"
+#include "base/scope_guard.hpp"
 #include "base/timer.hpp"
 
 #include <functional>
@@ -75,7 +76,12 @@ void AsyncRouter::RouterDelegateProxy::Cancel()
 bool AsyncRouter::FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
                                               EdgeProj & proj)
 {
-  /// @todo No need to put a lock_guard at first glance. May be wrong ..
+  lock_guard ul(m_guard);
+  // The road graph caches are calculation scratch state and cannot be read while CalculateRoute
+  // fills and clears them on the routing thread.
+  if (!m_router || m_isCalculating)
+    return false;
+
   return m_router->FindClosestProjectionToRoad(point, direction, radius, proj);
 }
 
@@ -156,7 +162,8 @@ void AsyncRouter::SetRouter(std::unique_ptr<IRouter> && router, std::unique_ptr<
   m_absentRegionsFinder = std::move(finder);
 }
 
-void AsyncRouter::CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & direction, bool adjustToPrevRoute,
+void AsyncRouter::CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & direction,
+                                 RouteAdjustmentContextPtr adjustmentContext,
                                  ReadyCallbackOwnership const & readyCallback,
                                  NeedMoreMapsCallback const & needMoreMapsCallback,
                                  RemoveRouteCallback const & removeRouteCallback,
@@ -166,7 +173,7 @@ void AsyncRouter::CalculateRoute(Checkpoints const & checkpoints, m2::PointD con
 
   m_checkpoints = checkpoints;
   m_startDirection = direction;
-  m_adjustToPrevRoute = adjustToPrevRoute;
+  m_adjustmentContext = std::move(adjustmentContext);
 
   ResetDelegate();
 
@@ -191,13 +198,6 @@ void AsyncRouter::ClearState()
   m_threadCondVar.notify_one();
 
   ResetDelegate();
-}
-
-void AsyncRouter::SwapAltRouteToActive()
-{
-  lock_guard ul(m_guard);
-  if (m_router)
-    m_router->SwapAltRouteToActive();
 }
 
 // static
@@ -271,7 +271,7 @@ void AsyncRouter::CalculateRoute()
   Checkpoints checkpoints;
   std::shared_ptr<RouterDelegateProxy> delegateProxy;
   m2::PointD startDirection;
-  bool adjustToPrevRoute = false;
+  RouteAdjustmentContextPtr adjustmentContext;
   std::shared_ptr<AbsentRegionsFinder> absentRegionsFinder;
   std::shared_ptr<IRouter> router;
   uint64_t routeId = 0;
@@ -291,7 +291,7 @@ void AsyncRouter::CalculateRoute()
 
     checkpoints = m_checkpoints;
     startDirection = m_startDirection;
-    adjustToPrevRoute = m_adjustToPrevRoute;
+    adjustmentContext = std::move(m_adjustmentContext);
     delegateProxy = m_delegateProxy;
     router = m_router;
     absentRegionsFinder = m_absentRegionsFinder;
@@ -299,6 +299,7 @@ void AsyncRouter::CalculateRoute()
     routerName = router->GetName();
     router->SetGuides(std::move(m_guides));
     m_guides.clear();
+    m_isCalculating = true;
   }
 
   auto result = std::make_shared<RoutesResult>(router->GetName(), routeId);
@@ -309,6 +310,12 @@ void AsyncRouter::CalculateRoute()
 
   try
   {
+    SCOPE_GUARD(routerIdle, [&]
+    {
+      lock_guard ul(m_guard);
+      m_isCalculating = false;
+    });
+
     LOG(LINFO, ("Calculating the route of direct length", checkpoints.GetSummaryLengthBetweenPointsMeters(),
                 "m. checkpoints:", checkpoints, "startDirection:", startDirection, "router name:", router->GetName()));
 
@@ -319,7 +326,7 @@ void AsyncRouter::CalculateRoute()
     if (code == RouterResultCode::NoError)
     {
       code =
-          router->CalculateRoute(checkpoints, startDirection, adjustToPrevRoute, delegateProxy->GetDelegate(), *result);
+          router->CalculateRoute(checkpoints, startDirection, adjustmentContext, delegateProxy->GetDelegate(), *result);
     }
 
     router->SetGuides({});

--- a/libs/routing/async_router.hpp
+++ b/libs/routing/async_router.hpp
@@ -36,22 +36,22 @@ public:
   ///
   /// @param checkpoints start, finish and intermadiate points
   /// @param direction start direction for routers with high cost of the turnarounds
-  /// @param adjustToPrevRoute adjust route to the previous one if possible
+  /// @param adjustmentContext state returned with the route selected for adjustment; null requests
+  ///                          a full route calculation
   /// @param readyCallback function to return routing result
   /// @param progressCallback function to update the router progress
   /// @param timeoutSec timeout to cancel routing. 0 is infinity.
   // @TODO(bykoianko) Gather |readyCallback|, |needMoreMapsCallback| and |removeRouteCallback|
   // to one delegate. No need to add |progressCallback| to the delegate.
-  void CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & direction, bool adjustToPrevRoute,
-                      ReadyCallbackOwnership const & readyCallback, NeedMoreMapsCallback const & needMoreMapsCallback,
+  void CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & direction,
+                      RouteAdjustmentContextPtr adjustmentContext, ReadyCallbackOwnership const & readyCallback,
+                      NeedMoreMapsCallback const & needMoreMapsCallback,
                       RemoveRouteCallback const & removeRouteCallback, ProgressCallback const & progressCallback,
                       uint32_t timeoutSec = RouterDelegate::kNoTimeout);
 
   void SetGuidesTracks(GuidesTracks && guides);
   /// Interrupt routing and clear buffers
   void ClearState();
-  /// Forward to the underlying IRouter. See IRouter::SwapAltRouteToActive.
-  void SwapAltRouteToActive();
 
   bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
                                    EdgeProj & proj);
@@ -111,7 +111,9 @@ private:
   GuidesTracks m_guides;
 
   m2::PointD m_startDirection = m2::PointD::Zero();
-  bool m_adjustToPrevRoute = false;
+  RouteAdjustmentContextPtr m_adjustmentContext;
+  /// True while the routing thread has exclusive ownership of the router for a calculation request.
+  bool m_isCalculating = false;
   std::shared_ptr<RouterDelegateProxy> m_delegateProxy;
   std::shared_ptr<AbsentRegionsFinder> m_absentRegionsFinder;
   std::shared_ptr<IRouter> m_router;

--- a/libs/routing/index_router.cpp
+++ b/libs/routing/index_router.cpp
@@ -361,19 +361,6 @@ void IndexRouter::ClearRouteCalculationState()
 void IndexRouter::ClearState()
 {
   ClearRouteCalculationState();
-
-  // Drop the adjust-cache for both the active and the alternative route so a later (re)build
-  // can't accidentally AdjustRoute against state from a cancelled session.
-  m_lastRoute.reset();
-  m_lastFakeEdges.reset();
-  m_lastAltRoute.reset();
-  m_lastAltFakeEdges.reset();
-}
-
-void IndexRouter::SwapAltRouteToActive()
-{
-  std::swap(m_lastRoute, m_lastAltRoute);
-  std::swap(m_lastFakeEdges, m_lastAltFakeEdges);
 }
 
 bool IndexRouter::FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
@@ -420,14 +407,16 @@ void IndexRouter::SetGuides(GuidesTracks && guides)
 }
 
 RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                             bool adjustToPrevRoute, RouterDelegate const & delegate,
-                                             RoutesResult & result)
+                                             RouteAdjustmentContextPtr const & adjustmentContext,
+                                             RouterDelegate const & delegate, RoutesResult & result)
 {
   auto const & startPoint = checkpoints.GetStart();
   auto const & finalPoint = checkpoints.GetFinish();
 
   Route route;
   Route altRoute;
+  RouteAdjustmentContextPtr routeAdjustmentContext;
+  RouteAdjustmentContextPtr altAdjustmentContext;
   RouterResultCode code;
   RouterResultCode altCode = RouterResultCode::RouteNotFound;
 
@@ -435,26 +424,32 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
   {
     SCOPE_GUARD(featureRoadGraphClear, [this] { ClearRouteCalculationState(); });
 
+    auto const previous = std::dynamic_pointer_cast<AdjustmentContext const>(adjustmentContext);
+    ASSERT(!adjustmentContext || previous, ("Unexpected route adjustment context for", GetName()));
     bool doCalculate = true;
-    if (adjustToPrevRoute && m_lastRoute && m_lastFakeEdges && finalPoint == m_lastRoute->GetFinish())
+    if (previous && finalPoint == previous->GetRoute().GetFinish())
     {
-      double const distanceToRoute = m_lastRoute->CalcDistance(startPoint);
+      double const distanceToRoute = previous->GetRoute().CalcDistance(startPoint);
       double const distanceToFinish = mercator::DistanceOnEarth(startPoint, finalPoint);
       if (distanceToRoute <= kAdjustRangeM && distanceToFinish >= kMinDistanceToFinishM)
       {
-        code = AdjustRoute(checkpoints, startDirection, delegate, route);
+        code = AdjustRoute(checkpoints, startDirection, *previous, delegate, route);
         if (code != RouterResultCode::RouteNotFound)
+        {
           doCalculate = false;
+          if (code == RouterResultCode::NoError)
+            routeAdjustmentContext = adjustmentContext;
+        }
         else
           LOG(LWARNING,
-              ("Can't adjust route, do full rebuild, prev start:", mercator::ToLatLon(m_lastRoute->GetStart()),
+              ("Can't adjust route, do full rebuild, prev start:", mercator::ToLatLon(previous->GetRoute().GetStart()),
                "start:", mercator::ToLatLon(startPoint), "finish:", mercator::ToLatLon(finalPoint)));
       }
     }
 
     if (doCalculate)
     {
-      code = DoCalculateRoute(checkpoints, startDirection, delegate, route);
+      code = DoCalculateRoute(checkpoints, startDirection, delegate, route, routeAdjustmentContext);
 
       // Compute an alternative alongside the Normal route. Only on a full (non-adjust) build and only
       // within a reasonable distance budget — the alternative search costs about 0.5-1x of the
@@ -466,19 +461,10 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
       if ((code == RouterResultCode::NoError || code == RouterResultCode::HasWarnings) && !delegate.IsCancelled() &&
           mercator::DistanceOnEarth(startPoint, finalPoint) <= altMaxDistanceM)
       {
-        // Save the Normal route's adjust-cache; the alternative computation would overwrite it.
-        auto savedLastRoute = std::move(m_lastRoute);
-        auto savedLastFakeEdges = std::move(m_lastFakeEdges);
         SCOPE_GUARD(restoreNormal, [&]
         {
           m_estimator->SetStrategy(EdgeEstimator::Strategy::Normal);
           m_estimator->SetTransitAltFactors(1.0, 1.0);
-          // Save the alternative route's adjust-cache.
-          m_lastAltRoute = std::move(m_lastRoute);
-          m_lastAltFakeEdges = std::move(m_lastFakeEdges);
-          // Restore the Normal cache.
-          m_lastRoute = std::move(savedLastRoute);
-          m_lastFakeEdges = std::move(savedLastFakeEdges);
         });
 
         if (m_vehicleType == VehicleType::Transit)
@@ -493,7 +479,7 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
           m_estimator->SetStrategy(EdgeEstimator::Strategy::DistanceBiased,
                                    !m_guides.IsAttached() /* tightHeuristicAllowed */);
         }
-        altCode = DoCalculateRoute(checkpoints, startDirection, delegate, altRoute);
+        altCode = DoCalculateRoute(checkpoints, startDirection, delegate, altRoute, altAdjustmentContext);
       }
     }
   }
@@ -506,6 +492,7 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
 
   if (code == RouterResultCode::NoError || code == RouterResultCode::HasWarnings)
   {
+    ASSERT(routeAdjustmentContext, ());
     // Calculate middle point of the longest length-diff part. nullopt if routes are equal.
     // Transit is distinguished by fake transit (subway/bus) segments, so compare by geometry;
     // road vehicles compare by real-road feature identity.
@@ -518,9 +505,10 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
                        : altRoute.FindMaxDiffMidpoint(route.GetRouteSegments());
     }
 
-    result.MakeFrom(GetName(), std::move(route));
+    result.MakeFrom(GetName(), std::move(route), std::move(routeAdjustmentContext));
     if (diffMidpoint)
     {
+      ASSERT(altAdjustmentContext, ());
       // Set mid-points for both routes.
       altRoute.SetDiffMidpoint(*diffMidpoint);
 
@@ -531,14 +519,7 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
       if (diffMidpoint)
         active.SetDiffMidpoint(*diffMidpoint);
 
-      result.m_routes.emplace_back(std::move(static_cast<RouteBase &>(altRoute)));
-    }
-    else
-    {
-      // Alt isn't surfaced to the user — drop its adjust-cache so a stale state can't be
-      // promoted by a stray SwapAltRouteToActive.
-      m_lastAltRoute.reset();
-      m_lastAltFakeEdges.reset();
+      result.AddAlternative(std::move(altRoute), std::move(altAdjustmentContext));
     }
   }
 
@@ -679,10 +660,9 @@ void IndexRouter::AddGuidesOsmConnectionsToGraphStarter(size_t checkpointIdxFrom
 }
 
 RouterResultCode IndexRouter::DoCalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                               RouterDelegate const & delegate, Route & route)
+                                               RouterDelegate const & delegate, Route & route,
+                                               RouteAdjustmentContextPtr & adjustmentContext)
 {
-  m_lastRoute.reset();
-
   TrafficStash::Guard guard(m_trafficStash);
   std::unique_ptr<WorldGraph> graph = MakeWorldGraph();
 
@@ -830,11 +810,13 @@ RouterResultCode IndexRouter::DoCalculateRoute(Checkpoints const & checkpoints, 
 
   LOG(LINFO, ("Route length:", route.GetTotalDistanceMeters(), "meters. ETA:", route.GetTotalTimeSec(), "seconds."));
 
-  m_lastRoute = std::make_unique<SegmentedRoute>(checkpoints.GetStart(), checkpoints.GetFinish(), route.GetSubroutes());
+  auto segmentedRoute =
+      std::make_unique<SegmentedRoute>(checkpoints.GetStart(), checkpoints.GetFinish(), route.GetSubroutes());
   for (Segment const & segment : segments)
-    m_lastRoute->AddStep(segment, mercator::FromLatLon(starter->GetPoint(segment, true /* front */)));
+    segmentedRoute->AddStep(segment, mercator::FromLatLon(starter->GetPoint(segment, true /* front */)));
 
-  m_lastFakeEdges = std::make_unique<FakeEdgesContainer>(std::move(*starter));
+  auto fakeEdges = std::make_unique<FakeEdgesContainer>(std::move(*starter));
+  adjustmentContext = std::make_shared<AdjustmentContext>(std::move(segmentedRoute), std::move(fakeEdges));
 
   return RouterResultCode::NoError;
 }
@@ -1171,7 +1153,8 @@ RouterResultCode IndexRouter::CalculateSubrouteLeapsOnlyMode(Checkpoints const &
 }
 
 RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                          RouterDelegate const & delegate, Route & route)
+                                          AdjustmentContext const & adjustmentContext, RouterDelegate const & delegate,
+                                          Route & route)
 {
   base::Timer timer;
   TrafficStash::Guard guard(m_trafficStash);
@@ -1188,18 +1171,20 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints, m2::P
     return RouterResultCode::StartPointNotFound;
   }
 
-  auto const & lastSubroutes = m_lastRoute->GetSubroutes();
+  auto const & previousRoute = adjustmentContext.GetRoute();
+  auto const & previousFakeEdges = adjustmentContext.GetFakeEdges();
+  auto const & lastSubroutes = previousRoute.GetSubroutes();
   CHECK(!lastSubroutes.empty(), ());
-  auto const & lastSubroute = m_lastRoute->GetSubroute(checkpoints.GetPassedIdx());
+  auto const & lastSubroute = previousRoute.GetSubroute(checkpoints.GetPassedIdx());
 
-  auto const & steps = m_lastRoute->GetSteps();
+  auto const & steps = previousRoute.GetSteps();
   CHECK(!steps.empty(), ());
 
   FakeEnding dummy{};
-  IndexGraphStarter starter(MakeFakeEnding(startSegments, pointFrom, *graph), dummy, m_lastFakeEdges->GetNumFakeEdges(),
-                            bestSegmentIsAlmostCodirectional, *graph);
+  IndexGraphStarter starter(MakeFakeEnding(startSegments, pointFrom, *graph), dummy,
+                            previousFakeEdges.GetNumFakeEdges(), bestSegmentIsAlmostCodirectional, *graph);
 
-  starter.Append(*m_lastFakeEdges);
+  starter.Append(previousFakeEdges);
 
   std::vector<SegmentEdge> prevEdges;
   CHECK_LESS_OR_EQUAL(lastSubroute.GetEndSegmentIdx(), steps.size(), ());

--- a/libs/routing/index_router.cpp
+++ b/libs/routing/index_router.cpp
@@ -15,6 +15,7 @@
 #include "routing/mwm_hierarchy_handler.hpp"
 #include "routing/pedestrian_directions.hpp"
 #include "routing/route.hpp"
+#include "routing/route_adjustment_context.hpp"
 #include "routing/routing_helpers.hpp"
 #include "routing/routing_options.hpp"
 #include "routing/single_vehicle_world_graph.hpp"
@@ -351,16 +352,11 @@ std::unique_ptr<WorldGraph> IndexRouter::MakeSingleMwmWorldGraph()
   return worldGraph;
 }
 
-void IndexRouter::ClearRouteCalculationState()
+void IndexRouter::ClearState()
 {
   m_roadGraph.ClearState();
   m_directionsEngine->Clear();
   m_dataSource.FreeHandles();
-}
-
-void IndexRouter::ClearState()
-{
-  ClearRouteCalculationState();
 }
 
 bool IndexRouter::FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
@@ -422,10 +418,9 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
 
   try
   {
-    SCOPE_GUARD(featureRoadGraphClear, [this] { ClearRouteCalculationState(); });
+    SCOPE_GUARD(featureRoadGraphClear, [this] { ClearState(); });
 
-    auto const previous = std::dynamic_pointer_cast<AdjustmentContext const>(adjustmentContext);
-    ASSERT(!adjustmentContext || previous, ("Unexpected route adjustment context for", GetName()));
+    auto const previous = adjustmentContext.get();
     bool doCalculate = true;
     if (previous && finalPoint == previous->GetRoute().GetFinish())
     {
@@ -437,8 +432,12 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
         if (code != RouterResultCode::RouteNotFound)
         {
           doCalculate = false;
-          if (code == RouterResultCode::NoError)
+          if (code == RouterResultCode::NoError || code == RouterResultCode::HasWarnings)
+          {
+            // AdjustRoute intentionally reuses the full build's state. Successive adjustments
+            // therefore keep a stable baseline instead of chaining from earlier adjustments.
             routeAdjustmentContext = adjustmentContext;
+          }
         }
         else
           LOG(LWARNING,
@@ -816,7 +815,7 @@ RouterResultCode IndexRouter::DoCalculateRoute(Checkpoints const & checkpoints, 
     segmentedRoute->AddStep(segment, mercator::FromLatLon(starter->GetPoint(segment, true /* front */)));
 
   auto fakeEdges = std::make_unique<FakeEdgesContainer>(std::move(*starter));
-  adjustmentContext = std::make_shared<AdjustmentContext>(std::move(segmentedRoute), std::move(fakeEdges));
+  adjustmentContext = std::make_shared<RouteAdjustmentContext>(std::move(segmentedRoute), std::move(fakeEdges));
 
   return RouterResultCode::NoError;
 }
@@ -1153,8 +1152,8 @@ RouterResultCode IndexRouter::CalculateSubrouteLeapsOnlyMode(Checkpoints const &
 }
 
 RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                          AdjustmentContext const & adjustmentContext, RouterDelegate const & delegate,
-                                          Route & route)
+                                          RouteAdjustmentContext const & adjustmentContext,
+                                          RouterDelegate const & delegate, Route & route)
 {
   base::Timer timer;
   TrafficStash::Guard guard(m_trafficStash);

--- a/libs/routing/index_router.hpp
+++ b/libs/routing/index_router.hpp
@@ -107,25 +107,6 @@ public:
   }
 
 private:
-  class AdjustmentContext final : public RouteAdjustmentContext
-  {
-  public:
-    AdjustmentContext(std::unique_ptr<SegmentedRoute> route, std::unique_ptr<FakeEdgesContainer> fakeEdges)
-      : m_route(std::move(route))
-      , m_fakeEdges(std::move(fakeEdges))
-    {}
-
-    SegmentedRoute const & GetRoute() const { return *m_route; }
-    FakeEdgesContainer const & GetFakeEdges() const { return *m_fakeEdges; }
-
-  private:
-    std::unique_ptr<SegmentedRoute> const m_route;
-    std::unique_ptr<FakeEdgesContainer> const m_fakeEdges;
-  };
-
-  // Lightweight cleanup run at the end of every CalculateRoute invocation.
-  void ClearRouteCalculationState();
-
   RouterResultCode CalculateSubrouteJointsMode(IndexGraphStarter & starter, RouterDelegate const & delegate,
                                                std::shared_ptr<AStarProgress> const & progress,
                                                std::vector<Segment> & subroute);
@@ -146,7 +127,7 @@ private:
                                      bool guidesActive = false);
 
   RouterResultCode AdjustRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                               AdjustmentContext const & adjustmentContext, RouterDelegate const & delegate,
+                               RouteAdjustmentContext const & adjustmentContext, RouterDelegate const & delegate,
                                Route & route);
 
   std::unique_ptr<WorldGraph> MakeWorldGraph();

--- a/libs/routing/index_router.hpp
+++ b/libs/routing/index_router.hpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace traffic
@@ -81,13 +82,11 @@ public:
 
   void SetGuides(GuidesTracks && guides) override;
   RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                  bool adjustToPrevRoute, RouterDelegate const & delegate,
+                                  RouteAdjustmentContextPtr const & adjustmentContext, RouterDelegate const & delegate,
                                   RoutesResult & result) override;
 
   bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
                                    EdgeProj & proj) override;
-
-  void SwapAltRouteToActive() override;
 
   bool GetBestOutgoingEdges(m2::PointD const & checkpoint, WorldGraph & graph, std::vector<Edge> & edges);
 
@@ -108,9 +107,23 @@ public:
   }
 
 private:
-  // Lightweight cleanup run at the end of every CalculateRoute invocation. Frees the road-graph,
-  // directions engine and data-source handles; does NOT touch m_lastRoute/m_lastAltRoute so the
-  // adjust-cache survives between a successful build and a later off-route rebuild.
+  class AdjustmentContext final : public RouteAdjustmentContext
+  {
+  public:
+    AdjustmentContext(std::unique_ptr<SegmentedRoute> route, std::unique_ptr<FakeEdgesContainer> fakeEdges)
+      : m_route(std::move(route))
+      , m_fakeEdges(std::move(fakeEdges))
+    {}
+
+    SegmentedRoute const & GetRoute() const { return *m_route; }
+    FakeEdgesContainer const & GetFakeEdges() const { return *m_fakeEdges; }
+
+  private:
+    std::unique_ptr<SegmentedRoute> const m_route;
+    std::unique_ptr<FakeEdgesContainer> const m_fakeEdges;
+  };
+
+  // Lightweight cleanup run at the end of every CalculateRoute invocation.
   void ClearRouteCalculationState();
 
   RouterResultCode CalculateSubrouteJointsMode(IndexGraphStarter & starter, RouterDelegate const & delegate,
@@ -125,14 +138,16 @@ private:
                                                   std::vector<Segment> & subroute);
 
   RouterResultCode DoCalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                    RouterDelegate const & delegate, Route & route);
+                                    RouterDelegate const & delegate, Route & route,
+                                    RouteAdjustmentContextPtr & adjustmentContext);
   RouterResultCode CalculateSubroute(Checkpoints const & checkpoints, size_t subrouteIdx,
                                      RouterDelegate const & delegate, std::shared_ptr<AStarProgress> const & progress,
                                      IndexGraphStarter & graph, std::vector<Segment> & subroute,
                                      bool guidesActive = false);
 
   RouterResultCode AdjustRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                               RouterDelegate const & delegate, Route & route);
+                               AdjustmentContext const & adjustmentContext, RouterDelegate const & delegate,
+                               Route & route);
 
   std::unique_ptr<WorldGraph> MakeWorldGraph();
 
@@ -297,15 +312,6 @@ private:
 
   std::shared_ptr<EdgeEstimator> m_estimator;
   std::unique_ptr<DirectionsEngine> m_directionsEngine;
-  std::unique_ptr<SegmentedRoute> m_lastRoute;
-  std::unique_ptr<FakeEdgesContainer> m_lastFakeEdges;
-  // Mirror of the active slots for the alternative route computed in CalculateRoute. Swapped
-  // into the active slots by SwapAltRouteToActive when the user selects the alternative, so
-  // AdjustRoute on a subsequent off-route rebuild adjusts to the route the user is following.
-  /// @todo Make a vector of alts here or in RoutesResult (preferred).
-  /// A major refactoring is needed, but IndexRouer becomes stateless (is a plus).
-  std::unique_ptr<SegmentedRoute> m_lastAltRoute;
-  std::unique_ptr<FakeEdgesContainer> m_lastAltFakeEdges;
 
   // If a ckeckpoint is near to the guide track we need to build route through this track.
   GuidesConnections m_guides;

--- a/libs/routing/route.hpp
+++ b/libs/routing/route.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "routing/lanes/lane_info.hpp"
+#include "routing/route_adjustment_context.hpp"
 #include "routing/routing_options.hpp"
 #include "routing/routing_settings.hpp"
 #include "routing/segment.hpp"
@@ -306,6 +307,12 @@ public:
   // A route is "valid" (for display purposes) when it has at least one segment and a starting subroute.
   bool IsValid() const { return !m_routeSegments.empty() && !m_subrouteAttrs.empty(); }
 
+  RouteAdjustmentContextPtr const & GetAdjustmentContext() const { return m_adjustmentContext; }
+  void SetAdjustmentContext(RouteAdjustmentContextPtr adjustmentContext)
+  {
+    m_adjustmentContext = std::move(adjustmentContext);
+  }
+
   /// \returns The midpoint of the longest divergence span — used to place the ETA balloon
   /// where the alt actually differs from |origin| — or nullopt if the route fails the threshold (equal).
   /// Diff is measured by real road-segment feature identity (suitable for road vehicles).
@@ -408,6 +415,9 @@ protected:
 
   // Pivot for the alternative-route ETA balloon — midpoint of the longest segment span.
   std::optional<m2::PointD> m_diffMidpoint;
+
+  // Immutable router-specific state for adjusting this exact route variant.
+  RouteAdjustmentContextPtr m_adjustmentContext;
 };
 
 /// \brief A RouteBase that the user is actively following: adds the matched position on the polyline,
@@ -422,7 +432,12 @@ public:
 
   /// \brief Promote an alternative (RouteBase) to a followed Route. The base's segments and their start
   /// point are used to (re)build the FollowedPolyline for follow-time matching.
-  explicit Route(RouteBase const & base) : RouteBase(base) { RebuildFollowedPolyline(); }
+  explicit Route(RouteBase const & base) : RouteBase(base)
+  {
+    // Adjustment state belongs to the retained result variant, not its followed UI copy.
+    m_adjustmentContext.reset();
+    RebuildFollowedPolyline();
+  }
 
   Route(Route const & rhs) = default;
 
@@ -566,12 +581,19 @@ public:
   RoutesResult() = default;
   RoutesResult(std::string routerName, uint64_t routesId) : m_routerName(std::move(routerName)), m_routesId(routesId) {}
 
-  void MakeFrom(std::string name, Route && route)
+  void MakeFrom(std::string name, Route && route, RouteAdjustmentContextPtr adjustmentContext = {})
   {
     m_routerName = std::move(name);
     m_routes.clear();
+    route.SetAdjustmentContext(std::move(adjustmentContext));
     m_routes.emplace_back(std::move(static_cast<RouteBase &>(route)));
     m_activeIdx = 0;
+  }
+
+  void AddAlternative(Route && route, RouteAdjustmentContextPtr adjustmentContext)
+  {
+    route.SetAdjustmentContext(std::move(adjustmentContext));
+    m_routes.emplace_back(std::move(static_cast<RouteBase &>(route)));
   }
 
   bool IsValid() const { return !m_routes.empty() && m_routes[m_activeIdx].IsValid(); }
@@ -586,6 +608,14 @@ public:
   {
     ASSERT_LESS(m_activeIdx, m_routes.size(), ());
     return m_routes[m_activeIdx];
+  }
+
+  RouteAdjustmentContextPtr GetActiveAdjustmentContext() const { return GetActive().GetAdjustmentContext(); }
+
+  void ClearAdjustmentContexts()
+  {
+    for (auto & route : m_routes)
+      route.SetAdjustmentContext({});
   }
 
   std::vector<RouteBase> m_routes;

--- a/libs/routing/route.hpp
+++ b/libs/routing/route.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "routing/lanes/lane_info.hpp"
-#include "routing/route_adjustment_context.hpp"
 #include "routing/routing_options.hpp"
 #include "routing/routing_settings.hpp"
 #include "routing/segment.hpp"
@@ -36,6 +35,9 @@ class RouteMatchingInfo;
 
 namespace routing
 {
+class RouteAdjustmentContext;
+using RouteAdjustmentContextPtr = std::shared_ptr<RouteAdjustmentContext const>;
+
 using SubrouteUid = uint64_t;
 SubrouteUid constexpr kInvalidSubrouteId = std::numeric_limits<uint64_t>::max();
 
@@ -307,12 +309,6 @@ public:
   // A route is "valid" (for display purposes) when it has at least one segment and a starting subroute.
   bool IsValid() const { return !m_routeSegments.empty() && !m_subrouteAttrs.empty(); }
 
-  RouteAdjustmentContextPtr const & GetAdjustmentContext() const { return m_adjustmentContext; }
-  void SetAdjustmentContext(RouteAdjustmentContextPtr adjustmentContext)
-  {
-    m_adjustmentContext = std::move(adjustmentContext);
-  }
-
   /// \returns The midpoint of the longest divergence span — used to place the ETA balloon
   /// where the alt actually differs from |origin| — or nullopt if the route fails the threshold (equal).
   /// Diff is measured by real road-segment feature identity (suitable for road vehicles).
@@ -415,9 +411,6 @@ protected:
 
   // Pivot for the alternative-route ETA balloon — midpoint of the longest segment span.
   std::optional<m2::PointD> m_diffMidpoint;
-
-  // Immutable router-specific state for adjusting this exact route variant.
-  RouteAdjustmentContextPtr m_adjustmentContext;
 };
 
 /// \brief A RouteBase that the user is actively following: adds the matched position on the polyline,
@@ -432,12 +425,7 @@ public:
 
   /// \brief Promote an alternative (RouteBase) to a followed Route. The base's segments and their start
   /// point are used to (re)build the FollowedPolyline for follow-time matching.
-  explicit Route(RouteBase const & base) : RouteBase(base)
-  {
-    // Adjustment state belongs to the retained result variant, not its followed UI copy.
-    m_adjustmentContext.reset();
-    RebuildFollowedPolyline();
-  }
+  explicit Route(RouteBase const & base) : RouteBase(base) { RebuildFollowedPolyline(); }
 
   Route(Route const & rhs) = default;
 
@@ -581,41 +569,48 @@ public:
   RoutesResult() = default;
   RoutesResult(std::string routerName, uint64_t routesId) : m_routerName(std::move(routerName)), m_routesId(routesId) {}
 
-  void MakeFrom(std::string name, Route && route, RouteAdjustmentContextPtr adjustmentContext = {})
+  void MakeFrom(std::string name, RouteBase && route, RouteAdjustmentContextPtr adjustmentContext)
   {
     m_routerName = std::move(name);
     m_routes.clear();
-    route.SetAdjustmentContext(std::move(adjustmentContext));
-    m_routes.emplace_back(std::move(static_cast<RouteBase &>(route)));
+    m_adjustmentContexts.clear();
+    m_routes.emplace_back(std::move(route));
+    m_adjustmentContexts.emplace_back(std::move(adjustmentContext));
     m_activeIdx = 0;
   }
 
-  void AddAlternative(Route && route, RouteAdjustmentContextPtr adjustmentContext)
+  void AddAlternative(RouteBase && route, RouteAdjustmentContextPtr adjustmentContext)
   {
-    route.SetAdjustmentContext(std::move(adjustmentContext));
-    m_routes.emplace_back(std::move(static_cast<RouteBase &>(route)));
+    AssertConsistent();
+    m_routes.emplace_back(std::move(route));
+    m_adjustmentContexts.emplace_back(std::move(adjustmentContext));
   }
 
-  bool IsValid() const { return !m_routes.empty() && m_routes[m_activeIdx].IsValid(); }
+  bool IsValid() const
+  {
+    AssertConsistent();
+    return m_activeIdx < m_routes.size() && m_routes[m_activeIdx].IsValid();
+  }
 
   RouteBase & GetActive()
   {
+    AssertConsistent();
     ASSERT_LESS(m_activeIdx, m_routes.size(), ());
     return m_routes[m_activeIdx];
   }
 
   RouteBase const & GetActive() const
   {
+    AssertConsistent();
     ASSERT_LESS(m_activeIdx, m_routes.size(), ());
     return m_routes[m_activeIdx];
   }
 
-  RouteAdjustmentContextPtr GetActiveAdjustmentContext() const { return GetActive().GetAdjustmentContext(); }
-
-  void ClearAdjustmentContexts()
+  RouteAdjustmentContextPtr const & GetActiveAdjustmentContext() const
   {
-    for (auto & route : m_routes)
-      route.SetAdjustmentContext({});
+    AssertConsistent();
+    ASSERT_LESS(m_activeIdx, m_adjustmentContexts.size(), ());
+    return m_adjustmentContexts[m_activeIdx];
   }
 
   std::vector<RouteBase> m_routes;
@@ -623,6 +618,12 @@ public:
   std::string m_routerName;
   // Session-unique id, shared by all alternatives in this result.
   uint64_t m_routesId = 0;
+
+private:
+  void AssertConsistent() const { ASSERT_EQUAL(m_routes.size(), m_adjustmentContexts.size(), ()); }
+
+  // Keep router state out of RouteBase so display/following copies cannot retain it accidentally.
+  std::vector<RouteAdjustmentContextPtr> m_adjustmentContexts;
 };
 
 /// \returns true if |turn| is not equal to turns::CarDirection::None or

--- a/libs/routing/route_adjustment_context.hpp
+++ b/libs/routing/route_adjustment_context.hpp
@@ -1,14 +1,33 @@
 #pragma once
 
+#include "routing/fake_edges_container.hpp"
+#include "routing/segmented_route.hpp"
+
+#include "base/assert.hpp"
+
 #include <memory>
 
 namespace routing
 {
-// Router-specific immutable state used to adjust a previously calculated route.
-class RouteAdjustmentContext
+// Immutable state captured by a full route build and reused as the baseline for subsequent adjustments.
+class RouteAdjustmentContext final
 {
 public:
-  virtual ~RouteAdjustmentContext() = default;
+  RouteAdjustmentContext(std::unique_ptr<SegmentedRoute> route, std::unique_ptr<FakeEdgesContainer> fakeEdges)
+    : m_route(std::move(route))
+    , m_fakeEdges(std::move(fakeEdges))
+  {
+    CHECK(m_route, ());
+    CHECK(m_fakeEdges, ());
+  }
+
+  SegmentedRoute const & GetRoute() const { return *m_route; }
+
+  FakeEdgesContainer const & GetFakeEdges() const { return *m_fakeEdges; }
+
+private:
+  std::unique_ptr<SegmentedRoute> const m_route;
+  std::unique_ptr<FakeEdgesContainer> const m_fakeEdges;
 };
 
 using RouteAdjustmentContextPtr = std::shared_ptr<RouteAdjustmentContext const>;

--- a/libs/routing/route_adjustment_context.hpp
+++ b/libs/routing/route_adjustment_context.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <memory>
+
+namespace routing
+{
+// Router-specific immutable state used to adjust a previously calculated route.
+class RouteAdjustmentContext
+{
+public:
+  virtual ~RouteAdjustmentContext() = default;
+};
+
+using RouteAdjustmentContextPtr = std::shared_ptr<RouteAdjustmentContext const>;
+}  // namespace routing

--- a/libs/routing/router.hpp
+++ b/libs/routing/router.hpp
@@ -2,6 +2,7 @@
 
 #include "routing/checkpoints.hpp"
 #include "routing/road_graph.hpp"
+#include "routing/route_adjustment_context.hpp"
 #include "routing/router_delegate.hpp"
 #include "routing/routing_callbacks.hpp"
 
@@ -63,22 +64,19 @@ public:
   ///
   /// @param checkpoints start, finish and intermediate points
   /// @param startDirection start direction for routers with high cost of the turnarounds
-  /// @param adjust adjust route to the previous one if possible
+  /// @param adjustmentContext immutable state returned with the previously selected route;
+  ///                          null requests a full route calculation
   /// @param delegate callback functions and cancellation flag
   /// @param result populated with one or more alternative routes (as RouteBase) when successful;
   ///               callers consume the active alternative via result.GetActive()
   /// @return ResultCode error code or NoError if at least one route was produced
   /// @see Cancellable
   virtual RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                          bool adjust, RouterDelegate const & delegate, RoutesResult & result) = 0;
+                                          RouteAdjustmentContextPtr const & adjustmentContext,
+                                          RouterDelegate const & delegate, RoutesResult & result) = 0;
 
   virtual bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
                                            EdgeProj & proj) = 0;
-
-  /// Swap the saved last-route state with the alternative's saved state. Called when the user
-  /// picks an alternative variant so a subsequent AdjustRoute (off-route rebuild) adjusts to
-  /// the selected route rather than the original primary. Default: no-op.
-  virtual void SwapAltRouteToActive() {}
 };
 
 }  // namespace routing

--- a/libs/routing/router.hpp
+++ b/libs/routing/router.hpp
@@ -2,7 +2,6 @@
 
 #include "routing/checkpoints.hpp"
 #include "routing/road_graph.hpp"
-#include "routing/route_adjustment_context.hpp"
 #include "routing/router_delegate.hpp"
 #include "routing/routing_callbacks.hpp"
 
@@ -10,11 +9,14 @@
 
 #include <functional>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace routing
 {
+class RouteAdjustmentContext;
+using RouteAdjustmentContextPtr = std::shared_ptr<RouteAdjustmentContext const>;
 
 using CountryParentNameGetterFn = std::function<std::string(std::string const &)>;
 

--- a/libs/routing/routes_builder/routes_builder.cpp
+++ b/libs/routing/routes_builder/routes_builder.cpp
@@ -296,7 +296,7 @@ RoutesBuilder::Result RoutesBuilder::Processor::operator()(Params const & params
   {
     m_delegate->SetTimeout(params.m_timeoutSeconds);
     base::Timer timer;
-    resultCode = m_router->CalculateRoute(params.m_checkpoints, m2::PointD::Zero(), false /* adjustToPrevRoute */,
+    resultCode = m_router->CalculateRoute(params.m_checkpoints, m2::PointD::Zero(), nullptr /* adjustmentContext */,
                                           *m_delegate, routesResult);
 
     if (resultCode != RouterResultCode::NoError)

--- a/libs/routing/routing_benchmarks/helpers.cpp
+++ b/libs/routing/routing_benchmarks/helpers.cpp
@@ -154,7 +154,7 @@ void TestRouter(routing::IRouter & router, m2::PointD const & startPos, m2::Poin
   routing::RoutesResult res(router.GetName(), 0 /* routes id */);
   auto const resultCode =
       router.CalculateRoute(routing::Checkpoints(startPos, finalPos), m2::PointD::Zero() /* startDirection */,
-                            false /* adjust */, delegate, res);
+                            nullptr /* adjustmentContext */, delegate, res);
   double const elapsedSec = timer.ElapsedSeconds();
   TEST_EQUAL(routing::RouterResultCode::NoError, resultCode, ());
   TEST(res.IsValid(), ());

--- a/libs/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/libs/routing/routing_integration_tests/routing_test_tools.cpp
@@ -153,7 +153,7 @@ TRouteResult CalculateRoute(IRouterComponents const & routerComponents, m2::Poin
   RouterDelegate delegate;
   RoutesResult res("mapsme", 0 /* routes id */);
   RouterResultCode result = routerComponents.GetRouter().CalculateRoute(
-      Checkpoints(startPoint, finalPoint), startDirection, false /* adjust */, delegate, res);
+      Checkpoints(startPoint, finalPoint), startDirection, nullptr /* adjustmentContext */, delegate, res);
   routerComponents.GetRouter().SetGuides({});
   return TRouteResult(PromoteActive(res), result);
 }
@@ -165,7 +165,7 @@ TRouteResult CalculateRoute(IRouterComponents const & routerComponents, Checkpoi
   RoutesResult res("mapsme", 0 /* routes id */);
   routerComponents.GetRouter().SetGuides(std::move(guides));
   RouterResultCode result = routerComponents.GetRouter().CalculateRoute(
-      checkpoints, m2::PointD::Zero() /* startDirection */, false /* adjust */, delegate, res);
+      checkpoints, m2::PointD::Zero() /* startDirection */, nullptr /* adjustmentContext */, delegate, res);
   routerComponents.GetRouter().SetGuides({});
   return TRouteResult(PromoteActive(res), result);
 }
@@ -175,7 +175,7 @@ TRoutesResult CalculateRoutes(IRouterComponents const & routerComponents, Checkp
   RouterDelegate delegate;
   RoutesResult res("mapsme", 0 /* routes id */);
   RouterResultCode const result = routerComponents.GetRouter().CalculateRoute(
-      checkpoints, m2::PointD::Zero() /* startDirection */, false /* adjust */, delegate, res);
+      checkpoints, m2::PointD::Zero() /* startDirection */, nullptr /* adjustmentContext */, delegate, res);
   routerComponents.GetRouter().SetGuides({});
 
   vector<shared_ptr<Route>> routes;

--- a/libs/routing/routing_session.cpp
+++ b/libs/routing/routing_session.cpp
@@ -64,7 +64,7 @@ void RoutingSession::BuildRoute(Checkpoints const & checkpoints, uint32_t timeou
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   CHECK(m_router, ());
   m_checkpoints = checkpoints;
-  m_router->ClearState();
+  ClearRouterState();
 
   m_isFollowing = false;
   m_routingRebuildCount = -1;  // -1 for the first rebuild.
@@ -89,9 +89,12 @@ void RoutingSession::RebuildRoute(m2::PointD const & startPoint, ReadyCallback c
 
   Checkpoints checkpoints(m_checkpoints);
   checkpoints.SetPointFrom(startPoint);
+  RouteAdjustmentContextPtr adjustmentContext;
+  if (adjustToPrevRoute && m_lastResult)
+    adjustmentContext = m_lastResult->GetActiveAdjustmentContext();
   // Use old-style callback construction, because lambda constructs buggy function on Android
   // (callback param isn't captured by value).
-  m_router->CalculateRoute(checkpoints, direction, adjustToPrevRoute, DoReadyCallback(*this, readyCallback),
+  m_router->CalculateRoute(checkpoints, direction, std::move(adjustmentContext), DoReadyCallback(*this, readyCallback),
                            needMoreMapsCallback, removeRouteCallback, m_progressCallback, timeoutSec);
 }
 
@@ -127,6 +130,13 @@ void RoutingSession::RemoveRoute()
   m_speedCameraManager.SetRoute(m_route);
 }
 
+void RoutingSession::ClearRouterState()
+{
+  if (m_lastResult)
+    m_lastResult->ClearAdjustmentContexts();
+  m_router->ClearState();
+}
+
 void RoutingSession::RebuildRouteOnTrafficUpdate()
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
@@ -150,7 +160,7 @@ void RoutingSession::RebuildRouteOnTrafficUpdate()
     }
 
     // Cancel current route building.
-    m_router->ClearState();
+    ClearRouterState();
   }
 
   RebuildRoute(startPoint, m_rebuildReadyCallback, nullptr /* needMoreMapsCallback */,
@@ -226,7 +236,7 @@ void RoutingSession::Reset()
 
   RemoveRoute();
   SetState(SessionState::NoValidRoute);
-  m_router->ClearState();
+  ClearRouterState();
 
   m_passedDistanceOnRouteMeters = 0.0;
   m_isFollowing = false;
@@ -592,8 +602,6 @@ bool RoutingSession::SwapActiveAlternative(size_t idx)
 
   m_speedCameraManager.Reset();
   m_speedCameraManager.SetRoute(m_route);
-  if (m_router)
-    m_router->SwapAltRouteToActive();
   return true;
 }
 

--- a/libs/routing/routing_session.cpp
+++ b/libs/routing/routing_session.cpp
@@ -64,7 +64,7 @@ void RoutingSession::BuildRoute(Checkpoints const & checkpoints, uint32_t timeou
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   CHECK(m_router, ());
   m_checkpoints = checkpoints;
-  ClearRouterState();
+  m_router->ClearState();
 
   m_isFollowing = false;
   m_routingRebuildCount = -1;  // -1 for the first rebuild.
@@ -130,13 +130,6 @@ void RoutingSession::RemoveRoute()
   m_speedCameraManager.SetRoute(m_route);
 }
 
-void RoutingSession::ClearRouterState()
-{
-  if (m_lastResult)
-    m_lastResult->ClearAdjustmentContexts();
-  m_router->ClearState();
-}
-
 void RoutingSession::RebuildRouteOnTrafficUpdate()
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
@@ -160,7 +153,7 @@ void RoutingSession::RebuildRouteOnTrafficUpdate()
     }
 
     // Cancel current route building.
-    ClearRouterState();
+    m_router->ClearState();
   }
 
   RebuildRoute(startPoint, m_rebuildReadyCallback, nullptr /* needMoreMapsCallback */,
@@ -236,7 +229,7 @@ void RoutingSession::Reset()
 
   RemoveRoute();
   SetState(SessionState::NoValidRoute);
-  ClearRouterState();
+  m_router->ClearState();
 
   m_passedDistanceOnRouteMeters = 0.0;
   m_isFollowing = false;
@@ -609,7 +602,7 @@ void RoutingSession::AssignRouteForTesting(Route && route, RouterResultCode e)
 {
   auto result = std::make_shared<RoutesResult>();
   if (route.IsValid())
-    result->m_routes.emplace_back(std::move(static_cast<RouteBase &>(route)));
+    result->MakeFrom({} /* routerName */, std::move(route), nullptr /* adjustmentContext */);
   AssignRoute(result, e);
 }
 

--- a/libs/routing/routing_session.hpp
+++ b/libs/routing/routing_session.hpp
@@ -177,7 +177,6 @@ private:
   void AssignRoute(std::shared_ptr<RoutesResult> const & result, RouterResultCode e);
   /// RemoveRoute() removes m_route and resets route attributes (m_lastDistance, m_moveAwayCounter).
   void RemoveRoute();
-  void ClearRouterState();
   void RebuildRouteOnTrafficUpdate();
 
   void PassCheckpoints();

--- a/libs/routing/routing_session.hpp
+++ b/libs/routing/routing_session.hpp
@@ -177,6 +177,7 @@ private:
   void AssignRoute(std::shared_ptr<RoutesResult> const & result, RouterResultCode e);
   /// RemoveRoute() removes m_route and resets route attributes (m_lastDistance, m_moveAwayCounter).
   void RemoveRoute();
+  void ClearRouterState();
   void RebuildRouteOnTrafficUpdate();
 
   void PassCheckpoints();

--- a/libs/routing/routing_tests/async_router_test.cpp
+++ b/libs/routing/routing_tests/async_router_test.cpp
@@ -1,134 +1,116 @@
 #include "testing/testing.hpp"
 
+#include "routing/async_router.hpp"
 #include "routing/route.hpp"
 #include "routing/router.hpp"
 #include "routing/routing_callbacks.hpp"
 
+#include "routing/routing_tests/tools.hpp"
+
+#include "base/scope_guard.hpp"
+
+#include <chrono>
 #include <condition_variable>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <vector>
 
 namespace async_router_test
 {
 using namespace routing;
-using namespace std::placeholders;
 using namespace std;
 
-class DummyRouter : public IRouter
+// Parks inside CalculateRoute until the test releases it and records projection calls.
+class BlockingRouter : public IRouter
 {
-  RouterResultCode m_result;
-
 public:
-  DummyRouter(RouterResultCode code, set<string> const & absent) : m_result(code) {}
-
-  // IRouter overrides:
-  string GetName() const override { return "Dummy"; }
+  string GetName() const override { return "blocking"; }
+  void ClearState() override {}
   void SetGuides(GuidesTracks && /* guides */) override {}
-  RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                  bool adjustToPrevRoute, RouterDelegate const & delegate,
-                                  RoutesResult & result) override
+
+  RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & /* startDirection */,
+                                  RouteAdjustmentContextPtr const & /* adjustmentContext */,
+                                  RouterDelegate const & /* delegate */, RoutesResult & result) override
   {
+    Notify(m_started);
+    {
+      unique_lock l(m_mutex);
+      m_cv.wait(l, [this] { return m_release; });
+    }
+
     Route route;
     route.SetGeometry(checkpoints.GetPoints().cbegin(), checkpoints.GetPoints().cend());
     result.MakeFrom(GetName(), std::move(route));
-    return m_result;
+    return RouterResultCode::NoError;
   }
 
-  bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
-                                   EdgeProj & proj) override
+  bool FindClosestProjectionToRoad(m2::PointD const & /* point */, m2::PointD const & /* direction */,
+                                   double /* radius */, EdgeProj & /* proj */) override
   {
+    ++m_projections;
     return false;
   }
-};
 
-struct DummyRoutingCallbacks
-{
-  vector<RouterResultCode> m_codes;
-  vector<set<string>> m_absent;
-  condition_variable m_cv;
-  mutex m_lock;
-  uint32_t const m_expected;
-  uint32_t m_called;
-
-  explicit DummyRoutingCallbacks(uint32_t expectedCalls) : m_expected(expectedCalls), m_called(0) {}
-
-  // ReadyCallbackOwnership callback
-  void operator()(shared_ptr<Route> route, RouterResultCode code)
+  bool WaitStarted(std::chrono::seconds timeout)
   {
-    CHECK(route, ());
-    m_codes.push_back(code);
-    TestAndNotifyReadyCallbacks();
+    unique_lock l(m_mutex);
+    return m_cv.wait_for(l, timeout, [this] { return m_started; });
   }
 
-  // NeedMoreMapsCallback callback
-  void operator()(uint64_t routeId, set<string> const & absent)
-  {
-    m_codes.push_back(RouterResultCode::NeedMoreMaps);
-    m_absent.emplace_back(absent);
-    TestAndNotifyReadyCallbacks();
-  }
+  void Release() { Notify(m_release); }
 
-  void WaitFinish()
-  {
-    unique_lock<mutex> lk(m_lock);
-    return m_cv.wait(lk, [this] { return m_called == m_expected; });
-  }
+  size_t m_projections = 0;
 
-  void TestAndNotifyReadyCallbacks()
+private:
+  void Notify(bool & flag)
   {
     {
-      lock_guard<mutex> calledLock(m_lock);
-      ++m_called;
-      TEST_LESS_OR_EQUAL(m_called, m_expected, ("The result callback called more times than expected."));
+      lock_guard l(m_mutex);
+      flag = true;
     }
     m_cv.notify_all();
   }
+
+  mutex m_mutex;
+  condition_variable m_cv;
+  bool m_started = false;
+  bool m_release = false;
 };
 
-// TODO(o.khlopkova) Uncomment and update these tests.
+// CalculateRoute and the synchronous projection lookup share road-graph scratch state, so
+// AsyncRouter must reject the lookup until the calculation releases the router.
+UNIT_CLASS_TEST(AsyncGuiThreadTest, ProjectionWhileCalculating)
+{
+  auto router = make_unique<BlockingRouter>();
+  auto * blocking = router.get();
 
-// UNIT_CLASS_TEST(AsyncGuiThreadTest, NeedMoreMapsSignalTest)
-//{
-//  set<string> const absentData({"test1", "test2"});
-//  unique_ptr<IOnlineFetcher> fetcher(new DummyFetcher(absentData));
-//  unique_ptr<IRouter> router(new DummyRouter(RouterResultCode::NoError, {}));
-//  DummyRoutingCallbacks resultCallback(2 /* expectedCalls */);
-//  AsyncRouter async(DummyStatisticsCallback, nullptr /* pointCheckCallback */);
-//  async.SetRouter(std::move(router), std::move(fetcher));
-//  async.CalculateRoute(Checkpoints({1, 2} /* start */, {5, 6} /* finish */), {3, 4}, false,
-//                       bind(ref(resultCallback), _1, _2) /* readyCallback */,
-//                       bind(ref(resultCallback), _1, _2) /* needMoreMapsCallback */,
-//                       nullptr /* removeRouteCallback */, nullptr /* progressCallback */);
-//
-//  resultCallback.WaitFinish();
-//
-//  TEST_EQUAL(resultCallback.m_codes.size(), 2, ());
-//  TEST_EQUAL(resultCallback.m_codes[0], RouterResultCode::NoError, ());
-//  TEST_EQUAL(resultCallback.m_codes[1], RouterResultCode::NeedMoreMaps, ());
-//  TEST_EQUAL(resultCallback.m_absent.size(), 2, ());
-//  TEST(resultCallback.m_absent[0].empty(), ());
-//  TEST_EQUAL(resultCallback.m_absent[1].size(), 2, ());
-//  TEST_EQUAL(resultCallback.m_absent[1], absentData, ());
-//}
+  auto readyPromise = make_shared<promise<void>>();
+  auto readyFuture = readyPromise->get_future();
 
-// UNIT_CLASS_TEST(AsyncGuiThreadTest, StandardAsyncFogTest)
-//{
-//  unique_ptr<IOnlineFetcher> fetcher(new DummyFetcher({}));
-//  unique_ptr<IRouter> router(new DummyRouter(RouterResultCode::NoError, {}));
-//  DummyRoutingCallbacks resultCallback(1 /* expectedCalls */);
-//  AsyncRouter async(DummyStatisticsCallback, nullptr /* pointCheckCallback */);
-//  async.SetRouter(std::move(router), std::move(fetcher));
-//  async.CalculateRoute(Checkpoints({1, 2} /* start */, {5, 6} /* finish */), {3, 4}, false,
-//                       bind(ref(resultCallback), _1, _2), nullptr /* needMoreMapsCallback */,
-//                       nullptr /* progressCallback */, nullptr /* removeRouteCallback */);
-//
-//  resultCallback.WaitFinish();
-//
-//  TEST_EQUAL(resultCallback.m_codes.size(), 1, ());
-//  TEST_EQUAL(resultCallback.m_codes[0], RouterResultCode::NoError, ());
-//  TEST_EQUAL(resultCallback.m_absent.size(), 1, ());
-//  TEST(resultCallback.m_absent[0].empty(), ());
-//}
+  AsyncRouter async(nullptr /* pointCheckCallback */);
+  async.SetRouter(std::move(router), nullptr /* absentRegionsFinder */);
+  async.CalculateRoute(Checkpoints({1, 2} /* start */, {5, 6} /* finish */), {3, 4} /* direction */,
+                       nullptr /* adjustmentContext */, [readyPromise](shared_ptr<RoutesResult>, RouterResultCode) {
+    readyPromise->set_value();
+  }, nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */, nullptr /* progressCallback */);
+
+  // ~AsyncRouter joins the routing thread, so the router must be let go even if a TEST throws.
+  SCOPE_GUARD(releaseRouter, [blocking] { blocking->Release(); });
+  TEST(blocking->WaitStarted(std::chrono::seconds(30)), ("Route calculation did not start."));
+
+  EdgeProj proj;
+  m2::PointD const point(1.0, 2.0);
+  m2::PointD const direction(0.0, 1.0);
+  TEST(!async.FindClosestProjectionToRoad(point, direction, 50.0 /* radius */, proj),
+       ("The projection lookup must not touch a calculating router."));
+  TEST_EQUAL(blocking->m_projections, 0, ());
+
+  blocking->Release();
+  TEST(readyFuture.wait_for(std::chrono::seconds(30)) == future_status::ready, ("Route was not built."));
+
+  // The mock finds nothing; reaching it once the router is idle is what matters.
+  async.FindClosestProjectionToRoad(point, direction, 50.0 /* radius */, proj);
+  TEST_EQUAL(blocking->m_projections, 1, ());
+}
 }  //  namespace async_router_test

--- a/libs/routing/routing_tests/async_router_test.cpp
+++ b/libs/routing/routing_tests/async_router_test.cpp
@@ -41,7 +41,7 @@ public:
 
     Route route;
     route.SetGeometry(checkpoints.GetPoints().cbegin(), checkpoints.GetPoints().cend());
-    result.MakeFrom(GetName(), std::move(route));
+    result.MakeFrom(GetName(), std::move(route), nullptr /* adjustmentContext */);
     return RouterResultCode::NoError;
   }
 

--- a/libs/routing/routing_tests/routing_session_test.cpp
+++ b/libs/routing/routing_tests/routing_session_test.cpp
@@ -14,6 +14,7 @@
 #include "base/logging.hpp"
 
 #include <chrono>
+#include <future>
 #include <initializer_list>
 #include <memory>
 #include <mutex>
@@ -62,8 +63,8 @@ public:
   void SetGuides(GuidesTracks && /* guides */) override {}
 
   RouterResultCode CalculateRoute(Checkpoints const & /* checkpoints */, m2::PointD const & /* startDirection */,
-                                  bool /* adjust */, RouterDelegate const & /* delegate */,
-                                  RoutesResult & result) override
+                                  RouteAdjustmentContextPtr const & /* adjustmentContext */,
+                                  RouterDelegate const & /* delegate */, RoutesResult & result) override
   {
     ++m_buildCount;
     result.MakeFrom(GetName(), Route(m_route));
@@ -75,6 +76,51 @@ public:
   {
     return false;
   }
+};
+
+class TestAdjustmentContext final : public RouteAdjustmentContext
+{
+public:
+  explicit TestAdjustmentContext(size_t id) : m_id(id) {}
+  size_t GetId() const { return m_id; }
+
+private:
+  size_t const m_id;
+};
+
+// Returns two variants on the first build and reports which variant's context the rebuild receives.
+class AdjustmentContextRouter final : public DummyRouter
+{
+public:
+  AdjustmentContextRouter(std::shared_ptr<size_t> buildCounter, std::shared_ptr<std::promise<size_t>> selectedContext)
+    : DummyRouter(*buildCounter)
+    , m_buildCounter(std::move(buildCounter))
+    , m_selectedContext(std::move(selectedContext))
+  {}
+
+  RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
+                                  RouteAdjustmentContextPtr const & adjustmentContext, RouterDelegate const & delegate,
+                                  RoutesResult & result) override
+  {
+    auto const code = DummyRouter::CalculateRoute(checkpoints, startDirection, adjustmentContext, delegate, result);
+    if (adjustmentContext)
+    {
+      auto const selected = std::dynamic_pointer_cast<TestAdjustmentContext const>(adjustmentContext);
+      TEST(selected, ());
+      m_selectedContext->set_value(selected->GetId());
+      return code;
+    }
+
+    result.GetActive().SetAdjustmentContext(std::make_shared<TestAdjustmentContext>(1));
+    auto alternative = result.GetActive();
+    alternative.SetAdjustmentContext(std::make_shared<TestAdjustmentContext>(2));
+    result.m_routes.emplace_back(std::move(alternative));
+    return code;
+  }
+
+private:
+  std::shared_ptr<size_t> m_buildCounter;
+  std::shared_ptr<std::promise<size_t>> m_selectedContext;
 };
 
 // Router which every next call of CalculateRoute() method return different return codes.
@@ -92,8 +138,8 @@ public:
   void SetGuides(GuidesTracks && /* guides */) override {}
 
   RouterResultCode CalculateRoute(Checkpoints const & /* checkpoints */, m2::PointD const & /* startDirection */,
-                                  bool /* adjust */, RouterDelegate const & /* delegate */,
-                                  RoutesResult & result) override
+                                  RouteAdjustmentContextPtr const & /* adjustmentContext */,
+                                  RouterDelegate const & /* delegate */, RoutesResult & result) override
   {
     TEST_LESS(m_returnCodesIdx, m_returnCodes.size(), ());
     Route route;
@@ -528,6 +574,40 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestFollowRoutePercentTest
     checkTimedSignal.Signal();
   });
   TEST(checkTimedSignal.WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route checking timeout."));
+}
+
+UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestSelectedAdjustmentContext)
+{
+  auto built = make_shared<TimedSignal>();
+  auto buildCount = make_shared<size_t>(0);
+  auto selectedContext = make_shared<promise<size_t>>();
+  auto selectedContextFuture = selectedContext->get_future();
+
+  GetPlatform().RunTask(Platform::Thread::Gui, [this, built, buildCount, selectedContext]
+  {
+    InitRoutingSession();
+    m_session->SetRouter(make_unique<AdjustmentContextRouter>(buildCount, selectedContext), nullptr);
+    m_session->SetRoutingCallbacks([built](RoutesResult const &, RouterResultCode) {
+      built->Signal();
+    }, nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */);
+    m_session->BuildRoute(Checkpoints(kTestRoute.front(), kTestRoute.back()), RouterDelegate::kNoTimeout);
+  });
+  TEST(built->WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not built."));
+
+  auto rebuilt = make_shared<TimedSignal>();
+  GetPlatform().RunTask(Platform::Thread::Gui, [this, rebuilt]
+  {
+    TEST(m_session->SwapActiveAlternative(1), ());
+    m_session->RebuildRoute(kTestRoute.front(), [rebuilt](RoutesResult const &, RouterResultCode)
+    { rebuilt->Signal(); }, nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */,
+                            RouterDelegate::kNoTimeout, SessionState::RouteRebuilding, true /* adjustToPrevRoute */);
+  });
+
+  TEST(selectedContextFuture.wait_for(kRouteBuildingMaxDuration) == future_status::ready,
+       ("The selected route context was not used."));
+  TEST_EQUAL(selectedContextFuture.get(), 2, ());
+  TEST(rebuilt->WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not rebuilt."));
+  TEST_EQUAL(*buildCount, 2, ());
 }
 
 UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestRouteRebuildingError)

--- a/libs/routing/routing_tests/routing_session_test.cpp
+++ b/libs/routing/routing_tests/routing_session_test.cpp
@@ -2,7 +2,9 @@
 
 #include "routing/routing_tests/tools.hpp"
 
+#include "routing/dummy_world_graph.hpp"
 #include "routing/route.hpp"
+#include "routing/route_adjustment_context.hpp"
 #include "routing/router.hpp"
 #include "routing/routing_callbacks.hpp"
 #include "routing/routing_helpers.hpp"
@@ -42,16 +44,29 @@ auto const kRouteBuildingMaxDuration = seconds(30);
 
 void FillSubroutesInfo(Route & route, vector<turns::TurnItem> const & turns = kTestTurnsReachOnly);
 
+RouteAdjustmentContextPtr MakeAdjustmentContext()
+{
+  DummyWorldGraph graph;
+  FakeEnding const ending;
+  IndexGraphStarter starter(ending, ending, 0 /* fakeNumerationStart */, false /* strictForward */, graph);
+  return make_shared<RouteAdjustmentContext>(
+      make_unique<SegmentedRoute>(m2::PointD::Zero(), m2::PointD::Zero(), vector<Route::SubrouteAttrs>{}),
+      make_unique<FakeEdgesContainer>(std::move(starter)));
+}
+
 // Simple router. It returns route given to him on creation.
 class DummyRouter : public IRouter
 {
 private:
   Route m_route;
   size_t & m_buildCount;
+  RouteAdjustmentContextPtr m_resultContext;
 
 public:
-  DummyRouter(size_t & buildCounter, vector<turns::TurnItem> const & turns = kTestTurnsReachOnly)
+  DummyRouter(size_t & buildCounter, vector<turns::TurnItem> const & turns = kTestTurnsReachOnly,
+              RouteAdjustmentContextPtr resultContext = nullptr)
     : m_buildCount(buildCounter)
+    , m_resultContext(std::move(resultContext))
   {
     m_route.SetGeometry(kTestRoute.begin(), kTestRoute.end());
     if (!turns.empty())
@@ -67,7 +82,7 @@ public:
                                   RouterDelegate const & /* delegate */, RoutesResult & result) override
   {
     ++m_buildCount;
-    result.MakeFrom(GetName(), Route(m_route));
+    result.MakeFrom(GetName(), Route(m_route), m_resultContext);
     return RouterResultCode::NoError;
   }
 
@@ -78,24 +93,17 @@ public:
   }
 };
 
-class TestAdjustmentContext final : public RouteAdjustmentContext
-{
-public:
-  explicit TestAdjustmentContext(size_t id) : m_id(id) {}
-  size_t GetId() const { return m_id; }
-
-private:
-  size_t const m_id;
-};
-
 // Returns two variants on the first build and reports which variant's context the rebuild receives.
 class AdjustmentContextRouter final : public DummyRouter
 {
 public:
-  AdjustmentContextRouter(std::shared_ptr<size_t> buildCounter, std::shared_ptr<std::promise<size_t>> selectedContext)
-    : DummyRouter(*buildCounter)
+  AdjustmentContextRouter(std::shared_ptr<size_t> buildCounter,
+                          std::shared_ptr<std::promise<RouteAdjustmentContext const *>> selectedContext,
+                          RouteAdjustmentContextPtr activeContext, RouteAdjustmentContextPtr alternativeContext)
+    : DummyRouter(*buildCounter, kTestTurnsReachOnly, activeContext)
     , m_buildCounter(std::move(buildCounter))
     , m_selectedContext(std::move(selectedContext))
+    , m_alternativeContext(std::move(alternativeContext))
   {}
 
   RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
@@ -105,22 +113,19 @@ public:
     auto const code = DummyRouter::CalculateRoute(checkpoints, startDirection, adjustmentContext, delegate, result);
     if (adjustmentContext)
     {
-      auto const selected = std::dynamic_pointer_cast<TestAdjustmentContext const>(adjustmentContext);
-      TEST(selected, ());
-      m_selectedContext->set_value(selected->GetId());
+      m_selectedContext->set_value(adjustmentContext.get());
       return code;
     }
 
-    result.GetActive().SetAdjustmentContext(std::make_shared<TestAdjustmentContext>(1));
     auto alternative = result.GetActive();
-    alternative.SetAdjustmentContext(std::make_shared<TestAdjustmentContext>(2));
-    result.m_routes.emplace_back(std::move(alternative));
+    result.AddAlternative(std::move(alternative), m_alternativeContext);
     return code;
   }
 
 private:
   std::shared_ptr<size_t> m_buildCounter;
-  std::shared_ptr<std::promise<size_t>> m_selectedContext;
+  std::shared_ptr<std::promise<RouteAdjustmentContext const *>> m_selectedContext;
+  RouteAdjustmentContextPtr m_alternativeContext;
 };
 
 // Router which every next call of CalculateRoute() method return different return codes.
@@ -145,7 +150,7 @@ public:
     Route route;
     route.SetGeometry(m_route.begin(), m_route.end());
     FillSubroutesInfo(route);
-    result.MakeFrom(GetName(), std::move(route));
+    result.MakeFrom(GetName(), std::move(route), nullptr /* adjustmentContext */);
     return m_returnCodes[m_returnCodesIdx++];
   }
 
@@ -580,13 +585,17 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestSelectedAdjustmentCont
 {
   auto built = make_shared<TimedSignal>();
   auto buildCount = make_shared<size_t>(0);
-  auto selectedContext = make_shared<promise<size_t>>();
+  auto selectedContext = make_shared<promise<RouteAdjustmentContext const *>>();
   auto selectedContextFuture = selectedContext->get_future();
+  auto activeContext = MakeAdjustmentContext();
+  auto alternativeContext = MakeAdjustmentContext();
 
-  GetPlatform().RunTask(Platform::Thread::Gui, [this, built, buildCount, selectedContext]
+  GetPlatform().RunTask(Platform::Thread::Gui,
+                        [this, built, buildCount, selectedContext, activeContext, alternativeContext]
   {
     InitRoutingSession();
-    m_session->SetRouter(make_unique<AdjustmentContextRouter>(buildCount, selectedContext), nullptr);
+    m_session->SetRouter(
+        make_unique<AdjustmentContextRouter>(buildCount, selectedContext, activeContext, alternativeContext), nullptr);
     m_session->SetRoutingCallbacks([built](RoutesResult const &, RouterResultCode) {
       built->Signal();
     }, nullptr /* rebuildReadyCallback */, nullptr /* needMoreMapsCallback */, nullptr /* removeRouteCallback */);
@@ -605,7 +614,7 @@ UNIT_CLASS_TEST(AsyncGuiThreadTestWithRoutingSession, TestSelectedAdjustmentCont
 
   TEST(selectedContextFuture.wait_for(kRouteBuildingMaxDuration) == future_status::ready,
        ("The selected route context was not used."));
-  TEST_EQUAL(selectedContextFuture.get(), 2, ());
+  TEST_EQUAL(selectedContextFuture.get(), alternativeContext.get(), ());
   TEST(rebuilt->WaitUntil(steady_clock::now() + kRouteBuildingMaxDuration), ("Route was not rebuilt."));
   TEST_EQUAL(*buildCount, 2, ());
 }

--- a/libs/routing/ruler_router.cpp
+++ b/libs/routing/ruler_router.cpp
@@ -37,8 +37,8 @@ namespace routing
 
  */
 RouterResultCode RulerRouter::CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                             bool adjustToPrevRoute, RouterDelegate const & delegate,
-                                             RoutesResult & result)
+                                             RouteAdjustmentContextPtr const & adjustmentContext,
+                                             RouterDelegate const & delegate, RoutesResult & result)
 {
   auto const & points = checkpoints.GetPoints();
   size_t const count = points.size();

--- a/libs/routing/ruler_router.cpp
+++ b/libs/routing/ruler_router.cpp
@@ -94,7 +94,7 @@ RouterResultCode RulerRouter::CalculateRoute(Checkpoints const & checkpoints, m2
   }
 
   route.SetGeometry(routeGeometry.begin(), routeGeometry.end());
-  result.MakeFrom(GetName(), std::move(route));
+  result.MakeFrom(GetName(), std::move(route), nullptr /* adjustmentContext */);
 
   return RouterResultCode::NoError;
 }

--- a/libs/routing/ruler_router.hpp
+++ b/libs/routing/ruler_router.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <string>
 #include "routing/router.hpp"
+
+#include <string>
 
 namespace routing
 {
@@ -13,7 +14,7 @@ class RulerRouter : public IRouter
   void SetGuides(GuidesTracks && guides) override {}
 
   RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                                  bool adjustToPrevRoute, RouterDelegate const & delegate,
+                                  RouteAdjustmentContextPtr const & adjustmentContext, RouterDelegate const & delegate,
                                   RoutesResult & result) override;
   bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction, double radius,
                                    EdgeProj & proj) override;


### PR DESCRIPTION
Alternative to #13518.

IndexRouter currently keeps active and alternative adjustment caches between requests, coupling the newest cache generation to the session result selected on the GUI thread.

## What changed

- RoutesResult owns an immutable adjustment context parallel to each route variant.
- RoutingSession passes the selected variant context into rebuilds; null requests a full build.
- IndexRouter creates concrete contexts only for successful full builds and reuses that stable baseline for subsequent adjustments.
- Failed and cancelled calculations cannot overwrite state belonging to a delivered result.
- Alternative selection is now a GUI-only result-index change; mutable router cache swapping is removed.
- Road projection remains gated while calculation scratch state is in use.

The context is kept outside RouteBase, so display and followed-route copies cannot retain routing state. The concrete holder needs no vtable, RTTI, or downcast.

## Trade-offs

The change touches every IRouter::CalculateRoute implementation and keeps one shared context per live variant. In return it naturally supports multiple alternatives and removes cache-generation bookkeeping and GUI-thread cache swaps.

## Testing

- routing_tests: Debug, Release, and ThreadSanitizer
- Non-unity builds of routing_tests, routes_builder, routing_benchmarks, and routing_integration_tests
- ARM64 Android assembleFdroidDebug
- Selected-context and projection concurrency tests repeated 100 times
- Full routing integration run against 260714 data completed without missing-map failures; its existing data-dependent expectations still report failures