### PR TITLE
[routing] Name transit alternative factors and drop an unused hook

### DIFF
--- a/libs/routing/index_router.cpp
+++ b/libs/routing/index_router.cpp
@@ -78,6 +78,11 @@ double constexpr kTransitMaxSpeedKMpH = 60.0;
 // Transit alternatives are exempt because they intentionally trade time for less walking.
 double constexpr kMaxAltEtaRatio = 1.5;
 
+// Transit has no distance-biased road model: its alternative biases walking legs and transfers
+// instead (e.g. a direct bus instead of subway + walk).
+double constexpr kTransitAltWalkFactor = 3.0;
+double constexpr kTransitAltTransferFactor = 2.0;
+
 bool IsAlternativeEtaAcceptable(VehicleType vehicleType, double activeEtaSec, double alternativeEtaSec)
 {
   return vehicleType == VehicleType::Transit || alternativeEtaSec <= kMaxAltEtaRatio * activeEtaSec;
@@ -484,7 +489,7 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
         if (m_vehicleType == VehicleType::Transit)
         {
           // Rewrite walking and transfer/boarding penalty for the alternative route.
-          m_estimator->SetTransitAltFactors(3.0 /* walk */, 2.0 /* transfer */);
+          m_estimator->SetTransitAltFactors(kTransitAltWalkFactor, kTransitAltTransferFactor);
         }
         else
         {

--- a/libs/routing/index_router.hpp
+++ b/libs/routing/index_router.hpp
@@ -94,13 +94,6 @@ public:
   VehicleType GetVehicleType() const { return m_vehicleType; }
   std::shared_ptr<NumMwmIds> const & GetNumMwmIds() const { return m_numMwmIds; }
 
-  // Test/tuning hook: bias the transit routing weight of walking and transfers.
-  // Used by tests to force a bus over a short walk.
-  void SetTransitAltFactors(double walkFactor, double transferFactor)
-  {
-    m_estimator->SetTransitAltFactors(walkFactor, transferFactor);
-  }
-
   template <class T>
   void SetCurrentTimeGetter(T && getter)
   {


### PR DESCRIPTION
Split out of #13508 as requested in its review. No behaviour change.

* Name the walking and transfer weight factors of the transit alternative instead of bare `3.0` and `2.0` literals.
* Remove `IndexRouter::SetTransitAltFactors()`: the test hook has no callers.

Testing: `routing_tests` pass, `routing_integration_tests` builds.
