### PR TITLE
fix(map): allow API callers to opt out of feature matching

### DIFF
--- a/docs/MAP_API.md
+++ b/docs/MAP_API.md
@@ -1,0 +1,36 @@
+# Independent points in the map API
+
+`om://map` links normally match each coordinate to a nearby or enclosing map
+feature. A supplied `n` replaces the displayed name, while the matched feature's
+classification and metadata remain available. This also preserves the behavior of
+Organic Maps' own shared coordinate/name links.
+
+A caller importing an independently identified place can append `match=none` after
+that point's `ll` to display its supplied coordinates and name without matching an
+OpenStreetMap feature:
+
+```text
+om://map?v=1&ll=40.2113819,19.5793909&n=Restorant%20Iliria%20Llogora&match=none
+```
+
+This prevents an imported restaurant from inheriting an enclosing park's metadata,
+including when a different POI or building happens to occupy the same coordinate.
+An unnamed point is shown with the normal coordinate-based title. The point's
+`id` and the request's `backurl` retain their existing meanings.
+
+The option applies only to the preceding `ll`, like `n` and `id`. Each new point
+starts with matching enabled, so one request can mix policies:
+
+```text
+om://map?ll=1,1&n=Independent&match=none&ll=2,2&n=Meeting%20point
+```
+
+`match` before any `ll` makes the request invalid. Only the value `none` disables
+matching; other values are ignored. The policy stays with the API pin when it is
+selected again. It is not serialized into saved bookmarks or subsequent shares.
+
+Existing links without this option, including generic `geo:` links and native
+Organic Maps shares, retain feature matching. An importer must explicitly build
+the map API link from its resolved coordinates and URL-encoded name. A resolver's
+existing `geo:` redirect does not opt in. Older Organic Maps versions ignore the
+new option and continue matching features.

--- a/docs/MAP_API.md
+++ b/docs/MAP_API.md
@@ -2,19 +2,23 @@
 
 `om://map` links normally match each coordinate to a nearby or enclosing map
 feature. A supplied `n` replaces the displayed name, while the matched feature's
-classification and metadata remain available. This also preserves the behavior of
-Organic Maps' own shared coordinate/name links.
+classification and metadata remain available. For an independently supplied place,
+spatial proximity does not establish that it is the same object: this can combine
+one place's name with an unrelated feature's identity, classification and metadata.
 
 A caller importing an independently identified place can append `match=none` after
 that point's `ll` to display its supplied coordinates and name without matching an
 OpenStreetMap feature:
 
 ```text
-om://map?v=1&ll=40.2113819,19.5793909&n=Restorant%20Iliria%20Llogora&match=none
+om://map?v=1&ll=1,2&n=Imported%20place&match=none
 ```
 
-This prevents an imported restaurant from inheriting an enclosing park's metadata,
-including when a different POI or building happens to occupy the same coordinate.
+This avoids associating the supplied place with a nearby or enclosing feature,
+including a different POI or building at the same coordinate. The caller explicitly
+chooses to keep the point independent rather than infer a feature identity from its
+location.
+
 An unnamed point is shown with the normal coordinate-based title. The point's
 `id` and the request's `backurl` retain their existing meanings.
 

--- a/libs/map/api_mark_point.hpp
+++ b/libs/map/api_mark_point.hpp
@@ -26,12 +26,16 @@ public:
   std::string const & GetApiID() const { return m_id; }
   void SetApiID(std::string const & id);
 
+  bool ShouldMatchFeature() const { return m_matchFeature; }
+  void SetMatchFeature(bool matchFeature) { m_matchFeature = matchFeature; }
+
   void SetStyle(df::ColorConstant style);
   df::ColorConstant GetStyle() const { return m_style; }
 
 private:
   std::string m_name;
   std::string m_id;
