### PR TITLE
[indexer] Fail fast on unknown color constants

### DIFF
--- a/libs/indexer/drawing_rules.cpp
+++ b/libs/indexer/drawing_rules.cpp
@@ -68,8 +68,10 @@ uint32_t RulesHolder::GetColor(std::string_view name) const
   auto const it = m_colors.find(name);
   if (it == m_colors.end())
   {
-    LOG(LWARNING, ("Requested color", name, "is not found"));
-    return 0;
+    // Names are constants from the code, so a miss is a bug in a style or in the code (LERROR aborts in Debug).
+    LOG(LERROR, ("Requested color", name, "is not found"));
+    // Opaque magenta (the stored alpha is inverted), so that a miss is visible on the map in Release too.
+    return 0xFF00FF;
   }
   return it->second;
 }

--- a/libs/map/style_tests/style_symbols_consistency_test.cpp
+++ b/libs/map/style_tests/style_symbols_consistency_test.cpp
@@ -90,4 +90,32 @@ UNIT_TEST(Test_SymbolsConsistency)
 
   TEST(res, ());
 }
+
+// The code requests named colors by name and a missing one aborts in Debug, so all styles must define the
+// same names. The merged style is skipped: it is a tools-only mix of the others.
+UNIT_TEST(Test_NamedColorsConsistency)
+{
+  auto const getNames = [](MapStyle mapStyle)
+  {
+    StringSet names;
+    for (auto const & color : drule::DecodeRules(mapStyle).namedColors)
+      names.insert(color.name);
+    return names;
+  };
+
+  StringSet const expected = getNames(kDefaultMapStyle);
+  TEST(!expected.empty(), ());
+  for (size_t s = 0; s < MapStyleCount; ++s)
+  {
+    MapStyle const mapStyle = static_cast<MapStyle>(s);
+    if (mapStyle == MapStyleMerged)
+      continue;
+
+    // Report just the differing names: every style defines about a hundred of them.
+    StringSet const names = getNames(mapStyle);
+    std::vector<std::string> diff;
+    std::set_symmetric_difference(names.begin(), names.end(), expected.begin(), expected.end(), back_inserter(diff));
+    TEST(diff.empty(), (mapStyle, "named colors differ:", diff));
+  }
+}
 }  // namespace style_symbols_consistency_tests


### PR DESCRIPTION
`RulesHolder::GetColor()` returned 0 and only logged a warning when a style does not define a requested named color, so the color silently became opaque black (the rules store inverted alpha). Every name that reaches it is a compile-time constant, so a miss is a bug in the style or in the code: `LOG(LERROR)` aborts in Debug and still only logs in Release.

The second commit adds a style test that all styles define the same named colors, so a color added to one style only is caught in CI instead of aborting when that style is selected.

Tested: full ctest (34/34) and the offscreen drape/drape_frontend/shaders tests in Debug. Removing a color from the vehicle styles makes the new test fail.
