### PR TITLE
[android] Keep the current list first in the bookmark list picker

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/ChooseBookmarkCategoryFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/ChooseBookmarkCategoryFragment.java
@@ -45,17 +45,24 @@ public class ChooseBookmarkCategoryFragment extends BaseMwmDialogFragment
   public Dialog onCreateDialog(@Nullable Bundle savedInstanceState)
   {
     final long checkedId = requireArguments().getLong(CATEGORY_ID);
-    // getCategories() is a live view that is re-sorted on every change; snapshot it so indices stay valid.
+    // getCategories() is a live view re-sorted on every change; snapshot it before reordering below.
     final List<BookmarkCategory> categories = new ArrayList<>(BookmarkManager.INSTANCE.getCategories());
 
-    final String[] names = new String[categories.size()];
+    // AlertController scrolls the checked row to the top, hiding every list above it. Keep it first instead.
     int checkedItem = -1;
     for (int i = 0; i < categories.size(); i++)
     {
-      names[i] = categories.get(i).getName();
       if (categories.get(i).getId() == checkedId)
-        checkedItem = i;
+      {
+        categories.add(0, categories.remove(i));
+        checkedItem = 0;
+        break;
+      }
     }
+
+    final String[] names = new String[categories.size()];
+    for (int i = 0; i < categories.size(); i++)
+      names[i] = categories.get(i).getName();
 
     final AlertDialog dialog =
         new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)


### PR DESCRIPTION
Fixes #13506.

The "Select list" dialog opened already scrolled: `AlertController` calls `listView.setSelection(mCheckedItem)`, which pins the current list to the top row. Every list above it was hidden, and the checkmark left the screen as soon as the user swiped down — so it looked both as if lists were missing and as if nothing was selected.

Reordering the snapshot so the current list comes first leaves the list at the top, with the order of the remaining lists unchanged. Passing `-1` instead would also stop the scrolling, but then no row is checked at all and the user loses the indication of which list the bookmark is in.

Regression from b982b8c997, which replaced the RecyclerView-based picker with `setSingleChoiceItems`.