+  bool m_matchFeature = true;
 
   /// @todo Replace ColorConstant with std::string for possible future custom styles.
   df::ColorConstant m_style;

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -872,8 +872,16 @@ std::optional<kml::TrackData> Framework::TryBuildRelationTrack(Track::TrackSelec
 
 void Framework::FillApiMarkInfo(ApiMarkPoint const & api, place_page::Info & info) const
 {
-  // An API point identifies a coordinate, not the feature underneath it (e.g. a large park).
-  GetSelectionProcessor().FillNotMatchedPlaceInfo(info, api.GetPivot(), api.GetName());
+  if (api.ShouldMatchFeature())
+  {
+    GetSelectionProcessor().FillPointInfo(info, api.GetPivot());
+    if (!api.GetName().empty())
+      info.SetCustomName(api.GetName());
+  }
+  else
+  {
+    GetSelectionProcessor().FillNotMatchedPlaceInfo(info, api.GetPivot(), api.GetName());
+  }
   info.SetApiId(api.GetApiID());
   info.SetApiUrl(GenerateApiBackUrl(api));
 }

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -872,10 +872,8 @@ std::optional<kml::TrackData> Framework::TryBuildRelationTrack(Track::TrackSelec
 
 void Framework::FillApiMarkInfo(ApiMarkPoint const & api, place_page::Info & info) const
 {
-  GetSelectionProcessor().FillPointInfo(info, api.GetPivot());
-  std::string const & name = api.GetName();
-  if (!name.empty())
-    info.SetCustomName(name);
+  // An API point identifies a coordinate, not the feature underneath it (e.g. a large park).
+  GetSelectionProcessor().FillNotMatchedPlaceInfo(info, api.GetPivot(), api.GetName());
   info.SetApiId(api.GetApiID());
   info.SetApiUrl(GenerateApiBackUrl(api));
 }

--- a/libs/map/map_tests/api_mark_tests.cpp
+++ b/libs/map/map_tests/api_mark_tests.cpp
@@ -1,12 +1,25 @@
 #include "testing/testing.hpp"
 
+#include "generator/generator_tests_support/test_feature.hpp"
+#include "generator/generator_tests_support/test_mwm_builder.hpp"
+
 #include "map/api_mark_point.hpp"
 #include "map/framework.hpp"
+
+#include "drape_frontend/drape_frontend_tests/visual_params_fixture.hpp"
+
+#include "platform/country_defines.hpp"
+#include "platform/local_country_file.hpp"
+#include "platform/local_country_file_utils.hpp"
+#include "platform/platform.hpp"
+
+#include "geometry/mercator.hpp"
 
 #include <string>
 
 namespace api_mark_tests
 {
+using df::test_support::VisualParamsFixture;
 // Returns the single API mark parsed from an om:// deep link. ExecuteMapApiRequest()
 // materializes the marks described by the URL into the API user-mark group.
 ApiMarkPoint const * CreateSingleApiMark(Framework & fm, std::string const & url)
@@ -47,5 +60,45 @@ UNIT_TEST(ApiPoint_PointIdIsIndependentOfBackUrl)
     TEST_EQUAL(mark->GetApiID(), "foo", ());
     TEST_NOT_EQUAL(mark->GetApiID(), fm.GenerateApiBackUrl(*mark), ("point id and back URL are distinct"));
   }
+}
+
+UNIT_CLASS_TEST(VisualParamsFixture, ApiPoint_DoesNotInheritEnclosingFeature)
+{
+  using namespace generator::tests_support;
+  Framework fm({} /* params */, false /* loadMaps */);
+  platform::LocalCountryFile country(GetPlatform().WritableDir(), platform::CountryFile("ApiPointPark"), 0);
+  platform::CountryIndexes::DeleteFromDisk(country);
+  country.DeleteFromDisk(MapFileType::Map);
+  {
+    TestPark park({{0, 0}, {2, 0}, {2, 2}, {0, 2}, {0, 0}}, "Enclosing park", "en");
+    park.GetMetadata().Set(feature::Metadata::FMD_WIKIPEDIA, "en:National_park");
+    TestMwmBuilder builder(country, feature::DataHeader::MapType::Country);
+    builder.Add(park);
+  }
+  TEST_EQUAL(fm.RegisterMap(country).second, MwmSet::RegResult::Success, ());
+  auto const point = mercator::FromLatLon(1, 1);
+  TEST(fm.GetFeatureAtPoint(point).IsValid(), ("The enclosing feature must be present."));
+
+  for (auto const * name : {"", "&n=Shared%20point"})
+  {
+    auto const * mark = CreateSingleApiMark(fm, std::string("om://map?ll=1,1&id=external&backurl=testapp") + name);
+    place_page::BuildInfo bi;
+    bi.m_source = place_page::BuildInfo::Source::User;
+    bi.m_mercator = point;
+    bi.m_userMarkId = mark->GetId();
+    fm.BuildAndSetPlacePageInfo(bi);
+    auto const & info = fm.GetCurrentPlacePageInfo();
+    TEST(!info.GetID().IsValid(), ("An external API point does not identify an OSM feature."));
+    TEST(info.GetMetadata(feature::Metadata::FMD_WIKIPEDIA).empty(), ());
+    TEST_ALMOST_EQUAL_ABS(info.GetMercator(), point, 1e-7, ());
+    TEST_EQUAL(info.GetApiId(), "external", ());
+    TEST_EQUAL(info.GetApiUrl(), fm.GenerateApiBackUrl(*mark), ());
+    if (*name)
+      TEST_EQUAL(info.GetTitle(), "Shared point", ());
+  }
+
+  fm.DeregisterAllMaps();
+  platform::CountryIndexes::DeleteFromDisk(country);
+  country.DeleteFromDisk(MapFileType::Map);
 }
 }  // namespace api_mark_tests

