### PR TITLE
[generator] Match deprecated natural=vineyard/orchard and amenity=embassy

### DIFF
--- a/data/replaced_tags.txt
+++ b/data/replaced_tags.txt
@@ -70,6 +70,7 @@ waterway=sanitary_dump_station : amenity=sanitary_dump_station
 compressed_air=yes : amenity=compressed_air
 
 amenity=monastery : amenity=place_of_worship
+amenity=embassy : office=diplomatic
 
 vending=parcel_pickup;parcel_mail_in : amenity=parcel_locker | u
 vending=parcel_pickup : amenity=parcel_locker | u
@@ -89,6 +90,8 @@ natural=marsh     : natural=wetland, wetland=marsh
 natural=waterfall : waterway=waterfall
 natural=forest    : natural=wood
 natural=shrubbery : natural=scrub
+natural=vineyard  : landuse=vineyard
+natural=orchard   : landuse=orchard
 cliff=yes         : natural=cliff
 
 # Deprecated water tagging. No 'u' flag: it would overwrite an existing natural=* tag,

--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -1750,6 +1750,25 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Cliff)
   }
 }
 
+UNIT_CLASS_TEST(TestWithClassificator, OsmType_DeprecatedTags)
+{
+  // A deprecated mapcss-mapping.csv row only remaps the type id of already built maps, so these
+  // tags need a replaced_tags.txt rule to be matched at all.
+  using Type = std::vector<std::string>;
+  std::vector<std::pair<Type, Tags>> const conversions = {
+      {{"landuse", "vineyard"}, {{"natural", "vineyard"}}},
+      {{"landuse", "orchard"}, {{"natural", "orchard"}}},
+      {{"office", "diplomatic"}, {{"amenity", "embassy"}}},
+  };
+
+  for (auto const & [type, tags] : conversions)
+  {
+    auto const params = GetFeatureBuilderParams(tags);
+    TEST_EQUAL(params.m_types.size(), 1, (tags, params));
+    TEST(params.IsTypeExist(GetType(type)), (tags, params));
+  }
+}
+
 UNIT_CLASS_TEST(TestWithClassificator, OsmType_DeprecatedWaterTags)
 {
   using Type = std::vector<std::string>;


### PR DESCRIPTION
## Problem

A deprecated row in `mapcss-mapping.csv` is excluded from the classificator, so its selectors never match OSM tags — the replacement column only remaps the old type id when reading already built maps. Three rows were left half-done, with a replacement declared but no `replaced_tags.txt` rule:

| tag | today | intended |
|---|---|---|
| `natural=vineyard` | no type at all | `landuse-vineyard` |
| `natural=orchard` | no type at all | `landuse-orchard` |
| `amenity=embassy` | only the generic `amenity` | `office-diplomatic` |

Vineyard and orchard features are dropped entirely; embassies lose their icon and searchability.

## Result

Three `replaced_tags.txt` rules, so the replacement types these rows already declare are actually produced.

Worth knowing before merging: **these tags are nearly extinct in OSM** — per taginfo, `natural=vineyard` has 0 objects, `natural=orchard` 1, `amenity=embassy` 61. This is a correctness fix that closes a documented gap, not a data win.

## Related

Found by sweeping every deprecated-with-replacement row in `mapcss-mapping.csv` (feeding each row's own source tags back through `GetFeatureBuilderParams` and comparing against its declared replacement). The same sweep found four more still-broken rows, left out of this PR:

- `historic=museum` → `tourism-museum` (42 objects)
- `waterway=lock` → `waterway-canal` (11)
- `amenity=speed_trap` → `highway-speed_camera` (2)
- `leisure=landscape_reserve` → `leisure-nature_reserve` (0)

and one deliberately **not** fixed: `sport=football` → `sport-soccer` (2621). OSM deprecated `sport=football` precisely because it is ambiguous between association and American football. Those pitches keep `leisure-pitch` today and merely lack a sport subtype, which is the safe state — mapping them all to soccer would actively mislabel some.

#13534 documents this trap in the `mapcss-mapping.csv` header and fixes the water-tag instances of it.

## Testing

New `OsmType_DeprecatedTags` covers all three conversions. Verified it fails on master without the rules (`natural=vineyard` yields 0 types) and passes with them. `generator_tests`, `indexer_tests` and `style_tests` pass. No generated files change — `replaced_tags.txt` is not an input to `generate_drules.sh`.