### PR TITLE
[routing] Preserve itineraries across replacement and restoration

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/ManageRouteController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/ManageRouteController.java
@@ -62,19 +62,7 @@ public class ManageRouteController implements ManageRouteAdapter.ManageRouteList
     // Make sure that the new route contains at least 2 points (start and destination).
     Assert.debug(newRoutePoints.size() >= 2, "There must be at least two route points");
 
-    // Remove all existing route points.
-    Framework.nativeRemoveRoutePoints();
-
-    // First, add the destination point.
-    Framework.addRoutePoint(newRoutePoints.get(newRoutePoints.size() - 1));
-
-    // Secondly, add the starting point.
-    Framework.addRoutePoint(newRoutePoints.get(0));
-
-    // And then, add all intermediate points (with no reordering).
-    for (int pos = 1; pos < newRoutePoints.size() - 1; pos++)
-      Framework.addRoutePoint(newRoutePoints.get(pos), false);
-    // Launch route planning.
+    Framework.nativeReplaceRoutePoints(newRoutePoints.toArray(new RouteMarkData[0]));
     RoutingController.get().launchPlanning();
   }
 

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -1451,9 +1451,9 @@ JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeAddRoutePoint(JNIEnv * e
   frm()->GetRoutingManager().AddRoutePoint(std::move(data), reorderIntermediatePoints);
 }
 
-JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeRemoveRoutePoints(JNIEnv * env, jclass)
+JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeReplaceRoutePoints(JNIEnv * env, jclass, jobjectArray points)
 {
-  frm()->GetRoutingManager().RemoveRoutePoints();
+  frm()->GetRoutingManager().ReplaceRoutePoints(routing_jni::ToNativeRouteMarkDataArray(env, points));
 }
 
 JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeRemoveRoutePoint(JNIEnv * env, jclass, jobject markType,

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/routing/RoutingJni.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/routing/RoutingJni.cpp
@@ -21,6 +21,12 @@ namespace routing_jni
 {
 namespace
 {
+jclass GetRouteMarkDataClass(JNIEnv * env)
+{
+  static jclass const clazz = jni::GetGlobalClassRef(env, "app/organicmaps/sdk/routing/RouteMarkData");
+  return clazz;
+}
+
 // Every routing enum below is mirrored one to one by a Java enum, so the constant is looked up by name.
 // jni::GetStaticFieldID catches a name drift between the two in Debug; a raw env->GetStaticFieldID
 // would silently return null and leave a pending NoSuchFieldError for the next JNI call to trip over.
@@ -340,17 +346,54 @@ jobject CreateRoutePointInfo(JNIEnv * env, place_page::Info const & info)
   return env->NewObject(clazz, ctorId, static_cast<jint>(info.GetRouteMarkType()), info.GetIntermediateIndex());
 }
 
+std::vector<RouteMarkData> ToNativeRouteMarkDataArray(JNIEnv * env, jobjectArray points)
+{
+  CHECK(points, ());
+  auto const count = env->GetArrayLength(points);
+  auto const clazz = GetRouteMarkDataClass(env);
+  static jfieldID const title = env->GetFieldID(clazz, "mTitle", "Ljava/lang/String;");
+  static jfieldID const subtitle = env->GetFieldID(clazz, "mSubtitle", "Ljava/lang/String;");
+  static jfieldID const myPosition = env->GetFieldID(clazz, "mIsMyPosition", "Z");
+  static jfieldID const passed = env->GetFieldID(clazz, "mIsPassed", "Z");
+  static jfieldID const lat = env->GetFieldID(clazz, "mLat", "D");
+  static jfieldID const lon = env->GetFieldID(clazz, "mLon", "D");
+  CHECK(title && subtitle && myPosition && passed && lat && lon, (jni::DescribeException()));
+
+  std::vector<RouteMarkData> result;
+  result.reserve(count);
+  for (jsize i = 0; i < count; ++i)
+  {
+    jni::TScopedLocalRef const point(env, env->GetObjectArrayElement(points, i));
+    CHECK(point.get(), ());
+    auto const readString = [&](jfieldID field)
+    {
+      jni::ScopedLocalRef<jstring> const value(env, static_cast<jstring>(env->GetObjectField(point.get(), field)));
+      return value.get() ? jni::ToNativeString(env, value.get()) : std::string{};
+    };
+    RouteMarkData data;
+    data.m_title = readString(title);
+    data.m_subTitle = readString(subtitle);
+    data.m_isMyPosition = env->GetBooleanField(point.get(), myPosition);
+    // Rebuilding removes visited intermediates instead of turning them into new stops.
+    data.m_isPassed = env->GetBooleanField(point.get(), passed);
+    data.m_position =
+        mercator::FromLatLon(env->GetDoubleField(point.get(), lat), env->GetDoubleField(point.get(), lon));
+    result.push_back(std::move(data));
+  }
+  return result;
+}
+
 jobjectArray CreateRouteMarkDataArray(JNIEnv * env, std::vector<RouteMarkData> const & points)
 {
   using namespace jni;
 
-  static jclass const pointClazz = GetGlobalClassRef(env, "app/organicmaps/sdk/routing/RouteMarkData");
+  auto const pointClazz = GetRouteMarkDataClass(env);
   // Java signature : RouteMarkData(String title, String subtitle, int pointType,
   //                                int intermediateIndex, boolean isVisible, boolean isMyPosition,
   //                                boolean isPassed, double lat, double lon)
   static jmethodID const pointConstructor =
       GetConstructorID(env, pointClazz, "(Ljava/lang/String;Ljava/lang/String;IIZZZDD)V");
-  return ToJavaArray(env, pointClazz, points, [](JNIEnv * env, RouteMarkData const & data)
+  return ToJavaArray(env, pointClazz, points, [pointClazz](JNIEnv * env, RouteMarkData const & data)
   {
     TScopedLocalRef const title(env, ToJavaString(env, data.m_title));
     TScopedLocalRef const subtitle(env, ToJavaString(env, data.m_subTitle));

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/routing/RoutingJni.hpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/routing/RoutingJni.hpp
@@ -24,4 +24,5 @@ jobjectArray CreateJunctionInfoArray(JNIEnv * env, std::vector<geometry::PointWi
 RouteMarkType GetRouteMarkType(JNIEnv * env, jobject markType);
 jobject CreateRoutePointInfo(JNIEnv * env, place_page::Info const & info);
 jobjectArray CreateRouteMarkDataArray(JNIEnv * env, std::vector<RouteMarkData> const & points);
+std::vector<RouteMarkData> ToNativeRouteMarkDataArray(JNIEnv * env, jobjectArray points);
 }  // namespace routing_jni

--- a/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
@@ -268,22 +268,11 @@ public class Framework
 
   public static native void nativeShowCountry(String countryId, boolean zoomToDownloadButton);
 
-  public static void addRoutePoint(RouteMarkData point)
-  {
-    addRoutePoint(point, true);
-  }
-
-  public static void addRoutePoint(RouteMarkData point, boolean reorderIntermediatePoints)
-  {
-    Framework.nativeAddRoutePoint(point.mTitle, point.mSubtitle, point.mPointType, point.mIntermediateIndex,
-                                  point.mIsMyPosition, point.mLat, point.mLon, reorderIntermediatePoints);
-  }
+  public static native void nativeReplaceRoutePoints(@NonNull RouteMarkData[] points);
 
   public static native void nativeAddRoutePoint(String title, String subtitle, @NonNull RouteMarkType markType,
                                                 int intermediateIndex, boolean isMyPosition, double lat, double lon,
                                                 boolean reorderIntermediatePoints);
-
-  public static native void nativeRemoveRoutePoints();
 
   public static native void nativeRemoveRoutePoint(@NonNull RouteMarkType markType, int intermediateIndex);
 

--- a/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/routing/RoutingController.java
@@ -145,7 +145,7 @@ public class RoutingController
   private final RoutingLoadPointsListener mRoutingLoadPointsListener = success ->
   {
     if (success)
-      prepare(getStartPoint(), getEndPoint());
+      rebuildLastRoute();
   };
 
   public static RoutingController get()
@@ -354,9 +354,10 @@ public class RoutingController
 
   public void rebuildLastRoute()
   {
-    setState(State.NONE);
+    mContainsCachedResult = false;
+    setState(State.PREPARE);
     setBuildState(BuildState.NONE);
-    prepare(getStartPoint(), getEndPoint());
+    startPlanning(getStartPoint(), getEndPoint());
   }
 
   public void prepare(@Nullable MapObject startPoint, @Nullable MapObject endPoint)

--- a/android/sdk/src/test/java/app/organicmaps/sdk/routing/RoutingControllerNavigationStateTest.java
+++ b/android/sdk/src/test/java/app/organicmaps/sdk/routing/RoutingControllerNavigationStateTest.java
@@ -1,8 +1,12 @@
 package app.organicmaps.sdk.routing;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mockStatic;
 
+import app.organicmaps.sdk.bookmarks.data.MapObject;
 import app.organicmaps.sdk.util.log.Logger;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -12,6 +16,52 @@ import org.mockito.MockedStatic;
 
 public class RoutingControllerNavigationStateTest
 {
+  @Test
+  public void rebuildingUsesExistingRoutePoints()
+  {
+    final RoutingController controller = new RoutingController() {
+      @Override
+      public MapObject getStartPoint()
+      {
+        return null;
+      }
+
+      @Override
+      public MapObject getEndPoint()
+      {
+        return null;
+      }
+
+      @Override
+      public void prepare(MapObject start, MapObject finish)
+      {
+        fail("Rebuilding must not reconstruct the core's existing route points");
+      }
+    };
+    final List<String> events = new ArrayList<>();
+    controller.attach(new RoutingController.Container() {
+      @Override
+      public void showRoutePlan(boolean show, Runnable completionListener)
+      {
+        assertTrue(show);
+        assertNotNull(completionListener);
+        events.add("plan");
+      }
+
+      @Override
+      public void onPlanningStarted()
+      {
+        events.add("started");
+      }
+    });
+    try (MockedStatic<Logger> ignored = mockStatic(Logger.class))
+    {
+      controller.rebuildLastRoute();
+    }
+    assertTrue(controller.isPlanning());
+    assertEquals(List.of("plan", "started"), events);
+  }
+
   @Test
   public void listenerReceivesOnlyNavigationBoundaryTransitions() throws ReflectiveOperationException
   {

--- a/libs/map/map_tests/routing_manager_tests.cpp
+++ b/libs/map/map_tests/routing_manager_tests.cpp
@@ -3,7 +3,20 @@
 #include "map/framework.hpp"
 #include "map/routing_mark.hpp"
 
+#include "geometry/mercator.hpp"
+
+#include "platform/gui_thread.hpp"
+#include "platform/platform.hpp"
+#include "platform/platform_tests_support/scoped_dir.hpp"
+#include "platform/settings.hpp"
+
 #include <algorithm>
+#include <chrono>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
 #include <vector>
 
 namespace routing_manager_tests
@@ -65,5 +78,303 @@ UNIT_TEST(RoutingManager_ContinueRouteToPointWithoutFinishFailsCleanly)
   auto newFinish = MakeRoutePoint(RouteMarkType::Finish, 0, 1.0);
   TEST(!routingManager.ContinueRouteToPoint(std::move(newFinish)), ());
   TEST_EQUAL(routingManager.GetRoutePointsCount(), 0, ());
+}
+
+// Only drain this fixture's GUI tasks: other Framework fixtures can leave callbacks on the OS queue.
+class RoutingTestGuiThread : public base::TaskLoop
+{
+public:
+  PushResult Push(Task && task) override
+  {
+    std::lock_guard lock(m_mutex);
+    m_tasks.push(std::move(task));
+    return {true, kNoId};
+  }
+  PushResult Push(Task const & task) override { return Push(Task(task)); }
+  void Drain()
+  {
+    for (;;)
+    {
+      Task task;
+      {
+        std::lock_guard lock(m_mutex);
+        if (m_tasks.empty())
+          return;
+        task = std::move(m_tasks.front());
+        m_tasks.pop();
+      }
+      task();
+    }
+  }
+
+private:
+  std::mutex m_mutex;
+  std::queue<Task> m_tasks;
+};
+
+// SetSettingsDir redirects route files, but settings:: retains its process-wide storage.
+// Restore the router setting separately so the fixture does not change another test's routing mode.
+class RoutingTestSettings
+{
+public:
+  RoutingTestSettings() : m_settingsDir(GetPlatform().SettingsDir()), m_hadRouter(settings::Get("router", m_router))
+  {
+    GetPlatform().SetSettingsDir(m_dir);
+    auto gui = std::make_unique<RoutingTestGuiThread>();
+    m_gui = gui.get();
+    GetPlatform().SetGuiThread(std::move(gui));
+  }
+  ~RoutingTestSettings()
+  {
+    if (m_hadRouter)
+      settings::Set("router", m_router);
+    else
+      settings::Delete("router");
+    GetPlatform().SetSettingsDir(m_settingsDir);
+    GetPlatform().SetGuiThread(std::make_unique<platform::GuiThread>());
+  }
+  void DrainGui() { m_gui->Drain(); }
+
+private:
+  RoutingTestGuiThread * m_gui = nullptr;
+  std::string const m_dir = GetPlatform().WritablePathForFile("routing_manager_test_settings");
+  platform::tests_support::ScopedDirCleanup m_dirCleanup{m_dir};
+  std::string m_settingsDir;
+  std::string m_router;
+  bool m_hadRouter;
+};
+
+class RoutingManagerTest
+{
+public:
+  RoutingManagerTest() : m_framework(m_frameworkParams), m_manager(m_framework.GetRoutingManager()) {}
+
+  ~RoutingManagerTest() { WaitForFileTasks(); }
+
+protected:
+  static void WaitForFileTasks()
+  {
+    std::promise<void> drained;
+    GetPlatform().RunTask(Platform::Thread::File, [&] { drained.set_value(); });
+    drained.get_future().wait();
+  }
+
+  template <typename Predicate>
+  void WaitUntil(Predicate && ready)
+  {
+    auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!ready() && std::chrono::steady_clock::now() < deadline)
+    {
+      m_settings.DrainGui();
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    TEST(ready(), ("Asynchronous routing operation timed out"));
+  }
+
+  static RouteMarkData MakePoint(RouteMarkType type, double lat, std::string title, size_t index = 0)
+  {
+    RouteMarkData point;
+    point.m_pointType = type;
+    point.m_intermediateIndex = index;
+    point.m_position = mercator::FromLatLon(lat, 1);
+    point.m_title = std::move(title);
+    point.m_subTitle = "subtitle:" + point.m_title;
+    return point;
+  }
+
+  void AddTestPoints()
+  {
+    m_manager.AddRoutePoint(MakePoint(RouteMarkType::Start, 1, "start"), false);
+    m_manager.AddRoutePoint(MakePoint(RouteMarkType::Intermediate, 1.001, "A", 0), false);
+    m_manager.AddRoutePoint(MakePoint(RouteMarkType::Intermediate, 1.002, "B", 1), false);
+    m_manager.AddRoutePoint(MakePoint(RouteMarkType::Intermediate, 1.003, "C", 2), false);
+    m_manager.AddRoutePoint(MakePoint(RouteMarkType::Finish, 1.004, "finish"), false);
+  }
+
+  void SavePoints()
+  {
+    m_manager.SaveRoutePoints();
+    WaitForFileTasks();
+  }
+
+  RoutingTestSettings m_settings;
+  FrameworkParams m_frameworkParams;
+  Framework m_framework;
+  RoutingManager & m_manager;
+};
+
+UNIT_CLASS_TEST(RoutingManagerTest, RestorePreservesOrderAndMetadata)
+{
+  AddTestPoints();
+  auto const before = m_manager.GetRoutePoints();
+  SavePoints();
+  m_manager.RemoveRoutePoints();
+  bool loaded = false;
+  m_manager.LoadRoutePoints([&](bool success)
+  {
+    TEST(success, ());
+    loaded = true;
+  });
+  WaitUntil([&] { return loaded; });
+  auto const after = m_manager.GetRoutePoints();
+  TEST_EQUAL(after.size(), before.size(), ());
+  for (size_t i = 0; i < after.size(); ++i)
+  {
+    TEST_EQUAL(after[i].m_position, before[i].m_position, (i));
+    TEST_EQUAL(after[i].m_title, before[i].m_title, (i));
+    TEST_EQUAL(after[i].m_subTitle, before[i].m_subTitle, (i));
+    TEST_EQUAL(after[i].m_intermediateIndex, before[i].m_intermediateIndex, (i));
+  }
+}
+
+UNIT_CLASS_TEST(RoutingManagerTest, LoadingSavedPointsDoesNotReplaceANewItinerary)
+{
+  AddTestPoints();
+  SavePoints();
+  m_manager.RemoveRoutePoints();
+  bool done = false;
+  m_manager.LoadRoutePoints([&](bool success)
+  {
+    TEST(!success, ());
+    done = true;
+  });
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Start, 3, "new start"), false);
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Finish, 4, "new finish"), false);
+  WaitUntil([&] { return done; });
+  TEST_EQUAL(m_manager.GetRoutePoints().back().m_title, "new finish", ());
+}
+
+UNIT_CLASS_TEST(RoutingManagerTest, AppendingIntermediateOptimizesTheAddedPoint)
+{
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Start, 1, "start"), false);
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Finish, 1.004, "finish"), false);
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Intermediate, 1.003, "C", 0));
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Intermediate, 1.001, "A", 1));
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Intermediate, 1.002, "B", 2));
+  auto const points = m_manager.GetRoutePoints();
+  TEST_EQUAL(points[1].m_title, "A", ());
+  TEST_EQUAL(points[2].m_title, "B", ());
+  TEST_EQUAL(points[3].m_title, "C", ());
+}
+
+UNIT_CLASS_TEST(RoutingManagerTest, ReplacingEndpointDoesNotReorderIntermediatePoints)
+{
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Start, 1, "start"), false);
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Finish, 1.004, "finish"), false);
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Intermediate, 1.003, "C", 0), false);
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Intermediate, 1.001, "A", 1), false);
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Intermediate, 1.002, "B", 2), false);
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Finish, 1.005, "new finish"));
+  auto const points = m_manager.GetRoutePoints();
+  TEST_EQUAL(points[1].m_title, "C", ());
+  TEST_EQUAL(points[2].m_title, "A", ());
+  TEST_EQUAL(points[3].m_title, "B", ());
+}
+
+UNIT_CLASS_TEST(RoutingManagerTest, BatchUsesArrayOrderAtThePointLimit)
+{
+  std::vector<RouteMarkData> points;
+  for (size_t i = 0; i < RoutePointsLayout::kMaxRoutePointsCount; ++i)
+    points.push_back(MakePoint(RouteMarkType::Start, 1 + i * 0.001, std::to_string(i), 99));
+  points[1].m_isPassed = true;
+  m_manager.ReplaceRoutePoints(points);
+  auto const actual = m_manager.GetRoutePoints();
+  TEST_EQUAL(actual.size(), points.size(), ());
+  TEST(actual.front().m_pointType == RouteMarkType::Start, ());
+  TEST(actual.back().m_pointType == RouteMarkType::Finish, ());
+  for (size_t i = 0; i < actual.size(); ++i)
+  {
+    TEST_EQUAL(actual[i].m_title, points[i].m_title, (i));
+    TEST_EQUAL(actual[i].m_subTitle, points[i].m_subTitle, (i));
+    TEST_EQUAL(actual[i].m_isPassed, points[i].m_isPassed, (i));
+    if (i > 0 && i + 1 < actual.size())
+    {
+      TEST(actual[i].m_pointType == RouteMarkType::Intermediate, (i));
+      TEST_EQUAL(actual[i].m_intermediateIndex, i - 1, (i));
+    }
+  }
+  TEST(actual[1].m_isVisible, ());
+
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Intermediate, 3, "rejected stop"));
+  auto const afterRejectedInsert = m_manager.GetRoutePoints();
+  TEST_EQUAL(afterRejectedInsert.size(), actual.size(), ());
+  for (size_t i = 0; i < actual.size(); ++i)
+    TEST_EQUAL(afterRejectedInsert[i].m_title, actual[i].m_title, (i));
+}
+
+UNIT_CLASS_TEST(RoutingManagerTest, BatchInvalidatesPreviousRouteTransactions)
+{
+  AddTestPoints();
+  auto const transaction = m_manager.OpenRoutePointsTransaction();
+  m_manager.ReplaceRoutePoints(
+      {MakePoint(RouteMarkType::Start, 3, "new start"), MakePoint(RouteMarkType::Finish, 4, "new finish")});
+  m_manager.CancelRoutePointsTransaction(transaction);
+  auto const points = m_manager.GetRoutePoints();
+  TEST_EQUAL(points.size(), 2, ());
+  TEST_EQUAL(points.front().m_title, "new start", ());
+  TEST_EQUAL(points.back().m_title, "new finish", ());
+}
+
+UNIT_CLASS_TEST(RoutingManagerTest, MyPositionTitleUsesCoreStrings)
+{
+  auto start = MakePoint(RouteMarkType::Start, 1, "");
+  start.m_isMyPosition = true;
+  m_manager.ReplaceRoutePoints({start, MakePoint(RouteMarkType::Finish, 2, "finish")});
+  TEST_EQUAL(m_manager.GetRoutePoints().front().m_title, "My Position", ());
+  m_framework.AddString("core_my_position", "Localized position");
+  m_manager.ReplaceRoutePoints({start, MakePoint(RouteMarkType::Finish, 2, "finish")});
+  TEST_EQUAL(m_manager.GetRoutePoints().front().m_title, "Localized position", ());
+}
+
+UNIT_CLASS_TEST(RoutingManagerTest, RestoredMyPositionReplacesSavedLabels)
+{
+  auto start = MakePoint(RouteMarkType::Start, 1, "saved label");
+  start.m_replaceWithMyPositionAfterRestart = true;
+  m_manager.ReplaceRoutePoints({start, MakePoint(RouteMarkType::Finish, 2, "finish")});
+  SavePoints();
+  m_manager.RemoveRoutePoints();
+  auto const currentPosition = mercator::FromLatLon(1.1, 1);
+  m_framework.GetBookmarkManager().MyPositionMark().SetUserPosition(currentPosition, true);
+  bool loaded = false;
+  m_manager.LoadRoutePoints([&](bool success)
+  {
+    TEST(success, ());
+    loaded = true;
+  });
+  WaitUntil([&] { return loaded; });
+  auto const restored = m_manager.GetRoutePoints().front();
+  TEST(restored.m_isMyPosition, ());
+  TEST_EQUAL(restored.m_position, currentPosition, ());
+  TEST_EQUAL(restored.m_title, "My Position", ());
+  TEST(restored.m_subTitle.empty(), ());
+}
+
+UNIT_CLASS_TEST(RoutingManagerTest, UnknownMyPositionKeepsIntermediateOrder)
+{
+  auto start = MakePoint(RouteMarkType::Start, 1, "my position");
+  start.m_isMyPosition = true;
+  start.m_position = m2::PointD::Zero();
+  m_manager.ReplaceRoutePoints({start, MakePoint(RouteMarkType::Finish, 1.004, "finish")});
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Intermediate, 1.003, "C", 0));
+  m_manager.AddRoutePoint(MakePoint(RouteMarkType::Intermediate, 1.001, "A", 1));
+  auto const points = m_manager.GetRoutePoints();
+  TEST_EQUAL(points[1].m_title, "C", ());
+  TEST_EQUAL(points[2].m_title, "A", ());
+}
+
+UNIT_CLASS_TEST(RoutingManagerTest, RebuildingBatchRemovesPassedIntermediates)
+{
+  auto start = MakePoint(RouteMarkType::Start, 1, "my position");
+  start.m_isMyPosition = true;
+  auto passed = MakePoint(RouteMarkType::Intermediate, 1.001, "passed stop");
+  passed.m_isPassed = true;
+  m_manager.ReplaceRoutePoints({start, passed, MakePoint(RouteMarkType::Finish, 1.004, "finish")});
+  m_manager.SetRouteBuildingListener([](routing::RouterResultCode code, storage::CountriesSet const &)
+  { TEST_EQUAL(code, routing::RouterResultCode::NoCurrentPosition, ()); });
+  // Passed-point cleanup happens before the synchronous missing-position result.
+  m_manager.BuildRoute();
+  auto const points = m_manager.GetRoutePoints();
+  TEST_EQUAL(points.size(), 2, ());
+  TEST_EQUAL(points.back().m_title, "finish", ());
 }
 }  // namespace routing_manager_tests