--- a/libs/map/map_tests/api_mark_tests.cpp
+++ b/libs/map/map_tests/api_mark_tests.cpp
@@ -5,6 +5,7 @@
 
 #include "map/api_mark_point.hpp"
 #include "map/framework.hpp"
+#include "map/share.hpp"
 
 #include "drape_frontend/drape_frontend_tests/visual_params_fixture.hpp"
 
@@ -62,7 +63,7 @@ UNIT_TEST(ApiPoint_PointIdIsIndependentOfBackUrl)
   }
 }
 
-UNIT_CLASS_TEST(VisualParamsFixture, ApiPoint_DoesNotInheritEnclosingFeature)
+UNIT_CLASS_TEST(VisualParamsFixture, ApiPoint_FeatureMatchingIsOptOut)
 {
   using namespace generator::tests_support;
   Framework fm({} /* params */, false /* loadMaps */);
@@ -71,30 +72,84 @@ UNIT_CLASS_TEST(VisualParamsFixture, ApiPoint_DoesNotInheritEnclosingFeature)
   country.DeleteFromDisk(MapFileType::Map);
   {
     TestPark park({{0, 0}, {2, 0}, {2, 2}, {0, 2}, {0, 0}}, "Enclosing park", "en");
-    park.GetMetadata().Set(feature::Metadata::FMD_WIKIPEDIA, "en:National_park");
+    TestPOI poi(mercator::FromLatLon(0.5, 0.5), "Existing cafe", "en");
+    auto const center = mercator::FromLatLon(1.5, 1.5);
+    TestBuilding building(m2::RectD(center.x - 0.001, center.y - 0.001, center.x + 0.001, center.y + 0.001),
+                          "Existing building", "1", "", "en");
     TestMwmBuilder builder(country, feature::DataHeader::MapType::Country);
-    builder.Add(park);
+    for (TestFeature * feature : std::initializer_list<TestFeature *>{&park, &poi, &building})
+    {
+      feature->GetMetadata().Set(feature::Metadata::FMD_WIKIPEDIA, "en:Test_feature");
+      feature->GetMetadata().Set(feature::Metadata::FMD_OPEN_HOURS, "24/7");
+      builder.Add(*feature);
+    }
   }
   TEST_EQUAL(fm.RegisterMap(country).second, MwmSet::RegResult::Success, ());
-  auto const point = mercator::FromLatLon(1, 1);
-  TEST(fm.GetFeatureAtPoint(point).IsValid(), ("The enclosing feature must be present."));
 
-  for (auto const * name : {"", "&n=Shared%20point"})
+  auto checkMark = [&](ApiMarkPoint const & mark, bool matchFeature, std::string const & name)
   {
-    auto const * mark = CreateSingleApiMark(fm, std::string("om://map?ll=1,1&id=external&backurl=testapp") + name);
+    auto const point = mark.GetPivot();
+    auto const featureId = fm.GetFeatureAtPoint(point);
+    TEST(featureId.IsValid(), ("A control feature must exist at the shared coordinate."));
+    TEST_EQUAL(mark.ShouldMatchFeature(), matchFeature, ());
     place_page::BuildInfo bi;
     bi.m_source = place_page::BuildInfo::Source::User;
     bi.m_mercator = point;
-    bi.m_userMarkId = mark->GetId();
+    bi.m_userMarkId = mark.GetId();
     fm.BuildAndSetPlacePageInfo(bi);
     auto const & info = fm.GetCurrentPlacePageInfo();
-    TEST(!info.GetID().IsValid(), ("An external API point does not identify an OSM feature."));
-    TEST(info.GetMetadata(feature::Metadata::FMD_WIKIPEDIA).empty(), ());
+    TEST_EQUAL(info.GetID().IsValid(), matchFeature, ());
+    if (matchFeature)
+      TEST_EQUAL(info.GetID(), featureId, ());
+    TEST_EQUAL(info.GetTypes().Empty(), !matchFeature, ());
+    TEST_EQUAL(info.GetMetadata(feature::Metadata::FMD_WIKIPEDIA).empty(), !matchFeature, ());
+    TEST_EQUAL(info.GetMetadata(feature::Metadata::FMD_OPEN_HOURS).empty(), !matchFeature, ());
     TEST_ALMOST_EQUAL_ABS(info.GetMercator(), point, 1e-7, ());
-    TEST_EQUAL(info.GetApiId(), "external", ());
-    TEST_EQUAL(info.GetApiUrl(), fm.GenerateApiBackUrl(*mark), ());
-    if (*name)
-      TEST_EQUAL(info.GetTitle(), "Shared point", ());
+    TEST_EQUAL(info.GetApiId(), mark.GetApiID(), ());
+    TEST_EQUAL(info.GetApiUrl(), fm.GenerateApiBackUrl(mark), ());
+    if (!name.empty())
+      TEST_EQUAL(info.GetTitle(), name, ());
+  };
+
+  // Area, coincident POI and building: matching depends on the caller's policy, not geometry.
+  for (auto const * ll : {"1,1", "0.5,0.5", "1.5,1.5"})
+  {
+    for (auto const * name : {"", "&n=Shared%20point"})
+    {
+      for (bool matchFeature : {true, false})
+      {
+        auto const link = std::string("om://map?ll=") + ll + "&id=external&backurl=testapp" + name +
+                          (matchFeature ? "" : "&match=none");
+        auto const * mark = CreateSingleApiMark(fm, link);
+        checkMark(*mark, matchFeature, *name ? "Shared point" : "");
+      }
+    }
+  }
+
+  // Exercise the actual native share builder, including a renamed meeting point inside the park.
+  for (auto const & ll : {ms::LatLon(1, 1), ms::LatLon(0.5, 0.5), ms::LatLon(1.5, 1.5)})
+  {
+    share::Place place;
+    place.m_ll = ll;
+    place.m_name = "We should meet here";
+    place.m_zoom = 17;
+    auto const * mark = CreateSingleApiMark(fm, share::Build(place, {}).m_url);
+    checkMark(*mark, true, place.m_name);
+  }
+
+  // Each pin keeps its policy when selected again after another pin in the same request.
+  TEST_EQUAL(fm.ParseAndSetApiURL("om://map?ll=1,1&n=Imported&id=plain&match=none&ll=1,1&n=Meeting&id=matched"),
+             url_scheme::ParsedMapApi::UrlType::Map, ());
+  fm.ExecuteMapApiRequest();
+  auto const & ids = fm.GetBookmarkManager().GetUserMarkIds(UserMark::Type::API);
+  TEST_EQUAL(ids.size(), 2, ());
+  for (int repeat = 0; repeat < 2; ++repeat)
+  {
+    for (auto const id : ids)
+    {
+      auto const * mark = fm.GetBookmarkManager().GetMark<ApiMarkPoint>(id);
+      checkMark(*mark, mark->GetApiID() == "matched", mark->GetName());
+    }
   }
 
   fm.DeregisterAllMaps();

--- a/libs/map/map_tests/mwm_url_tests.cpp
+++ b/libs/map/map_tests/mwm_url_tests.cpp
@@ -42,6 +42,22 @@ UNIT_TEST(MapApiSmoke)
   TEST_EQUAL(test.GetGlobalBackUrl(), "https://organicmaps.app", ());
 }
 
