### PR TITLE
[tools] Keep empty Java types multiline

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -60,6 +60,8 @@ TabWidth: 2
 ---
 Language: Java
 AllowShortFunctionsOnASingleLine: Empty
+BraceWrapping:
+  SplitEmptyRecord: true
 
 ---
 Language: ObjC

--- a/.clang-format
+++ b/.clang-format
@@ -61,6 +61,8 @@ TabWidth: 2
 Language: Java
 AllowShortFunctionsOnASingleLine: Empty
 BraceWrapping:
+  # Unlike C++, empty Java types stay multiline: clang-format 23.1.1 collapses
+  # empty interfaces and records to {} with the inherited false, 23.1.0 does not.
   SplitEmptyRecord: true
 
 ---


### PR DESCRIPTION
clang-format 23.1.1 formats empty Java interfaces and records differently from 23.1.0, causing code-style CI failures in otherwise unrelated pull requests.

Keep empty Java types multiline across clang-format 23.1.x by setting `SplitEmptyRecord: true` for Java.

Tested with clang-format 23.1.0 and 23.1.1. The full code-style check passes.

LLM tools were used to prepare this change.