--- a/libs/map/routing_manager.cpp
+++ b/libs/map/routing_manager.cpp
@@ -1011,6 +1011,7 @@ void RoutingManager::CloseRouting(bool removeRoutePoints)
 
   if (removeRoutePoints)
   {
+    m_routePointsTransactions.clear();
     m_bmManager->GetEditSession().ClearGroup(UserMark::Type::ROUTING);
     CancelRecommendation(Recommendation::RebuildAfterPointsLoading);
   }
@@ -1076,10 +1077,43 @@ void RoutingManager::AddRoutePoint(RouteMarkData && markData, bool reorderInterm
   }
 
   markData.m_isVisible = !markData.m_isMyPosition;
+  auto const type = markData.m_pointType;
+  auto const index = markData.m_intermediateIndex;
+  auto const count = routePoints.GetRoutePointsCount();
   routePoints.AddRoutePoint(std::move(markData));
 
-  if (reorderIntermediatePoints)
-    ReorderIntermediatePoints();
+  // At the point limit insertion is rejected; do not reorder the existing stop at this index.
+  if (reorderIntermediatePoints && type == RouteMarkType::Intermediate && routePoints.GetRoutePointsCount() > count)
+    ReorderIntermediatePoints(index);
+}
+
+void RoutingManager::ReplaceRoutePoints(std::vector<RouteMarkData> points)
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+  CHECK_GREATER_OR_EQUAL(points.size(), 2, ());
+  CHECK_LESS_OR_EQUAL(points.size(), RoutePointsLayout::kMaxRoutePointsCount, ());
+  CloseRouting(true /* remove route points */);
+
+  // Batch mark creation in one edit session.
+  RoutePointsLayout layout(*m_bmManager);
+  for (size_t i = 0; i < points.size(); ++i)
+  {
+    auto & point = points[i];
+    point.m_pointType = i == 0                 ? RouteMarkType::Start
+                      : i + 1 == points.size() ? RouteMarkType::Finish
+                                               : RouteMarkType::Intermediate;
+    point.m_intermediateIndex = point.m_pointType == RouteMarkType::Intermediate ? i - 1 : 0;
+    point.m_isVisible = !point.m_isMyPosition;
+    if (point.m_isMyPosition && point.m_title.empty())
+      point.m_title = m_callbacks.m_stringsBundleGetter().GetString("core_my_position");
+    if (point.m_isMyPosition && m_bmManager->MyPositionMark().HasPosition())
+      point.m_position = m_bmManager->MyPositionMark().GetPivot();
+  }
+
+  layout.AddRoutePoint(std::move(points.front()));
+  layout.AddRoutePoint(std::move(points.back()));
+  for (size_t i = 1; i + 1 < points.size(); ++i)
+    layout.AddRoutePoint(std::move(points[i]));
 }
 
 bool RoutingManager::ContinueRouteToPoint(RouteMarkData && markData)
