### PR TITLE
[routing] Fix comments on the transit alternative factors

### DIFF
--- a/libs/routing/index_router.cpp
+++ b/libs/routing/index_router.cpp
@@ -78,8 +78,8 @@ double constexpr kTransitMaxSpeedKMpH = 60.0;
 // Transit alternatives are exempt because they intentionally trade time for less walking.
 double constexpr kMaxAltEtaRatio = 1.5;
 
-// Transit has no distance-biased road model: its alternative biases walking legs and transfers
-// instead (e.g. a direct bus instead of subway + walk).
+// Bias the transit alternative away from walking and transfers,
+// see EdgeEstimator::SetTransitAltFactors().
 double constexpr kTransitAltWalkFactor = 3.0;
 double constexpr kTransitAltTransferFactor = 2.0;
 
@@ -511,7 +511,6 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints, m2
 
         if (m_vehicleType == VehicleType::Transit)
         {
-          // Rewrite walking and transfer/boarding penalty for the alternative route.
           m_estimator->SetTransitAltFactors(kTransitAltWalkFactor, kTransitAltTransferFactor);
         }
         else


### PR DESCRIPTION
Follow-up to #13557: its review comments were left unaddressed when it merged. Comment-only change.

* Transit is priced by `PedestrianEstimator`, which does have a distance-biased mode (4 km/h cap), so "Transit has no distance-biased road model" was wrong. Point to `EdgeEstimator::SetTransitAltFactors()`, whose doc already gives the example.
* Drop the comment that the named factors made redundant.

Testing: `routing_tests` pass.