+UNIT_TEST(MapApiFeatureMatching)
+{
+  ParsedMapApi test;
+  TEST_EQUAL(test.SetUrlAndParse("om://map?match=none&ll=1,2"), UrlType::Incorrect, ());
+  TEST_EQUAL(test.SetUrlAndParse("om://map?ll=1,2&match=none&ll=3,4&ll=5,6&match=unknown"), UrlType::Map, ());
+  auto const & points = test.GetMapPoints();
+  TEST_EQUAL(points.size(), 3, ());
+  TEST(!points[0].m_matchFeature, ());
+  TEST(points[1].m_matchFeature, ("The policy belongs to the preceding point only."));
+  TEST(points[2].m_matchFeature, ("Unknown values preserve the default."));
+  TEST_EQUAL(test.SetUrlAndParse("om://map?ll=1,2"), UrlType::Map, ());
+  TEST(test.GetMapPoints()[0].m_matchFeature, ("The policy must not leak into the next request."));
+  TEST_EQUAL(test.SetUrlAndParse("geo:1,2?q=1,2(Shared)"), UrlType::Map, ());
+  TEST(test.GetMapPoints()[0].m_matchFeature, ("Generic geo links retain feature matching."));
+}
+
 UNIT_TEST(RouteApiSmoke)
 {
   string const urlString = "mapswithme://route?sll=1,1&saddr=name0&dll=2,2&daddr=name1&type=vehicle";

--- a/libs/map/mwm_url.cpp
+++ b/libs/map/mwm_url.cpp
@@ -40,6 +40,7 @@ std::string_view constexpr kZoomLevel = "z";
 std::string_view constexpr kName = "n";
 std::string_view constexpr kId = "id";
 std::string_view constexpr kStyle = "s";
+std::string_view constexpr kMatch = "match";
 std::string_view constexpr kBackUrl = "backurl";
 std::string_view constexpr kVersion = "v";
 std::string_view constexpr kBalloonAction = "balloonaction";
@@ -327,6 +328,17 @@ void ParsedMapApi::ParseMapParam(std::string const & key, std::string const & va
       return;
     }
   }
