### PR TITLE
[android] Keep unsupported deep links out of bookmark import

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -182,11 +182,8 @@
         <action android:name="android.intent.action.VIEW"/>
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
-        <data android:scheme="http"/>
-        <data android:scheme="https"/>
         <data android:scheme="content"/>
         <data android:scheme="file"/>
-        <data android:scheme="data"/>
         <data android:host="*"/>
         <data android:mimeType="application/vnd.google-earth.kml+xml"/>
         <data android:mimeType="application/vnd.google-earth.kmz"/>
@@ -210,11 +207,8 @@
         <action android:name="android.intent.action.VIEW"/>
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
-        <data android:scheme="http"/>
-        <data android:scheme="https"/>
         <data android:scheme="content"/>
         <data android:scheme="file"/>
-        <data android:scheme="data"/>
         <data android:host="*"/>
         <data android:mimeType="application/geo+json"/>
         <data android:mimeType="application/vnd.geo+json"/>
@@ -236,7 +230,6 @@
         <category android:name="android.intent.category.BROWSABLE"/>
         <data android:scheme="content"/>
         <data android:scheme="file"/>
-        <data android:scheme="data"/>
         <data android:host="*"/>
         <data android:mimeType="*/*"/>
         <!-- See http://stackoverflow.com/questions/3400072/pathpattern-to-match-file-extension-does-not-work-if-a-period-exists-elsewhere-i -->
@@ -332,7 +325,6 @@
         <category android:name="android.intent.category.BROWSABLE"/>
         <data android:scheme="content"/>
         <data android:scheme="file"/>
-        <data android:scheme="data"/>
         <data android:host="*"/>
         <!-- See http://stackoverflow.com/questions/3400072/pathpattern-to-match-file-extension-does-not-work-if-a-period-exists-elsewhere-i -->
         <data android:pathPattern="/.*\\.kmz" />

--- a/android/app/src/main/java/app/organicmaps/intent/Factory.java
+++ b/android/app/src/main/java/app/organicmaps/intent/Factory.java
@@ -45,7 +45,14 @@ public class Factory
       // See KML/KMZ/KMB intent filters in manifest.
       final List<Uri> uris;
       if (Intent.ACTION_VIEW.equals(intent.getAction()))
-        uris = Collections.singletonList(intent.getData());
+      {
+        // Bookmark import reads local files or provider streams, not web or data URLs.
+        final Uri uri = intent.getData();
+        final String scheme = uri == null ? null : uri.getScheme();
+        if (!ContentResolver.SCHEME_CONTENT.equals(scheme) && !ContentResolver.SCHEME_FILE.equals(scheme))
+          return false;
+        uris = Collections.singletonList(uri);
+      }
       else if (Intent.ACTION_SEND.equals(intent.getAction()))
         uris = Collections.singletonList(IntentCompat.getParcelableExtra(intent, Intent.EXTRA_STREAM, Uri.class));
       else if (Intent.ACTION_SEND_MULTIPLE.equals(intent.getAction()))
@@ -59,7 +66,7 @@ public class Factory
       final File tempDir = new File(StorageUtils.getTempPath(app));
       final ContentResolver resolver = activity.getContentResolver();
       ThreadPool.getStorage().execute(() -> BookmarkManager.INSTANCE.importBookmarksFiles(resolver, uris, tempDir));
-      return false;
+      return true;
     }
   }
 

--- a/android/app/src/test/java/app/organicmaps/intent/KmzKmlProcessorTest.java
+++ b/android/app/src/test/java/app/organicmaps/intent/KmzKmlProcessorTest.java
@@ -1,0 +1,76 @@
+package app.organicmaps.intent;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import android.content.Intent;
+import android.net.Uri;
+import app.organicmaps.MwmActivity;
+import app.organicmaps.MwmApplication;
+import app.organicmaps.sdk.util.concurrency.ThreadPool;
+import java.io.File;
+import java.util.concurrent.ExecutorService;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+public class KmzKmlProcessorTest
+{
+  @Test
+  public void unsupportedSchemesDoNotStartImportEvenWithBookmarkMimeType()
+  {
+    for (String scheme : new String[] {"om", "ge0", "geo", "http", "https", "data", null})
+    {
+      final Intent intent = viewIntent(scheme);
+      when(intent.getType()).thenReturn("application/vnd.google-earth.kml+xml");
+      final MwmActivity activity = mock(MwmActivity.class);
+      assertFalse(new Factory.KmzKmlProcessor().process(intent, activity));
+      verifyNoInteractions(activity);
+    }
+  }
+
+  @Test
+  public void missingUriDoesNotStartImport()
+  {
+    final Intent intent = mock(Intent.class);
+    when(intent.getAction()).thenReturn(Intent.ACTION_VIEW);
+    final MwmActivity activity = mock(MwmActivity.class);
+    assertFalse(new Factory.KmzKmlProcessor().process(intent, activity));
+    verifyNoInteractions(activity);
+  }
+
+  @Test
+  public void localAndProviderFilesScheduleImportAndConsumeIntent()
+  {
+    for (String scheme : new String[] {"content", "file"})
+    {
+      final Intent intent = viewIntent(scheme);
+      final MwmActivity activity = mock(MwmActivity.class);
+      final MwmApplication app = mock(MwmApplication.class);
+      when(activity.getApplicationContext()).thenReturn(app);
+      when(app.getCacheDir()).thenReturn(new File("test-cache"));
+      final ExecutorService storage = mock(ExecutorService.class);
+      try (MockedStatic<ThreadPool> pool = mockStatic(ThreadPool.class))
+      {
+        pool.when(ThreadPool::getStorage).thenReturn(storage);
+        assertTrue(new Factory.KmzKmlProcessor().process(intent, activity));
+        verify(storage).execute(any(Runnable.class));
+      }
+    }
+  }
+
+  private static Intent viewIntent(String scheme)
+  {
+    final Intent intent = mock(Intent.class);
+    final Uri uri = mock(Uri.class);
+    when(intent.getAction()).thenReturn(Intent.ACTION_VIEW);
+    when(intent.getData()).thenReturn(uri);
+    when(uri.getScheme()).thenReturn(scheme);
+    return intent;
+  }
+}


### PR DESCRIPTION
Extracted from #12678; independently based on master.

Limit `ACTION_VIEW` bookmark import to `content://` and `file://` streams supported by the import path. Remove HTTP(S) and `data:` from bookmark intent filters; dedicated `omaps.app`, `ge0.me`, and OpenStreetMap web-link filters remain unchanged. Scheduled imports report the intent as handled. File sharing remains supported.

Removed the duplicated MIME whitelist. Processor tests verify rejected links never reach import setup, missing URIs are ignored, and local/provider files schedule an import and return `true`. Both review regressions were reproduced before the fix and pass now.

Validation: all 53 Android app/SDK unit tests pass; app lint completes without errors; XML/manifest checks and formatting pass. No device UI testing.