@@ -1205,7 +1239,7 @@ void RoutingManager::SetPointsFollowingMode(bool enabled)
   routePoints.SetFollowingMode(enabled);
 }
 
-void RoutingManager::ReorderIntermediatePoints()
+void RoutingManager::ReorderIntermediatePoints(size_t addedIndex)
 {
   RoutePointsLayout routePoints(*m_bmManager);
   size_t const reserveCount = routePoints.GetRoutePointsCount();
@@ -1217,14 +1251,17 @@ void RoutingManager::ReorderIntermediatePoints()
 
   RouteMarkPoint * addedPoint = nullptr;
   m2::PointD addedPosition;
-  for (auto const & p : routePoints.GetRoutePoints())
+  auto const points = routePoints.GetRoutePoints();
+  if (points.size() < 2 || points.front()->GetRoutePointType() != RouteMarkType::Start ||
+      points.back()->GetRoutePointType() != RouteMarkType::Finish)
+    return;
+
+  for (auto const & p : points)
   {
     CHECK(p, ());
     if (p->GetRoutePointType() == RouteMarkType::Intermediate)
     {
-      // Note. An added (new) intermediate point is the first intermediate point at |routePoints.GetRoutePoints()|.
-      // The other intermediate points are former ones.
-      if (addedPoint == nullptr)
+      if (p->GetIntermediateIndex() == addedIndex)
       {
         addedPoint = p;
         addedPosition = p->GetPivot();
@@ -1239,7 +1276,13 @@ void RoutingManager::ReorderIntermediatePoints()
   if (addedPoint == nullptr)
     return;
 
-  CheckpointPredictor predictor(m_routingSession.GetStartPoint(), m_routingSession.GetEndPoint());
+  auto const & myPosition = m_bmManager->MyPositionMark();
+  // An unresolved my-position mark can contain a placeholder pivot, not a usable routing origin.
+  if (!myPosition.HasPosition() && (points.front()->IsMyPosition() || points.back()->IsMyPosition()))
+    return;
+  auto const pivotOf = [&myPosition](RouteMarkPoint const * point)
+  { return point->IsMyPosition() ? myPosition.GetPivot() : point->GetPivot(); };
+  CheckpointPredictor predictor(pivotOf(points.front()), pivotOf(points.back()));
 
   size_t const insertIndex = predictor.PredictPosition(prevPositions, addedPosition);
   addedPoint->SetIntermediateIndex(insertIndex);
@@ -1609,39 +1652,32 @@ void RoutingManager::LoadRoutePoints(LoadRouteHandler const & handler)
     }
 
     auto points = DeserializeRoutePoints(data);
-    if (handler && points.empty())
+    if (points.empty())
     {
-      handler(false /* success */);
+      if (handler)
+        handler(false /* success */);
       return;
     }
 
     GetPlatform().RunTask(Platform::Thread::Gui, [this, handler, points = std::move(points)]() mutable
     {
       ASSERT(m_bmManager != nullptr, ());
-      // If we have found my position and the saved route used the user's position, we use my position as start point.
-      bool routeUsedPosition = false;
-      auto const & myPosMark = m_bmManager->MyPositionMark();
-      auto editSession = m_bmManager->GetEditSession();
-      editSession.ClearGroup(UserMark::Type::ROUTING);
-      for (auto & p : points)
+      // A new user/API itinerary can arrive while the saved file is being read.
+      if (IsRoutingActive() || GetRoutePointsCount() != 0)
       {
-        // Check if the saved route used the user's position
-        if (p.m_replaceWithMyPositionAfterRestart && p.m_pointType == RouteMarkType::Start)
-          routeUsedPosition = true;
-
-        if (p.m_replaceWithMyPositionAfterRestart && p.m_pointType == RouteMarkType::Start && myPosMark.HasPosition())
-        {
-          RouteMarkData startPt;
-          startPt.m_pointType = RouteMarkType::Start;
-          startPt.m_isMyPosition = true;
-          startPt.m_position = myPosMark.GetPivot();
-          AddRoutePoint(std::move(startPt));
-        }
-        else
-        {
-          AddRoutePoint(std::move(p));
-        }
+        if (handler)
+          handler(false /* success */);
+        return;
       }
+      auto const & myPosMark = m_bmManager->MyPositionMark();
+      bool const routeUsedPosition = points.front().m_replaceWithMyPositionAfterRestart;
+      if (routeUsedPosition && myPosMark.HasPosition())
+      {
+        points.front().m_isMyPosition = true;
+        points.front().m_title.clear();
+        points.front().m_subTitle.clear();
+      }
+      ReplaceRoutePoints(std::move(points));
 
       // If we don't have my position and the saved route used it, save loading timestamp.
       // Probably we will get my position soon.

--- a/libs/map/routing_manager.hpp
+++ b/libs/map/routing_manager.hpp
@@ -215,6 +215,8 @@ public:
   void GenerateNotifications(std::vector<std::string> & notifications, bool announceStreets);
 
   void AddRoutePoint(RouteMarkData && markData, bool reorderIntermediatePoints = true);
+  /// Replaces a complete itinerary. Array order defines start, intermediate indexes, and finish.
+  void ReplaceRoutePoints(std::vector<RouteMarkData> points);
   bool ContinueRouteToPoint(RouteMarkData && markData);
   std::vector<RouteMarkData> GetRoutePoints() const;
   size_t GetRoutePointsCount() const;
@@ -266,8 +268,9 @@ public:
 
   /// \returns true if there are route points saved in file and false otherwise.
   bool HasSavedRoutePoints() const;
-  /// \brief It loads road points from file and delete file after loading.
-  /// The result of the loading will be sent via SafeCallback.
+  /// Consumes saved points only if the route-point layout is still empty when reading finishes.
+  /// Removes the saved file after the read attempt, even if the points are not applied.
+  /// Completion is delivered on the GUI thread.
   using LoadRouteHandler = platform::SafeCallback<void(bool success)>;
   void LoadRoutePoints(LoadRouteHandler const & handler);
   /// \brief It saves route points to file.
@@ -336,7 +339,7 @@ private:
 
   void SetPointsFollowingMode(bool enabled);
 
-  void ReorderIntermediatePoints();
+  void ReorderIntermediatePoints(size_t addedIndex);
 
   m2::RectD ShowPreviewSegments(std::vector<RouteMarkData> const & routePoints);
   void HidePreviewSegments();


### PR DESCRIPTION
Extracted from #12678; based directly on master, without v2 deep-link or callback dependencies.

- Replace complete itineraries in array order through a core batch operation. Only individual intermediate-point insertion invokes optimization, using the current endpoints and the added point's index.
- Preserve saved stop order, reject a late restore if a new itinerary exists, and invalidate obsolete route-point transactions. Saved files are consumed even when their points are discarded.
- Restore My Position labels through the core strings bundle, clearing stale saved labels when substituting the current position.
- Android route management sends one JNI array and keeps existing marks/router selection during rebuilds. Passed-stop flags survive reordering, so rebuilding removes visited intermediates. Unused SDK point-add/remove wrappers and duplicate JNI checks are removed.

Validation:

- Three itinerary regressions fail on master; two label regressions fail before the review fixes. All pass here, alongside batch-limit, metadata, transaction, passed-stop, and unknown-position tests.
- Full C++ `map_tests` and `routing_tests` pass through `ctest`.
- Android arm64 native build and 51 app/SDK unit tests pass. App/SDK lint completes without errors, with an internal hardware-ID analyzer exception.
- 18 focused iOS deep-link/converter/CarPlay-helper tests pass on an arm64 iOS 26.5 simulator (`ENABLE_DEBUG_DYLIB=NO`).

No Android device or end-to-end CarPlay UI testing.