+  else if (key == kMatch)
+  {
+    if (m_mapPoints.empty())
+    {
+      LOG(LWARNING, ("Map API: Matching policy with no point. 'll' should come first!"));
+      correctOrder = false;
+      return;
+    }
+    if (value == "none")
+      m_mapPoints.back().m_matchFeature = false;
+  }
   else if (key == kBackUrl)
   {
     // Fix missing :// in back url, it's important for iOS
@@ -468,12 +480,13 @@ void ParsedMapApi::ExecuteMapApiRequest(Framework & fm) const
 
   // Add marks from the request.
   m2::RectD viewport;
-  for (auto const & [lat, lon, name, id, style] : m_mapPoints)
+  for (auto const & [lat, lon, name, id, style, matchFeature] : m_mapPoints)
   {
     m2::PointD const glPoint(mercator::FromLatLon(lat, lon));
     auto * mark = editSession.CreateUserMark<ApiMarkPoint>(glPoint);
     mark->SetName(name);
     mark->SetApiID(id);
+    mark->SetMatchFeature(matchFeature);
     mark->SetStyle(style::GetSupportedStyle(style));
     viewport.Add(glPoint);
   }

--- a/libs/map/mwm_url.hpp
+++ b/libs/map/mwm_url.hpp
@@ -17,6 +17,7 @@ struct MapPoint
   std::string m_name;
   std::string m_id;
   std::string m_style;
+  bool m_matchFeature = true;
 };
 
 struct RoutePoint


### PR DESCRIPTION
An independently supplied place can be incorrectly associated with a nearby or enclosing OpenStreetMap feature. Organic Maps matches the coordinate, loads the feature's details, then replaces its displayed name with the supplied name. The resulting place page combines one place's name with another object's identity, classification and metadata. Coordinates alone do not establish that they are the same object.

Add a per-point `match=none` option to `om://map`. An opted-out pin keeps its supplied name and coordinates without selecting an OSM feature, including coincident POIs and buildings. Links without the option retain existing matching. API IDs and callbacks remain intact.

```text
om://map?v=1&ll=1,2&n=Imported%20place&match=none
```

The policy follows each parsed point into its API mark and survives reselection. See [the API notes](docs/MAP_API.md) for ordering, compatibility and multiple-pin examples. Importers must explicitly construct this link; the resolver's generic `geo:` output does not opt in. Persisting the policy through saved bookmarks and later shares is outside this change.

Validation:

- All 198 `map_tests` pass on macOS. Generated-map coverage pairs opted-out and default pins inside a park and at a POI/building, checks native share links including a renamed meeting point, and verifies mixed-pin reselection, metadata, coordinates and API fields.
- Parser tests cover ordering, unknown values, per-point defaults, request reset and unchanged `geo:` handling.
- clang-format 23.1.0 and `git diff --check` pass. The companion Cherri tester compiles.
- Earlier simulator/iPhone reports exercised the original broad patch. This revision has not yet been retested on a physical phone or Android.

Related: #7173 and organicmaps/url-privacy-proxy#2.

Implemented and tested with OpenAI Codex assistance using GPT-6 Astra (high effort).
